### PR TITLE
Issue #3: ios/devel core bridge 변경 포팅

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "Vendor/rhwp"]
 	path = Vendor/rhwp
-	url = https://github.com/edwardkim/rhwp.git
+	url = https://github.com/postmelee/rhwp.git
 	branch = devel

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rhwp-mac
+# alhangeul-macos
 
 macOS용 HWP/HWPX Quick Look, Finder thumbnail, 문서 viewer 앱입니다.
 
@@ -32,7 +32,7 @@ xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug build
 
 ## rhwp 코어 최신화
 
-`rhwp` 코어는 upstream `devel` 브랜치를 기준으로 최신화합니다.
+`rhwp` 코어는 개인 fork `postmelee/rhwp`의 `devel` 브랜치를 기준으로 최신화합니다. upstream `edwardkim/rhwp`의 변경은 필요한 범위를 개인 fork에 반영한 뒤 이 저장소에서 submodule commit으로 고정합니다.
 
 ```bash
 ./scripts/update-rhwp-core.sh

--- a/RustBridge/Cargo.lock
+++ b/RustBridge/Cargo.lock
@@ -564,6 +564,8 @@ dependencies = [
  "paste",
  "pdf-writer",
  "quick-xml",
+ "serde",
+ "serde_json",
  "snafu",
  "strum",
  "subsetter",
@@ -634,6 +636,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]

--- a/RustBridge/src/lib.rs
+++ b/RustBridge/src/lib.rs
@@ -81,8 +81,11 @@ pub extern "C" fn rhwp_render_page_svg(handle: *const RhwpHandle, page: u32) -> 
 pub extern "C" fn rhwp_render_page_tree(handle: *const RhwpHandle, page: u32) -> *mut c_char {
     ffi_guard!(handle, ptr::null_mut(), {
         let h = unsafe { &*handle };
-        match h.doc.get_page_render_tree(page) {
-            Ok(json) => string_to_c(json),
+        match h.doc.build_page_render_tree(page) {
+            Ok(tree) => match serde_json::to_string(&tree.root) {
+                Ok(json) => string_to_c(json),
+                Err(_) => ptr::null_mut(),
+            },
             Err(_) => ptr::null_mut(),
         }
     })
@@ -90,14 +93,28 @@ pub extern "C" fn rhwp_render_page_tree(handle: *const RhwpHandle, page: u32) ->
 
 #[no_mangle]
 pub extern "C" fn rhwp_image_data(
-    _handle: *const RhwpHandle,
-    _bin_data_id: u16,
+    handle: *const RhwpHandle,
+    bin_data_id: u16,
     out_len: *mut usize,
 ) -> *const u8 {
-    if !out_len.is_null() {
-        unsafe { *out_len = 0; }
+    if handle.is_null() || out_len.is_null() || bin_data_id == 0 {
+        if !out_len.is_null() {
+            unsafe { *out_len = 0; }
+        }
+        return ptr::null();
     }
-    ptr::null()
+    let h = unsafe { &*handle };
+    let idx = (bin_data_id - 1) as usize;
+    match h.doc.get_bin_data(idx) {
+        Some(data) => {
+            unsafe { *out_len = data.len(); }
+            data.as_ptr()
+        }
+        None => {
+            unsafe { *out_len = 0; }
+            ptr::null()
+        }
+    }
 }
 
 #[no_mangle]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,8 @@
-# rhwp-mac 아키텍처
+# alhangeul-macos 아키텍처
 
 ## 소유 경계
 
-- `Vendor/rhwp`: upstream `edwardkim/rhwp`의 코어 엔진 submodule. 앱 코드는 수정하지 않는다.
+- `Vendor/rhwp`: 개인 fork `postmelee/rhwp`의 코어 엔진 submodule. 앱 코드는 수정하지 않는다.
 - `Sources/RhwpCoreBridge`: macOS 앱이 소유하는 Swift FFI/렌더 브리지.
 - `Sources/HostApp`: macOS viewer 앱.
 - `Sources/QLExtension`: Quick Look preview extension.
@@ -20,7 +20,7 @@
 
 ## rhwp submodule 정책
 
-코어 최신화 기준은 upstream `devel`이다. `ios/devel`은 iOS 앱 참고용 브랜치이며, 이 프로젝트의 코어 최신화 기준으로 사용하지 않는다.
+코어 최신화 기준은 `postmelee/rhwp`의 `devel`이다. upstream `edwardkim/rhwp`의 `devel`은 최신 core 참고 기준이고, `ios/devel`은 검증된 native viewer 변경을 선별 포팅하는 참고 브랜치로만 사용한다.
 
 submodule 업데이트 후에는 다음을 확인한다.
 
@@ -33,9 +33,9 @@ submodule 업데이트 후에는 다음을 확인한다.
 
 `rhwp-ffi-symbols.txt`의 심볼 목록을 기대 ABI로 사용한다. `cbindgen`으로 생성한 헤더의 `rhwp_` 심볼 목록이 달라지면 코어 ABI 변경으로 간주하고 Swift bridge를 함께 검토한다.
 
-## 현재 코어 API gap
+## 현재 코어 API 상태
 
-upstream `devel`은 최신 코어 브랜치지만, 기존 macOS prototype이 사용하던 iOS/macOS C ABI를 직접 제공하지 않는다. 이 레포는 `RustBridge` crate에서 C ABI를 소유한다.
+`postmelee/rhwp`의 `devel`은 upstream `devel`에 `ios/devel`의 native viewer core 변경을 선별 포팅한 브랜치다. 이 레포는 `RustBridge` crate에서 C ABI를 소유한다.
 
 현재 구현된 항목:
 
@@ -43,14 +43,10 @@ upstream `devel`은 최신 코어 브랜치지만, 기존 macOS prototype이 사
 2. `cbindgen` 기반 C header/modulemap 생성
 3. 기존 8개 FFI 심볼 export
 
-남은 gap:
+Issue #3에서 추가한 core API:
 
-1. `rhwp_render_page_tree`는 upstream `devel`의 compact render tree JSON을 반환한다. 기존 Swift `CGTreeRenderer`가 기대하던 상세 style JSON과 다르므로 renderer 호환 작업이 필요하다.
-2. upstream `devel`은 bin data 직접 조회 public API를 제공하지 않는다. 현재 `rhwp_image_data`는 null을 반환하며, 이미지 렌더링 복구가 별도 작업이다.
+1. 상세 render tree serde JSON 직렬화
+2. `build_page_render_tree`
+3. `get_bin_data`
 
-기존 기능을 완전히 복구하려면 다음 중 하나가 필요하다.
-
-- Swift renderer가 compact render tree JSON을 지원하도록 fallback renderer를 추가한다.
-- upstream `devel`이 상세 render tree와 이미지 데이터를 public API로 노출하도록 정리한다.
-
-`ios/devel`의 Swift/FFI 코드는 참고 자료로만 사용하고, 코어 최신화 기준으로 사용하지 않는다.
+`ios/devel`의 Swift/FFI 코드는 참고 자료로만 사용하고, 코어 최신화 기준으로 사용하지 않는다. 관련 Issue와 PR은 upstream이 아니라 이 저장소에서 관리한다.

--- a/docs/RHWP_CORE_BRIDGE_PLAN.md
+++ b/docs/RHWP_CORE_BRIDGE_PLAN.md
@@ -2,27 +2,20 @@
 
 ## 배경
 
-`rhwp-mac`은 upstream `rhwp`를 `Vendor/rhwp` submodule로 사용한다. 코어 최신화 기준은 `devel`이다.
+`alhangeul-macos`는 개인 fork `postmelee/rhwp`를 `Vendor/rhwp` submodule로 사용한다. 코어 최신화 기준은 `postmelee/rhwp`의 `devel`이다.
 
 기존 prototype은 `ios/devel`의 iOS viewer용 Swift/FFI 코드를 직접 공유했지만, 개인 레포 분리 후에는 이 전략을 유지하지 않는다. Swift bridge는 이 레포가 소유하고, `rhwp`는 코어 엔진으로만 소비한다.
 
 ## 현재 상태
 
-upstream `devel`에는 다음이 없다.
-
-- `staticlib` crate type
-- `cbindgen.toml`
-- `rhwp_open` 등 native viewer C ABI
-- Swift renderer가 기대하는 상세 render tree JSON public API
-
-따라서 기존 Quick Look/Thumbnail 렌더링을 그대로 복구하려면 bridge ABI 외에 renderer compatibility 단계를 별도 작업으로 진행해야 한다.
+upstream `devel`은 native viewer C ABI를 직접 제공하지 않는다. 이 레포는 `RustBridge`에서 C ABI를 소유하고, 개인 fork core는 Swift renderer가 기대하는 상세 render tree JSON과 이미지 데이터 조회에 필요한 최소 public API만 제공한다.
 
 ## 권장 방향
 
 1. 이 레포의 `RustBridge/` crate가 `Vendor/rhwp`를 path dependency로 사용하고, C ABI만 export한다.
 2. `cbindgen`은 `RustBridge`를 대상으로 실행한다.
 3. Swift는 `Rhwp.xcframework`의 `Rhwp` C module만 import한다.
-4. 부족한 render tree/image public API는 upstream core에 일반적인 public API로 제안한다.
+4. 부족한 render tree/image public API는 개인 fork `postmelee/rhwp`의 `devel`에서 먼저 고도화한다.
 
 ## RustBridge 구조
 

--- a/mydocs/orders/20260423.md
+++ b/mydocs/orders/20260423.md
@@ -1,0 +1,14 @@
+# 2026-04-23 오늘 할일
+
+## 완료
+
+- Issue #3: `ios/devel` native viewer core 변경을 개인 fork `postmelee/rhwp`의 `devel`에 포팅하고, `alhangeul-macos`가 해당 core fork를 submodule로 추적하도록 전환한다.
+
+## 검증
+
+- `cargo check --lib` (`Vendor/rhwp`)
+- `./scripts/build-rust-macos.sh`
+- `./scripts/check-no-appkit.sh`
+- `xcodegen generate`
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+- `./scripts/validate-stage3-render.sh`

--- a/mydocs/plans/task_3.md
+++ b/mydocs/plans/task_3.md
@@ -1,0 +1,26 @@
+# Issue #3 수행 계획서
+
+## 작업명
+
+`ios/devel` core bridge 변경 포팅
+
+## 배경
+
+`alhangeul-macos`는 별도 파생 프로젝트로 분리되었고, upstream `edwardkim/rhwp`의 최신 core는 `devel`에서 관리된다. 다만 기존 iOS/macOS 렌더링 경로에서 검증된 native viewer bridge 변경은 `ios/devel`에 남아 있다.
+
+부모 저장소에만 core 변경을 적용하면 submodule 내부 변경이 보존되지 않으므로, 개인 fork `postmelee/rhwp`의 `devel`에 필요한 core 변경을 포팅하고 `alhangeul-macos`가 해당 fork를 추적하도록 정리한다.
+
+## 목표
+
+- `postmelee/rhwp`의 `devel`에 native viewer용 최소 core API를 반영한다.
+- `alhangeul-macos`의 `Vendor/rhwp` submodule URL과 포인터를 개인 fork 기준으로 전환한다.
+- `RustBridge`가 compact render tree JSON 대신 상세 serde JSON을 반환하도록 갱신한다.
+- `rhwp_image_data`가 문서 이미지 데이터를 반환하도록 복구한다.
+
+## 완료 기준
+
+- `./scripts/build-rust-macos.sh` 통과
+- `./scripts/check-no-appkit.sh` 통과
+- `xcodegen generate` 통과
+- HostApp Debug 빌드 통과
+- 최종 보고서 작성 후 `local/task3 -> devel` PR 생성

--- a/mydocs/plans/task_3_impl.md
+++ b/mydocs/plans/task_3_impl.md
@@ -1,0 +1,25 @@
+# Issue #3 구현 계획서
+
+## 1단계: 기준 브랜치 및 문서 정리
+
+- `devel`을 원격 최신 상태로 동기화한다.
+- Issue #3을 생성하고 `local/task3` 브랜치를 분기한다.
+- 오늘 할일과 수행/구현 계획서를 작성한다.
+
+## 2단계: core fork 포팅
+
+- `Vendor/rhwp`에 `postmelee/rhwp` remote를 추가한다.
+- `postmelee/rhwp`의 `devel`을 기준으로 `ios/devel`의 native viewer core 변경을 최소 포팅한다.
+- 포팅 대상은 render tree serde 직렬화, `build_page_render_tree`, `get_bin_data`, 관련 `Serialize` derive로 제한한다.
+
+## 3단계: macOS bridge 연동
+
+- `alhangeul-macos` submodule URL을 `postmelee/rhwp`로 변경한다.
+- `RustBridge`가 포팅된 core API를 사용하도록 수정한다.
+- 문서에 core fork 추적 정책을 반영한다.
+
+## 4단계: 검증 및 보고
+
+- Rust bridge, XcodeGen, HostApp 빌드를 검증한다.
+- 단계 보고서와 최종 보고서를 작성한다.
+- 변경분을 커밋하고 `local/task3 -> devel` PR을 생성한다.

--- a/mydocs/report/task_3_report.md
+++ b/mydocs/report/task_3_report.md
@@ -1,0 +1,40 @@
+# Issue #3 최종 보고서
+
+## 작업 요약
+
+`ios/devel`에서 사용하던 native viewer core 변경을 개인 fork `postmelee/rhwp`의 `devel`에 선별 포팅하고, `alhangeul-macos`가 해당 core fork를 submodule로 추적하도록 전환했다.
+
+이번 작업은 upstream에 PR을 생성하지 않고, `alhangeul-macos` 저장소의 Issue #3과 PR에서만 추적한다.
+
+## 주요 변경
+
+- `Vendor/rhwp` submodule URL을 `https://github.com/postmelee/rhwp.git`로 변경했다.
+- `rhwp-core.lock`을 `postmelee/rhwp` commit `1e9d78a3209d7750d47b6e3af4af621b8fed4127`로 갱신했다.
+- `postmelee/rhwp` core에 native viewer용 최소 API를 추가했다.
+  - 상세 render tree serde JSON 직렬화
+  - `build_page_render_tree`
+  - `get_bin_data`
+- `RustBridge`를 갱신했다.
+  - `rhwp_render_page_tree`가 Swift `RenderTree` 모델이 기대하는 상세 JSON을 반환한다.
+  - `rhwp_image_data`가 bin data를 반환한다.
+- README와 architecture 문서를 개인 fork core 기준으로 갱신했다.
+
+## 검증
+
+- `cargo check --lib` (`Vendor/rhwp`)
+- `./scripts/build-rust-macos.sh`
+- `./scripts/check-no-appkit.sh`
+- `xcodegen generate`
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+- `./scripts/validate-stage3-render.sh`
+
+`validate-stage3-render.sh` 결과:
+
+- `KTX.hwp`: textRuns=435, nonWhitePixels=450455
+- `request.hwp`: textRuns=104, nonWhitePixels=54724
+- `exam_kor.hwp`: textRuns=69, nonWhitePixels=96464
+
+## 남은 사항
+
+- Finder Quick Look/Thumbnail extension을 실제 Finder 환경에서 smoke test해야 한다.
+- 향후 core 고도화는 `postmelee/rhwp`의 `devel`에서 진행하고, 앱 연동 변경은 `alhangeul-macos` Issue/PR로 추적한다.

