### PR TITLE
Task #64: task-register Skill label 선택 규칙 보강

### DIFF
--- a/mydocs/orders/20260426.md
+++ b/mydocs/orders/20260426.md
@@ -14,3 +14,4 @@
 | #55 | release tag dependency 전환을 위한 core API compatibility와 update architecture 정리 | 완료 | 완료: 06:25 |
 | #61 | PR 문서 링크 전수 보정과 작성 규격 강화 | 완료 | 완료: 08:17 |
 | #30 | RustBridge git-rev dependency 전환과 Vendor/rhwp submodule 제거 | 완료 | 완료: 09:10 |
+| #64 | task-register Skill label 선택 규칙 보강 | 진행중 | M010, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260426.md
+++ b/mydocs/orders/20260426.md
@@ -14,4 +14,4 @@
 | #55 | release tag dependency 전환을 위한 core API compatibility와 update architecture 정리 | 완료 | 완료: 06:25 |
 | #61 | PR 문서 링크 전수 보정과 작성 규격 강화 | 완료 | 완료: 08:17 |
 | #30 | RustBridge git-rev dependency 전환과 Vendor/rhwp submodule 제거 | 완료 | 완료: 09:10 |
-| #64 | task-register Skill label 선택 규칙 보강 | 진행중 | M010, 수행계획서 작성 후 승인 대기 |
+| #64 | task-register Skill label 선택 규칙 보강 | 완료 | 완료: 09:49 |

