### PR TITLE
Task #22: rework rhwp bridge and finder thumbnail flow

### DIFF
--- a/RhwpMac.xcodeproj/project.pbxproj
+++ b/RhwpMac.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		DF5B6080BFA8C4135DFAFE99 /* DocumentOpenRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4F7F314386F65D3115329DE /* DocumentOpenRouter.swift */; };
 		E9EA2350F03EE94ADF146B3D /* Rhwp.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1B5AA023F263DCFAD6F8B5D6 /* Rhwp.xcframework */; };
 		EAB5F41AD4E7D7AFBC60AFB4 /* RhwpDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16DE3288E2F8A233BC245AB8 /* RhwpDocument.swift */; };
+		EACCE151875ED82158EFE66C /* HwpThumbnailRenderCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989652C4D256966C6B1C52EE /* HwpThumbnailRenderCache.swift */; };
 		EFA2E950D11CF5A8EF550F85 /* HwpPageImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7FF97435E7DC2E83DDD7847 /* HwpPageImageRenderer.swift */; };
 		EFBDD3F470DFD0B9E6A0208D /* FontFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5A747CBC3DD3904017EFEC /* FontFallback.swift */; };
 		F46C29F61BC1DDEBDCCF320C /* HostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2AC35A93F10CDB30E5E218 /* HostApp.swift */; };
@@ -89,6 +90,7 @@
 		7AB45C92769C8141C6D321A0 /* ThumbnailExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ThumbnailExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		8BBB4293B1DF66D6308DC817 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		92FF2EC2F1F3AF82DD0665BC /* DocumentViewerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentViewerView.swift; sourceTree = "<group>"; };
+		989652C4D256966C6B1C52EE /* HwpThumbnailRenderCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HwpThumbnailRenderCache.swift; sourceTree = "<group>"; };
 		9D5A747CBC3DD3904017EFEC /* FontFallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFallback.swift; sourceTree = "<group>"; };
 		A717B7804A99A7F2314F7CC8 /* DocumentPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPageView.swift; sourceTree = "<group>"; };
 		B7F20D1D3A2381F4974AB4FD /* sample.hwpx */ = {isa = PBXFileReference; path = sample.hwpx; sourceTree = "<group>"; };
@@ -172,6 +174,7 @@
 			children = (
 				E57CF34A02A750F9E6818E13 /* .gitkeep */,
 				D39D31F2E27FE42F01A2FD88 /* HwpThumbnailProvider.swift */,
+				989652C4D256966C6B1C52EE /* HwpThumbnailRenderCache.swift */,
 				8BBB4293B1DF66D6308DC817 /* Info.plist */,
 				C0F6D72CB0515282F6BC022C /* ThumbnailExtension.entitlements */,
 			);
@@ -416,6 +419,7 @@
 				560CB413F200C0E8D3CD5BB3 /* FontFallback.swift in Sources */,
 				EFA2E950D11CF5A8EF550F85 /* HwpPageImageRenderer.swift in Sources */,
 				3A8005327A4303D22DE51C90 /* HwpThumbnailProvider.swift in Sources */,
+				EACCE151875ED82158EFE66C /* HwpThumbnailRenderCache.swift in Sources */,
 				3615F5A92CE720212B4C2358 /* RenderTree.swift in Sources */,
 				EAB5F41AD4E7D7AFBC60AFB4 /* RhwpDocument.swift in Sources */,
 			);
@@ -457,6 +461,7 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/HostApp/HostApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				EXECUTABLE_NAME = RhwpMacHost;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",
@@ -467,7 +472,7 @@
 					"@executable_path/../Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.postmelee.rhwpmac;
-				PRODUCT_NAME = "알한글";
+				PRODUCT_NAME = RhwpMac;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -478,6 +483,7 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/ThumbnailExtension/ThumbnailExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				EXECUTABLE_NAME = RhwpMacThumbnail;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",
@@ -489,7 +495,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.postmelee.rhwpmac.ThumbnailExtension;
-				PRODUCT_NAME = "알한글 Thumbnail";
+				PRODUCT_NAME = RhwpMacThumbnail;
 				SDKROOT = macosx;
 			};
 			name = Debug;
@@ -501,6 +507,7 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/HostApp/HostApp.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				EXECUTABLE_NAME = RhwpMacHost;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",
@@ -511,7 +518,7 @@
 					"@executable_path/../Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.postmelee.rhwpmac;
-				PRODUCT_NAME = "알한글";
+				PRODUCT_NAME = RhwpMac;
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -522,6 +529,7 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/QLExtension/QLExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				EXECUTABLE_NAME = RhwpMacPreview;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",
@@ -533,7 +541,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.postmelee.rhwpmac.QLExtension;
-				PRODUCT_NAME = "알한글 Preview";
+				PRODUCT_NAME = RhwpMacPreview;
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -663,6 +671,7 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/ThumbnailExtension/ThumbnailExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				EXECUTABLE_NAME = RhwpMacThumbnail;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",
@@ -674,7 +683,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.postmelee.rhwpmac.ThumbnailExtension;
-				PRODUCT_NAME = "알한글 Thumbnail";
+				PRODUCT_NAME = RhwpMacThumbnail;
 				SDKROOT = macosx;
 			};
 			name = Release;
@@ -685,6 +694,7 @@
 				CODE_SIGN_ENTITLEMENTS = Sources/QLExtension/QLExtension.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
+				EXECUTABLE_NAME = RhwpMacPreview;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\"Frameworks\"",
@@ -696,7 +706,7 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.postmelee.rhwpmac.QLExtension;
-				PRODUCT_NAME = "알한글 Preview";
+				PRODUCT_NAME = RhwpMacPreview;
 				SDKROOT = macosx;
 			};
 			name = Debug;

--- a/RustBridge/src/lib.rs
+++ b/RustBridge/src/lib.rs
@@ -2,7 +2,7 @@ use std::ffi::{c_char, CString};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
 
