### PR TITLE
Task #26: Thumbnail embedded preview quality gate

### DIFF
--- a/Sources/Shared/HwpPageImageRenderer.swift
+++ b/Sources/Shared/HwpPageImageRenderer.swift
@@ -129,12 +129,34 @@ enum HwpPageImageRenderer {
             return nil
         }
 
+        guard shouldUseEmbeddedThumbnail(imageSize: CGSize(width: image.width, height: image.height), maximumPixelSize: maximumPixelSize) else {
+            return nil
+        }
+
         let width = thumbnail.width > 0 ? thumbnail.width : image.width
         let height = thumbnail.height > 0 ? thumbnail.height : image.height
         return HwpRenderedPage(
             image: image,
             size: CGSize(width: width, height: height)
         )
+    }
+
+    private static func shouldUseEmbeddedThumbnail(imageSize: CGSize, maximumPixelSize: CGSize?) -> Bool {
+        guard let maximumPixelSize else {
+            return true
+        }
+
+        let requestedMaxDimension = max(maximumPixelSize.width, maximumPixelSize.height)
+        let embeddedMaxDimension = max(imageSize.width, imageSize.height)
+        guard requestedMaxDimension > 0, embeddedMaxDimension > 0 else {
+            return true
+        }
+
+        if requestedMaxDimension <= 128 {
+            return true
+        }
+
+        return embeddedMaxDimension >= requestedMaxDimension * 0.75
     }
 
     private static func renderScale(pageSize: CGSize, maximumPixelSize: CGSize?) -> CGFloat {

--- a/mydocs/orders/20260425.md
+++ b/mydocs/orders/20260425.md
@@ -15,4 +15,6 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
+| #26 | Finder thumbnail 저해상도 embedded preview 회귀 수정 | 완료 | Issue #22/PR #23 thumbnail fast path 품질 게이트 보완, 완료: 02:21 |
+| #35 | Quick Look/Thumbnail 공통 group drawing 저해상도 렌더링 수정 | 예정 | #26에서 근본 원인 분리 |
 | 생성필요 | Viewer 리팩토링 및 디버그 항목 제거 | 예정 | HostApp viewer 구조와 디버그 노출 항목 정리 |

--- a/mydocs/plans/task_m050_26.md
+++ b/mydocs/plans/task_m050_26.md
@@ -1,0 +1,76 @@
+# Issue #26 수행 계획서
+
+## 목적
+
+Finder Thumbnail extension에서 특정 HWP 파일의 썸네일이 큰 미리보기 영역에서 매우 낮은 해상도로 표시되는 회귀를 조사하고, embedded preview fast path에 품질 게이트를 추가한다.
+
+Issue #22 / PR #23에서 Thumbnail 경로가 embedded preview를 우선 사용하도록 최적화됐다. 이 최적화는 성능상 유효하지만, 문서 내부 preview 이미지가 요청 크기에 비해 지나치게 작으면 큰 Finder 썸네일 영역에서 확대되어 흐리게 보일 수 있다.
+
+## 배경
+
+초기 조사 결과는 다음과 같다.
+
+| 파일 | embedded preview | 현상 |
+|------|------------------|------|
+| `group-drawing-02.hwp` | `177x250` GIF | 큰 Finder 썸네일에서 저해상도처럼 보임 |
+| `pic-in-head-02.hwp` | `724x1024` PNG | 비교적 정상 표시 |
+
+`group-drawing-02.hwp`는 full render 경로로 `794x1123` 수준의 이미지를 만들 수 있다. 따라서 embedded preview가 너무 작은 경우에는 full render fallback을 선택해야 한다.
+
+## 범위
+
+### 포함
+
+- embedded preview 실제 픽셀 크기와 요청 픽셀 크기 비교
+- 작은 Finder icon 요청에서는 기존 fast path 유지
+- 큰 Finder preview 요청에서는 저해상도 embedded preview 대신 full render fallback 사용
+- 재현 샘플 기반 검증
+- 단계 보고서와 최종 보고서 작성
+
+### 제외
+
+- `Vendor/rhwp` core submodule 변경
+- Rust FFI 심볼 추가/변경
+- Quick Look discovery 실패 문제
+- group drawing 자체의 렌더링 품질 개선
+- 릴리스/배포/공증 작업
+
+## 설계 방향
+
+`Sources/Shared/HwpPageImageRenderer.swift`의 `decodeEmbeddedThumbnail(from:maximumPixelSize:)` 내부에서 embedded preview 사용 가능 여부를 판단한다.
+
+- `maximumPixelSize`가 없으면 기존 동작을 유지한다.
+- 요청 긴 변이 충분히 작으면 embedded preview를 그대로 사용한다.
+- 요청 긴 변이 크고 embedded preview가 요청 크기 대비 작으면 `nil`을 반환해 full render fallback으로 전환한다.
+
+## 리스크
+
+1. 품질 기준을 너무 엄격하게 잡으면 full render 비용이 과도하게 늘 수 있다.
+2. 품질 기준을 너무 느슨하게 잡으면 저해상도 preview 확대 문제가 남을 수 있다.
+3. 특정 파일의 실제 근본 원인이 embedded preview가 아니라 full render 내부 품질 문제일 수 있다.
+
+## 산출물
+
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `mydocs/orders/20260425.md`
+- `mydocs/plans/task_m050_26.md`
+- `mydocs/plans/task_m050_26_impl.md`
+- `mydocs/working/task_m050_26_stage1.md`
+- `mydocs/report/task_m050_26_report.md`
+
+## 검증 계획
+
+```bash
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build
+qlmanage -r cache
+qlmanage -t -x -s 512 -o /tmp/rhwp-task26-ql-512 /Users/melee/Documents/samples/group-drawing-02.hwp
+qlmanage -t -x -s 512 -o /tmp/rhwp-task26-ql-512 /Users/melee/Documents/samples/pic-in-head-02.hwp
+qlmanage -t -x -s 64 -o /tmp/rhwp-task26-ql-64 /Users/melee/Documents/samples/group-drawing-02.hwp
+git diff --check
+```
+
+## 승인 요청 사항
+
+이 수행 계획서 기준으로 구현 계획서 작성과 1단계 구현을 진행할지 승인 요청한다.

--- a/mydocs/plans/task_m050_26_impl.md
+++ b/mydocs/plans/task_m050_26_impl.md
@@ -1,0 +1,64 @@
+# Issue #26 구현 계획서
+
+## 구현 목표
+
+Thumbnail embedded preview fast path의 성능 이점은 유지하면서, 요청 크기에 비해 지나치게 작은 embedded preview가 큰 Finder thumbnail에 확대 표시되는 회귀를 막는다.
+
+## 단계 계획
+
+### 1단계. embedded preview 품질 게이트 구현
+
+- `decodeEmbeddedThumbnail(from:maximumPixelSize:)`에서 실제 디코딩 이미지 크기를 확인한다.
+- `maximumPixelSize`가 없으면 기존 동작을 유지한다.
+- 요청 긴 변이 `128px` 이하인 작은 요청은 embedded preview를 계속 허용한다.
+- 큰 요청에서는 embedded preview 긴 변이 요청 긴 변의 `75%` 이상일 때만 fast path를 사용한다.
+- 기준에 못 미치면 full render fallback으로 전환한다.
+
+### 2단계. 분기 확인
+
+- 임시 probe로 `group-drawing-02.hwp`와 `pic-in-head-02.hwp`의 64px/512px 요청 결과를 확인한다.
+- `group-drawing-02.hwp`는 512px 요청에서 full render fallback으로 전환되는지 확인한다.
+- `pic-in-head-02.hwp`는 512px 요청에서도 충분한 embedded preview fast path가 유지되는지 확인한다.
+
+### 3단계. 빌드와 Finder thumbnail 검증
+
+- Shared bridge 경계를 검사한다.
+- Xcode project를 재생성한다.
+- HostApp Debug build로 Thumbnail extension 빌드 포함 여부를 확인한다.
+- `qlmanage`로 재현 샘플과 비교 샘플의 thumbnail 생성을 확인한다.
+
+### 4단계. 보고서 정리
+
+- 단계 완료 보고서와 최종 보고서를 작성한다.
+- Finder 직접 확인에서 드러난 full render 공통 품질 문제는 별도 이슈로 분리한다.
+
+## 예상 변경 파일
+
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `mydocs/orders/20260425.md`
+- `mydocs/working/task_m050_26_stage1.md`
+- `mydocs/report/task_m050_26_report.md`
+
+## 단계별 검증
+
+```bash
+git diff --check -- Sources/Shared/HwpPageImageRenderer.swift
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build
+qlmanage -r cache
+qlmanage -t -x -s 512 -o /tmp/rhwp-task26-ql-512 /Users/melee/Documents/samples/group-drawing-02.hwp
+qlmanage -t -x -s 512 -o /tmp/rhwp-task26-ql-512 /Users/melee/Documents/samples/pic-in-head-02.hwp
+qlmanage -t -x -s 64 -o /tmp/rhwp-task26-ql-64 /Users/melee/Documents/samples/group-drawing-02.hwp
+git diff --check
+```
+
+## 보류 기준
+
+1. 품질 게이트가 정상 크기 embedded preview까지 과도하게 fallback시키는 경우
+2. full render fallback이 재현 파일에서 실패하는 경우
+3. 실제 Finder 확인 결과 full render fallback 후에도 저해상도 문제가 남는 경우
+
+## 승인 요청 사항
+
+이 구현 계획서 기준으로 1단계 구현에 들어갈지 승인 요청한다.

--- a/mydocs/report/task_m050_26_report.md
+++ b/mydocs/report/task_m050_26_report.md
@@ -1,0 +1,127 @@
+# Issue #26 최종 보고서
+
+## 개요
+
+Issue #26은 Issue #22 / PR #23에서 추가한 Thumbnail embedded preview fast path 이후, 특정 파일의 Finder thumbnail이 큰 preview 영역에서 저해상도로 보이는 회귀를 조사하고, embedded preview 품질 게이트를 추가한 작업이다.
+
+초기 가설은 embedded preview 자체가 작은 파일에서도 요청 크기와 무관하게 fast path를 우선 사용하는 문제였다. 재현 파일 `group-drawing-02.hwp`의 embedded preview는 `177x250` GIF였고, Finder의 `512px` thumbnail 요청에서 이 이미지를 확대하면 저해상도로 보일 수 있다.
+
+다만 Finder 직접 테스트와 추가 `qlmanage` 확인 결과, `group-drawing-02.hwp`는 embedded preview를 회피해 full render fallback을 사용해도 Quick Look preview와 Finder thumbnail 모두에서 여전히 작은 저해상도 그림처럼 보인다. 따라서 Issue #26의 변경은 유효한 방어 로직이지만, 해당 파일의 근본 원인은 Quick Look/Thumbnail 공통 렌더링 품질 문제로 분리한다.
+
+## 원인 분석
+
+초기 조사 결과는 다음과 같다.
+
+| 파일 | embedded preview | 판단 |
+|------|------------------|------|
+| `group-drawing-02.hwp` | `177x250` GIF | 큰 thumbnail 요청에는 부족 |
+| `pic-in-head-02.hwp` | `724x1024` PNG | `512px` 요청에 충분 |
+
+`group-drawing-02.hwp`는 full render 경로로는 `794x1123` 수준의 렌더가 가능했다. 이 확인으로 embedded preview fast path를 회피하는 방어 로직의 필요성은 확인했다.
+
+그러나 full render fallback 산출물과 Finder UI를 직접 확인한 결과, 해당 파일의 group drawing 자체가 고해상도 벡터/shape로 보이지 않고 저해상도 이미지처럼 렌더된다. 즉, `group-drawing-02.hwp`의 근본 문제는 Thumbnail extension만의 fast path가 아니라 `HwpPageImageRenderer` / `CGTreeRenderer` / core render tree의 group drawing 렌더링 경로로 보는 것이 맞다.
+
+## 변경 내용
+
+`Sources/Shared/HwpPageImageRenderer.swift`에 embedded preview 품질 게이트를 추가했다.
+
+- `maximumPixelSize`가 없는 호출은 기존 동작을 유지한다.
+- 요청 긴 변이 `128px` 이하이면 embedded preview fast path를 유지한다.
+- 요청 긴 변이 큰 경우 embedded preview 긴 변이 요청 긴 변의 `75%` 이상일 때만 fast path를 사용한다.
+- 기준에 못 미치면 `decodeEmbeddedThumbnail`이 `nil`을 반환해 기존 full render fallback으로 전환한다.
+
+이 정책으로 작은 Finder icon 요청에서는 성능 경로를 유지하고, 큰 Finder preview 요청에서는 저해상도 embedded preview 확대를 피한다.
+
+## 분기 확인
+
+임시 probe 결과:
+
+| 파일 | 요청 | 결과 이미지 | logical size | 판단 |
+|------|------|-------------|--------------|------|
+| `group-drawing-02.hwp` | `64px` | `45x64` | `177x250` | embedded preview 유지 |
+| `group-drawing-02.hwp` | `512px` | `363x512` | `793x1122` | full render fallback |
+| `pic-in-head-02.hwp` | `64px` | `45x64` | `724x1024` | embedded preview 유지 |
+| `pic-in-head-02.hwp` | `512px` | `362x512` | `724x1024` | embedded preview 유지 |
+
+## 검증 결과
+
+### Shared bridge 경계
+
+```bash
+./scripts/check-no-appkit.sh
+```
+
+결과:
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+### Xcode project 재생성
+
+```bash
+xcodegen generate
+```
+
+결과: 성공
+
+### HostApp Debug build
+
+```bash
+xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build
+```
+
+결과: 성공
+
+- `QLExtension`, `ThumbnailExtension`, `HostApp`가 dependency order로 빌드됐다.
+- `RhwpMacThumbnail.appex`가 HostApp bundle에 포함되고 embedded binary validation을 통과했다.
+
+### Finder thumbnail smoke test
+
+```bash
+qlmanage -r cache
+qlmanage -t -x -s 512 -o /tmp/rhwp-task26-ql-512 /Users/melee/Documents/samples/group-drawing-02.hwp
+qlmanage -t -x -s 512 -o /tmp/rhwp-task26-ql-512 /Users/melee/Documents/samples/pic-in-head-02.hwp
+qlmanage -t -x -s 64 -o /tmp/rhwp-task26-ql-64 /Users/melee/Documents/samples/group-drawing-02.hwp
+```
+
+결과: 모두 `produced one thumbnail`
+
+생성 PNG 크기:
+
+| 출력 | 크기 |
+|------|------|
+| `/tmp/rhwp-task26-ql-512/group-drawing-02.hwp.png` | `363x512` |
+| `/tmp/rhwp-task26-ql-512/pic-in-head-02.hwp.png` | `362x512` |
+| `/tmp/rhwp-task26-ql-64/group-drawing-02.hwp.png` | `46x64` |
+
+### Finder 직접 확인
+
+Finder에서 `/Users/melee/Documents/samples/group-drawing-02.hwp`와 `pic-in-head-02.hwp`를 직접 선택해 우측 preview 영역을 비교했다.
+
+- `pic-in-head-02.hwp`: 정상 문서 preview처럼 표시된다.
+- `group-drawing-02.hwp`: full render fallback을 타는 상태에서도 group drawing 영역이 작은 저해상도 그림처럼 보인다.
+
+추가로 `1024px` thumbnail 산출물도 확인했으나, `group-drawing-02.hwp`의 group drawing 품질은 근본적으로 개선되지 않았다.
+
+### diff 형식
+
+```bash
+git diff --check
+```
+
+결과: 통과
+
+## 남은 리스크
+
+- 품질 게이트 기준값 `75%`는 현재 재현 샘플 기준으로 보수적으로 정했다. 더 다양한 embedded preview 샘플이 쌓이면 threshold 조정 여지는 있다.
+- `group-drawing-02.hwp`의 근본 품질 문제는 Issue #35로 분리했다. 이 문제는 Thumbnail fast path가 아니라 Quick Look/Thumbnail 공통 렌더링 경로에서 다뤄야 한다.
+- Finder/Quick Look 캐시는 이전 썸네일을 재사용할 수 있으므로 실사용 확인 전 `qlmanage -r cache`가 필요할 수 있다.
+
+## 결론
+
+Issue #26에서는 저해상도 embedded preview를 큰 Finder thumbnail 요청에 그대로 사용하는 위험을 shared renderer 품질 게이트로 방어했다.
+
+작은 요청에서는 기존 fast path가 유지되고, 큰 요청에서만 full render fallback으로 전환되는 것을 확인했다. 따라서 #26 변경은 “embedded preview 품질 게이트 추가”라는 제한된 범위에서 유지한다.
+
+다만 `group-drawing-02.hwp`의 실제 저해상도 표시 문제는 full render fallback 후에도 남아 있으므로 #26에서 해결 완료로 보지 않는다. 근본 원인 분석과 수정은 Issue #35 `Quick Look/Thumbnail 공통 group drawing 저해상도 렌더링 수정`에서 진행한다.

--- a/mydocs/working/task_m050_26_stage1.md
+++ b/mydocs/working/task_m050_26_stage1.md
@@ -1,0 +1,90 @@
+# Issue #26 단계1 완료 보고서
+
+## 단계 목표
+
+Finder Thumbnail 경로에서 저해상도 embedded preview가 큰 요청에 그대로 확대되는 문제를 막기 위해 품질 게이트를 추가한다.
+
+## 변경 내용
+
+`Sources/Shared/HwpPageImageRenderer.swift`에 embedded preview 사용 여부를 판단하는 helper를 추가했다.
+
+- `maximumPixelSize`가 없는 호출은 기존 동작을 유지한다.
+- 요청 긴 변이 `128px` 이하이면 embedded preview fast path를 유지한다.
+- 요청 긴 변이 큰 경우 embedded preview 긴 변이 요청 긴 변의 `75%` 이상일 때만 fast path를 사용한다.
+- 기준을 만족하지 못하면 `decodeEmbeddedThumbnail`이 `nil`을 반환해 기존 full render fallback을 사용한다.
+
+## 분기 확인
+
+임시 probe 결과:
+
+| 파일 | 요청 | 결과 이미지 | logical size | 판단 |
+|------|------|-------------|--------------|------|
+| `group-drawing-02.hwp` | `64px` | `45x64` | `177x250` | embedded preview 유지 |
+| `group-drawing-02.hwp` | `512px` | `363x512` | `793x1122` | full render fallback |
+| `pic-in-head-02.hwp` | `64px` | `45x64` | `724x1024` | embedded preview 유지 |
+| `pic-in-head-02.hwp` | `512px` | `362x512` | `724x1024` | embedded preview 유지 |
+
+## 검증 결과
+
+### 코드 형식
+
+```bash
+git diff --check -- Sources/Shared/HwpPageImageRenderer.swift
+```
+
+결과: 통과
+
+### Shared bridge 경계
+
+```bash
+./scripts/check-no-appkit.sh
+```
+
+결과:
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+### Xcode project 재생성
+
+```bash
+xcodegen generate
+```
+
+결과: 성공
+
+### HostApp Debug build
+
+```bash
+xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build
+```
+
+결과: 성공
+
+### Finder thumbnail smoke test
+
+```bash
+qlmanage -r cache
+qlmanage -t -x -s 512 -o /tmp/rhwp-task26-ql-512 /Users/melee/Documents/samples/group-drawing-02.hwp
+qlmanage -t -x -s 512 -o /tmp/rhwp-task26-ql-512 /Users/melee/Documents/samples/pic-in-head-02.hwp
+qlmanage -t -x -s 64 -o /tmp/rhwp-task26-ql-64 /Users/melee/Documents/samples/group-drawing-02.hwp
+```
+
+결과: 모두 `produced one thumbnail`
+
+생성 PNG 크기:
+
+| 출력 | 크기 |
+|------|------|
+| `/tmp/rhwp-task26-ql-512/group-drawing-02.hwp.png` | `363x512` |
+| `/tmp/rhwp-task26-ql-512/pic-in-head-02.hwp.png` | `362x512` |
+| `/tmp/rhwp-task26-ql-64/group-drawing-02.hwp.png` | `46x64` |
+
+## 추가 확인
+
+Finder 직접 확인 결과, `group-drawing-02.hwp`는 full render fallback 후에도 Quick Look preview와 Finder thumbnail에서 group drawing 영역이 저해상도처럼 보인다. 따라서 이 단계의 변경은 embedded preview 확대 방어로 유지하고, 공통 렌더링 품질 문제는 Issue #35로 분리한다.
+
+## 승인 요청 사항
+
+이 단계 결과 기준으로 최종 보고서 작성과 #26 범위 축소 마무리를 승인 요청한다.


### PR DESCRIPTION
## 요약

- Thumbnail embedded preview가 요청 크기에 비해 너무 작은 경우 full render fallback을 사용하도록 품질 게이트를 추가했습니다.
- `group-drawing-02.hwp`의 근본 저해상도 렌더링 문제는 full render 이후에도 남아 있어 #35로 분리했습니다.

## 변경 내역

- **Stage 1**: `HwpPageImageRenderer`에 embedded preview 품질 게이트 추가
- **문서**: 수행 계획서, 구현 계획서, 단계 보고서, 최종 보고서 작성
- **후속 분리**: Quick Look/Thumbnail 공통 group drawing 렌더링 품질 문제를 #35로 분리

## 검증

- [x] `git diff --check`
- [x] `./scripts/check-no-appkit.sh`
- [x] `./scripts/build-rust-macos.sh`
- [ ] `xcodegen generate`
- [ ] `xcodebuild -project RhwpMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
- [ ] `./scripts/validate-stage3-render.sh`
- [x] Finder / Quick Look / Thumbnail 수동 확인

참고:
- 전용 `/tmp` worktree에서는 `Rhwp.xcframework`가 생성되어 있음에도 Xcode가 해당 경로를 찾지 못해 `xcodebuild`가 실패했습니다.
- 같은 코드 변경은 원래 workspace에서 Debug build 성공을 확인했습니다.

## 문서

- 수행 계획서: [task_m050_26.md](https://github.com/postmelee/alhangeul-macos/blob/015a2fe50cf6720e198551e54ef3588a5b133302/mydocs/plans/task_m050_26.md)
- 구현 계획서: [task_m050_26_impl.md](https://github.com/postmelee/alhangeul-macos/blob/015a2fe50cf6720e198551e54ef3588a5b133302/mydocs/plans/task_m050_26_impl.md)
- 단계 보고서: [task_m050_26_stage1.md](https://github.com/postmelee/alhangeul-macos/blob/015a2fe50cf6720e198551e54ef3588a5b133302/mydocs/working/task_m050_26_stage1.md)
- 최종 보고서: [task_m050_26_report.md](https://github.com/postmelee/alhangeul-macos/blob/015a2fe50cf6720e198551e54ef3588a5b133302/mydocs/report/task_m050_26_report.md)

## 관련 이슈

Closes #26
Related #35

## 남은 리스크

- `group-drawing-02.hwp`의 실제 저해상도 표시 문제는 이 PR의 품질 게이트만으로 해결되지 않습니다.
- 근본 원인 분석과 수정은 #35에서 진행합니다.