--- a/mydocs/plans/task_m010_64.md
+++ b/mydocs/plans/task_m010_64.md
@@ -1,0 +1,98 @@
+# Issue #64 수행 계획서
+
+## 작업명
+
+task-register Skill label 선택 규칙 보강
+
+## 이슈
+
+- GitHub Issue: #64
+- Milestone: v0.1.0
+- 문서 prefix: `task_m010_64`
+- 이슈 URL: https://github.com/postmelee/alhangeul-macos/issues/64
+
+## 목적
+
+신규 이슈 등록 시 label을 과하게 붙이지 않도록 `task-register` Skill의 label 후보 선택 규칙을 보강한다.
+
+완료 후 에이전트는 이슈 생성 초안을 만들 때 `type 1개 + area 1~2개 + kind/status 0~1개` 기준으로 label을 좁히고, 일반 이슈는 2~4개 label을 우선 제안해야 한다. 5개 이상 label이 필요한 예외 상황에서는 선택 이유를 명시하고 작업지시자 확인을 받아야 한다.
+
+## 배경
+
+기존 GitHub Issue 전체에 `area:*`, `kind:*` label을 추가해 영역과 작업 성격을 세분화했다. 이후 GitHub 공식 문서와 Kubernetes, VS Code, Rust 등 대형 저장소 사례를 확인한 결과, prefix 기반 label 체계 자체는 타당하지만 작은 저장소에서는 이슈당 label 수를 제한하는 운영 규칙이 필요하다는 점을 확인했다.
+
+현재 `task-register` Skill은 live label 목록을 조회하고 명확히 대응하는 label을 선택하라고만 안내한다. 이 상태로는 신규 이슈 등록 시 관련 있어 보이는 모든 `area:*` label을 붙이는 방식으로 흐를 수 있어 triage 가독성이 떨어진다.
+
+## 범위
+
+포함:
+
+- `mydocs/skills/task-register/SKILL.md`의 label 후보 선택 단계 보강
+- type, area, kind/status label 선택 기준 명시
+- 일반 이슈 label 권장 개수와 5개 이상 예외 처리 규칙 추가
+- 검증 섹션에 label 수와 선택 이유 확인 기준 추가
+
+제외:
+
+- 기존 GitHub Issue label 재정리
+- 새 GitHub label 생성 또는 삭제
+- milestone 변경
+- `task-start`, `task-final-report` 등 다른 Skill 변경
+- 코드, RustBridge, Xcode project, build script 변경
+
+## 설계 방향
+
+기존 `task-register` Skill의 "기존 label 목록을 live 조회하고, 새 label은 만들지 않는다"는 원칙은 유지한다. 새 규칙은 label 선택 단계의 세부 기준으로만 추가한다.
+
+label 후보 선택은 다음 순서로 제한한다.
+
+1. type label 1개: `bug`, `documentation`, `enhancement`, `duplicate`, `question` 등 작업 성격을 나타내는 기본 label 중 하나를 우선 고른다.
+2. area label 1~2개: 영향을 받는 모든 영역이 아니라 주 작업 소유 영역 기준으로 고른다.
+3. kind/status label 0~1개: `kind:architecture`, `kind:automation`, `kind:regression`, `kind:verification`, `kind:follow-up`처럼 처리 방식이나 맥락을 실제로 구분할 때만 붙인다.
+
+작업 범위가 넓어 5개 이상 label이 필요하면 이슈 초안의 label 선택 이유에 예외 사유를 별도로 적고, 이슈 생성 전 승인 요청에서 작업지시자 확인을 받도록 한다.
+
+## 예상 변경 파일
+
+- `mydocs/skills/task-register/SKILL.md`
+- `mydocs/orders/20260426.md`
+- 구현 계획서: `mydocs/plans/task_m010_64_impl.md`
+- 단계별 완료보고서: `mydocs/working/task_m010_64_stage{N}.md`
+- 최종 보고서: `mydocs/report/task_m010_64_report.md`
+
+## 잠정 단계
+
+1. Stage 1: 현재 `task-register` Skill의 label 선택 절차와 검증 문구 검토
+2. Stage 2: label 최소화 규칙과 예외 승인 기준을 Skill 본문에 반영
+3. Stage 3: 문서 검증, 단계 보고서 작성, 작업지시자 승인 요청
+4. Stage 4: 최종 보고서 작성, 오늘할일 완료 처리, PR 준비
+
+각 단계 완료 시 단계별 완료보고서를 작성하고 작업지시자 승인 후 다음 단계로 진행한다.
+
+## 검증 계획
+
+계획 문서 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260426.md mydocs/plans/task_m010_64.md
+```
+
+구현 단계 진입 후 최소 검증:
+
+```bash
+git diff --check
+rg -n "label 후보 선택|type 1개|area 1~2개|kind/status|5개 이상|선택 이유" mydocs/skills/task-register/SKILL.md
+```
+
+문서와 Skill 절차 보강만 수행하므로 Xcode/Rust 빌드는 수행하지 않는다.
+
+## 리스크
+
+- label 개수 제한이 너무 엄격하면 실제 교차 영역 작업을 충분히 표현하지 못할 수 있다. 5개 이상 예외 승인 규칙을 두어 필요한 경우 확장 가능하게 한다.
+- type, area, kind/status의 의미가 문서에만 있고 실제 label description과 어긋나면 혼란이 생길 수 있다. live 조회된 label의 `name`/`description`을 기준으로 판단한다는 기존 원칙을 유지한다.
+- `area:*`를 주 작업 소유 영역 기준으로 제한하면 관련 컴포넌트 검색 누락이 생길 수 있다. 단순 관련성이 아니라 triage와 작업 소유 판단에 필요한 label만 붙인다는 기준을 명확히 둔다.
+- Skill 규칙이 장황해지면 이슈 등록 시 읽기 부담이 커질 수 있다. label 선택 단계와 검증 섹션에만 짧게 반영한다.
+
+## 승인 요청 사항
+
+이 수행 계획서 기준으로 구현 계획서(`mydocs/plans/task_m010_64_impl.md`) 작성을 진행할지 승인 요청한다. 승인 전에는 `task-register` Skill 본문 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m010_64_impl.md
+++ b/mydocs/plans/task_m010_64_impl.md
@@ -1,0 +1,202 @@
+# Issue #64 구현 계획서
+
+수행계획서: `mydocs/plans/task_m010_64.md`
+
+## 작업명
+
+task-register Skill label 선택 규칙 보강
+
+## 구현 원칙
+
+- 승인된 수행계획서 `mydocs/plans/task_m010_64.md`를 기준으로 진행한다.
+- 변경 대상은 `task-register` Skill의 label 선택 절차와 검증 기준으로 한정한다.
+- 신규 GitHub label 생성, 기존 이슈 label 재정리, milestone 변경은 수행하지 않는다.
+- 기존 원칙인 live label 목록 조회, 기존 label만 사용, 새 label 생성 금지는 유지한다.
+- label 선택 규칙은 신규 이슈 등록 시 읽기 부담이 커지지 않도록 짧고 실행 가능한 문장으로 작성한다.
+- 문서와 Skill 절차 보강만 수행하므로 Rust/Swift/Xcode 빌드 검증은 수행하지 않는다.
+
+## Stage 1: 현재 label 선택 절차와 보강 위치 확정
+
+대상:
+
+- `mydocs/skills/task-register/SKILL.md`
+- `mydocs/plans/task_m010_64.md`
+- 현재 GitHub label 체계
+
+작업:
+
+1. `task-register` Skill의 현재 label 조회, 후보 선택, 이슈 초안 작성, 검증 섹션을 다시 확인한다.
+2. label 최소화 규칙을 넣을 정확한 위치를 확정한다.
+3. 검증 섹션에 추가할 label 개수와 선택 이유 기준을 확정한다.
+4. 기존 원칙과 충돌하지 않는 문구를 정리한다.
+5. Stage 1 단계 보고서를 작성한다.
+
+산출물:
+
+- `mydocs/working/task_m010_64_stage1.md`
+
+검증:
+
+```bash
+rg -n "기존 label 목록 확인|label 후보 선택|이슈 초안 작성|검증|새 label" \
+  mydocs/skills/task-register/SKILL.md
+git diff --check -- mydocs/working/task_m010_64_stage1.md
+```
+
+완료 조건:
+
+- Skill 본문에서 수정할 섹션이 Stage 1 보고서에 명시되어 있다.
+- `type`, `area`, `kind/status` 기준을 어느 항목에 추가할지 확정되어 있다.
+- 5개 이상 label 예외 처리 규칙의 위치가 확정되어 있다.
+
+커밋:
+
+```text
+Task #64 Stage 1: task-register label 선택 규칙 보강 위치 확정
+```
+
+## Stage 2: task-register Skill label 최소화 규칙 반영
+
+대상:
+
+- `mydocs/skills/task-register/SKILL.md`
+
+작업:
+
+1. `label 후보 선택` 단계에 다음 기준을 추가한다.
+   - type label 1개 우선 선택
+   - area label은 주 작업 소유 영역 기준으로 1~2개 선택
+   - kind/status label은 처리 방식이나 맥락 구분이 필요할 때 0~1개 선택
+   - 일반 이슈는 2~4개 label 권장
+   - 5개 이상 label은 예외 사유와 작업지시자 확인 필요
+2. `이슈 초안 작성` 단계의 label 설명에 선택 이유와 예외 사유 기재 기준을 보강한다.
+3. `검증` 섹션에 label 개수와 선택 이유 검증 기준을 추가한다.
+4. "새 label은 만들지 않는다"와 "조회된 기존 label만 후보" 원칙이 유지되는지 확인한다.
+5. Stage 2 단계 보고서를 작성한다.
+
+산출물:
+
+- `mydocs/skills/task-register/SKILL.md`
+- `mydocs/working/task_m010_64_stage2.md`
+
+검증:
+
+```bash
+rg -n "type label|area label|kind/status|2~4개|5개 이상|선택 이유|새 label은 만들지 않는다" \
+  mydocs/skills/task-register/SKILL.md
+git diff --check -- \
+  mydocs/skills/task-register/SKILL.md \
+  mydocs/working/task_m010_64_stage2.md
+```
+
+완료 조건:
+
+- 신규 이슈 등록 시 label을 보통 2~4개로 제한하는 규칙이 Skill에 반영되어 있다.
+- `area:*`는 관련 영역 전체가 아니라 주 작업 소유 영역 기준으로 고른다는 문구가 있다.
+- 5개 이상 label을 붙일 때 작업지시자 확인이 필요하다는 문구가 있다.
+- 기존 label만 사용하고 새 label을 만들지 않는 기존 제한이 유지된다.
+
+커밋:
+
+```text
+Task #64 Stage 2: task-register label 최소화 규칙 반영
+```
+
+## Stage 3: 통합 검증과 단계 결과 정리
+
+대상:
+
+- `mydocs/skills/task-register/SKILL.md`
+- Stage 1~2 단계 보고서
+
+작업:
+
+1. Skill 전체를 읽어 label 최소화 규칙이 이슈 생성 절차 흐름과 자연스럽게 이어지는지 확인한다.
+2. live label 목록 조회 원칙, 새 label 생성 금지, 생성 전 승인 원칙이 손상되지 않았는지 확인한다.
+3. 검색 기반 검증으로 핵심 문구가 모두 존재하는지 확인한다.
+4. `git diff --check`로 전체 문서 변경을 검증한다.
+5. Stage 3 단계 보고서를 작성한다.
+
+산출물:
+
+- `mydocs/working/task_m010_64_stage3.md`
+
+검증:
+
+```bash
+git diff --check
+rg -n "label 후보 선택|type label|area label|kind/status|2~4개|5개 이상|작업지시자 확인|새 label은 만들지 않는다" \
+  mydocs/skills/task-register/SKILL.md
+git status --short
+```
+
+완료 조건:
+
+- Skill 본문 변경이 검증된다.
+- 단계 보고서에 검증 명령과 결과가 기록되어 있다.
+- 최종 보고서 작성 단계로 넘어갈 수 있다.
+
+커밋:
+
+```text
+Task #64 Stage 3: task-register label 규칙 검증
+```
+
+## Stage 4: 최종 보고와 오늘할일 완료 처리
+
+대상:
+
+- `mydocs/report/task_m010_64_report.md`
+- `mydocs/orders/20260426.md`
+- 전체 변경 파일
+
+작업:
+
+1. 최종 결과 보고서를 작성한다.
+2. 오늘할일에서 #64 상태를 완료로 바꾸고 완료 시각을 기록한다.
+3. 전체 변경 범위와 검증 결과를 최종 확인한다.
+4. PR 게시 전 working tree 상태를 확인한다.
+
+산출물:
+
+- `mydocs/report/task_m010_64_report.md`
+- `mydocs/orders/20260426.md`
+
+검증:
+
+```bash
+git diff --check
+rg -n "#64|task-register Skill label 선택 규칙 보강|완료:" mydocs/orders/20260426.md
+test -f mydocs/report/task_m010_64_report.md
+git status --short
+```
+
+완료 조건:
+
+- 최종 보고서와 오늘할일 완료 처리가 끝난다.
+- 전체 변경이 커밋되어 PR 게시 승인 요청이 가능하다.
+- Skill 변경 범위가 `task-register` label 선택 규칙 보강에 한정되어 있다.
+
+커밋:
+
+```text
+Task #64 Stage 4 + 최종 보고서: task-register label 규칙 보강 결과 정리
+```
+
+## 단계별 커밋 메시지
+
+| Stage | 커밋 메시지 |
+|-------|-------------|
+| 1 | `Task #64 Stage 1: task-register label 선택 규칙 보강 위치 확정` |
+| 2 | `Task #64 Stage 2: task-register label 최소화 규칙 반영` |
+| 3 | `Task #64 Stage 3: task-register label 규칙 검증` |
+| 4 | `Task #64 Stage 4 + 최종 보고서: task-register label 규칙 보강 결과 정리` |
+
+## 후속 작업
+
+- Stage 4 완료 후 작업지시자 승인 시 `task-final-report` 절차로 `publish/task64` push와 draft PR 생성을 진행한다.
+- PR merge 후 정리는 `pr-merge-cleanup` 절차로 수행한다.
+
+## 승인 요청 사항
+
+이 구현 계획서 기준으로 Stage 1을 진행할지 승인 요청한다. 승인 전에는 `task-register` Skill 본문을 수정하지 않는다.