--- a/mydocs/working/task_3_stage1.md
+++ b/mydocs/working/task_3_stage1.md
@@ -1,0 +1,30 @@
+# Issue #3 단계 완료 보고서
+
+## 단계
+
+core bridge 포팅 및 macOS 연동 검증
+
+## 수행 내용
+
+- `postmelee/rhwp`의 `devel`을 upstream 최신 기준 위에 갱신했다.
+- `ios/devel`의 native viewer core 변경 중 필요한 항목만 선별 포팅했다.
+  - render tree 타입 serde 직렬화
+  - `DocumentCore::build_page_render_tree`
+  - `DocumentCore::get_bin_data`
+  - 관련 style/model 타입 `Serialize` derive
+- `RustBridge`가 compact JSON 대신 상세 render tree JSON을 반환하도록 수정했다.
+- `rhwp_image_data`가 문서 내 bin data를 반환하도록 수정했다.
+- `alhangeul-macos`의 submodule URL과 lock 파일을 `postmelee/rhwp` 기준으로 전환했다.
+
+## 검증
+
+- `cargo check --lib` (`Vendor/rhwp`)
+- `./scripts/build-rust-macos.sh`
+- `./scripts/check-no-appkit.sh`
+- `xcodegen generate`
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+- `./scripts/validate-stage3-render.sh`
+
+## 결과
+
+Quick Look/Thumbnail/HostApp이 사용하는 Swift render tree 디코드 경로가 다시 상세 JSON 기반으로 동작한다. `validate-stage3-render.sh`에서 `KTX.hwp`, `request.hwp`, `exam_kor.hwp` 3개 샘플 렌더링이 통과했다.

