### PR TITLE
Issue #9: README.md 상세 재작성

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,414 @@
 # alhangeul-macos
 
-macOS용 HWP/HWPX Quick Look, Finder thumbnail, 문서 viewer 앱입니다.
+<p align="center">
+  <strong>알한글 for macOS</strong><br/>
+  <em>HWP/HWPX Quick Look, Thumbnail, and native viewer app for macOS</em>
+</p>
 
-이 프로젝트는 `rhwp` 코어 엔진을 직접 vendoring하지 않고 `Vendor/rhwp` git submodule로 고정해 사용합니다. 앱, Quick Look 확장, Swift bridge, 배포 정책은 이 레포가 소유합니다.
+<p align="center">
+  <a href="https://github.com/postmelee/alhangeul-macos"><img src="https://img.shields.io/badge/platform-macOS%2012%2B-blue" alt="macOS 12+" /></a>
+  <a href="https://www.swift.org/"><img src="https://img.shields.io/badge/Swift-5.9-orange" alt="Swift 5.9" /></a>
+  <a href="https://www.rust-lang.org/"><img src="https://img.shields.io/badge/Rust-native%20bridge-orange" alt="Rust native bridge" /></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT" /></a>
+</p>
 
-## 기능
+---
 
-- Finder Quick Look preview: `.hwp`, `.hwpx` 첫 페이지 미리보기
-- Finder thumbnail: 첫 페이지 기반 아이콘 썸네일
-- macOS viewer app: 파일 열기, 다중 페이지 스크롤, 확대/축소
-- Rust `rhwp` 코어 정적 링크: `Rhwp.xcframework` 생성 후 앱/확장에서 사용
+`alhangeul-macos`는 macOS에서 HWP/HWPX 문서를 더 자연스럽게 다루기 위한 네이티브 앱 프로젝트입니다.
 