--- a/mydocs/report/task_m010_64_report.md
+++ b/mydocs/report/task_m010_64_report.md
@@ -1,0 +1,115 @@
+# Issue #64 최종 결과 보고서
+
+## 작업 요약
+
+- GitHub Issue: #64
+- Milestone: v0.1.0
+- 문서 prefix: `task_m010_64`
+- 작업명: task-register Skill label 선택 규칙 보강
+- 작업 브랜치: `local/task64`
+- 단계 수: 4단계
+
+`task-register` Skill에 신규 이슈 등록 시 label을 과하게 붙이지 않도록 최소화 규칙을 추가했다. 기존 live label 조회, 기존 label만 사용, 새 label 생성 금지, 이슈 생성 전 승인 원칙은 유지하면서, label 후보 선택 단계에 `type`, `area`, `kind/status` 기준을 명시했다.
+
+## 단계별 결과
+
+| Stage | 결과 | 산출물 |
+|-------|------|--------|
+| Stage 1 | 현재 label 선택 절차와 보강 위치 확정 | `mydocs/working/task_m010_64_stage1.md` |
+| Stage 2 | `task-register` Skill label 최소화 규칙 반영 | `mydocs/skills/task-register/SKILL.md`, `mydocs/working/task_m010_64_stage2.md` |
+| Stage 3 | 통합 검증과 단계 결과 정리 | `mydocs/working/task_m010_64_stage3.md` |
+| Stage 4 | 최종 보고, 오늘할일 완료 처리 | `mydocs/working/task_m010_64_stage4.md`, 본 보고서 |
+
+## 변경 파일과 영향 범위
+
+| 파일 | 영향 |
+|------|------|
+| `mydocs/skills/task-register/SKILL.md` | 신규 이슈 등록 시 label 선택 최소화 규칙 추가 |
+| `mydocs/orders/20260426.md` | #64 오늘할일 완료 처리 |
+| `mydocs/plans/task_m010_64.md` | 수행계획서 |
+| `mydocs/plans/task_m010_64_impl.md` | 구현계획서 |
+| `mydocs/working/task_m010_64_stage1.md` | Stage 1 완료 보고 |
+| `mydocs/working/task_m010_64_stage2.md` | Stage 2 완료 보고 |
+| `mydocs/working/task_m010_64_stage3.md` | Stage 3 완료 보고 |
+| `mydocs/working/task_m010_64_stage4.md` | Stage 4 완료 보고 |
+| `mydocs/report/task_m010_64_report.md` | 최종 결과 보고 |
+
+Rust, Swift, Xcode project, build script, GitHub label, milestone, 기존 Issue label은 변경하지 않았다.
+
+## 반영된 label 선택 규칙
+
+`task-register` Skill의 `label 후보 선택` 단계에 다음 기준을 추가했다.
+
+- label은 기본적으로 `type label 1개 + area label 1~2개 + kind/status label 0~1개`로 제한한다.
+- type label은 `bug`, `documentation`, `enhancement`, `duplicate`, `question` 등 작업 성격을 나타내는 label 중 1개를 우선 고른다.
+- `area:*` label은 영향을 받는 모든 영역이 아니라 주 작업 소유 영역 기준으로 고른다.
+- `kind:*` label은 처리 방식이나 맥락을 실제로 구분할 때만 붙인다.
+- 일반 이슈는 2~4개 label을 권장한다.
+- 5개 이상 label이 필요하면 이슈 초안에 예외 사유를 적고 작업지시자 확인을 받는다.
+
+`이슈 초안 작성` 단계에는 type/area/kind 기준의 선택 이유와 5개 이상 예외 사유 기재 기준을 추가했다. `검증` 섹션에는 label 개수, 예외 사유, `area:*` 주 작업 소유 영역 기준 확인을 추가했다.
+
+## 유지된 원칙
+
+| 원칙 | 결과 |
+|------|------|
+| GitHub label 목록을 live 조회한다 | 유지 |
+| 기억하고 있는 과거 label 목록으로 단정하지 않는다 | 유지 |
+| 조회된 기존 label만 후보로 사용한다 | 유지 |
+| 새 label은 만들지 않는다 | 유지 |
+| label이 애매하면 label 없이 생성하거나 작업지시자에게 확인한다 | 유지 |
+| 이슈 생성 전 제목/본문/milestone/label 초안을 승인받는다 | 유지 |
+| 이슈 생성 후 `task-start` 진입 승인 요청으로 멈춘다 | 유지 |
+
+## 검증 결과
+
+실행한 검증:
+
+```bash
+git diff --check
+rg -n "label 후보 선택|type label|area label|kind/status|2~4개|5개 이상|작업지시자 확인|새 label은 만들지 않는다" \
+  mydocs/skills/task-register/SKILL.md
+rg -n "#64|task-register Skill label 선택 규칙 보강|완료:" mydocs/orders/20260426.md
+test -f mydocs/report/task_m010_64_report.md
+git status --short
+```
+
+결과:
+
+- `git diff --check` 통과
+- `task-register` Skill에서 label 최소화 핵심 문구 검색 확인
+- 오늘할일 #64 완료 처리 확인
+- 최종 보고서 파일 존재 확인
+- Stage 4 커밋 전 변경 파일은 최종 보고서, Stage 4 보고서, 오늘할일로 한정됨
+
+문서와 Skill 절차 보강만 수행했으므로 Rust/Swift/Xcode 빌드 검증은 수행하지 않았다.
+
+## 수용 기준
+
+| 기준 | 결과 |
+|------|------|
+| 신규 이슈 등록 시 label을 보통 2~4개로 제한하는 규칙 반영 | OK |
+| `area:*`는 관련 영역 전체가 아니라 주 작업 소유 영역 기준으로 고르는 문구 반영 | OK |
+| 5개 이상 label에 작업지시자 확인 필요 문구 반영 | OK |
+| 기존 label만 사용하고 새 label을 만들지 않는 제한 유지 | OK |
+| 오늘할일 완료 처리 | OK |
+
+## 잔여 위험과 후속 작업
+
+- label 최소화 규칙은 Skill 절차 문서 기반이다. GitHub UI나 CLI가 자동으로 label 개수를 제한하지는 않으므로, 에이전트가 `task-register` 실행 시 해당 규칙을 따라야 한다.
+- 실제 신규 이슈 등록 시 작업 성격이 넓으면 label 5개 이상이 필요할 수 있다. 이 경우 예외 사유와 작업지시자 확인으로 처리한다.
+- 향후 label 체계가 바뀌면 `task-register`는 live 조회 기준으로 판단하지만, type/area/kind 분류 문구가 현재 label 체계와 어긋나는지는 별도 점검이 필요하다.
+
+## 커밋 목록
+
+```text
+7204912 Task #64: 수행 계획서 작성과 오늘할일 갱신
+c5d7798 Task #64: 구현 계획서 작성
+fa92ad5 Task #64 Stage 1: task-register label 선택 규칙 보강 위치 확정
+e05ffc5 Task #64 Stage 2: task-register label 최소화 규칙 반영
+c995ce1 Task #64 Stage 3: task-register label 규칙 검증
+```
+
+## 승인 요청 사항
+
+본 최종 결과 보고서 기준으로 `publish/task64` 원격 게시와 `devel` 대상 draft PR 생성을 승인 요청한다.