--- a/rhwp-core.lock
+++ b/rhwp-core.lock
@@ -1,6 +1,6 @@
-rhwp_repo = "https://github.com/edwardkim/rhwp.git"
+rhwp_repo = "https://github.com/postmelee/rhwp.git"
 rhwp_branch = "devel"
-rhwp_commit = "a9b11e20607cca251df73b917d22ba2ef497eb6c"
+rhwp_commit = "1e9d78a3209d7750d47b6e3af4af621b8fed4127"
 ffi_symbols_file = "rhwp-ffi-symbols.txt"
 generated_artifacts = [
   "Frameworks/universal/librhwp.a",

--- a/scripts/update-rhwp-core.sh
+++ b/scripts/update-rhwp-core.sh
@@ -19,7 +19,7 @@ git -C "$RHWP_ROOT" merge --ff-only origin/devel
 COMMIT="$(git -C "$RHWP_ROOT" rev-parse HEAD)"
 
 cat > "$LOCK_FILE" <<EOF
-rhwp_repo = "https://github.com/edwardkim/rhwp.git"
+rhwp_repo = "https://github.com/postmelee/rhwp.git"
 rhwp_branch = "devel"
 rhwp_commit = "$COMMIT"
 ffi_symbols_file = "rhwp-ffi-symbols.txt"


### PR DESCRIPTION
## 작업 요약

Closes #3

`ios/devel`에서 macOS 렌더링 호환성에 필요했던 native viewer core 변경을 선별해 개인 core fork인 `postmelee/rhwp`의 `devel`에 반영하고, `alhangeul-macos`가 그 core commit을 submodule로 추적하도록 전환했습니다.

이번 변경은 upstream `edwardkim/rhwp`로 PR을 생성하지 않고, `alhangeul-macos` 저장소의 `devel`로 통합하기 위한 PR입니다.

## 주요 변경

- `Vendor/rhwp` submodule URL을 `https://github.com/postmelee/rhwp.git`로 변경했습니다.
- `rhwp-core.lock`을 `postmelee/rhwp` commit `1e9d78a1d40c71779d81c6ec6870cd301d912626`로 갱신했습니다.
- core fork에 native viewer용 최소 API를 추가했습니다.
  - 상세 render tree serde JSON 직렬화
  - `build_page_render_tree`
  - `get_bin_data`
- `RustBridge`를 갱신했습니다.
  - `rhwp_render_page_tree`가 Swift `RenderTree` 모델이 기대하는 상세 JSON을 반환합니다.
  - `rhwp_image_data`가 core bin data를 반환합니다.
- README와 architecture 문서를 개인 fork core 운영 기준으로 갱신했습니다.
- task3 수행 계획서, 구현 계획서, 단계 보고서, 최종 보고서를 추가했습니다.

## 검증

- `cargo check --lib` (`Vendor/rhwp`)
- `./scripts/build-rust-macos.sh`
- `./scripts/check-no-appkit.sh`
- `xcodegen generate`
- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
- `./scripts/validate-stage3-render.sh`

`validate-stage3-render.sh` 샘플 결과:

- `KTX.hwp`: `textRuns=435`, `nonWhitePixels=450455`
- `request.hwp`: `textRuns=104`, `nonWhitePixels=54724`
- `exam_kor.hwp`: `textRuns=69`, `nonWhitePixels=96464`

## 남은 확인 사항

- Finder Quick Look/Thumbnail extension은 실제 Finder 환경에서 smoke test가 필요합니다.
- 향후 core 고도화는 `postmelee/rhwp`의 `devel`에서 진행하고, 앱 연동 변경은 `alhangeul-macos` Issue/PR로 추적합니다.
