### PR TITLE
Issue #5: rhwp core lock commit SHA 보정

### DIFF
--- a/mydocs/orders/20260423.md
+++ b/mydocs/orders/20260423.md
@@ -3,6 +3,7 @@
 ## 완료
 
 - Issue #3: `ios/devel` native viewer core 변경을 개인 fork `postmelee/rhwp`의 `devel`에 포팅하고, `alhangeul-macos`가 해당 core fork를 submodule로 추적하도록 전환한다.
+- Issue #5: PR #4 머지 후 확인된 `rhwp-core.lock` commit SHA 오기를 실제 submodule HEAD로 보정한다.
 
 ## 검증
 
@@ -12,3 +13,4 @@
 - `xcodegen generate`
 - `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
 - `./scripts/validate-stage3-render.sh`
+- Issue #5는 문서/lock 보정 작업이므로 `git diff --check`와 submodule HEAD 대조로 검증한다.

--- a/mydocs/plans/task_5.md
+++ b/mydocs/plans/task_5.md
@@ -1,0 +1,23 @@
+# Issue #5 수행 계획서
+
+## 목표
+
+PR #4 머지 후 `devel`에 반영된 `rhwp-core.lock`의 `rhwp_commit` 값과 Issue #3 최종 보고서의 core commit SHA를 실제 `Vendor/rhwp` submodule HEAD와 일치시킨다.
+
+## 범위
+
+- `rhwp-core.lock`의 commit SHA 보정
+- `mydocs/report/task_3_report.md`의 commit SHA 보정
+- Issue #5 진행 문서 추가
+
+## 제외 범위
+
+- core submodule 변경
+- Rust bridge 또는 Swift 코드 변경
+- 추가 빌드 산출물 재생성
+
+## 검증
+
+- `git submodule status Vendor/rhwp`로 실제 submodule HEAD 확인
+- `rg`로 잘못된 SHA가 남아 있지 않은지 확인
+- `git diff --check` 통과

--- a/mydocs/plans/task_5_impl.md
+++ b/mydocs/plans/task_5_impl.md
@@ -1,0 +1,18 @@
+# Issue #5 구현 계획서
+
+## 1단계: 기준 확인
+
+- `origin/devel` 기준에서 `local/task5`를 분기한다.
+- `Vendor/rhwp`의 실제 submodule HEAD를 확인한다.
+
+## 2단계: 보정
+
+- `rhwp-core.lock`의 `rhwp_commit`을 실제 submodule HEAD로 변경한다.
+- Issue #3 최종 보고서의 commit SHA를 동일하게 변경한다.
+- 오늘 할일 문서와 Issue #5 보고 문서를 추가한다.
+
+## 3단계: 검증 및 PR
+
+- 잘못된 SHA 잔존 여부를 검색한다.
+- `git diff --check`를 실행한다.
+- 변경분을 커밋하고 `local/task5 -> devel` PR을 생성한다.

--- a/mydocs/report/task_3_report.md
+++ b/mydocs/report/task_3_report.md
@@ -9,7 +9,7 @@
 ## 주요 변경
 
 - `Vendor/rhwp` submodule URL을 `https://github.com/postmelee/rhwp.git`로 변경했다.
-- `rhwp-core.lock`을 `postmelee/rhwp` commit `1e9d78a3209d7750d47b6e3af4af621b8fed4127`로 갱신했다.
+- `rhwp-core.lock`을 `postmelee/rhwp` commit `1e9d78a1d40c71779d81c6ec6870cd301d912626`로 갱신했다.
 - `postmelee/rhwp` core에 native viewer용 최소 API를 추가했다.
   - 상세 render tree serde JSON 직렬화
   - `build_page_render_tree`

--- a/mydocs/report/task_5_report.md
+++ b/mydocs/report/task_5_report.md
@@ -1,0 +1,21 @@
+# Issue #5 최종 보고서
+
+## 작업 요약
+
+PR #4 머지 후 `devel`에 반영된 `rhwp-core.lock`의 core commit SHA가 실제 `Vendor/rhwp` submodule HEAD와 다른 문제를 보정했다.
+
+## 변경 내용
+
+- `rhwp-core.lock`의 `rhwp_commit`을 `1e9d78a1d40c71779d81c6ec6870cd301d912626`로 변경했다.
+- Issue #3 최종 보고서의 core commit SHA를 동일하게 보정했다.
+- Issue #5 수행 계획서, 구현 계획서, 단계 보고서, 최종 보고서를 추가했다.
+
+## 검증
+
+- `git submodule status Vendor/rhwp`
+- 잘못된 SHA 잔존 여부 검색
+- `git diff --check`
+
+## 남은 사항
+
+- 없음

--- a/mydocs/working/task_5_stage1.md
+++ b/mydocs/working/task_5_stage1.md
@@ -1,0 +1,16 @@
+# Issue #5 단계 1 완료 보고서
+
+## 수행 내용
+
+- `origin/devel`에서 `local/task5` 브랜치를 생성했다.
+- `Vendor/rhwp` submodule HEAD가 `1e9d78a1d40c71779d81c6ec6870cd301d912626`임을 확인했다.
+- `rhwp-core.lock`과 Issue #3 최종 보고서에 남아 있던 잘못된 전체 SHA를 실제 submodule HEAD로 보정했다.
+
+## 검증
+
+- 이전 잘못된 SHA 잔존 여부를 검색한다.
+- `git diff --check`를 실행한다.
+
+## 결과
+
+코드와 submodule 내용은 변경하지 않고 lock 문서와 보고서의 추적 정보만 실제 상태와 일치시켰다.

--- a/rhwp-core.lock
+++ b/rhwp-core.lock
@@ -1,6 +1,6 @@
 rhwp_repo = "https://github.com/postmelee/rhwp.git"
 rhwp_branch = "devel"
-rhwp_commit = "1e9d78a3209d7750d47b6e3af4af621b8fed4127"
+rhwp_commit = "1e9d78a1d40c71779d81c6ec6870cd301d912626"
 ffi_symbols_file = "rhwp-ffi-symbols.txt"
 generated_artifacts = [
   "Frameworks/universal/librhwp.a",


### PR DESCRIPTION
## 작업 요약

Closes #5

PR #4가 머지된 뒤 확인 과정에서 `devel`의 `rhwp-core.lock`에 기록된 `rhwp_commit` 전체 SHA가 실제 `Vendor/rhwp` submodule HEAD와 다른 것을 확인했습니다. 이 PR은 코드 변경 없이 추적 정보만 실제 submodule 상태에 맞춰 보정합니다.

## 변경 내용

- `rhwp-core.lock`의 `rhwp_commit`을 실제 submodule HEAD인 `1e9d78a1d40c71779d81c6ec6870cd301d912626`로 보정했습니다.
- Issue #3 최종 보고서의 core commit SHA 기재를 동일하게 보정했습니다.
- Issue #5 수행 계획서, 구현 계획서, 단계 보고서, 최종 보고서를 추가했습니다.
- 오늘 할일 문서에 Issue #5 완료 항목과 검증 기준을 추가했습니다.

## 검증

- `git submodule status Vendor/rhwp`
- 잘못된 SHA 잔존 여부 검색
- `git diff --check`

## 참고

- 이 PR에는 core submodule, Rust bridge, Swift 코드 변경이 없습니다.