--- a/mydocs/skills/task-register/SKILL.md
+++ b/mydocs/skills/task-register/SKILL.md
@@ -56,6 +56,12 @@ allow_implicit_invocation: false
 5. label 후보 선택
    - 조회된 기존 label만 후보로 사용한다.
    - 작업 성격이 label의 `name`/`description`과 명확히 대응할 때만 선택한다.
+   - label은 기본적으로 `type label 1개 + area label 1~2개 + kind/status label 0~1개`로 제한한다.
+   - type label은 `bug`, `documentation`, `enhancement`, `duplicate`, `question` 등 작업 성격을 나타내는 label 중 1개를 우선 고른다.
+   - `area:*` label은 영향을 받는 모든 영역이 아니라 주 작업 소유 영역 기준으로 고른다.
+   - `kind:*` label은 `kind:architecture`, `kind:automation`, `kind:regression`, `kind:verification`, `kind:follow-up`처럼 처리 방식이나 맥락을 실제로 구분할 때만 붙인다.
+   - 일반 이슈는 2~4개 label을 권장한다.
+   - 5개 이상 label이 필요하면 이슈 초안에 예외 사유를 적고 작업지시자 확인을 받는다.
    - 후보가 명확하면 label 이름과 선택 이유를 기록한다.
    - 적합한 label이 없거나 애매하면 label 없이 생성하거나 작업지시자에게 확인한다.
    - 새 label은 만들지 않는다.
@@ -69,6 +75,7 @@ allow_implicit_invocation: false
      - 참고
    - milestone: live 조회 결과에서 고른 열린 milestone 1개와 선택 이유
    - label: live 조회 결과에서 고른 기존 label 0개 이상과 선택 이유
+   - label 선택 이유는 type/area/kind 기준으로 나누어 적고, 5개 이상이면 예외 사유를 별도로 적는다.
 7. 이슈 생성 전 승인 요청
    - 작업지시자에게 제목, 본문, milestone, label 초안과 선택 이유를 보여준다.
    - 작업지시자가 같은 스레드에서 생성 승인을 명시하기 전에는 `gh issue create`를 실행하지 않는다.
@@ -94,6 +101,9 @@ allow_implicit_invocation: false
 - 생성된 이슈가 `OPEN` 상태여야 한다.
 - milestone이 비어 있지 않고 live 조회 결과에 있던 열린 milestone이어야 한다.
 - label은 초안에서 승인된 기존 label만 붙어 있어야 한다.
+- 일반 이슈 label은 2~4개 권장 범위인지 확인한다.
+- 5개 이상 label이면 승인된 예외 사유가 생성 결과 보고에 포함되어야 한다.
+- `area:*` label은 주 작업 소유 영역 기준으로 선택되어야 한다.
 - 생성 결과 보고에 issue number, URL, milestone, label, 선택 이유가 포함되어야 한다.
 
 ## 절대 하지 말 것