-## 초기 설정
+현재 목표는 Finder에서 `.hwp`, `.hwpx` 파일을 바로 미리보고, 썸네일로 식별하고, 필요할 때 독립 viewer 앱에서 문서를 열어 확인할 수 있게 하는 것입니다. 장기적으로는 viewer를 넘어 편집과 저장, 그리고 Claude Code나 OpenAI Codex 같은 개발 에이전트가 한컴 문서를 직접 열고 수정하고 다시 확인하는 워크플로우까지 확장하는 것을 목표로 합니다.
+
+이 저장소는 Rust 기반 [`rhwp`](https://github.com/edwardkim/rhwp) core를 직접 vendoring하지 않고 `Vendor/rhwp` git submodule로 고정해 사용합니다. 앱, Quick Look/Thumbnail 확장, Swift bridge, macOS 패키징과 배포 정책은 이 저장소가 소유합니다.
+
+## 현재 구현 상태
+
+현재 구현된 기능은 다음과 같습니다.
+
+- Finder Quick Look preview extension
+  - `.hwp`, `.hwpx` 첫 페이지를 PNG preview로 렌더링
+  - 50 MB 초과 파일은 텍스트 안내 preview로 fallback
+- Finder thumbnail extension
+  - 첫 페이지 렌더링 결과를 Finder thumbnail로 사용
+  - 파일 확장자 badge 표시
+- macOS viewer app
+  - HWP/HWPX 파일 열기
+  - 다중 페이지 스크롤
+  - 확대/축소, 실제 크기
+  - 사이드바에서 문서명, 현재 페이지, zoom, extension 등록 상태 표시
+  - Finder나 다른 앱에서 파일 열기 요청 수신
+- Swift/CoreGraphics 렌더링
+  - `rhwp` render tree JSON을 Swift `RenderNode` 모델로 디코딩
+  - CoreGraphics/CoreText 기반 페이지 렌더링
+  - 텍스트, 이미지, 사각형, 선, 타원, path, page background, table cell clipping 일부 지원
+- Rust bridge
+  - `RustBridge` staticlib가 `Vendor/rhwp`를 path dependency로 사용
+  - `cbindgen`으로 C header/modulemap 생성
+  - `Rhwp.xcframework`로 HostApp, Quick Look, Thumbnail에서 공유
+  - FFI symbol set은 `rhwp-ffi-symbols.txt`로 고정
+- core submodule 운영
+  - `postmelee/rhwp`의 `devel`을 현재 사용 기준으로 고정
+  - 현재 lock commit은 `rhwp-core.lock`에 기록
+
+아직 정식 릴리스 이전 단계입니다. Finder Quick Look/Thumbnail extension은 실제 Finder 환경에서 추가 smoke test가 필요하며, 배포용 서명/공증/notarization 흐름은 후속 작업 대상입니다.
+
+## 지원 파일 형식
+
+앱과 extension은 다음 UTI를 등록하거나 인식합니다.
+
+- `com.postmelee.rhwpmac.hwp`
+- `com.postmelee.rhwpmac.hwpx`
+- `com.hancom.hwp`
+- `com.hancom.hwpx`
+- `com.haansoft.hancomofficeviewer.mac.hwp`
+- `com.haansoft.hancomofficeviewer.mac.hwpx`
+
+파일 확장자 기준으로는 `.hwp`, `.hwpx`를 대상으로 합니다.
+
+## 프로젝트 구조
+
+```text
+Sources/
+├── HostApp/                  # macOS viewer app
+│   ├── Services/             # 파일 열기, extension 상태 확인
+│   ├── Stores/               # 문서 viewer 상태
+│   ├── Support/              # 빌드 정보
+│   └── Views/                # SwiftUI/AppKit viewer UI
+├── QLExtension/              # Quick Look preview extension
+├── ThumbnailExtension/       # Finder thumbnail extension
+├── RhwpCoreBridge/           # Swift FFI wrapper와 render tree renderer
+└── Shared/                   # HostApp/extension 공통 helper
+
+RustBridge/
+├── Cargo.toml                # macOS C ABI staticlib crate
+├── cbindgen.toml             # C header 생성 설정
+└── src/lib.rs                # rhwp_* FFI entrypoints
+
+Vendor/
+└── rhwp/                     # postmelee/rhwp devel submodule
+
+docs/
+├── ARCHITECTURE.md           # 소유 경계와 bridge 정책
+└── RHWP_CORE_BRIDGE_PLAN.md  # core bridge 운영 계획
+
+scripts/
+├── build-rust-macos.sh       # universal staticlib + Rhwp.xcframework 생성
+├── check-no-appkit.sh        # RhwpCoreBridge AppKit/UIKit 의존성 검사
+├── validate-stage3-render.sh # 렌더링 smoke test
+├── package-release.sh        # release zip 생성
+└── update-rhwp-core.sh       # submodule 및 rhwp-core.lock 갱신
+```
+
+## 아키텍처
+
+```mermaid
+graph TB
+    File["HWP/HWPX file"] --> HostApp["HostApp"]
+    File --> QuickLook["Quick Look Preview"]
+    File --> Thumbnail["Finder Thumbnail"]
+
+    HostApp --> SwiftBridge["Sources/RhwpCoreBridge"]
+    QuickLook --> SharedRenderer["Sources/Shared"]
+    Thumbnail --> SharedRenderer
+    SharedRenderer --> SwiftBridge
+
+    SwiftBridge --> CABI["Rhwp.xcframework / C ABI"]
+    CABI --> RustBridge["RustBridge staticlib"]
+    RustBridge --> Core["Vendor/rhwp submodule"]
+
+    Core --> RenderTree["Render tree JSON"]
+    RenderTree --> SwiftBridge
+    SwiftBridge --> CG["CoreGraphics/CoreText rendering"]
+```
+
+소유 경계는 다음과 같습니다.
+
+- `Vendor/rhwp`: HWP/HWPX parser와 core rendering data를 제공하는 Rust core
+- `RustBridge`: macOS 앱용 C ABI를 소유하는 이 저장소의 bridge crate
+- `Sources/RhwpCoreBridge`: Swift FFI wrapper, render tree decoding, CoreGraphics renderer
+- `Sources/HostApp`: viewer 앱 UI와 문서 상태 관리
+- `Sources/QLExtension`, `Sources/ThumbnailExtension`: Finder 통합
+
+## Quick Start
+
+### 요구사항
+
+- macOS 12 Monterey 이상
+- Xcode 15 이상
+- Swift 5.9
+- Rust toolchain
+- `cbindgen`
+- XcodeGen
+
+초기 설정:
 
 ```bash
+git clone https://github.com/postmelee/alhangeul-macos.git
+cd alhangeul-macos
+
 git submodule update --init --recursive
 rustup target add aarch64-apple-darwin x86_64-apple-darwin
 cargo install cbindgen
 brew install xcodegen
 ```
 
-## 빌드
-
-`RustBridge` crate가 `Vendor/rhwp`를 path dependency로 사용해 macOS 앱용 C ABI를 export합니다.
+### 개발 빌드
 
 ```bash
 ./scripts/build-rust-macos.sh
 xcodegen generate
-xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug build
+xcodebuild -project RhwpMac.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build
 ```
 
-## rhwp 코어 최신화
+`project.yml`이 Xcode project의 원본입니다. target, source, bundle identifier, extension 설정을 바꿀 때는 `RhwpMac.xcodeproj`를 직접 수정하지 말고 `project.yml`을 수정한 뒤 `xcodegen generate`를 실행합니다.
 
-`rhwp` 코어는 개인 fork `postmelee/rhwp`의 `devel` 브랜치를 기준으로 최신화합니다. upstream `edwardkim/rhwp`의 변경은 필요한 범위를 개인 fork에 반영한 뒤 이 저장소에서 submodule commit으로 고정합니다.
+### 렌더링 검증
+
+```bash
+./scripts/validate-stage3-render.sh
+```
+
+기본 샘플:
+
+- `Vendor/rhwp/samples/basic/KTX.hwp`
+- `Vendor/rhwp/samples/basic/request.hwp`
+- `Vendor/rhwp/samples/exam_kor.hwp`
+
+이 검증은 Swift renderer가 render tree를 디코딩하고 실제 bitmap을 생성할 수 있는지 확인합니다. 출력은 `output/stage3-render/`에 생성됩니다.
+
+### 공유 Swift bridge 의존성 검사
+
+```bash
+./scripts/check-no-appkit.sh
+```
+
+`Sources/RhwpCoreBridge`는 HostApp과 extension에서 함께 사용되므로 AppKit/UIKit 의존성을 직접 갖지 않는 것을 원칙으로 합니다. AppKit이 필요한 코드는 HostApp, extension, 또는 `Sources/Shared` 경계에 둡니다.
+
+## 실행과 Finder 통합 확인
+
+개발 빌드 후 앱은 다음 경로에 생성됩니다.
+
+```text
+build/DerivedData/Build/Products/Debug/알한글.app
+```
+
+앱 실행:
+
+```bash
+open build/DerivedData/Build/Products/Debug/알한글.app
+```
+
+Quick Look과 Thumbnail extension 등록 상태는 앱 사이드바 또는 `pluginkit`으로 확인할 수 있습니다.
+
+```bash
+pluginkit -m | grep com.postmelee.rhwpmac
+```
+
+Finder/Quick Look 캐시를 갱신해야 할 때:
+
+```bash
+qlmanage -r
+qlmanage -r cache
+```
+
+특정 파일 preview를 강제로 열어볼 때:
+
+```bash
+qlmanage -p path/to/sample.hwp
+```
+
+## rhwp Core Submodule
+
+이 저장소는 core engine을 직접 개발하는 저장소가 아닙니다. `rhwp` core는 `Vendor/rhwp` submodule로 고정해 소비하고, macOS 앱과 bridge 코드는 이 저장소에서 관리합니다.
+
+현재 기준:
+
+```text
+core repo:   https://github.com/postmelee/rhwp.git
+core branch: devel
+lock file:   rhwp-core.lock
+```
+
+core 업데이트 절차:
 
 ```bash
 ./scripts/update-rhwp-core.sh
 ./scripts/build-rust-macos.sh
 ./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project RhwpMac.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+./scripts/validate-stage3-render.sh
 ```
 
-릴리스에는 `rhwp-core.lock`의 submodule commit을 함께 기록합니다.
+core 변경 원칙:
 
-## 릴리스 패키징
+- 앱 저장소에서 `Vendor/rhwp` 내부를 임시 수정한 채로 남기지 않습니다.
+- core API가 필요하면 먼저 `postmelee/rhwp`의 `devel`에 반영합니다.
+- 이 저장소에서는 submodule pointer와 `rhwp-core.lock`을 함께 갱신합니다.
+- FFI symbol set이 바뀌면 `rhwp-ffi-symbols.txt`, Swift bridge, release note를 함께 검토합니다.
+
+## 릴리스와 배포
+
+릴리스 zip 생성:
 
 ```bash
 ./scripts/package-release.sh 0.1.0
 ```
 
-산출물은 `build/release/rhwp-mac-<version>.zip`에 생성되며 SHA256을 출력합니다.
+산출물:
+
+```text
+build/release/rhwp-mac-0.1.0.zip
+```
+
+현재 `Casks/rhwp-mac.rb`는 Homebrew Cask 배포를 위한 초안입니다. 첫 공개 릴리스 전에는 다음을 확인해야 합니다.
+
+- GitHub release URL이 현재 저장소명 `postmelee/alhangeul-macos` 기준인지
+- zip 파일명과 cask token을 유지할지 변경할지
+- SHA256 고정 여부
+- Developer ID 서명과 notarization 여부
+- Gatekeeper 실행 경고 처리 방식
+
+## 개발 방식
+
+이 프로젝트는 Claude Code와 OpenAI Codex를 함께 사용하는 AI pair programming 방식으로 개발합니다. 단, AI가 아키텍처와 품질 판단을 대신하지 않습니다.
+
+개발 원칙:
+
+- 작업은 GitHub Issue 단위로 추적합니다.
+- 새 기능, 버그 수정, 구조 변경은 `이슈 -> 브랜치 -> 계획서 -> 구현 -> 검증 -> 최종 보고서 -> PR` 순서로 진행합니다.
+- OpenAI Codex용 규칙은 [`AGENTS.md`](AGENTS.md)에 정리되어 있습니다.
+- Claude Code를 사용할 때도 동일한 Issue/문서/검증 중심 흐름을 따릅니다.
+- 앱/bridge/문서 변경 PR은 `postmelee/alhangeul-macos`의 `devel`로 생성합니다.
+- upstream `edwardkim/rhwp`에는 이 저장소의 macOS 앱 작업 PR을 생성하지 않습니다.
+
+브랜치 예시:
+
+```bash
+git switch devel
+git fetch origin
+git pull --ff-only origin devel
+git switch -c local/task{issue}
+```
+
+PR 생성 예시:
+
+```bash
+git push -u origin local/task{issue}
+gh pr create \
+  --repo postmelee/alhangeul-macos \
+  --base devel \
+  --head local/task{issue} \
+  --draft \
+  --title "Issue #{issue}: 제목"
+```
+
+문서는 모두 한국어로 작성합니다. 작업 기록은 `mydocs/` 아래에 보관합니다.
+
+## 로드맵
+
+### M0 - 저장소 분리와 macOS viewer 기반 구축, 현재
+
+완료 또는 진행된 항목:
+
+- `alhangeul-macos` 개인 저장소 분리
+- `postmelee/rhwp` core fork를 submodule로 연결
+- `RustBridge` staticlib와 `Rhwp.xcframework` 빌드 흐름 구성
+- HostApp/QLExtension/ThumbnailExtension target 구성
+- HWP/HWPX 파일 열기, 첫 페이지 preview/thumbnail, 다중 페이지 viewer 구현
+- render tree JSON 기반 Swift/CoreGraphics 렌더링 경로 복구
+- 기본 렌더링 smoke test 구축
+- Codex 개발 규칙 `AGENTS.md` 작성
+
+남은 안정화 항목:
+
+- Finder 환경 Quick Look/Thumbnail smoke test 확대
+- 다양한 HWP/HWPX 샘플 렌더링 비교
+- 앱 번들 서명, notarization, 배포 정책 정리
+- Homebrew Cask metadata 정리
+- README, 사용자 매뉴얼, troubleshooting 문서 보강
+
+### M1 - Viewer 품질 안정화
+
+목표: macOS에서 신뢰할 수 있는 읽기 전용 HWP/HWPX viewer 제공
+
+- 페이지 렌더링 정확도 개선
+- 이미지, 표, 도형, 각주, 머리말/꼬리말 렌더링 품질 확대
+- 큰 문서 메모리 사용량과 page cache 정책 개선
+- Finder preview/thumbnail 실패 fallback UX 개선
+- 샘플 기반 회귀 테스트 확장
+- 첫 공개 릴리스와 설치 경로 정리
+
+### M2 - Editing 기반 도입
+
+목표: viewer에서 편집 가능한 macOS HWP/HWPX 앱으로 확장
+
+- 문서 모델 편집 command를 Swift UI에서 호출할 수 있는 bridge 설계
+- 텍스트 삽입, 삭제, 선택, 서식 변경의 최소 편집 루프 구현
+- HWP/HWPX 저장 경로와 손상 방지 정책 수립
+- undo/redo, dirty state, autosave 정책 검토
+- 편집 후 재조판과 렌더링 갱신 파이프라인 연결
+
+### M3 - 실사용 Editing
+
+목표: 제한된 문서 편집을 실사용 가능한 수준으로 고도화
+
+- 표 편집, 이미지 삽입/교체, 문단/글자 모양 편집
+- 서식 UI와 keyboard shortcut 체계화
+- HWP/HWPX round-trip 검증 확대
+- PDF 내보내기, 인쇄, 공유 기능 검토
+- macOS 문서 기반 앱 경험 강화
+
+### M4 - Agent Plugin과 문서 자동화
+
+목표: Claude Code나 OpenAI Codex 같은 에이전트가 한컴 문서를 직접 편집하고 결과를 확인하는 워크플로우 지원
+
+- 에이전트용 문서 열기, 내용 추출, 검색, 패치 API 설계
+- HWP/HWPX 파일을 구조화된 편집 단위로 노출
+- 에이전트가 문서를 수정한 뒤 viewer 화면 또는 렌더링 결과를 열어 확인하는 루프 지원
+- 실패 시 diff, screenshot, render output을 기반으로 다시 수정하는 검증 루프 구축
+- Codex Plugin 또는 Claude Code 연동 도구로 packaging
+
+이 단계의 목표는 단순 파일 변환이 아니라, 에이전트가 실제 문서 화면을 확인하며 수정 품질을 높일 수 있는 자동화 환경입니다.
+
+## 이 저장소가 하지 않는 일
+
+이 저장소는 다음을 직접 제공하지 않습니다.
+
+- npm package 배포
+- WebAssembly browser viewer/editor 배포
+- Chrome/Edge/Safari browser extension 배포
+- upstream `rhwp` core 자체의 공식 release 관리
+
+위 항목은 upstream `rhwp` 또는 별도 파생 프로젝트의 범위입니다. `alhangeul-macos`는 macOS native app과 Finder 통합에 집중합니다.
+
+## 관련 문서
+
+- [AGENTS.md](AGENTS.md) - Codex 작업 규칙
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) - 아키텍처와 소유 경계
+- [docs/RHWP_CORE_BRIDGE_PLAN.md](docs/RHWP_CORE_BRIDGE_PLAN.md) - core bridge 운영 계획
+- [rhwp-core.lock](rhwp-core.lock) - 현재 고정된 core commit
+- [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md) - third-party license
+
+## Notice
+
+본 제품은 한글과컴퓨터의 한글 문서 파일(`.hwp`, `.hwpx`) 공개 문서를 참고하여 개발하는 독립 오픈소스 프로젝트입니다.
+
+## Trademark
+
+"한글", "한컴", "HWP", "HWPX"는 주식회사 한글과컴퓨터의 등록 상표입니다. 본 프로젝트는 한글과컴퓨터와 제휴, 후원, 승인 관계가 없습니다.
+
+"Hangul", "Hancom", "HWP", and "HWPX" are registered trademarks of Hancom Inc. This project is independent and is not affiliated with, sponsored by, or endorsed by Hancom Inc.
+
+## License
+
+[MIT License](LICENSE)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <strong>알한글 for macOS</strong><br/>
-  <em>HWP/HWPX Quick Look, Thumbnail, and native viewer app for macOS</em>
+  <em>HWP/HWPX Quick Look, Thumbnail, and native viewer app</em>
 </p>
 
 <p align="center">