-use rhwp::wasm_api::HwpDocument;
+use rhwp::DocumentCore;
 
 macro_rules! ffi_guard {
     ($handle:expr, $default:expr, $body:expr) => {{
@@ -17,7 +17,7 @@ macro_rules! ffi_guard {
 }
 
 pub struct RhwpHandle {
-    doc: HwpDocument,
+    doc: DocumentCore,
 }
 
 #[repr(C)]
@@ -28,6 +28,64 @@ pub struct RhwpPageSize {
 }
 
 #[no_mangle]
+pub extern "C" fn rhwp_extract_thumbnail(
+    data: *const u8,
+    len: usize,
+    out_data: *mut *mut u8,
+    out_len: *mut usize,
+    out_width: *mut u32,
+    out_height: *mut u32,
+    out_format: *mut *mut c_char,
+) -> bool {
+    if data.is_null()
+        || len == 0
+        || out_data.is_null()
+        || out_len.is_null()
+        || out_width.is_null()
+        || out_height.is_null()
+        || out_format.is_null()
+    {
+        return false;
+    }
+
+    unsafe {
+        *out_data = ptr::null_mut();
+        *out_len = 0;
+        *out_width = 0;
+        *out_height = 0;
+        *out_format = ptr::null_mut();
+    }
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let bytes = unsafe { std::slice::from_raw_parts(data, len) };
+        let thumb = match rhwp::parser::extract_thumbnail_only(bytes) {
+            Some(thumb) => thumb,
+            None => return false,
+        };
+
+        let format = match CString::new(thumb.format) {
+            Ok(format) => format,
+            Err(_) => return false,
+        };
+        let mut owned = thumb.data.into_boxed_slice();
+        let owned_len = owned.len();
+        let owned_ptr = owned.as_mut_ptr();
+        std::mem::forget(owned);
+
+        unsafe {
+            *out_data = owned_ptr;
+            *out_len = owned_len;
+            *out_width = thumb.width;
+            *out_height = thumb.height;
+            *out_format = format.into_raw();
+        }
+        true
+    }));
+
+    result.unwrap_or(false)
+}
+
+#[no_mangle]
 pub extern "C" fn rhwp_open(data: *const u8, len: usize) -> *mut RhwpHandle {
     if data.is_null() || len == 0 {
         return ptr::null_mut();
@@ -35,7 +93,7 @@ pub extern "C" fn rhwp_open(data: *const u8, len: usize) -> *mut RhwpHandle {
 
     let result = catch_unwind(AssertUnwindSafe(|| {
         let bytes = unsafe { std::slice::from_raw_parts(data, len) };
-        match HwpDocument::from_bytes(bytes) {
+        match DocumentCore::from_bytes(bytes) {
             Ok(doc) => Box::into_raw(Box::new(RhwpHandle { doc })),
             Err(_) => ptr::null_mut(),
         }
@@ -121,6 +179,13 @@ pub extern "C" fn rhwp_image_data(
 pub extern "C" fn rhwp_free_string(ptr: *mut c_char) {
     if !ptr.is_null() {
         unsafe { drop(CString::from_raw(ptr)); }
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn rhwp_free_bytes(ptr: *mut u8, len: usize) {
+    if !ptr.is_null() {
+        unsafe { drop(Vec::from_raw_parts(ptr, len, len)); }
     }
 }
 

--- a/Sources/HostApp/HostApp.entitlements
+++ b/Sources/HostApp/HostApp.entitlements
@@ -2,5 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
 </dict>
 </plist>

--- a/Sources/HostApp/Info.plist
+++ b/Sources/HostApp/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>알한글</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/Sources/QLExtension/Info.plist
+++ b/Sources/QLExtension/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>알한글 Preview</string>
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>

--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -7,7 +7,6 @@ import CoreText
 import Foundation
 import ImageIO
 
-@MainActor
 class CGTreeRenderer {
     private var imageCache: [UInt16: CGImage] = [:]
     private weak var document: RhwpDocument?

--- a/Sources/RhwpCoreBridge/RhwpDocument.swift
+++ b/Sources/RhwpCoreBridge/RhwpDocument.swift
@@ -1,6 +1,13 @@
 import Foundation
 import Rhwp
 
+struct RhwpEmbeddedThumbnail {
+    let data: Data
+    let width: Int
+    let height: Int
+    let format: String?
+}
+
 /// Rust FFI 호출 에러
 enum RhwpError: LocalizedError {
     case parseFailure(filename: String?)
@@ -30,7 +37,6 @@ enum RhwpError: LocalizedError {
 /// - `rhwp_open`이 데이터를 파싱 후 IR로 복사하므로,
 ///   `Data.withUnsafeBytes` 밖에서 핸들을 사용해도 안전하다.
 /// - 향후 zero-copy 파싱 도입 시 이 가정을 재검토할 것.
-@MainActor
 class RhwpDocument {
     // 불완전 C 구조체(opaque type)이므로 rhwp_open 반환 타입 그대로 보관
     private let handle: OpaquePointer
@@ -96,5 +102,50 @@ class RhwpDocument {
             return nil
         }
         return Data(bytes: ptr, count: len)
+    }
+
+    static func extractEmbeddedThumbnail(from data: Data) -> RhwpEmbeddedThumbnail? {
+        guard !data.isEmpty else {
+            return nil
+        }
+
+        var outData: UnsafeMutablePointer<UInt8>?
+        var outLen: UInt = 0
+        var outWidth: UInt32 = 0
+        var outHeight: UInt32 = 0
+        var outFormat: UnsafeMutablePointer<CChar>?
+
+        let success = data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.baseAddress else { return false }
+            return rhwp_extract_thumbnail(
+                base.assumingMemoryBound(to: UInt8.self),
+                UInt(data.count),
+                &outData,
+                &outLen,
+                &outWidth,
+                &outHeight,
+                &outFormat
+            )
+        }
+
+        defer {
+            if let ptr = outData, outLen > 0 {
+                rhwp_free_bytes(ptr, outLen)
+            }
+            if let formatPtr = outFormat {
+                rhwp_free_string(formatPtr)
+            }
+        }
+
+        guard success, let thumbnailPtr = outData, outLen > 0 else {
+            return nil
+        }
+
+        return RhwpEmbeddedThumbnail(
+            data: Data(bytes: thumbnailPtr, count: Int(outLen)),
+            width: Int(outWidth),
+            height: Int(outHeight),
+            format: outFormat.map { String(cString: $0) }
+        )
     }
 }

--- a/Sources/Shared/HwpPageImageRenderer.swift
+++ b/Sources/Shared/HwpPageImageRenderer.swift
@@ -5,7 +5,7 @@ import UniformTypeIdentifiers
 
 let hwpQuickLookMaxFileSize = 50 * 1024 * 1024
 
-struct HwpRenderedPage {
+struct HwpRenderedPage: @unchecked Sendable {
     let image: CGImage
     let size: CGSize
 }
@@ -20,15 +20,21 @@ enum HwpRenderError: Error {
     case pngEncodingFailed
 }
 
-@MainActor
 enum HwpPageImageRenderer {
     static func renderFirstPage(fileURL: URL) throws -> HwpRenderedPage {
+        try renderFirstPage(fileURL: fileURL, maximumPixelSize: nil)
+    }
+
+    static func renderFirstPage(fileURL: URL, maximumPixelSize: CGSize?) throws -> HwpRenderedPage {
         let values = try fileURL.resourceValues(forKeys: [.fileSizeKey])
+        let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
+        if let embedded = decodeEmbeddedThumbnail(from: data, maximumPixelSize: maximumPixelSize) {
+            return embedded
+        }
         if let fileSize = values.fileSize, fileSize > hwpQuickLookMaxFileSize {
             throw HwpRenderError.fileTooLarge
         }
 
-        let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
         let document = try RhwpDocument(data: data, filename: fileURL.lastPathComponent)
         guard document.pageCount > 0 else {
             throw HwpRenderError.emptyDocument
@@ -42,8 +48,12 @@ enum HwpPageImageRenderer {
             throw HwpRenderError.invalidPageSize
         }
 
-        let width = max(1, Int(ceil(pageSize.width)))
-        let height = max(1, Int(ceil(pageSize.height)))
+        let renderScale = renderScale(
+            pageSize: CGSize(width: pageSize.width, height: pageSize.height),
+            maximumPixelSize: maximumPixelSize
+        )
+        let width = max(1, Int(ceil(pageSize.width * renderScale)))
+        let height = max(1, Int(ceil(pageSize.height * renderScale)))
         let bytesPerRow = width * 4
         var pixels = [UInt8](repeating: 255, count: height * bytesPerRow)
         let colorSpace = CGColorSpaceCreateDeviceRGB()
@@ -62,7 +72,7 @@ enum HwpPageImageRenderer {
         context.setFillColor(CGColor(gray: 1, alpha: 1))
         context.fill(CGRect(x: 0, y: 0, width: width, height: height))
         context.translateBy(x: 0, y: CGFloat(height))
-        context.scaleBy(x: 1, y: -1)
+        context.scaleBy(x: renderScale, y: -renderScale)
 
         let renderer = CGTreeRenderer()
         renderer.render(tree: tree, in: context, pageHeight: pageSize.height, document: document)
@@ -71,7 +81,10 @@ enum HwpPageImageRenderer {
             throw HwpRenderError.imageUnavailable
         }
 
-        return HwpRenderedPage(image: image, size: CGSize(width: width, height: height))
+        return HwpRenderedPage(
+            image: image,
+            size: CGSize(width: pageSize.width, height: pageSize.height)
+        )
     }
 
     static func encodePNG(_ image: CGImage) throws -> Data {
@@ -84,5 +97,61 @@ enum HwpPageImageRenderer {
             throw HwpRenderError.pngEncodingFailed
         }
         return data as Data
+    }
+
+    private static func decodeEmbeddedThumbnail(from data: Data, maximumPixelSize: CGSize?) -> HwpRenderedPage? {
+        guard let thumbnail = RhwpDocument.extractEmbeddedThumbnail(from: data) else {
+            return nil
+        }
+        guard let source = CGImageSourceCreateWithData(thumbnail.data as CFData, nil) else {
+            return nil
+        }
+
+        let image: CGImage?
+        if let maximumPixelSize {
+            let maxDimension = Int(max(maximumPixelSize.width, maximumPixelSize.height))
+            if maxDimension > 0 {
+                let options: CFDictionary = [
+                    kCGImageSourceCreateThumbnailFromImageAlways: true,
+                    kCGImageSourceCreateThumbnailWithTransform: true,
+                    kCGImageSourceShouldCacheImmediately: true,
+                    kCGImageSourceThumbnailMaxPixelSize: maxDimension
+                ] as CFDictionary
+                image = CGImageSourceCreateThumbnailAtIndex(source, 0, options)
+            } else {
+                image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+            }
+        } else {
+            image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+        }
+
+        guard let image else {
+            return nil
+        }
+
+        let width = thumbnail.width > 0 ? thumbnail.width : image.width
+        let height = thumbnail.height > 0 ? thumbnail.height : image.height
+        return HwpRenderedPage(
+            image: image,
+            size: CGSize(width: width, height: height)
+        )
+    }
+
+    private static func renderScale(pageSize: CGSize, maximumPixelSize: CGSize?) -> CGFloat {
+        guard
+            let maximumPixelSize,
+            pageSize.width > 0,
+            pageSize.height > 0,
+            maximumPixelSize.width > 0,
+            maximumPixelSize.height > 0
+        else {
+            return 1
+        }
+
+        let scale = min(
+            maximumPixelSize.width / pageSize.width,
+            maximumPixelSize.height / pageSize.height
+        )
+        return scale.isFinite && scale > 0 ? scale : 1
     }
 }

--- a/Sources/ThumbnailExtension/HwpThumbnailProvider.swift
+++ b/Sources/ThumbnailExtension/HwpThumbnailProvider.swift
@@ -6,27 +6,38 @@ final class HwpThumbnailProvider: QLThumbnailProvider {
         for request: QLFileThumbnailRequest,
         _ handler: @escaping (QLThumbnailReply?, Error?) -> Void
     ) {
-        Task { @MainActor in
-            do {
-                let renderedPage = try HwpPageImageRenderer.renderFirstPage(fileURL: request.fileURL)
-                let contextSize = Self.aspectFit(renderedPage.size, within: request.maximumSize)
-                let image = renderedPage.image
-                let reply = QLThumbnailReply(contextSize: contextSize) { context in
-                    Self.drawPageImage(image, in: context, size: contextSize)
-                    return true
+        do {
+            let renderRequest = try HwpThumbnailRenderRequest(
+                fileURL: request.fileURL,
+                maximumSize: request.maximumSize,
+                scale: request.scale
+            )
+            HwpThumbnailRenderCache.shared.renderedPage(for: renderRequest) { result in
+                switch result {
+                case .success(let renderedPage):
+                    let contextSize = Self.aspectFit(renderedPage.size, within: request.maximumSize)
+                    let image = renderedPage.image
+                    let reply = QLThumbnailReply(contextSize: contextSize) { context in
+                        Self.drawPageImage(image, in: context, size: contextSize)
+                        return true
+                    }
+                    reply.extensionBadge = request.fileURL.pathExtension.uppercased()
+                    handler(reply, nil)
+
+                case .failure(HwpRenderError.fileTooLarge):
+                    let reply = QLThumbnailReply(contextSize: request.maximumSize) { context in
+                        Self.drawFallback(in: context, size: request.maximumSize)
+                        return true
+                    }
+                    reply.extensionBadge = request.fileURL.pathExtension.uppercased()
+                    handler(reply, nil)
+
+                case .failure(let error):
+                    handler(nil, error)
                 }
-                reply.extensionBadge = request.fileURL.pathExtension.uppercased()
-                handler(reply, nil)
-            } catch HwpRenderError.fileTooLarge {
-                let reply = QLThumbnailReply(contextSize: request.maximumSize) { context in
-                    Self.drawFallback(in: context, size: request.maximumSize)
-                    return true
-                }
-                reply.extensionBadge = request.fileURL.pathExtension.uppercased()
-                handler(reply, nil)
-            } catch {
-                handler(nil, error)
             }
+        } catch {
+            handler(nil, error)
         }
     }
 

--- a/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift
+++ b/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift
@@ -1,0 +1,153 @@
+import CoreGraphics
+import Foundation
+
+struct HwpThumbnailRenderRequest {
+    let fileURL: URL
+    let maximumSize: CGSize
+    let maximumPixelSize: CGSize
+    let key: HwpThumbnailCacheKey
+
+    init(fileURL: URL, maximumSize: CGSize, scale: CGFloat) throws {
+        let values = try fileURL.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
+        let pixelWidth = Self.pixelBucket(for: maximumSize.width, scale: scale)
+        let pixelHeight = Self.pixelBucket(for: maximumSize.height, scale: scale)
+
+        self.fileURL = fileURL
+        self.maximumSize = maximumSize
+        self.maximumPixelSize = CGSize(width: pixelWidth, height: pixelHeight)
+        self.key = HwpThumbnailCacheKey(
+            path: fileURL.path,
+            modificationTime: values.contentModificationDateKeyTimeInterval,
+            fileSize: values.fileSize ?? 0,
+            pixelWidth: pixelWidth,
+            pixelHeight: pixelHeight
+        )
+    }
+
+    private static func pixelBucket(for value: CGFloat, scale: CGFloat) -> Int {
+        let scaledValue = max(16, Int(ceil(max(value, 1) * max(scale, 1))))
+        var bucket = 16
+        while bucket < scaledValue {
+            bucket *= 2
+        }
+        return min(bucket, 2048)
+    }
+}
+
+struct HwpThumbnailCacheKey: Hashable {
+    let path: String
+    let modificationTime: TimeInterval
+    let fileSize: Int
+    let pixelWidth: Int
+    let pixelHeight: Int
+}
+
+private extension URLResourceValues {
+    var contentModificationDateKeyTimeInterval: TimeInterval {
+        contentModificationDate?.timeIntervalSinceReferenceDate ?? 0
+    }
+}
+
+final class HwpThumbnailRenderCache {
+    static let shared = HwpThumbnailRenderCache()
+
+    private let stateQueue = DispatchQueue(label: "com.postmelee.rhwpmac.thumbnail-cache")
+    private let workerQueue = DispatchQueue(
+        label: "com.postmelee.rhwpmac.thumbnail-render",
+        qos: .utility,
+        attributes: .concurrent
+    )
+    private let maxEntryCount = 96
+
+    private var cachedPages: [HwpThumbnailCacheKey: HwpRenderedPage] = [:]
+    private var accessOrder: [HwpThumbnailCacheKey] = []
+    private var inFlight: [HwpThumbnailCacheKey: [(Result<HwpRenderedPage, Error>) -> Void]] = [:]
+
+    private init() {}
+
+    func renderedPage(
+        for request: HwpThumbnailRenderRequest,
+        completion: @escaping (Result<HwpRenderedPage, Error>) -> Void
+    ) {
+        stateQueue.async {
+            if let (matchedKey, cached) = self.cachedPage(for: request.key) {
+                self.touch(matchedKey)
+                self.workerQueue.async {
+                    completion(.success(cached))
+                }
+                return
+            }
+
+            if self.inFlight[request.key] != nil {
+                self.inFlight[request.key, default: []].append(completion)
+                return
+            }
+
+            self.inFlight[request.key] = [completion]
+            self.workerQueue.async {
+                let result = Result {
+                    try HwpPageImageRenderer.renderFirstPage(
+                        fileURL: request.fileURL,
+                        maximumPixelSize: request.maximumPixelSize
+                    )
+                }
+
+                self.stateQueue.async {
+                    let callbacks = self.inFlight.removeValue(forKey: request.key) ?? []
+                    if case .success(let page) = result {
+                        self.store(page, for: request.key)
+                    }
+                    for callback in callbacks {
+                        self.workerQueue.async {
+                            callback(result)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private func store(_ page: HwpRenderedPage, for key: HwpThumbnailCacheKey) {
+        cachedPages[key] = page
+        touch(key)
+
+        while accessOrder.count > maxEntryCount {
+            let removedKey = accessOrder.removeFirst()
+            cachedPages.removeValue(forKey: removedKey)
+        }
+    }
+
+    private func touch(_ key: HwpThumbnailCacheKey) {
+        accessOrder.removeAll { $0 == key }
+        accessOrder.append(key)
+    }
+
+    private func cachedPage(for requestedKey: HwpThumbnailCacheKey) -> (HwpThumbnailCacheKey, HwpRenderedPage)? {
+        if let cached = cachedPages[requestedKey] {
+            return (requestedKey, cached)
+        }
+
+        var bestMatch: (HwpThumbnailCacheKey, HwpRenderedPage)?
+        var bestArea = Int.max
+
+        for (candidateKey, page) in cachedPages {
+            guard
+                candidateKey.path == requestedKey.path,
+                candidateKey.modificationTime == requestedKey.modificationTime,
+                candidateKey.fileSize == requestedKey.fileSize,
+                candidateKey.pixelWidth >= requestedKey.pixelWidth,
+                candidateKey.pixelHeight >= requestedKey.pixelHeight
+            else {
+                continue
+            }
+
+            let area = candidateKey.pixelWidth * candidateKey.pixelHeight
+            if area < bestArea {
+                bestArea = area
+                bestMatch = (candidateKey, page)
+            }
+        }
+
+        return bestMatch
+    }
+}

--- a/Sources/ThumbnailExtension/Info.plist
+++ b/Sources/ThumbnailExtension/Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>알한글 Thumbnail</string>
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
@@ -35,8 +35,6 @@
 				<string>com.haansoft.hancomofficeviewer.mac.hwp</string>
 				<string>com.haansoft.hancomofficeviewer.mac.hwpx</string>
 			</array>
-			<key>QLThumbnailMinimumDimension</key>
-			<integer>64</integer>
 		</dict>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.quicklook.thumbnail</string>

--- a/mydocs/orders/20260423.md
+++ b/mydocs/orders/20260423.md
@@ -12,6 +12,12 @@
 | #15 | `AGENTS.md` Codex 표기 정리 및 `mydocs/orders/20260423.md` 형식 표준화 | 완료 | 계획서/단계 보고/최종 보고 작성 완료, 문서 작업 `git diff --check` 검증 |
 | #17 | `AGENTS.md` Git 워크플로우를 `devel` 대상 PR 기반으로 개편하고 `README.md` 워크플로우 요약을 정합화 | 완료 | `publish/task` 규칙, draft PR 기본값, 커밋 메시지 규칙 반영 완료 |
 
+## M050 — Viewer 안정화
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #22 | 배포 준비를 위한 `rhwp` 코어 소싱/FFI 결합 구조 재구성 | 진행중 | 최종 보고서 작성 완료, 승인 대기 |
+
 ## 검증 메모
 
 - `cargo check --lib` (`Vendor/rhwp`)
@@ -19,5 +25,17 @@
 - `./scripts/check-no-appkit.sh`
 - `xcodegen generate`
 - `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Release -derivedDataPath build/DerivedDataReleaseSigned CODE_SIGN_IDENTITY=- CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES build`
+- `pluginkit -mvv -i com.postmelee.rhwpmac.ThumbnailExtension`
+- `qlmanage -t -x -s 512 -o /tmp /Users/melee/Documents/projects/rhwp-mac/Vendor/rhwp/samples/basic/KTX.hwp`
+- `qlmanage -t -x -s 16 -o /tmp /Users/melee/Downloads/(양식)진행요원 근무일지_소프트 졸업작품 전시회.hwp`
+- `qlmanage -t -x -s 32 -o /tmp /Users/melee/Downloads/(양식)진행요원 근무일지_소프트 졸업작품 전시회.hwp`
+- `qlmanage -t -x -s 64 -o /tmp /Users/melee/Downloads/(양식)진행요원 근무일지_소프트 졸업작품 전시회.hwp`
+- `pluginkit -a /Users/melee/Applications/RhwpMac.app`
+- `pluginkit -mAvvv -D -i com.postmelee.rhwpmac.ThumbnailExtension`
+- `time qlmanage -t -x -s 16 -o /tmp /Users/melee/Downloads/교양및전공이수에관한규정 [별표 1] 교양 및 최소 전공교과목 이수 현황(2025.02.06. 개정) (2).hwp`
+- `time qlmanage -t -x -s 16 -o /tmp /Users/melee/Downloads/(붙임) 2021년 예비창업패키지 일반·특화분야 연계지원 안내문(최종).hwp`
+- `time qlmanage -t -x -s 16 -o /tmp /Users/melee/Downloads/(양식)진행요원 근무일지_소프트 졸업작품 전시회.hwp`
+- `git diff --check -- Sources/RhwpCoreBridge/RhwpDocument.swift Sources/RhwpCoreBridge/CGTreeRenderer.swift Sources/Shared/HwpPageImageRenderer.swift Sources/ThumbnailExtension/HwpThumbnailProvider.swift Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
 - `./scripts/validate-stage3-render.sh`
 - 문서 작업은 `git diff --check`로 검증한다.

--- a/mydocs/plans/task_m050_22.md
+++ b/mydocs/plans/task_m050_22.md
@@ -1,0 +1,141 @@
+# Issue #22 수행 계획서
+
+## 목적
+
+배포 준비 관점에서 macOS 앱 저장소의 `rhwp` 코어 소싱 방식과 FFI 결합 구조를 재정리한다.
+
+- `RustBridge`가 `wasm_api::HwpDocument`에 기대는 현재 구조를 네이티브 전용 코어 레이어 중심으로 단순화한다.
+- Quick Look, Thumbnail, Viewer가 실제로 필요한 최소 FFI 표면을 다시 정의한다.
+- `Vendor/rhwp` 전체 submodule 노출로 생기는 저장소 소유 경계 문제를 정리하고, 즉시 적용안과 후속 전환안을 구분한다.
+- `hwpql`에서 배울 점은 흡수하되, 현재 프로젝트의 render tree + 네이티브 renderer 구조는 유지한다.
+
+## 배경
+
+현재 구조의 핵심 문제는 다음과 같다.
+
+1. 앱 저장소가 `Vendor/rhwp` submodule 전체를 worktree에 포함하고 있어 제품과 무관한 문서/브라우저 확장/studio 파일까지 함께 노출된다.
+2. `RustBridge`는 현재 `rhwp::wasm_api::HwpDocument`에 의존하고 있어 macOS 네이티브 브리지가 WASM 어댑터 위에 놓여 있다.
+3. 실제 제품 경로에서 쓰는 API는 소수인데, 아키텍처 문서와 빌드 산출물 provenance는 그 최소 범위를 충분히 드러내지 못한다.
+4. Thumbnail은 현재 첫 페이지 직접 렌더링만 사용한다. 내장 preview image를 활용하는 fast path는 아직 없다.
+5. Thumbnail extension의 `QLThumbnailMinimumDimension`이 `64`로 설정되어 있어 Finder의 작은 아이콘 크기 요청에서는 썸네일 provider가 호출되지 않고 일반 아이콘으로 내려간다.
+6. small-size 지원 후 Finder에서 줌 변경/스크롤 시 thumbnail 요청량이 증가하면서, 현재 `MainActor` 고정 + 요청당 파일 재읽기/재렌더 구조가 버벅임으로 드러난다.
+7. 후속 분석 결과 `.hwp` / `.hwpx`가 전혀 없는 `Desktop` 폴더에서도 `아이콘 보기 + 최근 사용일 그룹 + 2축 스크롤` 조합에서 같은 버벅임이 재현됐다. 따라서 체감 버벅임의 근본 원인은 앱 extension이 아니라 Finder 보기 모드 자체일 가능성이 높다.
+
+반면 유지해야 할 장점도 분명하다.
+
+- Viewer/Quick Look/Thumbnail이 공통 render tree 경로를 공유한다.
+- Swift 쪽에서 page 단위 제어, zoom, 다중 페이지 렌더링을 직접 소유한다.
+- `Rhwp.xcframework` 심볼 집합을 저장소가 관리하고 있다.
+
+## 범위
+
+### 포함
+
+- `RustBridge`의 의존 대상을 `wasm_api` 래퍼에서 네이티브 코어 레이어로 옮기는 작업
+- Thumbnail 전용 fast path 후보(`extract_thumbnail_only`)의 FFI 노출 여부 검토와 필요 시 도입
+- Thumbnail extension의 최소 요청 크기 정책 재조정
+- Thumbnail 요청 성능 최적화
+- Swift bridge / Shared / Extension 계층의 호출 경로 정리
+- 아키텍처 및 배포 문서에서 코어 provenance와 소유 경계 정리
+- Finder grouped icon view 버벅임의 원인 분리와 `Feedback Assistant` 제출 문서 정리
+
+### 제외
+
+- `Vendor/rhwp` submodule의 즉시 제거
+- `postmelee/rhwp` 저장소를 여러 crate로 물리 분할하는 작업
+- Quick Look을 HTML/WebView 기반으로 되돌리는 구조 변경
+- 실제 릴리스/공증/배포 실행
+
+## 목표 구조
+
+### 즉시 적용 목표
+
+- `RustBridge`는 `rhwp::DocumentCore` 또는 그와 동등한 네이티브 query 표면에 직접 의존한다.
+- Viewer용 API와 Thumbnail용 API를 FFI 레벨에서 분리해 역할을 명확히 한다.
+- Swift 계층은 `RhwpDocument` 중심 구조를 유지하되, 어떤 FFI가 어떤 제품 경로를 위한 것인지 문서화한다.
+
+### 중기 목표
+
+- 코어 provenance를 `rhwp-core.lock` + FFI 산출물 검증 정보로 더 명확히 남긴다.
+- 앱 저장소가 코어 전체 worktree를 직접 소유하지 않아도 되는 운영 방식으로 옮길 수 있는 기반을 마련한다.
+
+### 장기 목표
+
+- upstream `rhwp`를 `core` / `wasm adapter` / 제품별 어댑터로 더 분리할 수 있게 요구사항을 정리한다.
+
+## 설계 방향
+
+### 1. `hwpql`에서 바로 배울 점
+
+- 네이티브 FFI는 웹 어댑터를 통하지 않고 `DocumentCore`와 parser query에 직접 붙인다.
+- Thumbnail은 `extract_thumbnail_only` 같은 fast path를 별도 API로 둔다.
+- 코어 commit과 산출물 해시 provenance를 릴리스 전에 검증한다.
+- Thumbnail extension이 작은 Finder 아이콘 요청도 받도록 `QLThumbnailMinimumDimension` 정책을 재검토한다. 렌더러가 충분히 빠르면 키를 제거해 표준 리스트 크기까지 지원한다.
+- small-size 지원 이후에도 Finder 줌/스크롤이 버벅이지 않도록 thumbnail 계산을 메인 액터에서 분리하고 요청 간 재사용 경로를 둔다.
+
+### 2. 현재 프로젝트가 유지해야 할 점
+
+- Viewer와 Quick Look이 render tree + CoreGraphics/CoreText 경로를 공유하는 구조
+- 페이지 캐시, 다중 페이지, zoom 같은 네이티브 viewer 제어권
+- AppKit/UI 상태와 공통 bridge 계층의 소유 경계
+
+### 3. 권장 전환안
+
+권장 순서는 다음과 같다.
+
+1. `RustBridge` 의존을 `wasm_api::HwpDocument`에서 `DocumentCore` 중심으로 교체
+2. Thumbnail fast path를 별도 FFI로 노출하고 Swift에서 fallback 정책 정리
+3. 아키텍처 문서와 릴리스 문서에 즉시안/중기안/장기안을 분리해 기록
+4. submodule 유지 여부는 이번 작업에서 결론만 기록하고, 실제 전환은 후속 타스크로 분리
+
+## 예상 효과
+
+1. macOS 네이티브 브리지가 WASM 계층 변경에 덜 흔들린다.
+2. FFI 표면이 제품 요구사항 기준으로 더 설명 가능해진다.
+3. Thumbnail 경로에 성능 최적화 여지가 생긴다.
+4. 작은 Finder 아이콘 크기에서도 시스템이 일반 아이콘 대신 썸네일 provider를 사용할 수 있다.
+5. Finder 아이콘 보기에서 줌 변경과 스크롤 시 thumbnail 재생성 누적 비용을 줄일 수 있다.
+6. 향후 submodule 축소 또는 git-rev pin 전환 논의를 더 안전하게 진행할 수 있다.
+
+## 리스크
+
+1. `DocumentCore` 직접 의존 전환 시 현재 FFI가 호출하는 네이티브 helper 위치를 다시 확인해야 한다.
+2. Thumbnail fast path는 embedded preview가 없는 문서에서 fallback 품질 정책이 필요하다.
+3. 심볼 집합 변경 시 `rhwp-ffi-symbols.txt`와 xcframework 재생성이 함께 따라온다.
+4. `QLThumbnailMinimumDimension`을 제거해도 Finder가 모든 표시 모드에서 항상 썸네일을 쓰는 것은 아니다. 작은 아이콘 영역 일부는 운영체제 정책에 따른다.
+5. `MainActor` 제거와 cache 도입 시 Rust FFI / Core Graphics / Core Text 경로의 thread-safety를 다시 검토해야 한다.
+6. 이번 타스크에서 submodule 제거까지 욕심내면 범위가 과도하게 커진다.
+7. Finder grouped icon view 버벅임은 앱 바깥 원인일 수 있으므로, 우리 쪽 최적화와 Apple 피드백 제출을 구분해 기록해야 한다.
+
+## 산출물
+
+- `mydocs/orders/20260423.md`
+- `mydocs/plans/task_m050_22.md`
+- `mydocs/plans/task_m050_22_impl.md`
+- `mydocs/troubleshootings/finder_icon_view_recent_opened_scroll_feedback_assistant.md`
+- 승인 후 예상 코드 변경:
+  - `RustBridge/src/lib.rs`
+  - `Sources/RhwpCoreBridge/RhwpDocument.swift`
+  - `Sources/Shared/HwpPageImageRenderer.swift`
+  - `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+  - `Sources/ThumbnailExtension/Info.plist`
+  - 필요 시 thumbnail cache helper 신규 파일
+  - 관련 문서/검증 스크립트 일부
+
+## 검증 계획
+
+- 계획 문서 단계: `git diff --check -- mydocs/orders/20260423.md mydocs/plans/task_m050_22.md mydocs/plans/task_m050_22_impl.md`
+- 구현 단계 진입 후 최소 검증:
+  - `./scripts/build-rust-macos.sh`
+  - `./scripts/check-no-appkit.sh`
+  - `xcodegen generate`
+  - `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+  - `qlmanage -t -x -s 16 -o /tmp <sample-or-user-file.hwp>`
+  - `qlmanage -t -x -s 32 -o /tmp <sample-or-user-file.hwp>`
+  - `qlmanage -t -x -s 64 -o /tmp <sample-or-user-file.hwp>`
+  - `time qlmanage -t -x -s 16 -o /tmp <sample-or-user-file.hwp>`
+  - `./scripts/validate-stage3-render.sh`
+
+## 승인 요청 사항
+
+- 이 수행 계획서 기준으로 구현 계획서 확정 후 1단계 구현에 들어갈지 승인 요청

--- a/mydocs/plans/task_m050_22_impl.md
+++ b/mydocs/plans/task_m050_22_impl.md
@@ -1,0 +1,106 @@
+# Issue #22 구현 계획서
+
+## 구현 목표
+
+배포 준비에 필요한 최소 범위로 `rhwp` 코어 소싱/FFI 결합 구조를 정리한다.
+
+- macOS 네이티브 브리지가 `wasm_api` 래퍼 대신 네이티브 코어 query 레이어에 직접 의존하게 한다.
+- Thumbnail 경로에 embedded preview fast path를 도입할 수 있는 FFI 표면을 정리한다.
+- Swift 계층과 문서에서 제품별 API 책임을 더 명확히 보이게 한다.
+
+## 단계 계획
+
+### 1단계. `RustBridge` 네이티브 의존 정리
+
+- `RustBridge/src/lib.rs`에서 `rhwp::wasm_api::HwpDocument` 의존을 제거한다.
+- `DocumentCore` 또는 동등한 네이티브 query 표면으로 `open`, `page_count`, `page_size`, `render_page_tree`, `image_data`를 다시 연결한다.
+- 기존 FFI 심볼 집합이 유지되는지 우선 확인하고, 불가피한 변경만 최소화한다.
+
+### 2단계. Thumbnail fast path FFI 추가
+
+- `parser::extract_thumbnail_only`를 감싸는 네이티브 FFI 함수를 설계한다.
+- 반환 메모리 수명, 포맷 문자열, fallback 규칙을 명확히 한다.
+- 기존 첫 페이지 직접 렌더 경로와 충돌하지 않도록 Thumbnail 전용 표면으로 분리한다.
+
+### 3단계. Swift 호출 경로 반영
+
+- `RhwpDocument` 또는 Shared helper에서 새/기존 FFI 역할을 정리한다.
+- `ThumbnailExtension`은 embedded preview 우선, 실패 시 현재 첫 페이지 렌더 fallback으로 구성한다.
+- Viewer와 Quick Look은 render tree 기반 기본 경로를 유지한다.
+
+### 4단계. 작은 Finder 아이콘 크기 지원
+
+- `Sources/ThumbnailExtension/Info.plist`의 `QLThumbnailMinimumDimension` 정책을 재조정한다.
+- 렌더러가 충분히 빠르면 Apple 문서 권고에 따라 해당 키를 제거해 표준 리스트/작은 아이콘 요청까지 썸네일 provider가 호출되도록 한다.
+- `qlmanage`의 소형 요청 크기(`16`, `32`, `64`)와 Finder 아이콘 보기에서 회귀 여부를 확인한다.
+
+### 5단계. Thumbnail 성능 경로 최적화
+
+- `HwpThumbnailProvider`에서 불필요한 `MainActor` 고정을 제거하고, thumbnail 계산을 UI 격리와 분리한다.
+- `HwpPageImageRenderer`, `RhwpDocument`, `CGTreeRenderer`의 actor 격리를 재검토해 thumbnail 경로가 메인 액터를 점유하지 않도록 정리한다.
+- 같은 파일에 대한 연속 요청에서 재사용할 수 있도록 `fileURL + 수정시각 + 요청 크기 bucket` 기준 캐시 또는 in-flight dedupe를 도입한다.
+- render fallback은 가능한 한 요청 크기 중심으로 비용을 제한하고, embedded preview decode도 중복 계산을 줄인다.
+
+### 6단계. 문서와 provenance 정리
+
+- `mydocs/tech/project_architecture.md`에 새 결합 구조와 제품별 API 책임을 반영한다.
+- 필요 시 `mydocs/manual/release_distribution_guide.md` 또는 관련 문서에 코어 provenance/산출물 검증 포인트를 추가한다.
+- 즉시안과 후속안(submodule 유지, git rev pin 전환, upstream 분리)을 구분해 기록한다.
+- Finder grouped icon view 버벅임이 `.hwp`가 없는 폴더에서도 재현된 사실을 문서화하고, 앱 문제와 Finder 문제를 분리한다.
+- `Feedback Assistant` 제출 경로, 권장 첨부물, 복붙 가능한 본문을 `mydocs/troubleshootings/` 문서로 정리한다.
+
+### 7단계. 검증 및 보고 준비
+
+- Rust bridge 재생성, Swift 빌드, 렌더 smoke test를 수행한다.
+- 단계별 완료 보고서와 최종 보고서에 넣을 검증 결과를 정리한다.
+
+## 단계별 검증
+
+- 1단계 후:
+  - `./scripts/build-rust-macos.sh`
+  - 필요 시 `git diff --check -- RustBridge/src/lib.rs rhwp-ffi-symbols.txt`
+
+- 2단계 후:
+  - `./scripts/build-rust-macos.sh`
+  - 필요 시 `git diff --check -- RustBridge/src/lib.rs rhwp-ffi-symbols.txt Sources/RhwpCoreBridge/RhwpDocument.swift`
+
+- 3단계 후:
+  - `./scripts/check-no-appkit.sh`
+  - `xcodegen generate`
+  - `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+
+- 4단계 후:
+  - `xcodegen generate`
+  - `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+  - `qlmanage -t -x -s 16 -o /tmp <sample-or-user-file.hwp>`
+  - `qlmanage -t -x -s 32 -o /tmp <sample-or-user-file.hwp>`
+  - `qlmanage -t -x -s 64 -o /tmp <sample-or-user-file.hwp>`
+
+- 5단계 후:
+  - `xcodegen generate`
+  - `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+  - `qlmanage -t -x -s 16 -o /tmp <sample-or-user-file.hwp>`
+  - `qlmanage -t -x -s 32 -o /tmp <sample-or-user-file.hwp>`
+  - `qlmanage -t -x -s 64 -o /tmp <sample-or-user-file.hwp>`
+  - `/usr/bin/time -lp qlmanage -t -x -s 16 -o /tmp <sample-or-user-file.hwp>`
+
+- 6단계 후:
+  - `git diff --check -- mydocs/tech/project_architecture.md mydocs/manual/release_distribution_guide.md mydocs/troubleshootings/finder_icon_view_recent_opened_scroll_feedback_assistant.md`
+
+- 7단계 후:
+  - `./scripts/validate-stage3-render.sh`
+  - `git diff --check`
+
+## 보류 기준
+
+다음 조건 중 하나가 발생하면 즉시 다음 단계로 넘어가지 않고 보고 후 승인 대기한다.
+
+1. `DocumentCore` 직접 의존으로 전환하는 과정에서 upstream `rhwp` 변경이 선행되어야 하는 경우
+2. Thumbnail fast path 도입이 기존 품질 기준과 충돌하는 경우
+3. FFI 심볼 변경이 Viewer/Quick Look/Thumbnail 전체에 광범위한 수정 영향을 주는 경우
+4. 작은 아이콘 영역에서 Finder가 운영체제 정책상 일반 아이콘을 유지하는 범위가 남아 있는 경우
+5. thumbnail 경로의 actor 격리 제거가 HostApp/Preview 경로와 충돌하는 경우
+
+## 승인 요청 사항
+
+- 이 구현 계획서 보정본 기준으로 7단계 진행 승인 요청

--- a/mydocs/report/task_m050_22_report.md
+++ b/mydocs/report/task_m050_22_report.md
@@ -1,0 +1,177 @@
+# Issue #22 최종 보고서
+
+## 개요
+
+Issue #22는 배포 준비 관점에서 `rhwp` 코어 소싱/FFI 결합 구조를 정리하고, Finder thumbnail 동작과 관련된 실사용 이슈를 함께 정리하는 작업이다.
+
+이번 작업에서 실제로 달성한 목표는 다음과 같다.
+
+- macOS 네이티브 브리지가 `wasm_api` 어댑터가 아니라 `DocumentCore`에 직접 붙도록 정리했다.
+- Thumbnail 전용 embedded preview fast path를 FFI와 Swift bridge에 추가했다.
+- Finder thumbnail이 실제 설치본 기준으로 동작하도록 bundle path, 설치/등록 경로를 정리했다.
+- small-size thumbnail 제한을 제거해 `16pt` 같은 작은 요청도 extension이 직접 처리하도록 바꿨다.
+- thumbnail 경로의 `MainActor` 병목, 요청당 재계산, 중복 렌더 문제를 줄이기 위한 성능 최적화를 적용했다.
+- 후속 분석을 통해 Finder grouped icon view 버벅임의 근본 원인은 앱 extension이 아니라 Finder 보기 모드 자체일 가능성이 높다는 점을 문서화하고, `Feedback Assistant` 제출용 문서까지 정리했다.
+
+즉, 이번 타스크는 단순한 FFI 정리에서 끝나지 않고, 실제 배포/운영에 필요한 Finder 통합 문제와 원인 분리까지 포함한 안정화 작업으로 마무리됐다.
+
+## 주요 변경
+
+### 1. Rust FFI와 코어 결합 구조 정리
+
+- `RustBridge/src/lib.rs`에서 `rhwp::wasm_api::HwpDocument` 의존을 제거하고 `rhwp::DocumentCore` 직접 결합으로 전환했다.
+- 기존 C ABI 심볼 집합은 최대한 유지해 Swift 상위 계층의 충격을 줄였다.
+- 이 변경으로 macOS 앱 브리지가 WASM 래퍼 변경에 덜 종속되게 됐다.
+
+### 2. Thumbnail fast path 추가
+
+- `rhwp_extract_thumbnail`과 `rhwp_free_bytes`를 추가했다.
+- HWP/HWPX 내부 embedded preview를 전체 문서 렌더 없이 읽을 수 있는 thumbnail 전용 FFI 표면을 마련했다.
+- Swift 쪽에서는 `RhwpDocument.extractEmbeddedThumbnail(from:)`로 이 경로를 감싸 raw pointer 수명 규칙을 bridge 내부로 숨겼다.
+
+### 3. Swift thumbnail 호출 경로 정리
+
+- `Sources/Shared/HwpPageImageRenderer.swift`를 `embedded preview 우선 -> 실패 시 기존 render tree 첫 페이지 렌더 fallback` 정책으로 바꿨다.
+- large file에서도 embedded preview가 있으면 먼저 fast path를 타도록 조정했다.
+- Viewer와 Quick Look은 기존 render tree 중심 구조를 유지했다.
+
+### 4. 실제 Finder 동작을 위한 설치/등록 경로 정리
+
+- `project.yml`과 각 `Info.plist`를 조정해 실제 bundle path는 ASCII, 표시명은 한글로 분리했다.
+- `HostApp.entitlements`에 sandbox/read-only entitlement를 반영했다.
+- 설치본은 `~/Applications/RhwpMac.app`로 고정하고, build 산출물은 `.app.disabled`로 내려 LaunchServices/Quick Look이 중복 discovery하지 않도록 운영 규칙을 맞췄다.
+
+이 변경으로 `pluginkit`과 `qlmanage` 기준의 실제 Finder thumbnail 동작이 안정화됐다.
+
+### 5. small-size thumbnail 지원
+
+- `Sources/ThumbnailExtension/Info.plist`에서 `QLThumbnailMinimumDimension = 64`를 제거했다.
+- 그 결과 작은 아이콘 크기에서도 thumbnail extension이 직접 호출되도록 바뀌었다.
+- 사용자 제보 파일 3개 모두 `16pt` 요청에서 `produced one thumbnail`을 확인했다.
+
+### 6. thumbnail 성능 경로 최적화
+
+- `RhwpDocument`, `CGTreeRenderer`, `HwpPageImageRenderer`의 `@MainActor` 고정을 제거했다.
+- 요청 크기 기반 size-aware 렌더를 도입했다.
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`를 추가해 cache와 in-flight dedupe를 넣었다.
+- `HwpThumbnailProvider`는 더 이상 `Task { @MainActor in ... }`를 사용하지 않는다.
+
+이 변경으로 HWP가 많은 폴더에서 thumbnail 경로가 메인 액터를 직접 점유하고 같은 파일을 반복 렌더하던 구조적 병목은 제거됐다.
+
+### 7. Finder grouped icon view 문제 원인 분리와 Apple 제출 문서 정리
+
+- 후속 분석 결과 `.hwp` / `.hwpx`가 전혀 없는 `Desktop` 폴더에서도 `아이콘 보기 + 최근 사용일 그룹 + 2축 스크롤` 조합에서 같은 버벅임이 재현됐다.
+- 따라서 Finder 스크롤 버벅임의 근본 원인을 우리 HWP thumbnail extension으로 단정할 수 없음을 확인했다.
+- 이 문제를 Apple에 바로 제출할 수 있도록 아래 문서를 작성했다.
+  - `mydocs/troubleshootings/finder_icon_view_recent_opened_scroll_feedback_assistant.md`
+
+## 산출물
+
+- 코드/설정
+  - `RustBridge/src/lib.rs`
+  - `Sources/RhwpCoreBridge/RhwpDocument.swift`
+  - `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+  - `Sources/Shared/HwpPageImageRenderer.swift`
+  - `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+  - `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+  - `Sources/ThumbnailExtension/Info.plist`
+  - `Sources/HostApp/HostApp.entitlements`
+  - `Sources/HostApp/Info.plist`
+  - `Sources/QLExtension/Info.plist`
+  - `project.yml`
+  - `rhwp-ffi-symbols.txt`
+- 문서
+  - `mydocs/orders/20260423.md`
+  - `mydocs/plans/task_m050_22.md`
+  - `mydocs/plans/task_m050_22_impl.md`
+  - `mydocs/working/task_m050_22_stage1.md`
+  - `mydocs/working/task_m050_22_stage2.md`
+  - `mydocs/working/task_m050_22_stage3.md`
+  - `mydocs/working/task_m050_22_stage4.md`
+  - `mydocs/working/task_m050_22_stage5.md`
+  - `mydocs/working/task_m050_22_stage6.md`
+  - `mydocs/working/task_m050_22_stage7.md`
+  - `mydocs/troubleshootings/finder_icon_view_recent_opened_scroll_feedback_assistant.md`
+  - `mydocs/report/task_m050_22_report.md`
+
+## 검증 결과
+
+### 1. Rust/FFI 산출물 검증
+
+- `./scripts/build-rust-macos.sh`
+  - arm64/x86_64 staticlib 빌드 성공
+  - universal staticlib 생성 성공
+  - `cbindgen` header 및 `rhwp-ffi-symbols.txt` 비교 통과
+  - `Rhwp.xcframework` 재생성 성공
+
+### 2. Shared Swift bridge 경계 검증
+
+- `./scripts/check-no-appkit.sh`
+  - 결과: `OK: shared Swift code has no AppKit/UIKit dependencies`
+
+### 3. Xcode/앱 빌드 검증
+
+- `xcodegen generate`
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Release -derivedDataPath build/DerivedDataReleaseSigned CODE_SIGN_IDENTITY=- CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES build`
+
+### 4. Finder thumbnail 검증
+
+- `pluginkit -a /Users/melee/Applications/RhwpMac.app`
+- `pluginkit -mAvvv -D -i com.postmelee.rhwpmac.ThumbnailExtension`
+  - 활성 경로:
+    - `/Users/melee/Applications/RhwpMac.app/Contents/PlugIns/RhwpMacThumbnail.appex`
+- `qlmanage -r`
+- `qlmanage -r cache`
+- `qlmanage -t -x -s 512 -o /tmp Vendor/rhwp/samples/basic/KTX.hwp`
+  - 결과: `produced one thumbnail`
+- 사용자 제보 파일 3종에 대한 `16pt` thumbnail 검증
+  - 결과: 모두 `produced one thumbnail`
+- 대표 파일의 `32pt`, `64pt` 추가 검증
+  - 결과: 모두 `produced one thumbnail`
+
+### 5. render smoke test
+
+- `./scripts/validate-stage3-render.sh output/stage3-render-20260424`
+  - `KTX.hwp`: `page=1 size=1123x794 textRuns=435 hangulRuns=76 hangulScalars=209 nonWhitePixels=450455`
+  - `request.hwp`: `page=1 size=567x794 textRuns=104 hangulRuns=36 hangulScalars=309 nonWhitePixels=54724`
+  - `exam_kor.hwp`: `page=1 size=1123x1588 textRuns=69 hangulRuns=51 hangulScalars=940 nonWhitePixels=96464`
+
+### 6. 문서/패치 형식 검증
+
+- `git diff --check`
+  - 형식 오류 없음
+
+## 최종 판단
+
+이번 작업으로 정리된 결론은 다음과 같다.
+
+1. macOS 앱의 FFI 결합 구조는 더 이상 `wasm_api` 어댑터에 기대지 않고 `DocumentCore` 중심으로 정리됐다.
+2. Thumbnail은 embedded preview fast path와 render fallback을 함께 가지는 구조가 됐다.
+3. 작은 아이콘 크기에서 썸네일이 안 보이던 직접 원인은 `QLThumbnailMinimumDimension` 설정이었고, 이 제한은 제거됐다.
+4. HWP thumbnail 경로의 `MainActor` 병목과 반복 렌더 비용은 코드 수준에서 줄였다.
+5. 다만 Finder의 grouped icon view 버벅임은 `.hwp`가 없는 폴더에서도 재현되므로, 우리 앱 extension이 근본 원인이라고 볼 수 없다.
+
+즉, 이번 타스크는 앱 쪽에서 해결 가능한 문제와 Finder 자체 문제를 분리해 정리한 상태로 마무리된다.
+
+## 남은 리스크와 후속 권장 사항
+
+### 1. Finder grouped icon view 버벅임
+
+- 앱 최적화와 별개로 Finder 자체 문제가 남아 있다.
+- 이미 `Feedback Assistant` 제출용 문서를 준비했으므로, 실제 화면 녹화와 함께 Apple에 제출하는 것이 맞다.
+
+### 2. 검증 산출물 캐시 재사용 주의
+
+- `./scripts/validate-stage3-render.sh`를 기본 출력 경로 `output/stage3-render`로 반복 실행하면, 과거 다른 작업 디렉터리의 module cache가 남아 `SwiftShims` cache path mismatch가 재발할 수 있다.
+- 이는 제품 기능 회귀가 아니라 로컬 검증 산출물 재사용 문제이므로, 새 출력 경로를 주거나 캐시를 정리하는 식으로 운영하는 것이 안전하다.
+
+### 3. 문서/브랜치 후속 절차
+
+- 이 최종 보고서 승인 후에는 작업지시자 판단에 따라 stage 문서와 코드 변경을 커밋하고, 이후 `publish/task22` 생성 및 `devel` 대상 draft PR 절차로 넘어가면 된다.
+
+## 결론
+
+- `rhwp` 코어 결합 구조, thumbnail fast path, Finder 실제 thumbnail 동작, small-size 지원, thumbnail 성능 경로 최적화까지 배포 준비에 필요한 핵심 정리는 완료됐다.
+- 동시에 Finder 스크롤 버벅임은 우리 앱 문제와 Apple 플랫폼 문제를 구분해 설명 가능한 상태가 됐다.
+- 다음 액션은 `Feedback Assistant` 제출과 PR 준비다.

--- a/mydocs/troubleshootings/finder_icon_view_recent_opened_scroll_feedback_assistant.md
+++ b/mydocs/troubleshootings/finder_icon_view_recent_opened_scroll_feedback_assistant.md
@@ -1,0 +1,169 @@
+# Finder 최근 사용일 그룹 스크롤 버벅임 `Feedback Assistant` 제출 정리
+
+## 작성 목적
+
+2026년 4월 24일 기준으로 확인한 Finder 스크롤 버벅임 재현 조건과, Apple `Feedback Assistant`에 바로 제출할 수 있는 내용을 한 문서에 정리한다.
+
+이 문서는 다음 상황을 전제로 한다.
+
+- Finder `아이콘 보기`
+- `최근 사용일(Date Last Opened)` 기준 정렬 또는 그룹
+- `어제`, `이전 7일`, `더 이전 날짜` 같은 그룹 섹션이 생김
+- 세로 스크롤과 가로 스크롤이 동시에 가능한 2축 레이아웃
+
+## 현재 판단
+
+현재까지의 결론은 다음과 같다.
+
+1. 이 현상은 `.hwp` / `.hwpx`가 많은 폴더에서 더 눈에 띌 수는 있다.
+2. 하지만 `.hwp` / `.hwpx`가 전혀 없는 `Desktop` 폴더에서도 같은 보기 모드에서 같은 현상이 재현됐다.
+3. 우리 앱의 thumbnail extension은 `hwp` / `hwpx` UTI에만 등록되어 있으므로, HWP가 없는 폴더에서는 호출될 수 없다.
+4. 따라서 근본 원인은 우리 앱 extension이 아니라 Finder의 `아이콘 보기 + 최근 사용일 그룹 + 2축 스크롤` 조합일 가능성이 높다.
+
+즉, 이 문서의 목적은 앱 버그 신고가 아니라 macOS/Finder 동작 버그를 Apple에 전달하는 것이다.
+
+## 제출 경로
+
+가능하면 `Feedback Assistant`로 제출한다.
+
+- 앱: Spotlight에서 `Feedback Assistant` 실행
+- URL 스킴: `applefeedback://`
+- 웹: [feedbackassistant.apple.com](https://feedbackassistant.apple.com)
+- 안내 문서: [Apple Developer - Feedback Assistant](https://developer.apple.com/feedback-assistant/)
+
+`Feedback Assistant`를 쓸 수 없는 경우에는 일반 피드백 폼을 대안으로 쓸 수 있다.
+
+- [Apple Product Feedback - macOS](https://www.apple.com/feedback/macos/)
+
+단, 일반 피드백 폼보다 `Feedback Assistant`가 더 적합하다.
+
+- macOS 앱에서 제출하면 진단 정보 수집이 더 용이하다.
+- Apple이 후속 질문이나 추가 로그 요청을 같은 리포트에서 이어갈 수 있다.
+
+## 제출 전 준비물
+
+권장 첨부물은 아래와 같다.
+
+1. 문제 재현 화면 녹화 1개
+2. grouped icon layout이 보이는 Finder 스크린샷 1장 이상
+3. 문제가 잘 드러나는 폴더 경로 예시
+4. 가능하면 비교 자료
+   - 같은 폴더에서 다른 정렬 기준일 때는 정상이라는 영상
+   - `.hwp`가 없는 폴더에서도 재현된다는 영상
+
+가능하면 아래 정보도 같이 적는다.
+
+- macOS 버전과 build 번호
+- 사용 기기 모델
+- 트랙패드 또는 마우스 사용 여부
+- 외부 모니터 사용 여부
+
+## `Feedback Assistant` 입력 가이드
+
+권장 시작 토픽은 `macOS`이다.
+
+가능하면 영역은 Finder 또는 Files/Windowing 계열로 고른다. 정확한 세부 카테고리 이름은 시점에 따라 달라질 수 있으므로, `Finder`와 가장 가까운 항목을 고르면 된다.
+
+한 리포트에는 한 이슈만 적는다.
+
+- 이번 리포트의 범위:
+  - Finder grouped icon view에서의 스크롤 관성/정지 문제
+- 넣지 말아야 할 내용:
+  - HWP 썸네일 품질 개선
+  - Quick Look extension 구현 세부
+  - 우리 앱 아키텍처 변경 요청
+
+## 복붙용 제출 초안
+
+### 제목
+
+`Finder icon view grouped by Date Last Opened stops inertial scrolling in bidirectional layout`
+
+### 요약
+
+Finder에서 `아이콘 보기`를 사용하고 `Date Last Opened`로 그룹 또는 정렬하면, 세로/가로 스크롤이 모두 가능한 grouped icon layout에서 관성 스크롤이 자연스럽게 이어지지 않고 즉시 멈추는 현상이 발생한다. 경우에 따라 다음 클릭이나 추가 입력이 들어오면, 멈춰 있던 스크롤이 뒤늦게 다시 진행되는 것처럼 보인다.
+
+### 재현 절차
+
+1. Finder에서 항목 수가 충분히 많은 폴더를 연다.
+2. 보기 방식을 `아이콘 보기`로 바꾼다.
+3. `정렬` 또는 `그룹` 기준을 `Date Last Opened`로 맞춘다.
+4. `Yesterday`, `Previous 7 Days` 같은 그룹 섹션이 보이고, 세로/가로 스크롤이 모두 가능한 상태를 만든다.
+5. 트랙패드 또는 마우스로 빠르게 스크롤한다.
+
+### 실제 결과
+
+- 관성 스크롤이 자연스럽게 감속되지 않고 바로 멈춘다.
+- 경우에 따라 다음 클릭 또는 추가 입력이 들어오면, 멈춰 있던 스크롤이 뒤늦게 다시 진행되는 것처럼 보인다.
+- 같은 폴더라도 다른 보기/정렬 조합에서는 덜 두드러지거나 재현되지 않는다.
+
+### 기대 결과
+
+- grouped icon layout에서도 일반적인 Finder 관성 스크롤이 유지되어야 한다.
+- 추가 클릭 없이 스크롤 감속과 화면 갱신이 자연스럽게 이어져야 한다.
+
+### 추가 관찰
+
+- 이 문제는 특정 서드파티 Quick Look Thumbnail extension이 없어도 재현된다.
+- `.hwp` / `.hwpx` 파일이 전혀 없는 `Desktop` 폴더에서도 같은 보기 모드에서 동일 증상이 확인됐다.
+- 따라서 특정 문서 포맷 extension 하나의 문제라기보다, Finder의 `아이콘 보기 + Date Last Opened 그룹 + 2축 스크롤` 조합에서 발생하는 UI/스크롤 처리 문제로 보인다.
+
+### 영향
+
+- 많은 파일을 가진 폴더에서 탐색 경험이 눈에 띄게 저하된다.
+- 스크롤이 끊기고 입력 반응이 어색해 Finder가 잠깐 멈춘 것처럼 느껴진다.
+
+## 한국어 초안
+
+제목:
+
+`Finder 아이콘 보기에서 최근 사용일 그룹 정렬 시 2축 스크롤 관성이 끊기고 클릭 후 다시 진행됨`
+
+본문:
+
+Finder에서 `아이콘 보기`를 사용하고 `최근 사용일(Date Last Opened)`로 그룹 또는 정렬하면, 세로 스크롤과 가로 스크롤이 모두 가능한 grouped icon layout에서 스크롤 관성이 부드럽게 이어지지 않고 즉시 멈추는 현상이 발생합니다. 경우에 따라 다음 클릭이나 추가 입력이 들어오면, 멈춰 있던 스크롤이 뒤늦게 다시 진행되는 것처럼 보입니다.
+
+재현 절차는 다음과 같습니다.
+
+1. Finder에서 항목 수가 충분히 많은 폴더를 엽니다.
+2. 보기 방식을 `아이콘 보기`로 바꿉니다.
+3. `정렬` 또는 `그룹` 기준을 `최근 사용일(Date Last Opened)`로 설정합니다.
+4. `어제`, `이전 7일`, `더 이전 날짜` 같은 그룹 섹션이 보이고, 세로/가로 스크롤이 모두 가능한 상태를 만듭니다.
+5. 트랙패드 또는 마우스로 빠르게 스크롤합니다.
+
+실제 결과:
+
+- 관성 스크롤이 자연스럽게 감속되지 않고 바로 멈춥니다.
+- 경우에 따라 다음 클릭 또는 추가 입력이 들어오면, 멈춰 있던 스크롤이 뒤늦게 다시 진행되는 것처럼 보입니다.
+- 같은 폴더라도 다른 보기/정렬 조합에서는 덜 두드러지거나 재현되지 않습니다.
+
+기대 결과:
+
+- grouped icon layout에서도 일반적인 Finder 관성 스크롤이 유지되어야 합니다.
+- 추가 클릭 없이 스크롤 감속과 화면 갱신이 자연스럽게 이어져야 합니다.
+
+추가 관찰:
+
+- 이 문제는 특정 서드파티 Quick Look Thumbnail extension이 없어도 재현됩니다.
+- `.hwp` / `.hwpx` 파일이 전혀 없는 `Desktop` 폴더에서도 같은 보기 모드에서 동일 증상이 확인됐습니다.
+- 따라서 특정 문서 포맷 extension 하나의 문제라기보다, Finder의 `아이콘 보기 + 최근 사용일 그룹 + 2축 스크롤` 조합에서 발생하는 UI/스크롤 처리 문제로 보입니다.
+
+## 제출 후 처리
+
+리포트를 제출하면 `Feedback Assistant ID`가 발급된다. 이후 보완 자료는 같은 리포트에 이어서 넣는다.
+
+- 추가 정보: 화면 녹화, 스크린샷, 비교 영상
+- 추가 설명: 어떤 폴더에서 재현됐는지, 어떤 정렬/그룹에서만 재현되는지
+
+업데이트 방법 안내:
+
+- [Update or close submitted feedback in Feedback Assistant on Mac](https://support.apple.com/guide/feedback-assistant/update-or-close-submitted-feedback-fbacc24e7d22/mac)
+
+## 참고 링크
+
+- [Apple Developer - Feedback Assistant](https://developer.apple.com/feedback-assistant/)
+- [Feedback Assistant User Guide for Mac](https://support.apple.com/en-lamr/guide/feedback-assistant/welcome/mac)
+- [Create new feedback in Feedback Assistant on Mac](https://support.apple.com/en-lamr/guide/feedback-assistant/fbad45b5bb25/mac)
+- [Feedback - macOS - Apple](https://www.apple.com/feedback/macos/)
+- [Finder에서 항목 정렬 및 배치](https://support.apple.com/sr-rs/guide/mac-help/mchlp1745/mac)
+- [Finder에서 항목을 빠르게 보는 방법](https://support.apple.com/en-lamr/guide/mac-help/mh11493/mac)

--- a/mydocs/working/task_m050_22_stage1.md
+++ b/mydocs/working/task_m050_22_stage1.md
@@ -1,0 +1,49 @@
+# Issue #22 단계 1 완료 보고서
+
+## 작업 내용
+
+- `RustBridge/src/lib.rs`에서 `rhwp::wasm_api::HwpDocument` 의존을 제거했다.
+- FFI 핸들 내부 타입을 `DocumentCore`로 교체해 macOS 네이티브 브리지가 WASM 어댑터가 아니라 코어 레이어에 직접 붙도록 정리했다.
+- 기존 FFI 심볼 집합과 Swift 호출 표면은 유지한 채 내부 결합만 교체했다.
+
+## 변경 상세
+
+### 1. 브리지 의존 대상 교체
+
+- `use rhwp::wasm_api::HwpDocument;`를 `use rhwp::DocumentCore;`로 변경했다.
+- `RhwpHandle`의 `doc` 필드를 `DocumentCore`로 교체했다.
+- `rhwp_open`은 `HwpDocument::from_bytes` 대신 `DocumentCore::from_bytes`를 사용하도록 바꿨다.
+
+### 2. 유지한 사항
+
+- `rhwp_open`, `rhwp_page_count`, `rhwp_page_size`, `rhwp_render_page_svg`, `rhwp_render_page_tree`, `rhwp_image_data`, `rhwp_free_string`, `rhwp_close` 심볼 집합은 유지했다.
+- Swift 쪽 `RhwpDocument`와 extension/viewer 호출 경로는 이번 단계에서 수정하지 않았다.
+- render tree 기반 Viewer/Quick Look 구조도 그대로 유지했다.
+
+## 판단
+
+- `DocumentCore`는 현재 FFI가 필요로 하는 `from_bytes`, `page_count`, `get_page_info_native`, `build_page_render_tree`, `render_page_svg_native`, `get_bin_data`를 직접 제공하므로, 1단계 목표는 추가 설계 변경 없이 달성 가능했다.
+- 이 변경으로 네이티브 브리지가 `wasm_api` 레이어의 구조 변화에 덜 종속되게 되었다.
+
+## 검증
+
+- `rg -n "wasm_api::HwpDocument|HwpDocument::from_bytes" RustBridge/src/lib.rs`
+  - 결과 없음
+- `git diff --check -- RustBridge/src/lib.rs`
+- `./scripts/build-rust-macos.sh`
+  - arm64/x86_64 `RustBridge` 빌드 성공
+  - universal staticlib 생성 성공
+  - `cbindgen` header 및 `rhwp-ffi-symbols.txt` 비교 통과
+  - `Rhwp.xcframework` 재생성 성공
+
+참고:
+
+- `xcodebuild -create-xcframework` 실행 중 CoreSimulator 관련 경고 로그는 있었지만, xcframework 생성 자체는 정상 완료되었다.
+
+## 다음 단계
+
+- 2단계에서 Thumbnail 전용 fast path 후보인 `extract_thumbnail_only`를 감싸는 FFI를 설계하고, 현재 첫 페이지 직접 렌더 fallback과의 책임 경계를 정리한다.
+
+## 승인 요청 사항
+
+- 이 단계 완료 기준으로 2단계 진행 승인 요청

--- a/mydocs/working/task_m050_22_stage2.md
+++ b/mydocs/working/task_m050_22_stage2.md
@@ -1,0 +1,88 @@
+# Issue #22 단계 2 완료 보고서
+
+## 작업 내용
+
+- Thumbnail 전용 fast path 후보인 `extract_thumbnail_only`를 감싸는 Rust FFI를 `RustBridge`에 추가했다.
+- 새 FFI가 반환하는 이미지 바이트의 소유권을 해제할 수 있도록 `rhwp_free_bytes`를 함께 추가했다.
+- `rhwp-ffi-symbols.txt`를 갱신하고 `build-rust-macos.sh`로 심볼/헤더/xcframework 재생성을 검증했다.
+
+## 추가한 FFI 표면
+
+### 1. `rhwp_extract_thumbnail`
+
+입력:
+
+- 원본 파일 바이트 포인터와 길이
+
+출력:
+
+- `out_data`: heap-allocated 썸네일 바이트
+- `out_len`: 바이트 길이
+- `out_width`: 썸네일 너비
+- `out_height`: 썸네일 높이
+- `out_format`: `png` / `bmp` / `gif` / `unknown`
+
+반환:
+
+- 성공 시 `true`
+- 썸네일 없음 또는 입력 오류 시 `false`
+
+설계 의도:
+
+- Viewer/Quick Look용 문서 핸들 기반 FFI와 분리된, Thumbnail 전용 raw-bytes fast path를 제공한다.
+- `extract_thumbnail_only`는 전체 문서 open/paginate 없이 HWP/HWPX 컨테이너에서 preview 이미지만 읽으므로 Thumbnail 최적화에 적합하다.
+
+### 2. `rhwp_free_bytes`
+
+- `rhwp_extract_thumbnail`이 heap에 소유권을 넘긴 이미지 바이트를 해제하는 함수다.
+- 기존 `rhwp_free_string`과 역할을 맞춰, 문자열/바이트 해제 책임을 명확히 분리했다.
+
+## 유지한 사항
+
+- 기존 문서 핸들 기반 FFI (`rhwp_open`, `rhwp_page_count`, `rhwp_page_size`, `rhwp_render_page_svg`, `rhwp_render_page_tree`, `rhwp_image_data`, `rhwp_close`)는 그대로 유지했다.
+- Swift `ThumbnailExtension`은 이번 단계에서 아직 새 FFI를 사용하지 않는다.
+- 첫 페이지 직접 렌더 fallback 정책도 이번 단계에서는 변경하지 않았다.
+
+## 메모리/소유권 규칙
+
+1. `rhwp_extract_thumbnail` 성공 시:
+   - `out_data`는 호출자가 `rhwp_free_bytes(out_data, out_len)`로 해제해야 한다.
+   - `out_format`은 호출자가 `rhwp_free_string(out_format)`로 해제해야 한다.
+2. 실패 시:
+   - 출력 포인터와 길이/크기는 0 또는 null로 초기화된다.
+3. `rhwp_image_data`와 달리:
+   - 이번 fast path의 바이트는 문서 핸들 내부 버퍼가 아니라 별도 heap 소유 메모리다.
+
+## 판단
+
+- Stage 1에서 네이티브 브리지가 `DocumentCore`에 직접 붙도록 정리한 덕분에, Stage 2는 `parser::extract_thumbnail_only`를 별도 raw-bytes API로 추가하는 선에서 분리된 역할을 만들 수 있었다.
+- 이 설계로 다음 단계에서 `ThumbnailExtension`은 `embedded preview 우선 -> 실패 시 현재 첫 페이지 렌더 fallback` 정책을 구현할 수 있다.
+- Quick Look과 Viewer는 계속 render tree 기반 경로를 유지하고, Thumbnail만 별도 fast path를 가지게 된다.
+
+## 검증
+
+- `git diff --check -- RustBridge/src/lib.rs rhwp-ffi-symbols.txt`
+- `rg -n "rhwp_extract_thumbnail|rhwp_free_bytes" RustBridge/src/lib.rs rhwp-ffi-symbols.txt`
+- `./scripts/build-rust-macos.sh`
+  - arm64/x86_64 빌드 성공
+  - `rhwp-ffi-symbols.txt` 비교 통과
+  - 생성 헤더에 다음 시그니처 반영 확인
+    - `bool rhwp_extract_thumbnail(...)`
+    - `void rhwp_free_bytes(uint8_t *ptr, uintptr_t len);`
+  - `Rhwp.xcframework` 재생성 성공
+
+참고:
+
+- `xcodebuild -create-xcframework` 과정에서 CoreSimulator 관련 경고가 있었지만, 산출물 생성과 심볼 검증은 정상 완료되었다.
+
+## 다음 단계
+
+- 3단계에서 Swift 호출 경로를 반영한다.
+- 목표 정책:
+  - `ThumbnailExtension`: embedded preview 우선
+  - 실패 시 현재 `HwpPageImageRenderer.renderFirstPage` fallback
+  - Viewer/Quick Look: 현행 render tree 경로 유지
+
+## 승인 요청 사항
+
+- 이 단계 완료 기준으로 3단계 진행 승인 요청

--- a/mydocs/working/task_m050_22_stage3.md
+++ b/mydocs/working/task_m050_22_stage3.md
@@ -1,0 +1,96 @@
+# Issue #22 단계 3 완료 보고서
+
+## 작업 내용
+
+- `RhwpDocument`에 embedded preview fast path를 감싸는 Swift 호출 경로를 추가했다.
+- `HwpPageImageRenderer`를 `embedded preview 우선 -> 실패 시 기존 render tree 첫 페이지 렌더 fallback` 정책으로 정리했다.
+- 실제 Finder thumbnail 동작을 막던 macOS 등록 경로 문제를 함께 정리했다.
+
+## 코드 변경
+
+### 1. `RhwpDocument` FFI 역할 정리
+
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`에 `RhwpEmbeddedThumbnail` 구조체를 추가했다.
+- `RhwpDocument.extractEmbeddedThumbnail(from:)`를 추가해 `rhwp_extract_thumbnail` / `rhwp_free_bytes` / `rhwp_free_string` 호출과 메모리 해제를 Swift bridge 내부로 숨겼다.
+- 이로써 Swift 상위 계층은 raw pointer 수명 규칙을 직접 다루지 않고 `Data + width/height + format` 형태로 embedded preview를 받게 됐다.
+
+### 2. `HwpPageImageRenderer` fallback 정책 반영
+
+- `Sources/Shared/HwpPageImageRenderer.swift`에서 파일 데이터를 먼저 읽고 embedded preview decode를 시도하도록 바꿨다.
+- embedded preview decode 성공 시 해당 이미지를 그대로 thumbnail/preview 입력으로 사용한다.
+- embedded preview가 없거나 decode에 실패하면 기존 `RhwpDocument` + render tree + `CGTreeRenderer` 경로로 첫 페이지를 렌더한다.
+- `fileTooLarge` 제한은 render fallback 직전에만 적용되도록 옮겨, large file에서도 embedded preview가 있으면 fast path를 우선 사용할 수 있게 했다.
+
+### 3. 실제 Finder 동작을 위한 macOS 번들/서명 경로 정리
+
+- `Sources/HostApp/HostApp.entitlements`에 `com.apple.security.app-sandbox`, `com.apple.security.files.user-selected.read-only`를 추가했다.
+- `project.yml`의 `PRODUCT_NAME`을 ASCII 경로용 값으로 분리했다.
+  - `HostApp`: `RhwpMac`
+  - `QLExtension`: `RhwpMacPreview`
+  - `ThumbnailExtension`: `RhwpMacThumbnail`
+- 각 `Info.plist`의 `CFBundleDisplayName`은 기존 한글 표시명을 유지하고, `CFBundleName`도 명시 문자열로 고정했다.
+- 결과적으로 사용자 표시명은 유지하면서, 실제 `.app` / `.appex` 경로는 ASCII가 되어 LaunchServices / ExtensionKit / Finder 경로 해석 충돌을 피하게 했다.
+
+## 실제 원인 분석
+
+Finder에서 thumbnail이 안 뜨던 직접 원인은 두 가지였다.
+
+1. 초기 Debug/Release 산출물은 extension이 PlugInKit/ExtensionKit에 안정적으로 수용되지 않았다.
+2. 특히 한글 bundle path를 가진 `.app` / `.appex`가 LaunchServices database에서 안정적으로 해석되지 않아,
+   `com.apple.quicklook.ThumbnailsAgent`가 `not found in LS database`로 launch에 실패했다.
+
+추가로 build 산출물 경로와 설치본 경로가 같은 bundle ID로 동시에 discovery되면, Quick Look가 build path 인스턴스를 먼저 잡는 경우가 있어 실제 설치본이 아닌 경로를 launch하려는 현상도 확인했다.
+
+이번 단계에서는:
+
+- 설치본을 `~/Applications/RhwpMac.app`로 고정하고
+- build 산출물 `.app`는 `.app.disabled`로 바꿔 자동 discovery 후보에서 제외하고
+- `pluginkit -a /Users/melee/Applications/RhwpMac.app`로 설치본을 활성 인스턴스로 재등록하는 방식으로
+
+실제 Finder/qlmanage 경로를 안정화했다.
+
+## 검증
+
+### 정적/빌드 검증
+
+- `git diff --check -- Sources/RhwpCoreBridge/RhwpDocument.swift Sources/Shared/HwpPageImageRenderer.swift Sources/HostApp/HostApp.entitlements Sources/HostApp/Info.plist Sources/QLExtension/Info.plist Sources/ThumbnailExtension/Info.plist project.yml`
+- `./scripts/check-no-appkit.sh`
+- `xcodegen generate`
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Release -derivedDataPath build/DerivedDataReleaseSigned CODE_SIGN_IDENTITY=- CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES build`
+
+### 시스템 등록/실동작 검증
+
+- `pluginkit -mvv -i com.postmelee.rhwpmac.ThumbnailExtension`
+  - 활성 인스턴스:
+    - `/Users/melee/Applications/RhwpMac.app/Contents/PlugIns/RhwpMacThumbnail.appex`
+- `qlmanage -r`
+- `qlmanage -r cache`
+- `qlmanage -t -x -s 512 -o /tmp /Users/melee/Documents/projects/rhwp-mac/Vendor/rhwp/samples/basic/KTX.hwp`
+  - 결과:
+    - `produced one thumbnail`
+- Finder 실제 화면 확인
+  - `/tmp/rhwp-finder-check/KTX.hwp`와 `samples` 폴더의 HWP/HWPX 파일에서 기본 아이콘이 아니라 문서 썸네일이 표시되는 것을 확인했다.
+
+### 로그 검증
+
+- `log show`에서 `com.postmelee.rhwpmac.ThumbnailExtension` 프로세스가 `com.apple.quicklook.ThumbnailsAgent`에 의해 실제로 launch되는 것을 확인했다.
+- 최종 상태에서는 `xpcservice<com.postmelee.rhwpmac.ThumbnailExtension...>` 프로세스가 실행되고 completion까지 진행되는 로그를 확인했다.
+
+## 판단
+
+- Stage 2에서 추가한 FFI는 Stage 3에서 Swift bridge 내부로 안전하게 흡수됐다.
+- Thumbnail 경로는 이제 embedded preview fast path와 기존 render fallback을 함께 가진다.
+- 실제 배포/실사용 기준으로는 FFI 구조 개선만으로 충분하지 않았고, bundle path / sandbox / LaunchServices 등록까지 함께 맞춰야 Finder thumbnail이 동작함을 확인했다.
+
+## 다음 단계
+
+- 4단계에서 아키텍처/배포 문서에 이번 변경을 반영한다.
+- 특히 다음 항목을 문서화한다.
+  - `RhwpDocument`의 fast path / render path 책임 분리
+  - Finder/Quick Look 검증 시 설치본 경로와 build 산출물 경로를 함께 두지 않는 운영 규칙
+  - ASCII bundle path와 한글 표시명 분리 원칙
+
+## 승인 요청 사항
+
+- 이 단계 완료 기준으로 4단계(문서와 provenance 정리) 진행 승인 요청

--- a/mydocs/working/task_m050_22_stage4.md
+++ b/mydocs/working/task_m050_22_stage4.md
@@ -1,0 +1,94 @@
+# Issue #22 단계 4 완료 보고서
+
+## 작업 내용
+
+- `ThumbnailExtension`의 최소 요청 크기 제한을 제거했다.
+- 수정된 Release 설치본을 `~/Applications/RhwpMac.app`에 다시 배치하고 PlugInKit에 재등록했다.
+- 작은 요청 크기(`16`, `32`, `64`)에서 실제로 thumbnail provider가 동작하는지 사용자 파일 기준으로 다시 검증했다.
+
+## 코드 변경
+
+### 1. `QLThumbnailMinimumDimension` 제거
+
+- `Sources/ThumbnailExtension/Info.plist`에서 `NSExtensionAttributes.QLThumbnailMinimumDimension` 키를 제거했다.
+- 기존 값은 `64`였고, 이 값 때문에 Finder의 작은 아이콘 보기나 표준 리스트 크기 일부에서 thumbnail extension이 호출되지 않고 일반 아이콘으로 내려가고 있었다.
+- Apple 문서 권고에 맞춰, 현재 생성기가 충분히 빠른 전제에서 최소 크기 키를 생략하는 방향으로 정리했다.
+
+### 2. 설치본/빌드 산출물 재정리
+
+- `build/DerivedDataReleaseSigned/Build/Products/Release/RhwpMac.app`를 기반으로 `~/Applications/RhwpMac.app`를 다시 설치했다.
+- 기존 설치본은 `~/.Trash/RhwpMac.app.stage4-before-small-thumbnail-fix`로 백업 이동했다.
+- build 산출물 경로가 LaunchServices/Quick Look discovery에 다시 개입하지 않도록 다음 앱 번들은 `.app.disabled`로 바꿨다.
+  - `build/DerivedData/Build/Products/Debug/RhwpMac.app.disabled`
+  - `build/DerivedDataReleaseSigned/Build/Products/Release/RhwpMac.app.disabled`
+
+## 원인 정리
+
+small-size thumbnail 미노출의 직접 원인은 FFI나 렌더러가 아니라 thumbnail extension 설정이었다.
+
+- 기존 설정:
+  - `QLThumbnailMinimumDimension = 64`
+- 결과:
+  - `64pt`보다 작은 요청에서는 macOS가 우리 thumbnail provider를 호출하지 않고 일반 아이콘을 사용
+- 수정 후:
+  - extension 수준의 최소 크기 제한이 사라져 `16pt`, `32pt`, `64pt` 요청 모두 provider가 처리 가능해졌다.
+
+즉, 이번 문제는 "특정 파일이 렌더되지 않는다"가 아니라 "작은 요청 크기에서는 extension이 아예 호출되지 않는다"가 본질이었다.
+
+## 검증
+
+### 정적 검증
+
+- `git diff --check -- Sources/ThumbnailExtension/Info.plist`
+- `xcodegen generate`
+
+### 빌드 검증
+
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Release -derivedDataPath build/DerivedDataReleaseSigned CODE_SIGN_IDENTITY=- CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES build`
+
+### 설치/등록 검증
+
+- `pluginkit -a /Users/melee/Applications/RhwpMac.app`
+- `pluginkit -mAvvv -D -i com.postmelee.rhwpmac.ThumbnailExtension`
+  - 활성 경로:
+    - `/Users/melee/Applications/RhwpMac.app/Contents/PlugIns/RhwpMacThumbnail.appex`
+- 설치본 `Info.plist` 확인:
+  - `QLThumbnailMinimumDimension` 키가 더 이상 존재하지 않음
+
+### small-size thumbnail 검증
+
+- `qlmanage -r`
+- `qlmanage -r cache`
+- `qlmanage -t -x -s 16 -o /tmp /Users/melee/Downloads/교양및전공이수에관한규정 [별표 1] 교양 및 최소 전공교과목 이수 현황(2025.02.06. 개정) (2).hwp`
+  - 결과: `produced one thumbnail`
+- `qlmanage -t -x -s 16 -o /tmp /Users/melee/Downloads/(붙임) 2021년 예비창업패키지 일반·특화분야 연계지원 안내문(최종).hwp`
+  - 결과: `produced one thumbnail`
+- `qlmanage -t -x -s 16 -o /tmp /Users/melee/Downloads/(양식)진행요원 근무일지_소프트 졸업작품 전시회.hwp`
+  - 결과: `produced one thumbnail`
+- `qlmanage -t -x -s 32 -o /tmp /Users/melee/Downloads/(양식)진행요원 근무일지_소프트 졸업작품 전시회.hwp`
+  - 결과: `produced one thumbnail`
+- `qlmanage -t -x -s 64 -o /tmp /Users/melee/Downloads/(양식)진행요원 근무일지_소프트 졸업작품 전시회.hwp`
+  - 결과: `produced one thumbnail`
+
+## 판단
+
+- 우리 thumbnail extension은 이제 extension 설정 차원에서 모든 작은 요청 크기를 받을 수 있다.
+- 사용자 제보 파일 3개 모두 `16pt` 요청에서 썸네일 생성이 확인됐다.
+- 따라서 이번 수정으로 "특정 크기 이상에서만 보이던" 현상은 앱 설정 기준으로 해소됐다.
+
+남는 주의점은 있다.
+
+- Finder의 아주 일부 표시 모드나 운영체제 정책상 일반 아이콘이 선택되는 경우는 앱이 완전히 강제할 수 없다.
+- 다만 이번 단계에서 제거한 `64pt` 하한은 더 이상 우리 쪽 제한이 아니다.
+
+## 다음 단계
+
+- 5단계에서 아키텍처/배포 문서에 다음 내용을 반영한다.
+  - Thumbnail extension 최소 크기 정책 제거 이유
+  - 설치본과 build 산출물 중복 discovery 방지 규칙
+  - small-size thumbnail 검증 절차
+
+## 승인 요청 사항
+
+- 이 단계 완료 기준으로 5단계(문서와 provenance 정리) 진행 승인 요청

--- a/mydocs/working/task_m050_22_stage5.md
+++ b/mydocs/working/task_m050_22_stage5.md
@@ -1,0 +1,121 @@
+# Issue #22 단계 5 완료 보고서
+
+## 작업 내용
+
+- Finder thumbnail 경로의 `MainActor` 고정을 제거했다.
+- thumbnail 요청 크기에 맞춘 size-aware 렌더를 도입했다.
+- 같은 파일의 연속 thumbnail 요청에서 중복 렌더를 줄이기 위한 cache / in-flight dedupe를 추가했다.
+
+## 코드 변경
+
+### 1. thumbnail 렌더 경로의 actor 격리 제거
+
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`에서 `RhwpDocument`의 `@MainActor`를 제거했다.
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`에서 `CGTreeRenderer`의 `@MainActor`를 제거했다.
+- `Sources/Shared/HwpPageImageRenderer.swift`에서 `HwpPageImageRenderer`의 `@MainActor`를 제거했다.
+
+이 변경으로 thumbnail extension이 파일 읽기, embedded thumbnail decode, render tree fallback을 메인 액터에 직렬화하지 않고 수행할 수 있게 됐다.
+
+### 2. size-aware 렌더 도입
+
+- `Sources/Shared/HwpPageImageRenderer.swift`에 `renderFirstPage(fileURL:maximumPixelSize:)`를 추가했다.
+- embedded thumbnail 경로는 `CGImageSourceCreateThumbnailAtIndex`를 사용해 요청 크기 기준으로 downsample decode 하도록 정리했다.
+- render fallback 경로는 페이지 원본 크기 전체를 항상 그리던 기존 방식 대신, 요청 pixel size에 맞춰 bitmap context 크기와 렌더 scale을 계산해 그리도록 바꿨다.
+
+즉, `16pt` thumbnail을 위해 페이지 전체를 불필요하게 큰 비트맵으로 렌더하던 과잉 작업을 줄였다.
+
+### 3. thumbnail cache / in-flight dedupe 추가
+
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`를 추가했다.
+- cache key는 다음 기준을 사용한다.
+  - 파일 경로
+  - 수정 시각
+  - 파일 크기
+  - 요청 크기를 기반으로 계산한 pixel bucket
+- 동일 key에 대한 동시 요청은 하나의 렌더 작업으로 합치고, 완료 후 모든 대기 요청에 같은 결과를 전달한다.
+- 더 큰 pixel bucket으로 이미 만든 이미지가 있으면 더 작은 요청은 그 이미지를 재사용하도록 했다.
+
+### 4. Thumbnail provider 호출 경로 변경
+
+- `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`는 더 이상 `Task { @MainActor in ... }`를 사용하지 않는다.
+- provider는 `HwpThumbnailRenderRequest`를 만들고 `HwpThumbnailRenderCache`를 통해 background queue에서 렌더 결과를 받아 reply를 생성한다.
+
+## 원인 정리
+
+Finder 줌 변경/스크롤 버벅임의 핵심 원인은 thumbnail extension 경로였다.
+
+기존 구조는 다음 문제가 겹쳐 있었다.
+
+1. thumbnail 요청마다 `MainActor`에서 파일을 다시 읽고 렌더 경로를 다시 계산했다.
+2. thumbnail 요청 크기와 무관하게 첫 페이지를 원본 페이지 크기 기준으로 렌더했다.
+3. 같은 파일에 대한 연속 요청을 재사용하는 cache가 없었다.
+
+small-size thumbnail 지원을 위해 `QLThumbnailMinimumDimension`을 제거한 뒤에는 Finder가 더 작은 요청에서도 extension을 호출하기 시작했고, 이 구조적 비용이 체감 버벅임으로 더 잘 드러났다.
+
+## 검증
+
+### 정적 검증
+
+- `git diff --check -- Sources/RhwpCoreBridge/RhwpDocument.swift Sources/RhwpCoreBridge/CGTreeRenderer.swift Sources/Shared/HwpPageImageRenderer.swift Sources/ThumbnailExtension/HwpThumbnailProvider.swift Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+
+### 빌드 검증
+
+- `xcodegen generate`
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
+- `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Release -derivedDataPath build/DerivedDataReleaseSigned CODE_SIGN_IDENTITY=- CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES build`
+
+### 설치/등록 검증
+
+- `~/Applications/RhwpMac.app`를 새 Release 산출물로 교체
+- build 경로의 `.app`는 다시 `.app.disabled`로 변경
+- `pluginkit -a /Users/melee/Applications/RhwpMac.app`
+- `pluginkit -mAvvv -D -i com.postmelee.rhwpmac.ThumbnailExtension`
+  - 활성 경로:
+    - `/Users/melee/Applications/RhwpMac.app/Contents/PlugIns/RhwpMacThumbnail.appex`
+
+### 기능 검증
+
+- `qlmanage -r`
+- `qlmanage -r cache`
+- `qlmanage -t -x -s 16 -o /tmp /Users/melee/Downloads/교양및전공이수에관한규정 [별표 1] 교양 및 최소 전공교과목 이수 현황(2025.02.06. 개정) (2).hwp`
+  - 결과: `produced one thumbnail`
+- `qlmanage -t -x -s 16 -o /tmp /Users/melee/Downloads/(양식)진행요원 근무일지_소프트 졸업작품 전시회.hwp`
+  - 결과: `produced one thumbnail`
+
+### 시간 측정 참고
+
+- `/usr/bin/time -lp qlmanage -t -x -s 16 -o /tmp ...`
+  - 첫 번째 대표 파일: `real 0.29`
+  - 두 번째 대표 파일: `real 0.75`
+
+이 수치는 참고만 가능하다.
+
+- `qlmanage` 단일 실행 시간에는 quicklookd / extension 프로세스 기동, LaunchServices, 시스템 캐시 상태가 함께 섞인다.
+- 따라서 이 값만으로 Finder 스크롤 체감이 얼마나 좋아졌는지 단정하기는 어렵다.
+
+이번 단계의 핵심은 micro-benchmark 결과보다, 기존에 확인된 구조적 병목(`MainActor` 고정, 요청당 재계산, cache 부재)을 코드에서 제거했다는 점이다.
+
+## 판단
+
+- thumbnail 경로는 이제 메인 액터를 직접 점유하지 않는다.
+- small-size 요청은 요청 크기에 맞춰 더 작은 비트맵으로 처리한다.
+- 같은 파일의 반복 요청은 cache와 in-flight dedupe로 중복 작업을 줄인다.
+
+즉, Finder zoom/scroll 버벅임에 대해 코드 수준에서 가장 직접적인 병목은 제거한 상태다.
+
+남는 항목은 있다.
+
+- 실제 Finder 체감 개선 폭은 폴더 구성, 파일 개수, 시스템 캐시 상태에 따라 달라질 수 있다.
+- 더 정밀한 확인이 필요하면 Finder 실제 UI에서 large file set을 대상으로 시각 검증하거나, thumbnail extension에 telemetry를 추가해 cache hit / miss를 직접 기록해야 한다.
+
+## 다음 단계
+
+- 6단계에서 아키텍처/배포 문서에 다음 내용을 반영한다.
+  - thumbnail 경로의 actor 격리 변경
+  - small-size 지원 이후의 성능 최적화 구조
+  - cache / in-flight dedupe 정책
+  - Finder/qlmanage 성능 검증 시 해석 주의점
+
+## 승인 요청 사항
+
+- 이 단계 완료 기준으로 6단계(문서와 provenance 정리) 진행 승인 요청

--- a/mydocs/working/task_m050_22_stage6.md
+++ b/mydocs/working/task_m050_22_stage6.md
@@ -1,0 +1,58 @@
+# Issue #22 단계 6 완료 보고서
+
+## 작업 내용
+
+- Finder grouped icon view 버벅임을 앱 문제와 Finder 문제로 분리해 문서화했다.
+- `Feedback Assistant`에 바로 제출할 수 있도록 제출 경로, 권장 첨부물, 복붙용 본문을 정리한 문서를 추가했다.
+- 기존 계획서와 오늘할일 문서에 이번 분석 범위를 반영했다.
+
+## 문서 변경
+
+### 1. 수행 계획서/구현 계획서 보정
+
+- `mydocs/plans/task_m050_22.md`
+  - `.hwp`가 없는 `Desktop`에서도 같은 현상이 재현된 사실을 배경과 리스크에 반영했다.
+  - stage 6 산출물에 `Feedback Assistant` 제출 문서를 추가했다.
+- `mydocs/plans/task_m050_22_impl.md`
+  - 6단계에 Finder grouped icon view 버벅임의 원인 분리와 `Feedback Assistant` 제출 문서 정리를 추가했다.
+  - 6단계 문서 검증 대상에 새 troubleshooting 문서를 포함했다.
+
+### 2. 오늘할일 갱신
+
+- `mydocs/orders/20260423.md`
+  - `#22`의 현재 진행 메모를 Finder grouped icon view 분석과 `Feedback Assistant` 제출 문서 정리 기준으로 갱신했다.
+
+### 3. troubleshooting 문서 추가
+
+- `mydocs/troubleshootings/finder_icon_view_recent_opened_scroll_feedback_assistant.md`
+  - 현재까지의 판단을 한 문서로 정리했다.
+  - `Feedback Assistant` 제출 경로를 명시했다.
+  - 권장 첨부물과 입력 가이드를 넣었다.
+  - 영어/한국어 복붙 초안을 함께 넣었다.
+  - 제출 후 같은 report를 업데이트하는 링크도 포함했다.
+
+## 판단 정리
+
+현재까지의 가장 중요한 결론은 다음과 같다.
+
+1. HWP thumbnail extension은 HWP가 많은 폴더에서 부하를 일부 더할 수는 있다.
+2. 하지만 `.hwp` / `.hwpx`가 없는 `Desktop` 폴더에서도 같은 현상이 재현됐다.
+3. 따라서 Finder grouped icon view 버벅임의 근본 원인을 우리 앱 extension으로 단정할 수 없다.
+4. Apple에 전달해야 하는 문제 정의는 `Finder 아이콘 보기 + 최근 사용일 그룹 + 2축 스크롤` 조합의 UI/scroll 문제다.
+
+즉, stage 5의 thumbnail 경로 최적화는 HWP 폴더에서의 기여도를 줄이는 조치로는 의미가 있지만, 이번 Finder 보기 모드 문제를 단독으로 해결하는 수정은 아니다.
+
+## 검증
+
+### 문서 검증
+
+- `git diff --check -- mydocs/orders/20260423.md mydocs/plans/task_m050_22.md mydocs/plans/task_m050_22_impl.md mydocs/troubleshootings/finder_icon_view_recent_opened_scroll_feedback_assistant.md mydocs/working/task_m050_22_stage6.md`
+
+## 다음 단계
+
+- 7단계에서 최종 보고 또는 후속 정리 범위를 확정한다.
+- 필요하면 `Feedback Assistant` 제출 후 발급된 ID와 후속 보완 내역을 별도 문서에 추적한다.
+
+## 승인 요청 사항
+
+- 이 단계 완료 기준으로 7단계 진행 승인 요청

--- a/mydocs/working/task_m050_22_stage7.md
+++ b/mydocs/working/task_m050_22_stage7.md
@@ -1,0 +1,102 @@
+# Issue #22 단계 7 완료 보고서
+
+## 작업 내용
+
+- 최종 보고 전 필요한 검증 항목을 다시 실행해 결과를 정리했다.
+- stage 6까지 반영된 문서와 코드 변경이 현재 워크스페이스 기준으로 정합한지 확인했다.
+- 최종 보고서에 넣을 검증 결과와 주의사항을 정리했다.
+
+## 검증 결과
+
+### 1. render smoke test
+
+실행 명령:
+
+- `./scripts/validate-stage3-render.sh output/stage3-render-20260424`
+
+결과:
+
+- `KTX.hwp`
+  - `page=1`
+  - `size=1123x794`
+  - `textRuns=435`
+  - `hangulRuns=76`
+  - `hangulScalars=209`
+  - `nonWhitePixels=450455`
+- `request.hwp`
+  - `page=1`
+  - `size=567x794`
+  - `textRuns=104`
+  - `hangulRuns=36`
+  - `hangulScalars=309`
+  - `nonWhitePixels=54724`
+- `exam_kor.hwp`
+  - `page=1`
+  - `size=1123x1588`
+  - `textRuns=69`
+  - `hangulRuns=51`
+  - `hangulScalars=940`
+  - `nonWhitePixels=96464`
+
+출력 PNG는 아래 경로에 생성됐다.
+
+- `output/stage3-render-20260424/KTX-page1.png`
+- `output/stage3-render-20260424/request-page1.png`
+- `output/stage3-render-20260424/exam_kor-page1.png`
+
+### 2. Shared Swift bridge 경계 검사
+
+실행 명령:
+
+- `./scripts/check-no-appkit.sh`
+
+결과:
+
+- `OK: shared Swift code has no AppKit/UIKit dependencies`
+
+즉, `Sources/RhwpCoreBridge`가 여전히 AppKit/UIKit 직접 의존 없이 유지되고 있음을 확인했다.
+
+### 3. 문서/패치 형식 검사
+
+실행 명령:
+
+- `git diff --check`
+
+결과:
+
+- 형식 오류 없음
+
+## 검증 중 확인한 주의사항
+
+초기에 기본 출력 경로로 `./scripts/validate-stage3-render.sh`를 실행했을 때, 과거 다른 작업 디렉터리 경로를 포함한 Swift/Clang module cache 때문에 아래 오류가 발생했다.
+
+- `SwiftShims` precompiled module cache path mismatch
+- `missing required module 'SwiftShims'`
+
+이 문제는 현재 코드 문제가 아니라 이전 출력 디렉터리 `output/stage3-render` 재사용으로 생긴 환경성 이슈였다.
+
+이번 단계에서는 새 출력 경로 `output/stage3-render-20260424`를 사용해 같은 smoke test를 재실행했고, 정상 통과를 확인했다.
+
+따라서 최종 보고에는 다음 해석을 함께 남겨야 한다.
+
+1. 렌더 smoke test 자체는 통과했다.
+2. 기본 출력 디렉터리를 계속 재사용할 경우 로컬 환경에 따라 module cache path mismatch가 재발할 수 있다.
+3. 이 문제는 제품 기능 회귀와는 별개로, 검증 산출물 캐시 재사용 정책 차원의 주의사항이다.
+
+## 판단
+
+이 단계 기준으로 확인된 내용은 다음과 같다.
+
+1. Rust bridge + Swift render 경로는 샘플 문서 3종에서 여전히 정상 동작한다.
+2. `RhwpCoreBridge` 계층은 AppKit/UIKit 직접 의존 없이 유지된다.
+3. 문서와 코드 패치 형식에도 현재 깨진 부분이 없다.
+4. stage 1부터 stage 6까지의 변경은 최종 보고 단계로 넘어갈 수 있는 상태다.
+
+## 다음 단계
+
+- `mydocs/report/task_m050_22_report.md` 최종 결과 보고서 작성
+- 필요 시 검증 주의사항으로 `validate-stage3-render` 캐시 재사용 문제를 함께 기록
+
+## 승인 요청 사항
+
+- 이 단계 완료 기준으로 최종 결과 보고서 작성 진행 승인 요청

--- a/project.yml
+++ b/project.yml
@@ -25,7 +25,8 @@ targets:
         embed: false
     settings:
       base:
-        PRODUCT_NAME: 알한글
+        PRODUCT_NAME: RhwpMac
+        EXECUTABLE_NAME: RhwpMacHost
         PRODUCT_BUNDLE_IDENTIFIER: com.postmelee.rhwpmac
         INFOPLIST_FILE: Sources/HostApp/Info.plist
         CODE_SIGN_ENTITLEMENTS: Sources/HostApp/HostApp.entitlements
@@ -44,7 +45,8 @@ targets:
         embed: false
     settings:
       base:
-        PRODUCT_NAME: 알한글 Preview
+        PRODUCT_NAME: RhwpMacPreview
+        EXECUTABLE_NAME: RhwpMacPreview
         PRODUCT_BUNDLE_IDENTIFIER: com.postmelee.rhwpmac.QLExtension
         INFOPLIST_FILE: Sources/QLExtension/Info.plist
         CODE_SIGN_ENTITLEMENTS: Sources/QLExtension/QLExtension.entitlements
@@ -62,7 +64,8 @@ targets:
         embed: false
     settings:
       base:
-        PRODUCT_NAME: 알한글 Thumbnail
+        PRODUCT_NAME: RhwpMacThumbnail
+        EXECUTABLE_NAME: RhwpMacThumbnail
         PRODUCT_BUNDLE_IDENTIFIER: com.postmelee.rhwpmac.ThumbnailExtension
         INFOPLIST_FILE: Sources/ThumbnailExtension/Info.plist
         CODE_SIGN_ENTITLEMENTS: Sources/ThumbnailExtension/ThumbnailExtension.entitlements

--- a/rhwp-ffi-symbols.txt
+++ b/rhwp-ffi-symbols.txt
@@ -1,4 +1,6 @@
 rhwp_close
+rhwp_extract_thumbnail
+rhwp_free_bytes
 rhwp_free_string
 rhwp_image_data
 rhwp_open


### PR DESCRIPTION
## 요약
- RustBridge를 wasm_api에서 DocumentCore 직접 결합으로 전환
- embedded preview fast path와 small-size thumbnail 지원 추가
- thumbnail 경로 MainActor 제거, size-aware render, cache/in-flight dedupe 적용
- Finder grouped icon view 버벅임을 Finder 자체 문제와 앱 문제로 분리하고 Feedback Assistant 제출 문서 추가

## 검증
- ./scripts/build-rust-macos.sh
- ./scripts/check-no-appkit.sh
- xcodegen generate
- xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Release -derivedDataPath build/DerivedDataReleaseSigned CODE_SIGN_IDENTITY=- CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES build
- qlmanage -t -x -s 512 -o /tmp Vendor/rhwp/samples/basic/KTX.hwp
- qlmanage -t -x -s 16/32/64 -o /tmp 사용자 제보 HWP 파일
- ./scripts/validate-stage3-render.sh output/stage3-render-20260424
- git diff --check

## 문서
- 최종 보고서: [task_m050_22_report.md](https://github.com/postmelee/alhangeul-macos/blob/d5bd5083abc9f04d73e95b152d6ce055c081b4c4/mydocs/report/task_m050_22_report.md)
- Finder Feedback Assistant 제출 문서: [finder_icon_view_recent_opened_scroll_feedback_assistant.md](https://github.com/postmelee/alhangeul-macos/blob/d5bd5083abc9f04d73e95b152d6ce055c081b4c4/mydocs/troubleshootings/finder_icon_view_recent_opened_scroll_feedback_assistant.md)