--- a/mydocs/working/task_m010_64_stage1.md
+++ b/mydocs/working/task_m010_64_stage1.md
@@ -1,0 +1,160 @@
+# Issue #64 Stage 1 완료 보고서
+
+## 단계 목적
+
+현재 `task-register` Skill의 label 선택 절차를 확인하고, label 최소화 규칙을 어느 위치에 어떤 기준으로 반영할지 확정한다. 이번 단계에서는 Skill 본문을 수정하지 않고 조사와 설계만 수행한다.
+
+## 조사 대상
+
+- `mydocs/skills/task-register/SKILL.md`
+- `mydocs/plans/task_m010_64.md`
+- GitHub label 목록
+
+## 현재 Skill 구조 확인
+
+`task-register`의 label 관련 흐름은 다음 세 지점으로 나뉘어 있다.
+
+| 위치 | 현재 역할 | 보강 필요 |
+|------|-----------|-----------|
+| 3. 기존 label 목록 확인 | `gh api repos/.../labels`로 live label을 조회하고 `name`/`description` 기준으로 판단 | 기존 원칙 유지 |
+| 5. label 후보 선택 | 기존 label 중 명확히 대응하는 label을 선택하고, 모호하면 label 없이 생성하거나 확인 | label 최소화 규칙의 주 위치 |
+| 6. 이슈 초안 작성 | 선택한 label과 선택 이유를 초안에 포함 | 5개 이상 예외 사유 기재 기준 추가 |
+| 검증 | 승인된 기존 label만 붙었는지 확인 | label 개수와 선택 이유 검증 기준 추가 |
+| 절대 하지 말 것 | 새 milestone 또는 새 label 생성 금지 | 기존 원칙 유지 |
+
+현재 5단계는 "명확히 대응할 때만 선택"이라고만 되어 있어 관련 영역 label을 과하게 붙이는 상황을 막지 못한다. 따라서 Stage 2의 본문 변경은 5단계를 중심으로 하되, 6단계와 검증 섹션에 짧은 보강을 함께 넣는 것이 적절하다.
+
+## 현재 GitHub label 체계
+
+Stage 1에서 조회한 label은 총 25개다.
+
+### type 후보
+
+| label | 설명 | 사용 기준 |
+|-------|------|-----------|
+| `bug` | Something isn't working | 동작 오류, 회귀, 실패 원인 수정 |
+| `documentation` | Improvements or additions to documentation | 문서, manual, Skill, task 문서 변경 |
+| `duplicate` | This issue or pull request already exists | 실질적으로 같은 이슈가 이미 있는 경우 |
+| `enhancement` | New feature or request | 새 기능, 기능 개선, 운영 절차 개선 |
+| `question` | Further information is requested | 정보 요청 또는 범위 확인이 주목적인 항목 |
+
+기본 label 중 `good first issue`, `help wanted`, `invalid`, `wontfix`는 일반 신규 내부 타스크 등록의 기본 type으로 쓰기보다 예외 상태 또는 contributor-facing label로 유지하는 편이 맞다.
+
+### area 후보
+
+| label | 설명 |
+|-------|------|
+| `area:bridge-ffi` | RustBridge, C ABI, Swift bridge boundary work |
+| `area:ci-cd` | Build, package, sign, notarize, DMG, Homebrew, release automation |
+| `area:core` | rhwp core provenance, dependency, release tag related work |
+| `area:docs` | README, manuals, architecture docs, generated task documents |
+| `area:localization` | Localized display names and Korean/English presentation |
+| `area:quick-look` | Quick Look preview extension integration |
+| `area:rendering` | Render tree, image data, visual quality, renderer behavior |
+| `area:test-assets` | Sample documents, fixtures, smoke/render verification assets |
+| `area:thumbnail` | Finder thumbnail extension integration |
+| `area:viewer-app` | HostApp viewer, app UX, document opening behavior |
+| `area:workflow` | AGENTS, SKILL, task workflow, PR process, issue operations |
+
+`area:*`는 관련 가능성이 있는 모든 영역이 아니라 주 작업 소유 영역을 고르는 기준으로 제한해야 한다. 교차 영역 작업도 보통 2개까지만 붙이고, 세 번째 area가 필요하면 초안에서 이유를 설명하는 방식이 낫다.
+
+### kind/status 후보
+
+| label | 설명 |
+|-------|------|
+| `kind:architecture` | Architecture, ownership boundary, dependency design |
+| `kind:automation` | Scripts, release automation, verification automation |
+| `kind:follow-up` | Follow-up from a prior task, PR, or residual risk |
+| `kind:regression` | Regression or quality degradation found after prior work |
+| `kind:verification` | Manual verification, smoke test, or measurement-focused work |
+
+`kind:*`는 작업 처리 방식이나 맥락이 실제 triage에 도움이 될 때만 붙인다. 단순히 관련 단어가 본문에 있다는 이유로 추가하지 않는다.
+
+## Stage 2 수정 위치 확정
+
+### 1. `5. label 후보 선택`
+
+여기에 핵심 규칙을 추가한다.
+
+- label은 기본적으로 `type 1개 + area 1~2개 + kind/status 0~1개`로 제한한다.
+- type label은 `bug`, `documentation`, `enhancement`, `duplicate`, `question` 등 작업 성격을 나타내는 label 중 1개를 우선 고른다.
+- `area:*`는 영향을 받는 모든 영역이 아니라 주 작업 소유 영역 기준으로 고른다.
+- `kind:*`는 `architecture`, `automation`, `regression`, `verification`, `follow-up`처럼 처리 방식이나 맥락을 실제로 구분할 때만 붙인다.
+- 일반 이슈는 2~4개 label을 권장한다.
+- 5개 이상 label이 필요하면 이슈 초안에 예외 사유를 적고 작업지시자 확인을 받는다.
+
+기존 문장인 "조회된 기존 label만 후보로 사용한다", "새 label은 만들지 않는다"는 그대로 유지한다.
+
+### 2. `6. 이슈 초안 작성`
+
+현재는 "label: live 조회 결과에서 고른 기존 label 0개 이상과 선택 이유"라고 되어 있다. 여기에 다음 취지를 추가한다.
+
+- label은 type/area/kind 기준으로 나누어 선택 이유를 적는다.
+- 5개 이상이면 예외 사유를 별도로 적는다.
+
+### 3. `검증`
+
+현재 검증은 "승인된 기존 label만 붙어 있어야 한다"에 머문다. 다음 기준을 추가한다.
+
+- 일반 이슈 label이 2~4개 권장 범위인지 확인한다.
+- 5개 이상 label이면 승인된 예외 사유가 생성 결과 보고에 포함되어야 한다.
+- `area:*`가 주 작업 소유 영역 기준으로 선택되었는지 확인한다.
+
+## 기존 원칙과의 충돌 검토
+
+| 기존 원칙 | 유지 여부 | 비고 |
+|-----------|-----------|------|
+| GitHub label 목록을 live 조회한다 | 유지 | 기억 기반 label 판단 금지 원칙과 충돌 없음 |
+| 조회된 기존 label만 후보로 쓴다 | 유지 | 새 label 생성은 계속 금지 |
+| label이 애매하면 label 없이 생성하거나 확인한다 | 유지 | 개수 제한과 상호 보완 관계 |
+| 이슈 생성 전 제목/본문/milestone/label 초안을 승인받는다 | 유지 | 5개 이상 예외 사유 확인 지점으로 활용 |
+| 이슈 생성 후 `task-start` 승인 대기 | 유지 | 이번 변경은 이슈 등록 이후 흐름에 영향 없음 |
+
+## Stage 2 반영 방침
+
+Stage 2에서는 `mydocs/skills/task-register/SKILL.md`만 수정한다. 매뉴얼 변경은 이번 작업 범위에 포함하지 않는다.
+
+문구는 다음 기준으로 작성한다.
+
+- 짧은 bullet 중심으로 작성해 이슈 등록 절차의 가독성을 유지한다.
+- `type`, `area`, `kind/status`의 의미를 설명하되, label 목록 전체를 Skill에 다시 복제하지 않는다.
+- "관련 있어 보이면 모두 붙인다"가 아니라 "검색과 triage에 실제로 필요한 label만 붙인다"는 기준을 명확히 둔다.
+- 5개 이상 label은 금지가 아니라 예외 승인 대상으로 둔다.
+
+## 실행한 명령
+
+```bash
+rg -n "기존 label 목록 확인|label 후보 선택|이슈 초안 작성|## 검증|새 label" mydocs/skills/task-register/SKILL.md
+sed -n '1,170p' mydocs/skills/task-register/SKILL.md
+gh api repos/postmelee/alhangeul-macos/labels --paginate --jq '.[] | {name,description,color}'
+git status --short --branch
+```
+
+## 검증 결과
+
+구현계획서의 Stage 1 검증 명령을 실행했다.
+
+```bash
+rg -n "기존 label 목록 확인|label 후보 선택|이슈 초안 작성|검증|새 label" \
+  mydocs/skills/task-register/SKILL.md
+git diff --check -- mydocs/working/task_m010_64_stage1.md
+```
+
+결과:
+
+- `task-register`의 label 관련 위치 확인 완료
+- 현재 GitHub label 25개 조회 완료
+- Stage 2 수정 위치와 문구 방향 확정
+- Stage 1 보고서 공백 검증 통과
+
+## 완료 조건 확인
+
+| 완료 조건 | 결과 |
+|-----------|------|
+| Skill 본문에서 수정할 섹션이 Stage 1 보고서에 명시되어 있음 | 충족 |
+| `type`, `area`, `kind/status` 기준을 어느 항목에 추가할지 확정되어 있음 | 충족 |
+| 5개 이상 label 예외 처리 규칙의 위치가 확정되어 있음 | 충족 |
+
+## 승인 요청 사항
+
+본 Stage 1 결과 기준으로 Stage 2: `task-register` Skill label 최소화 규칙 반영을 진행할지 승인 요청한다.