@@ -14,57 +14,245 @@
 
 ---
 
-`alhangeul-macos`는 macOS에서 HWP/HWPX 문서를 더 자연스럽게 다루기 위한 네이티브 앱 프로젝트입니다.
+HWP/HWPX 파일을 **macOS에서 더 자연스럽게** 열어보세요. Finder에서 미리보고, 썸네일로 식별하고, 필요하면 네이티브 viewer 앱에서 바로 확인할 수 있게 하는 것이 이 프로젝트의 첫 목표입니다.
 
-현재 목표는 Finder에서 `.hwp`, `.hwpx` 파일을 바로 미리보고, 썸네일로 식별하고, 필요할 때 독립 viewer 앱에서 문서를 열어 확인할 수 있게 하는 것입니다. 장기적으로는 viewer를 넘어 편집과 저장, 그리고 Claude Code나 OpenAI Codex 같은 개발 에이전트가 한컴 문서를 직접 열고 수정하고 다시 확인하는 워크플로우까지 확장하는 것을 목표로 합니다.
+alhangeul-macos는 Rust 기반 [`rhwp`](https://github.com/edwardkim/rhwp) 코어를 macOS 앱으로 연결하는 오픈소스 프로젝트입니다. 닫힌 포맷의 벽을 깨고, 모든 사람, 모든 AI, 모든 플랫폼에서 한글 문서를 자유롭게 읽고 쓸 수 있게 한다는 `rhwp`의 방향을 macOS 네이티브 환경으로 확장합니다.
 
-이 저장소는 Rust 기반 [`rhwp`](https://github.com/edwardkim/rhwp) core를 직접 vendoring하지 않고 `Vendor/rhwp` git submodule로 고정해 사용합니다. 앱, Quick Look/Thumbnail 확장, Swift bridge, macOS 패키징과 배포 정책은 이 저장소가 소유합니다.
+이 저장소는 `rhwp` 코어 엔진을 직접 vendoring하지 않고 `Vendor/rhwp` git submodule로 고정해 사용합니다. 앱, Quick Look 확장, Thumbnail 확장, Swift bridge, macOS UX는 이 저장소가 소유합니다.
 
-## 현재 구현 상태
+## 로드맵
 
-현재 구현된 기능은 다음과 같습니다.
+먼저 macOS에서 안정적으로 열어보고, 편집으로 확장하고, 에이전트가 직접 다루는 문서 환경으로 완성한다.
 
-- Finder Quick Look preview extension
-  - `.hwp`, `.hwpx` 첫 페이지를 PNG preview로 렌더링
-  - 50 MB 초과 파일은 텍스트 안내 preview로 fallback
-- Finder thumbnail extension
-  - 첫 페이지 렌더링 결과를 Finder thumbnail로 사용
-  - 파일 확장자 badge 표시
-- macOS viewer app
-  - HWP/HWPX 파일 열기
-  - 다중 페이지 스크롤
-  - 확대/축소, 실제 크기
-  - 사이드바에서 문서명, 현재 페이지, zoom, extension 등록 상태 표시
-  - Finder나 다른 앱에서 파일 열기 요청 수신
-- Swift/CoreGraphics 렌더링
-  - `rhwp` render tree JSON을 Swift `RenderNode` 모델로 디코딩
-  - CoreGraphics/CoreText 기반 페이지 렌더링
-  - 텍스트, 이미지, 사각형, 선, 타원, path, page background, table cell clipping 일부 지원
-- Rust bridge
-  - `RustBridge` staticlib가 `Vendor/rhwp`를 path dependency로 사용
-  - `cbindgen`으로 C header/modulemap 생성
-  - `Rhwp.xcframework`로 HostApp, Quick Look, Thumbnail에서 공유
-  - FFI symbol set은 `rhwp-ffi-symbols.txt`로 고정
-- core submodule 운영
-  - `postmelee/rhwp`의 `devel`을 현재 사용 기준으로 고정
-  - 현재 lock commit은 `rhwp-core.lock`에 기록
+```text
+0.1 ──── 0.5 ──── 1.0 ──── 2.0
+뷰어      안정화    편집      에이전트
+```
 
-아직 정식 릴리스 이전 단계입니다. Finder Quick Look/Thumbnail extension은 실제 Finder 환경에서 추가 smoke test가 필요하며, 배포용 서명/공증/notarization 흐름은 후속 작업 대상입니다.
+| 단계 | 방향 | 전략 |
+|------|------|------|
+| **0.1 → 0.5** | Quick Look/Thumbnail/viewer 기반 안정화 | Finder 통합과 렌더링 품질을 먼저 견고하게 |
+| **0.5 → 1.0** | 읽기 전용 viewer 위에 편집 기반 도입 | core command와 Swift UI 사이의 안전한 bridge 구축 |
+| **1.0 → 2.0** | AI 문서 자동화와 플러그인 체계 | 에이전트가 문서를 열고 수정하고 화면으로 검증하는 루프 제공 |
 
-## 지원 파일 형식
+> viewer만 만드는 것이 최종 목표가 아닙니다. macOS에서 HWP/HWPX를 읽고, 편집하고, 나중에는 Claude Code나 OpenAI Codex 같은 에이전트가 직접 문서를 수정하고 결과를 확인할 수 있는 환경을 만드는 것이 장기 목표입니다.
 
-앱과 extension은 다음 UTI를 등록하거나 인식합니다.
+## 이정표
 
-- `com.postmelee.rhwpmac.hwp`
-- `com.postmelee.rhwpmac.hwpx`
-- `com.hancom.hwp`
-- `com.hancom.hwpx`
-- `com.haansoft.hancomofficeviewer.mac.hwp`
-- `com.haansoft.hancomofficeviewer.mac.hwpx`
+### v0.1.0 — macOS Viewer 기반 (현재)
 
-파일 확장자 기준으로는 `.hwp`, `.hwpx`를 대상으로 합니다.
+> 저장소 분리, Finder 통합, 읽기 전용 viewer 기반 구축
 
-## 프로젝트 구조
+- `postmelee/alhangeul-macos` 개인 저장소로 분리
+- `postmelee/rhwp`의 `devel`을 `Vendor/rhwp` submodule로 연결
+- Rust `rhwp` core를 macOS 앱에서 사용할 수 있도록 `RustBridge` staticlib와 `Rhwp.xcframework` 구성
+- Finder Quick Look preview extension 구현
+- Finder thumbnail extension 구현
+- HostApp viewer에서 HWP/HWPX 열기, 다중 페이지 스크롤, 확대/축소 지원
+- Swift `RenderNode` 모델과 CoreGraphics/CoreText renderer 구성
+- `validate-stage3-render.sh` 기반 렌더링 smoke test 구축
+- OpenAI Codex용 `AGENTS.md` 규칙 파일 작성
+
+#### 현재 확인된 한계
+
+- Finder Quick Look/Thumbnail extension은 실제 Finder 환경에서 추가 smoke test가 필요합니다.
+- 렌더링 품질은 core render tree와 Swift renderer가 지원하는 노드 범위에 영향을 받습니다.
+- 수식, 양식 개체, 일부 고급 도형과 복잡한 조판은 후속 품질 개선 대상입니다.
+
+### v0.5.0 — Viewer 안정화
+
+> macOS에서 신뢰할 수 있는 읽기 전용 HWP/HWPX viewer 제공
+
+- 다양한 HWP/HWPX 샘플에 대한 렌더링 회귀 테스트 확대
+- 이미지, 표, 도형, 각주, 머리말/꼬리말 렌더링 품질 개선
+- 큰 문서의 메모리 사용량과 page cache 정책 개선
+- Finder preview/thumbnail 실패 fallback UX 개선
+- 문서 열기, zoom, 페이지 이동, extension 상태 표시 UX 정리
+
+### v1.0.0 — Editing 기반
+
+> viewer에서 편집 가능한 macOS HWP/HWPX 앱으로 확장
+
+- `rhwp` document command를 Swift UI에서 호출할 수 있는 bridge 설계
+- 텍스트 선택, 삽입, 삭제, 글자/문단 서식 변경의 최소 편집 루프 구현
+- 편집 후 재조판과 렌더링 갱신 파이프라인 연결
+- undo/redo, dirty state, autosave 정책 수립
+- HWP/HWPX 저장 경로와 손상 방지 정책 수립
+
+### v2.0.0 — Agent Plugin과 문서 자동화
+
+> 에이전트가 문서를 직접 편집하고 화면으로 검증하는 단계
+
+- Claude Code와 OpenAI Codex용 문서 열기, 내용 추출, 검색, 패치 API 설계
+- HWP/HWPX 파일을 구조화된 편집 단위로 노출
+- 에이전트가 문서를 수정한 뒤 viewer 화면 또는 렌더링 결과를 열어 확인하는 루프 지원
+- 실패 시 diff, screenshot, render output을 기반으로 다시 수정하는 검증 루프 구축
+- Codex Plugin 또는 Claude Code 연동 도구로 packaging
+
+자세한 구조와 bridge 정책은 [아키텍처 문서](docs/ARCHITECTURE.md)를 참조하세요.
+
+---
+
+## Features
+
+### Finder Integration (Finder 통합)
+
+- `.hwp`, `.hwpx` Quick Look preview
+- 첫 페이지 기반 Finder thumbnail
+- `.hwp`, `.hwpx` 및 Hancom 계열 UTI 등록
+- 50 MB 초과 파일 preview fallback
+- 앱 사이드바에서 Quick Look/Thumbnail extension 등록 상태 확인
+
+### Native Viewer (네이티브 뷰어)
+
+- macOS SwiftUI 기반 HostApp
+- HWP/HWPX 파일 열기
+- Finder 또는 다른 앱에서 파일 열기 요청 수신
+- 다중 페이지 스크롤
+- 확대, 축소, 실제 크기
+- 문서명, 현재 페이지, 전체 페이지 수, zoom 상태 표시
+
+### Rendering (렌더링)
+
+- Rust core render tree JSON 디코딩
+- CoreGraphics 기반 page rendering
+- CoreText 기반 text run rendering
+- 이미지 bin data 조회 및 렌더링
+- 페이지 배경, 사각형, 선, 타원, path, 그룹 노드 일부 렌더링
+- table cell clipping
+- 밑줄, 취소선, 음영 등 일부 text decoration
+
+### Core Bridge (코어 브리지)
+
+- `Vendor/rhwp` submodule을 path dependency로 사용하는 `RustBridge` crate
+- C ABI 기반 `rhwp_*` FFI entrypoint
+- `cbindgen` header/modulemap 생성
+- universal static library 생성
+- `Rhwp.xcframework`를 HostApp, Quick Look, Thumbnail target에서 공유
+- FFI symbol set을 `rhwp-ffi-symbols.txt`로 고정
+
+### Development Workflow (개발 워크플로우)
+
+- XcodeGen 기반 project 생성
+- Rust bridge와 Swift renderer 분리
+- `check-no-appkit.sh`로 shared Swift bridge의 AppKit/UIKit 의존성 검사
+- `validate-stage3-render.sh`로 렌더링 smoke test
+- GitHub Issue 기반 task branch와 한국어 작업 문서
+
+## Quick Start (소스 빌드)
+
+처음 프로젝트에 참여하는 개발자는 온보딩 가이드(추후 추가 예정)를 먼저 읽어보세요. 프로젝트 아키텍처, 디버깅 도구, 개발 워크플로우를 한눈에 파악할 수 있습니다.
+
+### Requirements
+
+- macOS 12 Monterey 이상
+- Xcode 15 이상
+- Swift 5.9
+- Rust toolchain
+- `cbindgen`
+- XcodeGen
+
+### Initial Setup
+
+```bash
+git clone https://github.com/postmelee/alhangeul-macos.git
+cd alhangeul-macos
+
+git submodule update --init --recursive
+rustup target add aarch64-apple-darwin x86_64-apple-darwin
+cargo install cbindgen
+brew install xcodegen
+```
+
+### Rust Bridge Build
+
+```bash
+./scripts/build-rust-macos.sh
+```
+
+이 스크립트는 `RustBridge`를 arm64/x86_64 macOS staticlib로 빌드하고, `cbindgen` header를 생성한 뒤 `Frameworks/Rhwp.xcframework`를 만듭니다.
+
+### Xcode Project
+
+```bash
+xcodegen generate
+```
+
+`project.yml`이 Xcode project의 원본입니다. target, source, bundle identifier, extension 설정을 바꿀 때는 `RhwpMac.xcodeproj`를 직접 수정하지 말고 `project.yml`을 수정한 뒤 다시 생성합니다.
+
+### Native Build
+
+```bash
+xcodebuild -project RhwpMac.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+
+개발 빌드 후 앱은 다음 경로에 생성됩니다.
+
+```text
+build/DerivedData/Build/Products/Debug/알한글.app
+```
+
+### Run
+
+```bash
+open build/DerivedData/Build/Products/Debug/알한글.app
+```
+
+Quick Look과 Thumbnail extension 등록 상태는 앱 사이드바 또는 `pluginkit`으로 확인할 수 있습니다.
+
+```bash
+pluginkit -m | grep com.postmelee.rhwpmac
+```
+
+Finder/Quick Look 캐시를 갱신해야 할 때:
+
+```bash
+qlmanage -r
+qlmanage -r cache
+```
+
+특정 파일 preview를 강제로 열어볼 때:
+
+```bash
+qlmanage -p path/to/sample.hwp
+```
+
+### Render Smoke Test
+
+```bash
+./scripts/validate-stage3-render.sh
+```
+
+기본 샘플:
+
+- `Vendor/rhwp/samples/basic/KTX.hwp`
+- `Vendor/rhwp/samples/basic/request.hwp`
+- `Vendor/rhwp/samples/exam_kor.hwp`
+
+### Shared Bridge Check
+
+```bash
+./scripts/check-no-appkit.sh
+```
+
+`Sources/RhwpCoreBridge`는 HostApp과 extension에서 함께 사용되므로 AppKit/UIKit 의존성을 직접 갖지 않는 것을 원칙으로 합니다. AppKit이 필요한 코드는 HostApp, extension, 또는 `Sources/Shared` 경계에 둡니다.
+
+### rhwp Core Update
+
+```bash
+./scripts/update-rhwp-core.sh
+./scripts/build-rust-macos.sh
+./scripts/check-no-appkit.sh
+```
+
+`rhwp` core는 `postmelee/rhwp`의 `devel` 브랜치를 기준으로 고정합니다. 현재 고정 commit은 [rhwp-core.lock](rhwp-core.lock)에 기록합니다.
+
+## Project Structure
 
 ```text
 Sources/
@@ -90,324 +278,163 @@ docs/
 ├── ARCHITECTURE.md           # 소유 경계와 bridge 정책
 └── RHWP_CORE_BRIDGE_PLAN.md  # core bridge 운영 계획
 
+mydocs/                       # 한국어 작업 문서
+├── orders/                   # 오늘 할일
+├── plans/                    # 수행 계획서, 구현 계획서
+├── working/                  # 단계별 완료 보고서
+└── report/                   # 최종 보고서
+
 scripts/
 ├── build-rust-macos.sh       # universal staticlib + Rhwp.xcframework 생성
 ├── check-no-appkit.sh        # RhwpCoreBridge AppKit/UIKit 의존성 검사
 ├── validate-stage3-render.sh # 렌더링 smoke test
-├── package-release.sh        # release zip 생성
 └── update-rhwp-core.sh       # submodule 및 rhwp-core.lock 갱신
 ```
 
-## 아키텍처
+## AI 페어 프로그래밍으로 개발합니다
+
+> 출처: 이 섹션의 문제의식과 개발 방법론 설명은 upstream [`edwardkim/rhwp` README.md](https://github.com/edwardkim/rhwp/blob/main/README.md)의 "AI 페어 프로그래밍으로 개발합니다" 섹션을 바탕으로 합니다. alhangeul-macos에서는 같은 절차를 Claude Code와 OpenAI Codex에 함께 적용합니다.
+
+> **이것은 바이브 코딩이 아닙니다.** AI가 주는 코드를 읽지도 않고 수락하는 것이 아닙니다. 모든 계획은 검토되고, 모든 결과물은 검증되며, 모든 결정의 뒤에는 사람이 있습니다.
+
+바이브 코딩 — AI 출력을 읽지 않고 수락하고, AI에게 아키텍처 결정을 맡기고, 이해하지 못하는 코드를 배포하는 것 — 은 함정입니다. 겉보기에는 동작하지만, 이해하지 못했기 때문에 문제가 생겨도 진단할 수 없는 코드가 만들어집니다.
+
+이 프로젝트는 정반대의 접근을 취합니다. 사람 **작업지시자**가 방향, 품질, 아키텍처 결정의 완전한 소유권을 유지하고, AI는 혼자서는 불가능한 속도와 규모로 구현을 수행합니다. 핵심 차이: **사람은 절대 생각을 멈추지 않습니다.**
+
+### 바이브 코딩 vs. AI 주도 개발
+
+| | 바이브 코딩 | 이 프로젝트 |
+|--|-----------|-----------|
+| **사람의 역할** | AI 출력 수락 | 지시, 검토, 결정 |
+| **계획** | 없음 — "그냥 만들어" | 계획서 작성 → 승인 → 실행 |
+| **품질 관문** | 동작하길 바람 | 빌드 + 렌더링 smoke test + 코드 리뷰 |
+| **디버깅** | AI에게 AI 버그 수정 요청 | 사람이 진단, AI가 구현 |
+| **아키텍처** | 우연히 형성 | 의도적 설계 (core, bridge, app 경계) |
+| **문서** | 없음 | `mydocs/` 프로세스 기록 |
+| **결과물** | 취약, 유지보수 어려움 | 검증 가능한 변경 단위 |
+
+AI는 배율기입니다. 하지만 배율기는 기존 프로세스를 증폭시킵니다. 프로세스 없음 × AI = 빠른 혼돈. 좋은 프로세스 × AI = 비범한 결과물.
+
+### 개발 프로세스
+
+이 프로젝트는 **[Claude Code](https://claude.ai/code)** 와 **OpenAI Codex**를 페어 프로그래밍 파트너로 사용하여 개발합니다. 전체 개발 과정은 Issue, branch, 작업 문서, PR에 투명하게 남깁니다.
+
+```text
+작업지시자 (사람)                    AI 페어 프로그래머 (Claude Code / Codex)
+────────────────                    ─────────────────────────────────────
+방향 설정, 우선순위 결정        →    분석, 계획, 구현
+계획 검토, 승인                ←    구현 계획서 작성
+도메인 피드백 제공              →    디버깅, 테스트, 반복
+아키텍처 결정                  →    정밀하게 실행
+품질 및 정확성 판단            ←    코드, 문서, 테스트 생성
+```
+
+`mydocs/` 디렉토리에 개발 기록이 있습니다: 일일 작업 기록, 구현 계획서, 단계별 완료 보고서, 최종 보고서, 기술 연구 문서, 트러블슈팅 기록.
+
+> `mydocs/`는 코드에 대한 문서만이 아닙니다 — **AI로 소프트웨어를 만드는 방법**에 대한 문서입니다.
+
+**Hyper-Waterfall 방법론** — 거시적 워터폴 + 미시적 애자일, AI가 이 둘을 동시에 가능하게 한다.
+
+### Git 워크플로우
+
+```text
+local/task{N}  ──커밋──커밋──┐
+                              ├─→ devel PR + merge
+                              ├─→ main merge + 태그 (릴리즈 시점)
+```
+
+| 브랜치 | 용도 |
+|--------|------|
+| `main` | 릴리즈 |
+| `devel` | 개발 통합 |
+| `local/task{N}` | GitHub Issue 번호 기반 타스크 브랜치 |
+
+### 타스크 관리
+
+- **GitHub Issues**로 타스크 번호 자동 채번 — 중복 방지
+- 브랜치명: `local/task{issue번호}`
+- 오늘할일: `mydocs/orders/yyyymmdd.md`
+- 커밋 메시지: `Issue #{번호}: 내용`
+- PR 대상: `postmelee/alhangeul-macos`의 `devel`
+
+### 타스크 진행 절차
+
+1. `gh issue create` → GitHub Issue 등록
+2. `origin/devel` 기준으로 `local/task{issue번호}` 브랜치 생성
+3. 수행계획서 작성 → 구현 계획서 작성 → 구현 → 검증
+4. 단계별 완료 보고서와 최종 보고서 작성
+5. 최종 보고서 기반 PR 생성
+
+### 디버깅 프로토콜
+
+1. `validate-stage3-render.sh` → 기본 샘플 렌더링 확인
+2. `pluginkit -m` → Quick Look/Thumbnail extension 등록 확인
+3. `qlmanage -p` → Finder preview 경로 확인
+4. 필요 시 `Vendor/rhwp`의 dump/export 도구로 core rendering data 확인
+
+### 문서 생성 규칙
+
+모든 문서는 **한국어**로 작성합니다.
+
+```text
+mydocs/
+├── orders/           # 오늘 할일 (yyyymmdd.md)
+├── plans/            # 수행 계획서, 구현 계획서
+│   └── archives/     # 완료된 계획서 보관
+├── working/          # 단계별 완료 보고서
+├── report/           # 최종 보고서
+├── feedback/         # 코드 리뷰 피드백
+├── tech/             # 기술 사항 정리 문서
+├── manual/           # 매뉴얼, 가이드 문서
+└── troubleshootings/ # 트러블슈팅 관련 문서
+```
+
+| 문서 유형 | 위치 | 파일명 규칙 |
+|----------|------|------------|
+| 오늘 할일 | `orders/` | `yyyymmdd.md` |
+| 수행 계획서 | `plans/` | `task_{issue}.md` |
+| 구현 계획서 | `plans/` | `task_{issue}_impl.md` |
+| 완료 보고서 | `working/` | `task_{issue}_stage{N}.md` |
+| 최종 보고서 | `report/` | `task_{issue}_report.md` |
+
+## Architecture
 
 ```mermaid
 graph TB
-    File["HWP/HWPX file"] --> HostApp["HostApp"]
-    File --> QuickLook["Quick Look Preview"]
-    File --> Thumbnail["Finder Thumbnail"]
-
-    HostApp --> SwiftBridge["Sources/RhwpCoreBridge"]
-    QuickLook --> SharedRenderer["Sources/Shared"]
-    Thumbnail --> SharedRenderer
-    SharedRenderer --> SwiftBridge
-
-    SwiftBridge --> CABI["Rhwp.xcframework / C ABI"]
-    CABI --> RustBridge["RustBridge staticlib"]
-    RustBridge --> Core["Vendor/rhwp submodule"]
-
-    Core --> RenderTree["Render tree JSON"]
+    HWP[HWP/HWPX File] --> HostApp[HostApp Viewer]
+    HWP --> Preview[Quick Look Preview]
+    HWP --> Thumbnail[Finder Thumbnail]
+    HostApp --> SwiftBridge[RhwpCoreBridge]
+    Preview --> Shared[Shared Page Renderer]
+    Thumbnail --> Shared
+    Shared --> SwiftBridge
+    SwiftBridge --> CABI[Rhwp.xcframework / C ABI]
+    CABI --> RustBridge[RustBridge]
+    RustBridge --> Core[Vendor/rhwp Core]
+    Core --> RenderTree[Render Tree JSON]
     RenderTree --> SwiftBridge
-    SwiftBridge --> CG["CoreGraphics/CoreText rendering"]
+    SwiftBridge --> CG[CoreGraphics/CoreText]
 ```
 
-소유 경계는 다음과 같습니다.
+## HWPUNIT
 
-- `Vendor/rhwp`: HWP/HWPX parser와 core rendering data를 제공하는 Rust core
-- `RustBridge`: macOS 앱용 C ABI를 소유하는 이 저장소의 bridge crate
-- `Sources/RhwpCoreBridge`: Swift FFI wrapper, render tree decoding, CoreGraphics renderer
-- `Sources/HostApp`: viewer 앱 UI와 문서 상태 관리
-- `Sources/QLExtension`, `Sources/ThumbnailExtension`: Finder 통합
+- 1 inch = 7,200 HWPUNIT
+- 1 inch = 25.4 mm
+- 1 HWPUNIT ≈ 0.00353 mm
 
-## Quick Start
+## Contributing
 
-### 요구사항
-
-- macOS 12 Monterey 이상
-- Xcode 15 이상
-- Swift 5.9
-- Rust toolchain
-- `cbindgen`
-- XcodeGen
-
-초기 설정:
-
-```bash
-git clone https://github.com/postmelee/alhangeul-macos.git
-cd alhangeul-macos
-
-git submodule update --init --recursive
-rustup target add aarch64-apple-darwin x86_64-apple-darwin
-cargo install cbindgen
-brew install xcodegen
-```
-
-### 개발 빌드
-
-```bash
-./scripts/build-rust-macos.sh
-xcodegen generate
-xcodebuild -project RhwpMac.xcodeproj \
-  -scheme HostApp \
-  -configuration Debug \
-  -derivedDataPath build/DerivedData \
-  CODE_SIGNING_ALLOWED=NO \
-  build
-```
-
-`project.yml`이 Xcode project의 원본입니다. target, source, bundle identifier, extension 설정을 바꿀 때는 `RhwpMac.xcodeproj`를 직접 수정하지 말고 `project.yml`을 수정한 뒤 `xcodegen generate`를 실행합니다.
-
-### 렌더링 검증
-
-```bash
-./scripts/validate-stage3-render.sh
-```
-
-기본 샘플:
-
-- `Vendor/rhwp/samples/basic/KTX.hwp`
-- `Vendor/rhwp/samples/basic/request.hwp`
-- `Vendor/rhwp/samples/exam_kor.hwp`
-
-이 검증은 Swift renderer가 render tree를 디코딩하고 실제 bitmap을 생성할 수 있는지 확인합니다. 출력은 `output/stage3-render/`에 생성됩니다.
-
-### 공유 Swift bridge 의존성 검사
-
-```bash
-./scripts/check-no-appkit.sh
-```
-
-`Sources/RhwpCoreBridge`는 HostApp과 extension에서 함께 사용되므로 AppKit/UIKit 의존성을 직접 갖지 않는 것을 원칙으로 합니다. AppKit이 필요한 코드는 HostApp, extension, 또는 `Sources/Shared` 경계에 둡니다.
-
-## 실행과 Finder 통합 확인
-
-개발 빌드 후 앱은 다음 경로에 생성됩니다.
-
-```text
-build/DerivedData/Build/Products/Debug/알한글.app
-```
-
-앱 실행:
-
-```bash
-open build/DerivedData/Build/Products/Debug/알한글.app
-```
-
-Quick Look과 Thumbnail extension 등록 상태는 앱 사이드바 또는 `pluginkit`으로 확인할 수 있습니다.
-
-```bash
-pluginkit -m | grep com.postmelee.rhwpmac
-```
-
-Finder/Quick Look 캐시를 갱신해야 할 때:
-
-```bash
-qlmanage -r
-qlmanage -r cache
-```
-
-특정 파일 preview를 강제로 열어볼 때:
-
-```bash
-qlmanage -p path/to/sample.hwp
-```
-
-## rhwp Core Submodule
-
-이 저장소는 core engine을 직접 개발하는 저장소가 아닙니다. `rhwp` core는 `Vendor/rhwp` submodule로 고정해 소비하고, macOS 앱과 bridge 코드는 이 저장소에서 관리합니다.
-
-현재 기준:
-
-```text
-core repo:   https://github.com/postmelee/rhwp.git
-core branch: devel
-lock file:   rhwp-core.lock
-```
-
-core 업데이트 절차:
-
-```bash
-./scripts/update-rhwp-core.sh
-./scripts/build-rust-macos.sh
-./scripts/check-no-appkit.sh
-xcodegen generate
-xcodebuild -project RhwpMac.xcodeproj \
-  -scheme HostApp \
-  -configuration Debug \
-  -derivedDataPath build/DerivedData \
-  CODE_SIGNING_ALLOWED=NO \
-  build
-./scripts/validate-stage3-render.sh
-```
-
-core 변경 원칙:
-
-- 앱 저장소에서 `Vendor/rhwp` 내부를 임시 수정한 채로 남기지 않습니다.
-- core API가 필요하면 먼저 `postmelee/rhwp`의 `devel`에 반영합니다.
-- 이 저장소에서는 submodule pointer와 `rhwp-core.lock`을 함께 갱신합니다.
-- FFI symbol set이 바뀌면 `rhwp-ffi-symbols.txt`, Swift bridge, release note를 함께 검토합니다.
-
-## 릴리스와 배포
-
-릴리스 zip 생성:
-
-```bash
-./scripts/package-release.sh 0.1.0
-```
-
-산출물:
-
-```text
-build/release/rhwp-mac-0.1.0.zip
-```
-
-현재 `Casks/rhwp-mac.rb`는 Homebrew Cask 배포를 위한 초안입니다. 첫 공개 릴리스 전에는 다음을 확인해야 합니다.
-
-- GitHub release URL이 현재 저장소명 `postmelee/alhangeul-macos` 기준인지
-- zip 파일명과 cask token을 유지할지 변경할지
-- SHA256 고정 여부
-- Developer ID 서명과 notarization 여부
-- Gatekeeper 실행 경고 처리 방식
-
-## 개발 방식
-
-이 프로젝트는 Claude Code와 OpenAI Codex를 함께 사용하는 AI pair programming 방식으로 개발합니다. 단, AI가 아키텍처와 품질 판단을 대신하지 않습니다.
-
-개발 원칙:
-
-- 작업은 GitHub Issue 단위로 추적합니다.
-- 새 기능, 버그 수정, 구조 변경은 `이슈 -> 브랜치 -> 계획서 -> 구현 -> 검증 -> 최종 보고서 -> PR` 순서로 진행합니다.
-- OpenAI Codex용 규칙은 [`AGENTS.md`](AGENTS.md)에 정리되어 있습니다.
-- Claude Code를 사용할 때도 동일한 Issue/문서/검증 중심 흐름을 따릅니다.
-- 앱/bridge/문서 변경 PR은 `postmelee/alhangeul-macos`의 `devel`로 생성합니다.
-- upstream `edwardkim/rhwp`에는 이 저장소의 macOS 앱 작업 PR을 생성하지 않습니다.
-
-브랜치 예시:
-
-```bash
-git switch devel
-git fetch origin
-git pull --ff-only origin devel
-git switch -c local/task{issue}
-```
-
-PR 생성 예시:
-
-```bash
-git push -u origin local/task{issue}
-gh pr create \
-  --repo postmelee/alhangeul-macos \
-  --base devel \
-  --head local/task{issue} \
-  --draft \
-  --title "Issue #{issue}: 제목"
-```
-
-문서는 모두 한국어로 작성합니다. 작업 기록은 `mydocs/` 아래에 보관합니다.
-
-## 로드맵
-
-### M0 - 저장소 분리와 macOS viewer 기반 구축, 현재
-
-완료 또는 진행된 항목:
-
-- `alhangeul-macos` 개인 저장소 분리
-- `postmelee/rhwp` core fork를 submodule로 연결
-- `RustBridge` staticlib와 `Rhwp.xcframework` 빌드 흐름 구성
-- HostApp/QLExtension/ThumbnailExtension target 구성
-- HWP/HWPX 파일 열기, 첫 페이지 preview/thumbnail, 다중 페이지 viewer 구현
-- render tree JSON 기반 Swift/CoreGraphics 렌더링 경로 복구
-- 기본 렌더링 smoke test 구축
-- Codex 개발 규칙 `AGENTS.md` 작성
-
-남은 안정화 항목:
-
-- Finder 환경 Quick Look/Thumbnail smoke test 확대
-- 다양한 HWP/HWPX 샘플 렌더링 비교
-- 앱 번들 서명, notarization, 배포 정책 정리
-- Homebrew Cask metadata 정리
-- README, 사용자 매뉴얼, troubleshooting 문서 보강
-
-### M1 - Viewer 품질 안정화
-
-목표: macOS에서 신뢰할 수 있는 읽기 전용 HWP/HWPX viewer 제공
-
-- 페이지 렌더링 정확도 개선
-- 이미지, 표, 도형, 각주, 머리말/꼬리말 렌더링 품질 확대
-- 큰 문서 메모리 사용량과 page cache 정책 개선
-- Finder preview/thumbnail 실패 fallback UX 개선
-- 샘플 기반 회귀 테스트 확장
-- 첫 공개 릴리스와 설치 경로 정리
-
-### M2 - Editing 기반 도입
-
-목표: viewer에서 편집 가능한 macOS HWP/HWPX 앱으로 확장
-
-- 문서 모델 편집 command를 Swift UI에서 호출할 수 있는 bridge 설계
-- 텍스트 삽입, 삭제, 선택, 서식 변경의 최소 편집 루프 구현
-- HWP/HWPX 저장 경로와 손상 방지 정책 수립
-- undo/redo, dirty state, autosave 정책 검토
-- 편집 후 재조판과 렌더링 갱신 파이프라인 연결
-
-### M3 - 실사용 Editing
-
-목표: 제한된 문서 편집을 실사용 가능한 수준으로 고도화
-
-- 표 편집, 이미지 삽입/교체, 문단/글자 모양 편집
-- 서식 UI와 keyboard shortcut 체계화
-- HWP/HWPX round-trip 검증 확대
-- PDF 내보내기, 인쇄, 공유 기능 검토
-- macOS 문서 기반 앱 경험 강화
-
-### M4 - Agent Plugin과 문서 자동화
-
-목표: Claude Code나 OpenAI Codex 같은 에이전트가 한컴 문서를 직접 편집하고 결과를 확인하는 워크플로우 지원
-
-- 에이전트용 문서 열기, 내용 추출, 검색, 패치 API 설계
-- HWP/HWPX 파일을 구조화된 편집 단위로 노출
-- 에이전트가 문서를 수정한 뒤 viewer 화면 또는 렌더링 결과를 열어 확인하는 루프 지원
-- 실패 시 diff, screenshot, render output을 기반으로 다시 수정하는 검증 루프 구축
-- Codex Plugin 또는 Claude Code 연동 도구로 packaging
-
-이 단계의 목표는 단순 파일 변환이 아니라, 에이전트가 실제 문서 화면을 확인하며 수정 품질을 높일 수 있는 자동화 환경입니다.
-
-## 이 저장소가 하지 않는 일
-
-이 저장소는 다음을 직접 제공하지 않습니다.
-
-- npm package 배포
-- WebAssembly browser viewer/editor 배포
-- Chrome/Edge/Safari browser extension 배포
-- upstream `rhwp` core 자체의 공식 release 관리
-
-위 항목은 upstream `rhwp` 또는 별도 파생 프로젝트의 범위입니다. `alhangeul-macos`는 macOS native app과 Finder 통합에 집중합니다.
-
-## 관련 문서
-
-- [AGENTS.md](AGENTS.md) - Codex 작업 규칙
-- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) - 아키텍처와 소유 경계
-- [docs/RHWP_CORE_BRIDGE_PLAN.md](docs/RHWP_CORE_BRIDGE_PLAN.md) - core bridge 운영 계획
-- [rhwp-core.lock](rhwp-core.lock) - 현재 고정된 core commit
-- [THIRD_PARTY_LICENSES.md](THIRD_PARTY_LICENSES.md) - third-party license
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## Notice
 
-본 제품은 한글과컴퓨터의 한글 문서 파일(`.hwp`, `.hwpx`) 공개 문서를 참고하여 개발하는 독립 오픈소스 프로젝트입니다.
+본 제품은 한글과컴퓨터의 한글 문서 파일(`.hwp`, `.hwpx`) 공개 문서를 참고하여 개발하였습니다.
 
 ## Trademark
 
-"한글", "한컴", "HWP", "HWPX"는 주식회사 한글과컴퓨터의 등록 상표입니다. 본 프로젝트는 한글과컴퓨터와 제휴, 후원, 승인 관계가 없습니다.
+"한글", "한컴", "HWP", "HWPX"는 주식회사 한글과컴퓨터의 등록 상표입니다. 본 프로젝트는 한글과컴퓨터와 제휴, 후원, 승인 관계가 없는 독립적인 오픈소스 프로젝트입니다.
 
-"Hangul", "Hancom", "HWP", and "HWPX" are registered trademarks of Hancom Inc. This project is independent and is not affiliated with, sponsored by, or endorsed by Hancom Inc.
+"Hangul", "Hancom", "HWP", and "HWPX" are registered trademarks of Hancom Inc. This project is an independent open-source project with no affiliation, sponsorship, or endorsement by Hancom Inc.
 
 ## License
 

--- a/mydocs/orders/20260423.md
+++ b/mydocs/orders/20260423.md
@@ -5,6 +5,7 @@
 - Issue #3: `ios/devel` native viewer core 변경을 개인 fork `postmelee/rhwp`의 `devel`에 포팅하고, `alhangeul-macos`가 해당 core fork를 submodule로 추적하도록 전환한다.
 - Issue #5: PR #4 머지 후 확인된 `rhwp-core.lock` commit SHA 오기를 실제 submodule HEAD로 보정한다.
 - Issue #7: upstream `CLAUDE.md`를 참고해 `alhangeul-macos`용 Codex 규칙 파일 `AGENTS.md`를 작성한다.
+- Issue #9: 현재 구현 상태와 장기 로드맵을 반영해 `README.md`를 `alhangeul-macos` 기준으로 상세 재작성한다.
 
 ## 검증
 
@@ -16,3 +17,4 @@
 - `./scripts/validate-stage3-render.sh`
 - Issue #5는 문서/lock 보정 작업이므로 `git diff --check`와 submodule HEAD 대조로 검증한다.
 - Issue #7은 문서 작업이므로 `git diff --check`로 검증한다.
+- Issue #9는 README 문서 작업이므로 `git diff --check`로 검증한다.

--- a/mydocs/plans/task_9.md
+++ b/mydocs/plans/task_9.md
@@ -1,0 +1,24 @@
+# Issue #9 수행 계획서
+
+## 목표
+
+`alhangeul-macos`의 현재 구현 상태와 장기 방향을 반영해 `README.md`를 상세 재작성한다.
+
+## 범위
+
+- 현재 코드와 문서를 확인해 구현된 기능을 파악한다.
+- upstream `rhwp` README 구조를 참고하되 npm, WASM browser, browser extension 등 이 저장소에 필요 없는 내용은 제외한다.
+- macOS Quick Look, Thumbnail, HostApp viewer, RustBridge, `rhwp` submodule, 배포/개발 환경을 중심으로 README를 작성한다.
+- Claude Code와 OpenAI Codex를 함께 사용하는 개발 방식을 반영한다.
+- Viewer 안정화, Editing, Agent Plugin 단계까지 로드맵을 명시한다.
+
+## 제외 범위
+
+- Swift/Rust 소스 변경
+- core submodule 변경
+- Xcode project 재생성
+- 배포용 서명 또는 notarization 구성
+
+## 검증
+
+- `git diff --check`

--- a/mydocs/plans/task_9_impl.md
+++ b/mydocs/plans/task_9_impl.md
@@ -1,0 +1,20 @@
+# Issue #9 구현 계획서
+
+## 1단계: 프로젝트 상태 조사
+
+- `README.md`, `AGENTS.md`, `docs/ARCHITECTURE.md`, `docs/RHWP_CORE_BRIDGE_PLAN.md`를 확인한다.
+- HostApp, Quick Look, Thumbnail, Swift bridge, RustBridge 코드를 확인한다.
+- 릴리스 스크립트와 Homebrew Cask 초안을 확인한다.
+
+## 2단계: README 재작성
+
+- 프로젝트 소개와 현재 구현 상태를 정리한다.
+- 지원 파일 형식, 구조, 아키텍처, Quick Start, Finder 통합 확인, submodule 운영을 작성한다.
+- 개발 방식과 로드맵을 작성한다.
+- 이 저장소가 하지 않는 일을 명시해 upstream `rhwp`와 역할을 분리한다.
+
+## 3단계: 검증 및 보고
+
+- 문서 diff 검사를 실행한다.
+- 수행 계획서, 구현 계획서, 단계 보고서, 최종 보고서를 작성한다.
+- 변경분을 커밋하고 `local/task9 -> devel` PR을 생성한다.

--- a/mydocs/report/task_9_report.md
+++ b/mydocs/report/task_9_report.md
@@ -2,18 +2,17 @@
 
 ## 작업 요약
 
-`README.md`를 `alhangeul-macos`의 현재 구현 상태와 장기 로드맵 기준으로 상세 재작성했다.
+`README.md`를 upstream `rhwp` README의 순서와 작성 포맷을 따르도록 다시 재작성했다.
 
 ## 변경 내용
 
-- 프로젝트 소개를 macOS Quick Look, Thumbnail, HostApp viewer 중심으로 재작성했다.
-- 현재 구현된 기능과 아직 남은 안정화 항목을 분리해 정리했다.
-- 지원 UTI, 프로젝트 구조, Mermaid 아키텍처, Quick Start, Finder 통합 확인 절차를 추가했다.
-- `postmelee/rhwp` core submodule 운영 원칙과 `rhwp-core.lock` 관리 기준을 추가했다.
-- 릴리스 패키징과 Homebrew Cask 초안의 확인 필요 사항을 명시했다.
-- Claude Code와 OpenAI Codex를 함께 사용하는 개발 방식을 설명했다.
-- M0부터 M4까지 Viewer 안정화, Editing, Agent Plugin 로드맵을 추가했다.
-- npm package, WASM browser viewer/editor, browser extension은 이 저장소 범위가 아님을 명시했다.
+- 원본 README의 큰 순서인 `로드맵 -> 이정표 -> Features -> Quick Start (소스 빌드) -> AI 페어 프로그래밍으로 개발합니다` 흐름을 반영했다.
+- macOS Quick Look, Thumbnail, HostApp viewer, RustBridge, `postmelee/rhwp` submodule 기준으로 내용을 수정했다.
+- 온보딩 가이드는 추후 추가 예정임을 전제로 Quick Start 문구를 먼저 반영했다.
+- "AI 페어 프로그래밍으로 개발합니다" 섹션은 upstream README의 문제의식과 문체를 최대한 보존하고 출처를 명시했다.
+- Claude Code와 OpenAI Codex를 함께 사용하는 현재 개발 방식을 반영했다.
+- Viewer 안정화, Editing, Agent Plugin 로드맵을 이정표에 추가했다.
+- 릴리스/배포 절차는 타인용 README에서 제외했다. 해당 내용은 저장소 소유자용 `AGENTS.md` 또는 별도 릴리스 문서에서 다루는 것이 적절하다고 판단했다.
 
 ## 검증
 
@@ -21,5 +20,6 @@
 
 ## 남은 사항
 
-- 첫 공개 릴리스 전 cask token, zip 파일명, GitHub release URL, SHA256, 서명/notarization 정책을 확정해야 한다.
+- 온보딩 가이드는 후속 작업에서 추가해야 한다.
+- `CONTRIBUTING.md`는 후속 작업에서 추가해야 한다.
 - README에 삽입할 실제 screenshot 또는 동영상은 후속 작업에서 추가할 수 있다.

--- a/mydocs/report/task_9_report.md
+++ b/mydocs/report/task_9_report.md
@@ -1,0 +1,25 @@
+# Issue #9 최종 보고서
+
+## 작업 요약
+
+`README.md`를 `alhangeul-macos`의 현재 구현 상태와 장기 로드맵 기준으로 상세 재작성했다.
+
+## 변경 내용
+
+- 프로젝트 소개를 macOS Quick Look, Thumbnail, HostApp viewer 중심으로 재작성했다.
+- 현재 구현된 기능과 아직 남은 안정화 항목을 분리해 정리했다.
+- 지원 UTI, 프로젝트 구조, Mermaid 아키텍처, Quick Start, Finder 통합 확인 절차를 추가했다.
+- `postmelee/rhwp` core submodule 운영 원칙과 `rhwp-core.lock` 관리 기준을 추가했다.
+- 릴리스 패키징과 Homebrew Cask 초안의 확인 필요 사항을 명시했다.
+- Claude Code와 OpenAI Codex를 함께 사용하는 개발 방식을 설명했다.
+- M0부터 M4까지 Viewer 안정화, Editing, Agent Plugin 로드맵을 추가했다.
+- npm package, WASM browser viewer/editor, browser extension은 이 저장소 범위가 아님을 명시했다.
+
+## 검증
+
+- `git diff --check`
+
+## 남은 사항
+
+- 첫 공개 릴리스 전 cask token, zip 파일명, GitHub release URL, SHA256, 서명/notarization 정책을 확정해야 한다.
+- README에 삽입할 실제 screenshot 또는 동영상은 후속 작업에서 추가할 수 있다.

--- a/mydocs/working/task_9_stage1.md
+++ b/mydocs/working/task_9_stage1.md
@@ -1,0 +1,30 @@
+# Issue #9 단계 1 완료 보고서
+
+## 수행 내용
+
+- 원격 `devel` 최신 상태와 기존 PR merge 상태를 확인했다.
+- Issue #9를 생성하고 `origin/devel` 기준으로 `local/task9` 브랜치를 생성했다.
+- 다음 파일을 기준으로 현재 프로젝트 상태를 확인했다.
+  - `README.md`
+  - `AGENTS.md`
+  - `docs/ARCHITECTURE.md`
+  - `docs/RHWP_CORE_BRIDGE_PLAN.md`
+  - `Sources/HostApp`
+  - `Sources/QLExtension`
+  - `Sources/ThumbnailExtension`
+  - `Sources/RhwpCoreBridge`
+  - `RustBridge/src/lib.rs`
+  - `scripts/`
+  - `Casks/rhwp-mac.rb`
+
+## 확인한 구현 상태
+
+- HostApp viewer는 HWP/HWPX 열기, 다중 페이지 스크롤, 확대/축소를 제공한다.
+- Quick Look preview와 Thumbnail extension은 첫 페이지 bitmap 렌더링 경로를 공유한다.
+- Swift renderer는 render tree JSON을 CoreGraphics/CoreText로 렌더링한다.
+- RustBridge는 `rhwp` core를 C ABI와 `Rhwp.xcframework`로 노출한다.
+- 릴리스 패키징 스크립트와 Homebrew Cask 초안은 있으나, 첫 공개 릴리스 전 배포 metadata 정리가 필요하다.
+
+## 결과
+
+README를 현재 macOS 앱 저장소 기준으로 재작성할 근거를 확보했다.

--- a/mydocs/working/task_9_stage2.md
+++ b/mydocs/working/task_9_stage2.md
@@ -1,0 +1,27 @@
+# Issue #9 단계 2 완료 보고서
+
+## 수행 내용
+
+- 작업지시자 피드백에 따라 README를 다시 재작성했다.
+- upstream `rhwp` README의 순서와 작성 포맷을 우선 반영했다.
+- 공개 독자가 읽는 문서임을 고려해 릴리스/배포 절차는 README에서 제외했다.
+- Contributing은 원본 README처럼 `CONTRIBUTING.md`를 참조하도록 남겼다.
+
+## 반영 사항
+
+- `로드맵`
+- `이정표`
+- `Features`
+- `Quick Start (소스 빌드)`
+- `Project Structure`
+- `AI 페어 프로그래밍으로 개발합니다`
+- `Architecture`
+- `HWPUNIT`
+- `Contributing`
+- `Notice`
+- `Trademark`
+- `License`
+
+## 결과
+
+README의 흐름이 upstream README와 더 가까워졌고, 내용은 `alhangeul-macos`의 macOS 앱/bridge/Finder 통합 기준으로 정리됐다.


### PR DESCRIPTION
## 작업 요약

Closes #9

`README.md`를 upstream `rhwp` README의 순서와 작성 포맷을 따르도록 다시 재작성했습니다. 공개 독자가 읽는 문서라는 전제를 우선해, macOS 앱 사용/개발에 필요한 정보와 장기 방향을 중심으로 정리했습니다.

## 변경 내용

- 원본 README의 큰 흐름인 `로드맵 -> 이정표 -> Features -> Quick Start (소스 빌드) -> AI 페어 프로그래밍으로 개발합니다` 순서를 반영했습니다.
- `alhangeul-macos` 기준으로 macOS Quick Look, Thumbnail, HostApp viewer, RustBridge, `postmelee/rhwp` submodule 내용을 작성했습니다.
- 온보딩 가이드는 추후 추가 예정임을 전제로 Quick Start 문구를 먼저 반영했습니다.
- `AI 페어 프로그래밍으로 개발합니다` 섹션은 upstream README의 문제의식과 문체를 최대한 보존하고 출처를 명시했습니다.
- Claude Code와 OpenAI Codex를 함께 사용하는 현재 개발 방식을 반영했습니다.
- Viewer 안정화, Editing, Agent Plugin 로드맵을 이정표에 추가했습니다.
- Contributing은 원본 README처럼 `CONTRIBUTING.md`를 참조하도록 남겼습니다.
- 릴리스/배포 절차는 타인용 README에서 제외했습니다.
- 릴리스/배포 상세 절차는 `mydocs/manual/release_distribution_guide.md`로 분리했습니다.
- `AGENTS.md`에는 릴리스/배포 작업 전 manual을 반드시 읽으라는 짧은 참조 규칙만 남겼습니다.
- Issue #9 단계 보고서와 최종 보고서를 갱신했습니다.

## 검증

- `git diff --check`

## 남은 사항

- 온보딩 가이드는 후속 작업에서 추가해야 합니다.
- `CONTRIBUTING.md`는 후속 작업에서 추가해야 합니다.
- README에 삽입할 실제 screenshot 또는 동영상은 후속 작업에서 추가할 수 있습니다.
- 첫 공개 릴리스 전 cask token, zip 파일명, GitHub Release URL, SHA256, 서명/notarization 정책을 확정해야 합니다.