--- a/mydocs/working/task_m010_64_stage2.md
+++ b/mydocs/working/task_m010_64_stage2.md
@@ -1,0 +1,103 @@
+# Issue #64 Stage 2 완료 보고서
+
+## 단계 목적
+
+Stage 1에서 확정한 위치에 따라 `task-register` Skill 본문에 label 최소화 규칙과 예외 승인 기준을 반영한다.
+
+## 변경 대상
+
+- `mydocs/skills/task-register/SKILL.md`
+
+## 변경 요약
+
+`task-register` Skill의 기존 원칙은 유지했다.
+
+- GitHub label 목록을 live 조회한다.
+- 조회된 기존 label만 후보로 사용한다.
+- 작업 성격이 label의 `name`/`description`과 명확히 대응할 때만 선택한다.
+- 적합한 label이 없거나 애매하면 label 없이 생성하거나 작업지시자에게 확인한다.
+- 새 label은 만들지 않는다.
+
+위 원칙 위에 label 개수와 선택 기준을 추가했다.
+
+## 상세 변경
+
+### `5. label 후보 선택`
+
+다음 규칙을 추가했다.
+
+- label은 기본적으로 `type label 1개 + area label 1~2개 + kind/status label 0~1개`로 제한한다.
+- type label은 `bug`, `documentation`, `enhancement`, `duplicate`, `question` 등 작업 성격을 나타내는 label 중 1개를 우선 고른다.
+- `area:*` label은 영향을 받는 모든 영역이 아니라 주 작업 소유 영역 기준으로 고른다.
+- `kind:*` label은 `kind:architecture`, `kind:automation`, `kind:regression`, `kind:verification`, `kind:follow-up`처럼 처리 방식이나 맥락을 실제로 구분할 때만 붙인다.
+- 일반 이슈는 2~4개 label을 권장한다.
+- 5개 이상 label이 필요하면 이슈 초안에 예외 사유를 적고 작업지시자 확인을 받는다.
+
+### `6. 이슈 초안 작성`
+
+label 선택 이유 작성 기준을 보강했다.
+
+- label 선택 이유는 type/area/kind 기준으로 나누어 적는다.
+- 5개 이상이면 예외 사유를 별도로 적는다.
+
+### `검증`
+
+생성된 이슈의 label 검증 기준을 보강했다.
+
+- 일반 이슈 label은 2~4개 권장 범위인지 확인한다.
+- 5개 이상 label이면 승인된 예외 사유가 생성 결과 보고에 포함되어야 한다.
+- `area:*` label은 주 작업 소유 영역 기준으로 선택되어야 한다.
+
+## 설계 판단
+
+label 목록 전체를 Skill 본문에 복제하지 않았다. 실제 label 목록은 계속 live 조회 결과를 기준으로 판단해야 하기 때문이다.
+
+`type`, `area`, `kind/status` 기준은 특정 저장소 label 체계를 설명하기 위한 운영 원칙으로만 추가했다. label이 새로 추가되거나 설명이 바뀌어도 `name`/`description` 기준 판단 원칙은 유지된다.
+
+5개 이상 label은 금지하지 않았다. 대형 변경이나 교차 영역 작업에서는 필요할 수 있으므로, 예외 사유와 작업지시자 확인을 요구하는 방식으로 제한했다.
+
+## 변경하지 않은 항목
+
+- GitHub label 생성/삭제 없음
+- 기존 GitHub Issue label 재정리 없음
+- milestone 변경 없음
+- `task-start`, `task-final-report` 등 다른 Skill 변경 없음
+- 매뉴얼 변경 없음
+
+## 실행한 명령
+
+```bash
+sed -n '52,108p' mydocs/skills/task-register/SKILL.md
+git diff -- mydocs/skills/task-register/SKILL.md
+```
+
+## 검증 결과
+
+구현계획서의 Stage 2 검증 명령을 실행했다.
+
+```bash
+rg -n "type label|area label|kind/status|2~4개|5개 이상|선택 이유|새 label은 만들지 않는다" \
+  mydocs/skills/task-register/SKILL.md
+git diff --check -- \
+  mydocs/skills/task-register/SKILL.md \
+  mydocs/working/task_m010_64_stage2.md
+```
+
+결과:
+
+- label 최소화 핵심 문구 검색 통과
+- `새 label은 만들지 않는다` 기존 제한 유지 확인
+- Skill 본문과 Stage 2 보고서 공백 검증 통과
+
+## 완료 조건 확인
+
+| 완료 조건 | 결과 |
+|-----------|------|
+| 신규 이슈 등록 시 label을 보통 2~4개로 제한하는 규칙이 Skill에 반영되어 있음 | 충족 |
+| `area:*`는 관련 영역 전체가 아니라 주 작업 소유 영역 기준으로 고른다는 문구가 있음 | 충족 |
+| 5개 이상 label을 붙일 때 작업지시자 확인이 필요하다는 문구가 있음 | 충족 |
+| 기존 label만 사용하고 새 label을 만들지 않는 기존 제한이 유지됨 | 충족 |
+
+## 승인 요청 사항
+
+본 Stage 2 결과 기준으로 Stage 3: 통합 검증과 단계 결과 정리를 진행할지 승인 요청한다.

--- a/mydocs/working/task_m010_64_stage3.md
+++ b/mydocs/working/task_m010_64_stage3.md
@@ -1,0 +1,107 @@
+# Issue #64 Stage 3 완료 보고서
+
+## 단계 목적
+
+Stage 2에서 변경한 `task-register` Skill의 label 최소화 규칙이 전체 이슈 등록 절차와 충돌하지 않는지 통합 검증한다.
+
+## 검증 대상
+
+- `mydocs/skills/task-register/SKILL.md`
+- Stage 1 보고서: `mydocs/working/task_m010_64_stage1.md`
+- Stage 2 보고서: `mydocs/working/task_m010_64_stage2.md`
+
+## 확인 결과
+
+### Skill 절차 흐름
+
+`task-register`의 기존 흐름은 유지됐다.
+
+1. 중복 이슈 확인
+2. 열린 milestone 목록 확인
+3. 기존 label 목록 확인
+4. milestone 후보 선택
+5. label 후보 선택
+6. 이슈 초안 작성
+7. 이슈 생성 전 승인 요청
+8. 승인 후 이슈 생성
+9. 생성 결과 확인
+10. `task-start` 진입 승인 요청
+
+이번 변경은 5단계, 6단계, 검증 섹션만 보강한다. 이슈 생성 시점이나 `task-start` 책임 경계에는 영향을 주지 않는다.
+
+### 유지된 기존 원칙
+
+| 원칙 | 확인 결과 |
+|------|-----------|
+| label 목록은 live 조회 결과를 기준으로 판단 | 유지 |
+| 기억하고 있는 과거 label 목록으로 단정하지 않음 | 유지 |
+| 조회된 기존 label만 후보로 사용 | 유지 |
+| 새 label 생성 금지 | 유지 |
+| label이 모호하면 label 없이 생성하거나 작업지시자 확인 | 유지 |
+| 이슈 생성 전 제목/본문/milestone/label 초안 승인 필요 | 유지 |
+| 이슈 생성 후 `task-start` 진입 승인 요청 | 유지 |
+
+### 새로 검증한 규칙
+
+| 규칙 | 확인 결과 |
+|------|-----------|
+| `type label 1개 + area label 1~2개 + kind/status label 0~1개` 제한 | 반영됨 |
+| type label은 작업 성격을 나타내는 label 중 1개 우선 선택 | 반영됨 |
+| `area:*`는 주 작업 소유 영역 기준 선택 | 반영됨 |
+| `kind:*`는 처리 방식이나 맥락 구분이 필요할 때만 선택 | 반영됨 |
+| 일반 이슈는 2~4개 label 권장 | 반영됨 |
+| 5개 이상 label은 예외 사유와 작업지시자 확인 필요 | 반영됨 |
+| 이슈 초안에 type/area/kind 기준 선택 이유 기재 | 반영됨 |
+| 검증 섹션에 label 개수와 예외 사유 기준 추가 | 반영됨 |
+
+## 실행한 명령
+
+```bash
+git diff --check
+rg -n "label 후보 선택|type label|area label|kind/status|2~4개|5개 이상|작업지시자 확인|새 label은 만들지 않는다" \
+  mydocs/skills/task-register/SKILL.md
+git status --short --branch
+sed -n '1,140p' mydocs/skills/task-register/SKILL.md
+```
+
+## 검증 결과
+
+```text
+git diff --check
+```
+
+결과: 통과.
+
+```text
+rg -n "label 후보 선택|type label|area label|kind/status|2~4개|5개 이상|작업지시자 확인|새 label은 만들지 않는다" mydocs/skills/task-register/SKILL.md
+```
+
+결과:
+
+- `label 후보 선택` 위치 확인
+- `type label`, `area label`, `kind/status` 기준 확인
+- `2~4개`, `5개 이상`, `작업지시자 확인` 예외 기준 확인
+- `새 label은 만들지 않는다` 기존 제한 유지 확인
+
+```text
+git status --short --branch
+```
+
+결과: Stage 3 보고서 작성 전 작업 트리는 `local/task64...origin/devel [ahead 4]` 상태였고 미커밋 변경은 없었다.
+
+## 완료 조건 확인
+
+| 완료 조건 | 결과 |
+|-----------|------|
+| Skill 본문 변경이 검증됨 | 충족 |
+| 단계 보고서에 검증 명령과 결과가 기록됨 | 충족 |
+| 최종 보고서 작성 단계로 넘어갈 수 있음 | 충족 |
+
+## 잔여 위험
+
+- 실제 신규 이슈 등록 시 label 개수 판단은 작업 성격과 live label description에 따라 달라질 수 있다. Skill은 기준을 제공하지만, 모호한 경우 작업지시자 확인을 계속 요구한다.
+- 5개 이상 label 예외 기준은 문서화되었지만 자동 강제는 아니다. 이 절차는 에이전트와 작업지시자의 승인 흐름으로 통제한다.
+
+## 승인 요청 사항
+
+본 Stage 3 결과 기준으로 Stage 4: 최종 보고와 오늘할일 완료 처리를 진행할지 승인 요청한다.

--- a/mydocs/working/task_m010_64_stage4.md
+++ b/mydocs/working/task_m010_64_stage4.md
@@ -1,0 +1,48 @@
+# Issue #64 Stage 4 완료 보고서
+
+## 단계 목적
+
+최종 결과 보고서를 작성하고, 오늘할일에서 #64를 완료 처리한 뒤 전체 변경 범위를 검증한다.
+
+## 변경 대상
+
+- `mydocs/report/task_m010_64_report.md`
+- `mydocs/working/task_m010_64_stage4.md`
+- `mydocs/orders/20260426.md`
+
+## 작업 결과
+
+- 최종 결과 보고서 `mydocs/report/task_m010_64_report.md`를 작성했다.
+- Stage 4 완료 보고서인 본 문서를 작성했다.
+- 오늘할일 `mydocs/orders/20260426.md`에서 #64 상태를 `완료`로 변경하고 완료 시각을 기록했다.
+
+## 검증 명령
+
+```bash
+git diff --check
+rg -n "label 후보 선택|type label|area label|kind/status|2~4개|5개 이상|작업지시자 확인|새 label은 만들지 않는다" \
+  mydocs/skills/task-register/SKILL.md
+rg -n "#64|task-register Skill label 선택 규칙 보강|완료:" mydocs/orders/20260426.md
+test -f mydocs/report/task_m010_64_report.md
+git status --short
+```
+
+## 검증 결과
+
+- `git diff --check`: 통과
+- `task-register` Skill 핵심 문구 검색: 확인
+- 오늘할일 #64 완료 처리 검색: 확인
+- 최종 보고서 파일 존재: 확인
+- Stage 4 커밋 전 변경 파일: 최종 보고서, Stage 4 보고서, 오늘할일
+
+## 완료 조건 확인
+
+| 완료 조건 | 결과 |
+|-----------|------|
+| 최종 보고서와 오늘할일 완료 처리가 끝남 | 충족 |
+| 전체 변경이 커밋되어 PR 게시 승인 요청이 가능함 | 충족 |
+| Skill 변경 범위가 `task-register` label 선택 규칙 보강에 한정됨 | 충족 |
+
+## 승인 요청 사항
+
+본 Stage 4 결과와 최종 보고서 기준으로 PR 게시 절차 진행 승인을 요청한다.


### PR DESCRIPTION
## 요약

- `task-register` Skill의 label 후보 선택 절차에 label 최소화 규칙을 추가했습니다.
- 신규 이슈 등록 시 `type label 1개 + area label 1~2개 + kind/status label 0~1개` 기준을 우선 적용하도록 했습니다.
- 일반 이슈는 2~4개 label을 권장하고, 5개 이상 label이 필요하면 예외 사유와 작업지시자 확인을 요구하도록 했습니다.
- 기존 live label 조회, 기존 label만 사용, 새 label 생성 금지, 이슈 생성 전 승인 원칙은 유지했습니다.

## 변경 내역

- **Stage 1**: 현재 `task-register` Skill의 label 선택 흐름과 보강 위치 확정
- **Stage 2**: `task-register` Skill에 label 최소화 규칙과 예외 승인 기준 반영
- **Stage 3**: Skill 전체 흐름과 기존 원칙 유지 여부 통합 검증
- **Stage 4**: 최종 보고서 작성과 오늘할일 완료 처리

## 검증

- [x] `git diff --check`
- [x] `rg -n "label 후보 선택|type label|area label|kind/status|2~4개|5개 이상|작업지시자 확인|새 label은 만들지 않는다" mydocs/skills/task-register/SKILL.md`
- [x] `rg -n "#64|task-register Skill label 선택 규칙 보강|완료:" mydocs/orders/20260426.md`
- [x] `test -f mydocs/report/task_m010_64_report.md`

문서와 Skill 절차 보강만 수행했으므로 Rust/Swift/Xcode 빌드는 수행하지 않았습니다.

## 문서

- 수행 계획서: [task_m010_64.md](https://github.com/postmelee/alhangeul-macos/blob/2015196da450d6a3da8280eb465735048ae9eecd/mydocs/plans/task_m010_64.md)
- 구현 계획서: [task_m010_64_impl.md](https://github.com/postmelee/alhangeul-macos/blob/2015196da450d6a3da8280eb465735048ae9eecd/mydocs/plans/task_m010_64_impl.md)
- Stage 1 보고서: [task_m010_64_stage1.md](https://github.com/postmelee/alhangeul-macos/blob/2015196da450d6a3da8280eb465735048ae9eecd/mydocs/working/task_m010_64_stage1.md)
- Stage 2 보고서: [task_m010_64_stage2.md](https://github.com/postmelee/alhangeul-macos/blob/2015196da450d6a3da8280eb465735048ae9eecd/mydocs/working/task_m010_64_stage2.md)
- Stage 3 보고서: [task_m010_64_stage3.md](https://github.com/postmelee/alhangeul-macos/blob/2015196da450d6a3da8280eb465735048ae9eecd/mydocs/working/task_m010_64_stage3.md)
- Stage 4 보고서: [task_m010_64_stage4.md](https://github.com/postmelee/alhangeul-macos/blob/2015196da450d6a3da8280eb465735048ae9eecd/mydocs/working/task_m010_64_stage4.md)
- 최종 보고서: [task_m010_64_report.md](https://github.com/postmelee/alhangeul-macos/blob/2015196da450d6a3da8280eb465735048ae9eecd/mydocs/report/task_m010_64_report.md)

## 관련 이슈

Closes #64

## 남은 리스크

- label 최소화 규칙은 Skill 절차 문서 기반이며 GitHub UI/CLI에서 자동 강제되지는 않습니다.
- 실제 신규 이슈 등록 시 5개 이상 label이 필요한 교차 영역 작업은 예외 사유와 작업지시자 확인으로 처리해야 합니다.
