### PR TITLE
Task #106: Swift native renderer 이미지 crop/effect/brightness/contrast 보강

### DIFF
--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -265,17 +265,23 @@ class CGTreeRenderer {
         ctx.saveGState()
         applyTransform(img.transform, bbox: bbox, in: ctx)
 
-        let drawImage = croppedImage(for: cgImage, crop: img.crop)
+        let drawImage = preparedImage(for: cgImage, node: img)
         let r = cgRect(bbox)
+        let drawRect = imageDestinationRect(for: img, size: r.size)
         // CG draw(image:) 는 이미지를 rect에 맞춰 그리지만 상하 반전으로 그린다.
         // 이미지 영역에서만 Y축 반전하여 올바르게 표시한다.
         ctx.saveGState()
         ctx.translateBy(x: r.minX, y: r.minY + r.height)
         ctx.scaleBy(x: 1, y: -1)
-        ctx.draw(drawImage, in: CGRect(x: 0, y: 0, width: r.width, height: r.height))
+        ctx.draw(drawImage, in: drawRect)
         ctx.restoreGState()
 
         ctx.restoreGState()
+    }
+
+    private func preparedImage(for image: CGImage, node: ImageNode) -> CGImage {
+        let cropped = croppedImage(for: image, crop: node.crop)
+        return adjustedImage(for: cropped, node: node)
     }
 
     private func croppedImage(for image: CGImage, crop: [Int32]?) -> CGImage {
@@ -294,6 +300,138 @@ class CGTreeRenderer {
 
         let sourceRect = CGRect(x: left, y: top, width: right - left, height: bottom - top)
         return image.cropping(to: sourceRect) ?? image
+    }
+
+    private func adjustedImage(for image: CGImage, node: ImageNode) -> CGImage {
+        let effect = normalizedImageEffect(node.effect)
+        let brightness = node.brightness ?? 0
+        let contrast = node.contrast ?? 0
+        guard effect != nil || brightness != 0 || contrast != 0 else { return image }
+
+        let width = image.width
+        let height = image.height
+        guard width > 0, height > 0 else { return image }
+
+        let bytesPerPixel = 4
+        let bitsPerComponent = 8
+        let bytesPerRow = width * bytesPerPixel
+        let bitmapInfo = CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue)
+            .union(.byteOrder32Big)
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        var pixels = [UInt8](repeating: 0, count: height * bytesPerRow)
+
+        return pixels.withUnsafeMutableBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress,
+                  let bitmapContext = CGContext(
+                    data: baseAddress,
+                    width: width,
+                    height: height,
+                    bitsPerComponent: bitsPerComponent,
+                    bytesPerRow: bytesPerRow,
+                    space: colorSpace,
+                    bitmapInfo: bitmapInfo.rawValue
+                  ) else {
+                return image
+            }
+
+            bitmapContext.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            applyImageAdjustments(
+                to: rawBuffer,
+                width: width,
+                height: height,
+                bytesPerRow: bytesPerRow,
+                effect: effect,
+                brightness: brightness,
+                contrast: contrast
+            )
+            return bitmapContext.makeImage() ?? image
+        }
+    }
+
+    private func applyImageAdjustments(
+        to rawBuffer: UnsafeMutableRawBufferPointer,
+        width: Int,
+        height: Int,
+        bytesPerRow: Int,
+        effect: ImageEffect?,
+        brightness: Int,
+        contrast: Int
+    ) {
+        let slope = max(0, 1.0 + Double(contrast) / 100.0)
+        let intercept = Double(brightness) / 100.0 * slope
+        let bytes = rawBuffer.bindMemory(to: UInt8.self)
+
+        for y in 0..<height {
+            let rowOffset = y * bytesPerRow
+            for x in 0..<width {
+                let offset = rowOffset + x * 4
+                var red = Double(bytes[offset]) / 255.0
+                var green = Double(bytes[offset + 1]) / 255.0
+                var blue = Double(bytes[offset + 2]) / 255.0
+
+                if effect == .grayscale || effect == .blackWhite {
+                    let gray = red * 0.299 + green * 0.587 + blue * 0.114
+                    red = gray
+                    green = gray
+                    blue = gray
+                }
+
+                if brightness != 0 || contrast != 0 {
+                    red = red * slope + intercept
+                    green = green * slope + intercept
+                    blue = blue * slope + intercept
+                }
+
+                bytes[offset] = normalizedColorByte(red)
+                bytes[offset + 1] = normalizedColorByte(green)
+                bytes[offset + 2] = normalizedColorByte(blue)
+            }
+        }
+    }
+
+    private func normalizedColorByte(_ value: Double) -> UInt8 {
+        UInt8(max(0, min(255, Int((value * 255.0).rounded()))))
+    }
+
+    private enum ImageEffect {
+        case grayscale
+        case blackWhite
+    }
+
+    private func normalizedImageEffect(_ effect: String?) -> ImageEffect? {
+        guard let effect else { return nil }
+        let normalized = effect
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "_", with: "")
+            .lowercased()
+
+        switch normalized {
+        case "", "realpic", "none":
+            return nil
+        case "grayscale", "gray", "greyscale", "grey":
+            return .grayscale
+        case "blackwhite", "blackandwhite", "monochrome":
+            // Render as grayscale for now; threshold parity needs a dedicated sample.
+            return .blackWhite
+        default:
+            return nil
+        }
+    }
+
+    private func imageDestinationRect(for img: ImageNode, size: CGSize) -> CGRect {
+        let fullRect = CGRect(origin: .zero, size: size)
+        guard let fillMode = img.fillMode?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !fillMode.isEmpty else {
+            return fullRect
+        }
+
+        switch fillMode.replacingOccurrences(of: "_", with: "").lowercased() {
+        case "fittosize", "stretch", "stretchtofit":
+            return fullRect
+        default:
+            return fullRect
+        }
     }
 
     // MARK: - 그룹

--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -365,9 +365,18 @@ class CGTreeRenderer {
             let rowOffset = y * bytesPerRow
             for x in 0..<width {
                 let offset = rowOffset + x * 4
-                var red = Double(bytes[offset]) / 255.0
-                var green = Double(bytes[offset + 1]) / 255.0
-                var blue = Double(bytes[offset + 2]) / 255.0
+                let alpha = Double(bytes[offset + 3]) / 255.0
+                guard alpha > 0 else {
+                    bytes[offset] = 0
+                    bytes[offset + 1] = 0
+                    bytes[offset + 2] = 0
+                    continue
+                }
+
+                // CGContext stores premultiplied RGBA. Apply filters in straight color space.
+                var red = clampedUnit((Double(bytes[offset]) / 255.0) / alpha)
+                var green = clampedUnit((Double(bytes[offset + 1]) / 255.0) / alpha)
+                var blue = clampedUnit((Double(bytes[offset + 2]) / 255.0) / alpha)
 
                 if effect == .grayscale || effect == .blackWhite {
                     let gray = red * 0.299 + green * 0.587 + blue * 0.114
@@ -382,11 +391,15 @@ class CGTreeRenderer {
                     blue = blue * slope + intercept
                 }
 
-                bytes[offset] = normalizedColorByte(red)
-                bytes[offset + 1] = normalizedColorByte(green)
-                bytes[offset + 2] = normalizedColorByte(blue)
+                bytes[offset] = normalizedColorByte(clampedUnit(red) * alpha)
+                bytes[offset + 1] = normalizedColorByte(clampedUnit(green) * alpha)
+                bytes[offset + 2] = normalizedColorByte(clampedUnit(blue) * alpha)
             }
         }
+    }
+
+    private func clampedUnit(_ value: Double) -> Double {
+        max(0, min(1, value))
     }
 
     private func normalizedColorByte(_ value: Double) -> UInt8 {

--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -8,6 +8,8 @@ import Foundation
 import ImageIO
 
 class CGTreeRenderer {
+    private let imageCropUnitsPerPixel = 75.0
+
     private var imageCache: [UInt16: CGImage] = [:]
     private weak var document: RhwpDocument?
 
@@ -263,16 +265,35 @@ class CGTreeRenderer {
         ctx.saveGState()
         applyTransform(img.transform, bbox: bbox, in: ctx)
 
+        let drawImage = croppedImage(for: cgImage, crop: img.crop)
         let r = cgRect(bbox)
         // CG draw(image:) 는 이미지를 rect에 맞춰 그리지만 상하 반전으로 그린다.
         // 이미지 영역에서만 Y축 반전하여 올바르게 표시한다.
         ctx.saveGState()
         ctx.translateBy(x: r.minX, y: r.minY + r.height)
         ctx.scaleBy(x: 1, y: -1)
-        ctx.draw(cgImage, in: CGRect(x: 0, y: 0, width: r.width, height: r.height))
+        ctx.draw(drawImage, in: CGRect(x: 0, y: 0, width: r.width, height: r.height))
         ctx.restoreGState()
 
         ctx.restoreGState()
+    }
+
+    private func croppedImage(for image: CGImage, crop: [Int32]?) -> CGImage {
+        guard let crop, crop.count == 4 else { return image }
+
+        let imageWidth = Double(image.width)
+        let imageHeight = Double(image.height)
+        guard imageWidth > 0, imageHeight > 0 else { return image }
+
+        let left = max(0, floor(Double(crop[0]) / imageCropUnitsPerPixel))
+        let top = max(0, floor(Double(crop[1]) / imageCropUnitsPerPixel))
+        let right = min(imageWidth, ceil(Double(crop[2]) / imageCropUnitsPerPixel))
+        let bottom = min(imageHeight, ceil(Double(crop[3]) / imageCropUnitsPerPixel))
+
+        guard right > left, bottom > top else { return image }
+
+        let sourceRect = CGRect(x: left, y: top, width: right - left, height: bottom - top)
+        return image.cropping(to: sourceRect) ?? image
     }
 
     // MARK: - 그룹

--- a/Sources/RhwpCoreBridge/RenderTree.swift
+++ b/Sources/RhwpCoreBridge/RenderTree.swift
@@ -301,17 +301,22 @@ struct ImageNode: Decodable {
     let controlIndex: Int?
     let fillMode: String?
     let originalSize: [Double]?
+    let originalSizeHU: [Double]?
+    let effect: String?
+    let brightness: Int?
+    let contrast: Int?
     let transform: ShapeTransform
     let crop: [Int32]?
 
     enum CodingKeys: String, CodingKey {
-        case transform, crop
+        case transform, crop, effect, brightness, contrast
         case binDataId = "bin_data_id"
         case sectionIndex = "section_index"
         case paraIndex = "para_index"
         case controlIndex = "control_index"
         case fillMode = "fill_mode"
         case originalSize = "original_size"
+        case originalSizeHU = "original_size_hu"
     }
 }
 

--- a/mydocs/orders/20260501.md
+++ b/mydocs/orders/20260501.md
@@ -11,3 +11,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #108 | Swift native renderer 도형 children 렌더링 보강 | 완료 | 완료: 15:28, BookReview 텍스트 렌더 회복 |
+| #106 | Swift native renderer 이미지 crop/effect/brightness/contrast 보강 | 진행중 | M015, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260501.md
+++ b/mydocs/orders/20260501.md
@@ -11,4 +11,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #108 | Swift native renderer 도형 children 렌더링 보강 | 완료 | 완료: 15:28, BookReview 텍스트 렌더 회복 |
-| #106 | Swift native renderer 이미지 crop/effect/brightness/contrast 보강 | 진행중 | M015, 수행계획서 작성 후 승인 대기 |
+| #106 | Swift native renderer 이미지 crop/effect/brightness/contrast 보강 | 완료 | 완료: 11:05, 이미지 crop/effect/brightness/contrast 보강 및 검증 통과 |

--- a/mydocs/plans/task_m015_106.md
+++ b/mydocs/plans/task_m015_106.md
@@ -1,0 +1,96 @@
+# Task M015 #106 수행계획서
+
+## 목적
+
+Swift native renderer가 rhwp core v0.7.9 PageRenderTree의 이미지 `crop`, `effect`, `brightness`, `contrast`, `fill_mode` 계열 정보를 반영하도록 보강한다.
+
+완료 후 `samples/복학원서.hwp` 첫 페이지의 워터마크 이미지가 core SVG와 같은 방향으로 흐린 배경처럼 표시되어야 하며, HostApp, Quick Look, Thumbnail이 공유하는 native render 경로에서 이미지가 상하 반전되거나 bbox 밖으로 밀리지 않아야 한다.
+
+## 배경
+
+M015의 첫 작업 #108에서 도형 children 렌더링은 보강됐지만, 이미지 렌더링은 아직 단순 bbox 맞춤 draw에 가깝다. 현재 Swift 모델은 `ImageNode`의 `crop`, `fill_mode`, `original_size` 일부 필드를 가지고 있으나 `CGTreeRenderer`는 crop source rect를 적용하지 않고 전체 이미지를 bbox에 맞춰 그린다.
+
+이슈 #106에 따르면 `samples/복학원서.hwp`에서 rhwp core v0.7.9 SVG는 워터마크 이미지의 `effect=GrayScale`, `brightness=-50`, `contrast=70`, `crop`을 반영한다. Swift native renderer는 해당 정보 일부를 디코드하지 않거나 draw에 적용하지 않아 워터마크가 흐린 배경이 아니라 풀컬러 인장처럼 보인다.
+
+## 범위
+
+포함:
+
+- `samples/복학원서.hwp` 기준 render tree JSON과 core SVG에서 이미지 필드와 좌표 의미 확인
+- `RenderTree.swift`의 `ImageNode` 모델에 필요한 이미지 효과 필드 디코딩 보강
+- `CGTreeRenderer` 이미지 draw에서 crop source rect 계산과 적용
+- grayscale 또는 black-white 계열 effect, brightness, contrast의 1차 적용
+- `fill_mode`와 `original_size`/원본 크기 정보의 최소 지원 범위 정리
+- image transform, crop, filter, y-flip 적용 순서 검증
+
+제외:
+
+- WMF/BMP 변환 정책 재설계
+- PageLayerTree ABI 추가 또는 기본 렌더 경로 전환
+- 모든 이미지 fill mode의 완전 parity
+- 고급 이미지 효과 전체 구현
+- rhwp core upstream 수정
+
+## 설계 방향
+
+제품 기준 경로는 기존 `rhwp_render_page_tree` + Swift `RenderTree` + `CGTreeRenderer` 경로를 유지한다. 이미지 보강은 Swift renderer 내부의 모델 디코딩과 draw helper 수준으로 제한하고, HostApp/Quick Look/Thumbnail 상위 호출부는 바꾸지 않는다.
+
+먼저 render tree JSON의 실제 필드명과 값 단위를 확인한다. `crop`은 이슈의 75 HU/px 규칙과 원본 이미지 픽셀 크기를 함께 검토해 source rect 계산식을 고정한다. 필드가 없거나 지원 범위를 벗어나는 경우에는 기존 bbox 전체 draw fallback을 유지한다.
+
+이미지 효과는 AppKit/UIKit 없이 CoreGraphics와 필요 시 CoreImage 기반으로 처리한다. `Sources/RhwpCoreBridge`의 플랫폼 UI 프레임워크 직접 의존 금지 규칙은 유지한다. 적용 순서는 transform으로 bbox 좌표계를 맞춘 뒤 source crop과 이미지 보정을 적용하고, 마지막에 기존 y-flip 보정을 유지하는 방향으로 검증한다.
+
+## 예상 변경 파일
+
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+- `mydocs/orders/20260501.md`
+- `mydocs/plans/task_m015_106.md`
+- 단계별 완료보고서와 최종 보고서
+
+## 잠정 단계
+
+1. `복학원서.hwp` 이미지 렌더 기준 재현과 필드 의미 확정
+2. `ImageNode` 디코딩 보강과 crop source rect 계산 구현
+3. grayscale/brightness/contrast 보정과 fill mode fallback 구현
+4. `복학원서.hwp` 및 대표 이미지 샘플 render smoke/diff 검증
+5. HostApp build, 경계 규칙 검증, 최종 보고서 정리
+
+## 검증 계획
+
+- `samples/복학원서.hwp`로 `scripts/render-debug-compare.sh`를 실행해 render tree JSON, core SVG, native PNG, summary를 생성한다.
+- render tree JSON에서 이미지 `crop`, `effect`, `brightness`, `contrast`, `fill_mode`, 원본 크기 관련 필드를 확인한다.
+- 변경 전후 native PNG에서 워터마크가 core SVG와 같은 방향으로 흐리게 처리되는지 비교한다.
+- crop source rect가 원본 픽셀 크기와 HU 단위 규칙에 맞는지 계산 근거를 단계 보고서에 기록한다.
+- 대표 이미지 포함 샘플에서 native PNG가 non-blank이고 이미지가 상하 반전되거나 bbox 밖으로 밀리지 않는지 확인한다.
+- `Sources/RhwpCoreBridge`에 AppKit/UIKit 직접 의존이 생기지 않았는지 확인한다.
+- HostApp Debug build와 `git diff --check`를 실행한다.
+
+후보 명령:
+
+```bash
+shasum -a 256 samples/복학원서.hwp
+./scripts/render-debug-compare.sh /private/tmp/rhwp-task106-stage1 --page 1 samples/복학원서.hwp
+sed -n '1,140p' /private/tmp/rhwp-task106-stage1/복학원서-page1-summary.txt
+rg -n "\"Image\"|\"crop\"|\"effect\"|\"brightness\"|\"contrast\"|\"fill_mode\"|\"original\"" /private/tmp/rhwp-task106-stage1/복학원서-page1-render-tree.json
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project AlhangeulMac.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+git diff --check
+```
+
+## 리스크
+
+- crop 단위 해석이 틀리면 이미지가 잘리거나 bbox 안에서 위치가 어긋날 수 있다.
+- brightness/contrast 보정 수식이 core SVG 또는 브라우저 필터와 완전히 같지 않으면 시각 차이가 남을 수 있다.
+- CoreImage 사용 시 색공간이나 alpha 처리 차이로 기존 이미지 샘플의 색이 달라질 수 있다.
+- fill mode를 제한적으로 지원하면 일부 문서는 기존과 동일한 fallback으로 남을 수 있다.
+- `qlmanage` 기반 SVG rasterize/diff는 로컬 macOS 환경이나 sandbox 상태에 따라 선택 산출물 생성이 실패할 수 있다.
+
+## 승인 요청 사항
+
+이 수행계획서 승인 후 구현계획서 작성을 진행한다.

--- a/mydocs/plans/task_m015_106_impl.md
+++ b/mydocs/plans/task_m015_106_impl.md
@@ -1,0 +1,273 @@
+# Task M015 #106 구현 계획서
+
+수행계획서: `mydocs/plans/task_m015_106.md`
+
+각 단계 완료 후 `task-stage-report` 절차로 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #106 Swift native renderer 이미지 crop/effect/brightness/contrast 보강
+- 마일스톤: M015 (`첫 출시 전 Swift 렌더 보강`)
+- 브랜치: `local/task106`
+- 작업 위치: `/Users/melee/Documents/projects/rhwp-mac-task106`
+- 주 대상: `Sources/RhwpCoreBridge/RenderTree.swift`, `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+- 기준 샘플: `samples/복학원서.hwp`
+- 목표: PageRenderTree 이미지 노드의 crop/effect/brightness/contrast를 Swift native renderer에 반영해 core SVG와 native PNG의 워터마크 이미지 차이를 줄인다.
+
+## 구현 원칙
+
+- 제품 기준 경로는 기존 `rhwp_render_page_tree` + Swift `RenderTree` + `CGTreeRenderer` 경로를 유지한다.
+- PageLayerTree ABI 추가 또는 기본 렌더 경로 전환은 하지 않는다.
+- `Sources/RhwpCoreBridge`에는 AppKit/UIKit 직접 의존을 추가하지 않는다.
+- HostApp, Quick Look, Thumbnail 상위 호출부는 변경하지 않고 공통 renderer 내부에서 처리한다.
+- render tree JSON의 실제 필드명과 단위를 Stage 1에서 먼저 확인한 뒤 코드 변경에 반영한다.
+- 지원하지 못하는 effect/fill mode는 crash 없이 기존 전체 이미지 bbox draw로 fallback한다.
+- 이미지 캐시는 원본 `binDataId` 기준 캐시와 노드별 crop/effect 결과를 혼동하지 않는다.
+- CoreImage를 쓰는 경우 `render-debug-compare.sh`와 `validate-stage3-render.sh`의 `swiftc` 링크 옵션도 함께 갱신한다.
+
+## Stage 1. 기준 재현과 이미지 필드 의미 확정
+
+### 목표
+
+- `복학원서.hwp`에서 core SVG와 native PNG의 워터마크 이미지 차이를 현재 브랜치에서 재현한다.
+- render tree JSON과 core SVG가 제공하는 `crop`, `effect`, `brightness`, `contrast`, `fill_mode`, 원본 크기 필드명을 확정한다.
+- crop 값의 단위와 source rect 변환 규칙을 코드 변경 전에 고정한다.
+
+### 작업
+
+- `samples/복학원서.hwp`의 sample hash를 기록한다.
+- `render-debug-compare.sh`로 변경 전 기준 산출물을 생성한다.
+- summary의 page size, native non-white pixel, diff 생성 여부를 기록한다.
+- render tree JSON에서 `Image` 노드와 관련 필드를 추출한다.
+- core SVG에서 이미지 filter, crop/clip, transform 표현을 확인한다.
+- 기존 `ImageNode` 모델과 `renderImage` 구현이 어떤 필드를 놓치는지 정리한다.
+- crop source rect 계산에 필요한 원본 이미지 픽셀 크기와 HU 단위 변환 근거를 보고서에 기록한다.
+
+### 예상 변경 파일
+
+- `mydocs/working/task_m015_106_stage1.md`
+
+### 검증
+
+```bash
+git status --short --branch
+shasum -a 256 samples/복학원서.hwp
+./scripts/render-debug-compare.sh /private/tmp/rhwp-task106-stage1 --page 1 samples/복학원서.hwp
+test -s /private/tmp/rhwp-task106-stage1/복학원서-page1-render-tree.json
+test -s /private/tmp/rhwp-task106-stage1/복학원서-page1-core.svg
+test -s /private/tmp/rhwp-task106-stage1/복학원서-page1-native.png
+test -s /private/tmp/rhwp-task106-stage1/복학원서-page1-summary.txt
+sed -n '1,140p' /private/tmp/rhwp-task106-stage1/복학원서-page1-summary.txt
+rg -n "\"Image\"|\"crop\"|\"effect\"|\"brightness\"|\"contrast\"|\"fill_mode\"|\"original\"" /private/tmp/rhwp-task106-stage1/복학원서-page1-render-tree.json
+rg -n "filter|feColorMatrix|feComponentTransfer|brightness|contrast|clipPath|<image" /private/tmp/rhwp-task106-stage1/복학원서-page1-core.svg
+git diff --check
+```
+
+### 완료 기준
+
+- 기준 산출물 위치와 핵심 summary 값이 보고서에 기록된다.
+- Swift renderer가 빠뜨린 이미지 필드와 적용 순서가 확인된다.
+- crop source rect 계산식의 입력 값과 남은 불확실성이 정리된다.
+
+### 커밋 메시지
+
+```text
+Task #106 Stage 1: 이미지 렌더 기준과 필드 의미 확정
+```
+
+## Stage 2. ImageNode 디코딩과 crop source rect 적용
+
+### 목표
+
+- `RenderTree.swift`가 Stage 1에서 확인한 이미지 필드를 디코딩한다.
+- `CGTreeRenderer`가 crop source rect를 계산해 원본 이미지의 해당 영역만 bbox에 그린다.
+
+### 작업
+
+- `ImageNode`에 `effect`, `brightness`, `contrast`, `originalSizeHU` 또는 Stage 1에서 확인한 원본 크기 필드를 추가한다.
+- 기존 `fillMode`, `originalSize`, `crop` 디코딩과 새 필드가 누락 값에 안전하도록 optional로 둔다.
+- `renderImage`에서 원본 `CGImage` 로딩과 draw 대상 이미지 생성을 분리한다.
+- crop 값이 유효하면 source rect를 원본 이미지 픽셀 좌표로 변환하고 `cgImage.cropping(to:)`를 적용한다.
+- crop 값이 없거나 rect가 비정상이면 기존 전체 이미지 draw fallback을 유지한다.
+- Stage 2에서는 색상 effect를 적용하지 않고 crop과 draw 좌표 안정성만 검증한다.
+
+### 예상 변경 파일
+
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+- `mydocs/working/task_m015_106_stage2.md`
+
+### 검증
+
+```bash
+git status --short --branch
+git diff -- Sources/RhwpCoreBridge/RenderTree.swift Sources/RhwpCoreBridge/CGTreeRenderer.swift
+./scripts/check-no-appkit.sh
+./scripts/render-debug-compare.sh /private/tmp/rhwp-task106-stage2 --page 1 samples/복학원서.hwp
+test -s /private/tmp/rhwp-task106-stage2/복학원서-page1-native.png
+sed -n '1,140p' /private/tmp/rhwp-task106-stage2/복학원서-page1-summary.txt
+git diff --check -- Sources/RhwpCoreBridge/RenderTree.swift Sources/RhwpCoreBridge/CGTreeRenderer.swift mydocs/working/task_m015_106_stage2.md
+```
+
+### 완료 기준
+
+- 새 이미지 필드가 디코딩 실패 없이 optional로 수용된다.
+- crop이 있는 이미지가 source rect 기반으로 그려진다.
+- crop이 없는 기존 이미지 샘플의 전체 bbox draw fallback이 유지된다.
+- AppKit/UIKit 직접 의존 금지 검증이 통과한다.
+
+### 커밋 메시지
+
+```text
+Task #106 Stage 2: 이미지 crop source rect 적용
+```
+
+## Stage 3. 이미지 effect와 fill mode fallback 보강
+
+### 목표
+
+- grayscale/black-white 계열 effect와 brightness/contrast를 native PNG에 반영한다.
+- `fill_mode`와 원본 크기 정보는 안전한 최소 지원 및 fallback 정책으로 정리한다.
+
+### 작업
+
+- Stage 1에서 확인한 effect 문자열 또는 enum 값을 Swift 모델과 renderer helper에서 처리한다.
+- grayscale은 우선 구현하고, black-white 계열 값이 확인되면 threshold 기반 또는 명시 fallback으로 처리한다.
+- brightness/contrast는 core SVG의 필터 방향과 같은 방향으로 보정하되, 완전 수치 parity가 어려우면 1차 근사로 문서화한다.
+- CoreImage를 사용하면 `CGTreeRenderer.swift`에 `import CoreImage`를 추가하고, `scripts/render-debug-compare.sh`와 `scripts/validate-stage3-render.sh`에 `-framework CoreImage`를 추가한다.
+- CoreImage를 쓰지 않는 경우에는 CoreGraphics bitmap context 기반 픽셀 보정 helper를 추가한다.
+- `fill_mode`는 `FitToSize` 또는 Stage 1에서 확인한 기본 모드를 우선 지원하고, 미지원 값은 기존 bbox draw fallback으로 남긴다.
+- 원본 이미지 캐시와 crop/effect 결과 캐시를 섞지 않도록 노드별 처리 결과는 현재 draw 호출 안에서만 사용하거나 별도 key 정책을 둔다.
+
+### 예상 변경 파일
+
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+- 필요 시 `scripts/render-debug-compare.sh`
+- 필요 시 `scripts/validate-stage3-render.sh`
+- `mydocs/working/task_m015_106_stage3.md`
+
+### 검증
+
+```bash
+git status --short --branch
+git diff -- Sources/RhwpCoreBridge/RenderTree.swift Sources/RhwpCoreBridge/CGTreeRenderer.swift scripts/render-debug-compare.sh scripts/validate-stage3-render.sh
+./scripts/check-no-appkit.sh
+./scripts/render-debug-compare.sh /private/tmp/rhwp-task106-stage3 --page 1 samples/복학원서.hwp
+test -s /private/tmp/rhwp-task106-stage3/복학원서-page1-native.png
+sed -n '1,160p' /private/tmp/rhwp-task106-stage3/복학원서-page1-summary.txt
+git diff --check -- Sources/RhwpCoreBridge/RenderTree.swift Sources/RhwpCoreBridge/CGTreeRenderer.swift scripts/render-debug-compare.sh scripts/validate-stage3-render.sh mydocs/working/task_m015_106_stage3.md
+```
+
+### 완료 기준
+
+- `복학원서.hwp` native PNG 워터마크가 기존 풀컬러 표시보다 core SVG와 같은 방향으로 흐리게 보인다.
+- crop과 effect가 함께 적용돼도 이미지가 상하 반전되거나 bbox 밖으로 밀리지 않는다.
+- 미지원 effect/fill mode는 crash 없이 fallback한다.
+- script 기반 render smoke가 새 framework 의존성 때문에 깨지지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #106 Stage 3: 이미지 효과와 fill mode fallback 보강
+```
+
+## Stage 4. 대표 이미지 샘플 render smoke 검증
+
+### 목표
+
+- `복학원서.hwp` 외 대표 이미지 포함 샘플에서 기존 이미지 렌더링이 회귀하지 않았는지 확인한다.
+- core SVG/native PNG 비교 산출물과 summary 값을 보고서에 남긴다.
+
+### 작업
+
+- `복학원서.hwp`, `samples/20250130-hongbo.hwp`, `samples/aift.hwp`를 render-debug 대상으로 실행한다.
+- 각 summary에서 `NativePNGSize`, `NativeNonWhitePixels`, `TextRuns`, `MissingHangulGlyphs`, diff 상태를 기록한다.
+- 가능하면 core raster PNG와 diff PNG를 확인하되, `qlmanage` 실패는 필수 실패로 보지 않고 summary의 `DiffReason`으로 기록한다.
+- Stage 2/3 전후 산출물을 비교해 워터마크 개선과 기존 이미지 회귀 여부를 정리한다.
+
+### 예상 변경 파일
+
+- `mydocs/working/task_m015_106_stage4.md`
+
+### 검증
+
+```bash
+git status --short --branch
+./scripts/render-debug-compare.sh /private/tmp/rhwp-task106-stage4 --page 1 samples/복학원서.hwp samples/20250130-hongbo.hwp samples/aift.hwp
+test -s /private/tmp/rhwp-task106-stage4/복학원서-page1-summary.txt
+test -s /private/tmp/rhwp-task106-stage4/20250130-hongbo-page1-summary.txt
+test -s /private/tmp/rhwp-task106-stage4/aift-page1-summary.txt
+sed -n '1,160p' /private/tmp/rhwp-task106-stage4/복학원서-page1-summary.txt
+sed -n '1,160p' /private/tmp/rhwp-task106-stage4/20250130-hongbo-page1-summary.txt
+sed -n '1,160p' /private/tmp/rhwp-task106-stage4/aift-page1-summary.txt
+git diff --check -- mydocs/working/task_m015_106_stage4.md
+```
+
+### 완료 기준
+
+- 기준 샘플 3개 모두 필수 산출물(render tree JSON, core SVG, native PNG, summary)이 생성된다.
+- `복학원서.hwp` 워터마크 개선 결과가 보고서에 기록된다.
+- 대표 이미지 샘플에서 native PNG가 blank가 아니고 기존 이미지가 사라지지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #106 Stage 4: 이미지 샘플 렌더 smoke 검증
+```
+
+## Stage 5. 통합 검증과 최종 보고
+
+### 목표
+
+- HostApp, Quick Look, Thumbnail 공통 renderer 변경으로서 기본 build/smoke를 확인한다.
+- 최종 보고서와 오늘할일을 정리하고 PR 전 상태를 만든다.
+
+### 작업
+
+- `Sources/RhwpCoreBridge` 경계 검증을 다시 실행한다.
+- `validate-stage3-render.sh`로 기본 native render pipeline 회귀를 확인한다.
+- `xcodegen generate` 후 HostApp Debug build를 실행한다.
+- Stage 1-4 결과, 변경 파일, 검증 명령, 잔여 리스크를 최종 보고서에 정리한다.
+- 오늘할일 #106 행을 완료 상태로 갱신한다.
+
+### 예상 변경 파일
+
+- `mydocs/working/task_m015_106_stage5.md`
+- `mydocs/report/task_m015_106_report.md`
+- `mydocs/orders/20260501.md`
+
+### 검증
+
+```bash
+git status --short --branch
+./scripts/check-no-appkit.sh
+./scripts/validate-stage3-render.sh
+xcodegen generate
+xcodebuild -project AlhangeulMac.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+git diff --check
+```
+
+### 완료 기준
+
+- AppKit/UIKit 직접 의존 금지 검증이 통과한다.
+- 기본 render smoke와 HostApp Debug build가 통과한다.
+- 최종 보고서에 구현 내용, 검증 결과, 남은 parity 차이가 정리된다.
+- 오늘할일 #106 행이 완료 상태로 갱신된다.
+
+### 커밋 메시지
+
+```text
+Task #106 Stage 5 + 최종 보고서: 이미지 렌더 보강 검증
+```
+
+## 승인 요청 사항
+
+1. 위 5단계 구현계획으로 Stage 1 기준 재현과 이미지 필드 의미 확정에 착수해도 되는지 승인 요청한다.
+2. Stage 1은 source code 변경 없이 조사와 단계 보고서 작성으로 진행한다.
+3. Stage 2부터 `Sources/RhwpCoreBridge/RenderTree.swift`와 `Sources/RhwpCoreBridge/CGTreeRenderer.swift` 코드 변경이 포함된다.

--- a/mydocs/report/task_m015_106_report.md
+++ b/mydocs/report/task_m015_106_report.md
@@ -24,19 +24,21 @@ render tree의 watermark image node에는 `crop`, `original_size_hu`, `effect`, 
 
 `복학원서.hwp`의 watermark는 Stage 3 이후 native PNG에서도 grayscale 및 brightness/contrast 적용 상태로 렌더된다.
 
-## 변경 파일
+## 변경 파일 목록과 영향 범위
 
-- `Sources/RhwpCoreBridge/RenderTree.swift`
-- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
-- `mydocs/plans/task_m015_106.md`
-- `mydocs/plans/task_m015_106_impl.md`
-- `mydocs/working/task_m015_106_stage1.md`
-- `mydocs/working/task_m015_106_stage2.md`
-- `mydocs/working/task_m015_106_stage3.md`
-- `mydocs/working/task_m015_106_stage4.md`
-- `mydocs/working/task_m015_106_stage5.md`
-- `mydocs/report/task_m015_106_report.md`
-- `mydocs/orders/20260501.md`
+| 파일 | 변경 내용 | 영향 범위 |
+|------|-----------|-----------|
+| `Sources/RhwpCoreBridge/RenderTree.swift` | `ImageNode`에 `original_size_hu`, `effect`, `brightness`, `contrast`, `crop` decode 필드 추가 | HostApp, Quick Look, Thumbnail이 공유하는 render tree image 모델 |
+| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | 이미지 source crop, grayscale, brightness/contrast 보정, fill mode fallback 보강 | Swift native renderer 이미지 출력 품질 |
+| `mydocs/plans/task_m015_106.md` | 수행 계획서 작성 | Task #106 진행 기준과 승인 기록 |
+| `mydocs/plans/task_m015_106_impl.md` | 단계별 구현 계획 작성 | 구현 범위, 검증 절차, 단계 구분 |
+| `mydocs/working/task_m015_106_stage1.md` | 이미지 렌더 기준과 필드 의미 확정 보고 | 기준 샘플, core SVG 비교, crop 단위 판단 |
+| `mydocs/working/task_m015_106_stage2.md` | crop source rect 적용 보고 | Stage 2 변경과 검증 기록 |
+| `mydocs/working/task_m015_106_stage3.md` | 이미지 효과와 fill mode fallback 보강 보고 | Stage 3 변경과 검증 기록 |
+| `mydocs/working/task_m015_106_stage4.md` | 대표 샘플 smoke 검증 보고 | 샘플별 native render 결과와 잔여 위험 |
+| `mydocs/working/task_m015_106_stage5.md` | 통합 검증 보고 | 최종 수용 기준 검증 결과 |
+| `mydocs/report/task_m015_106_report.md` | 최종 보고서 작성 | 작업 요약, 검증 결과, 잔여 위험 정리 |
+| `mydocs/orders/20260501.md` | 오늘할일 #106 완료 처리 | 작업 진행 상태 추적 |
 
 ## 단계별 결과
 

--- a/mydocs/report/task_m015_106_report.md
+++ b/mydocs/report/task_m015_106_report.md
@@ -1,0 +1,180 @@
+# Task M015 #106 최종 보고서
+
+## 작업 개요
+
+- 이슈: #106 Swift native renderer 이미지 crop/effect/brightness/contrast 보강
+- 마일스톤: M015 (`첫 출시 전 Swift 렌더 보강`)
+- 브랜치: `local/task106`
+- 핵심 변경: Swift native renderer가 이미지 crop source rect, effect, brightness, contrast 필드를 반영하도록 보강
+- 기준 샘플: `samples/복학원서.hwp`
+
+## 완료 내용
+
+`복학원서.hwp`에서 워터마크 이미지가 core SVG와 다르게 풀컬러로 표시되던 원인을 추적했다.
+
+render tree의 watermark image node에는 `crop`, `original_size_hu`, `effect`, `brightness`, `contrast` 값이 있었지만, 기존 Swift native renderer는 `crop`을 destination fit 계산에만 일부 사용하고 `effect`, `brightness`, `contrast`를 decode하지 않았다. 그 결과 core SVG가 적용하던 grayscale 및 brightness/contrast 필터가 native PNG에는 적용되지 않았다.
+
+이번 작업에서 `RenderTree.ImageNode`가 이미지 렌더 관련 필드를 decode하도록 확장했고, `CGTreeRenderer`의 이미지 준비 pipeline을 다음 순서로 정리했다.
+
+1. `crop` 값을 source pixel rect로 변환해 `CGImage.cropping(to:)` 적용
+2. bitmap context에 RGBA로 복사
+3. grayscale effect 적용
+4. brightness/contrast 보정 적용
+5. fill mode가 명확하지 않은 경우 bbox 전체 draw fallback 유지
+
+`복학원서.hwp`의 watermark는 Stage 3 이후 native PNG에서도 grayscale 및 brightness/contrast 적용 상태로 렌더된다.
+
+## 변경 파일
+
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+- `mydocs/plans/task_m015_106.md`
+- `mydocs/plans/task_m015_106_impl.md`
+- `mydocs/working/task_m015_106_stage1.md`
+- `mydocs/working/task_m015_106_stage2.md`
+- `mydocs/working/task_m015_106_stage3.md`
+- `mydocs/working/task_m015_106_stage4.md`
+- `mydocs/working/task_m015_106_stage5.md`
+- `mydocs/report/task_m015_106_report.md`
+- `mydocs/orders/20260501.md`
+
+## 단계별 결과
+
+### Stage 1 기준 확정
+
+`samples/복학원서.hwp` SHA-256:
+
+```text
+da81b4010331bcac290f900c7cf224c97ee8355399614725ce46c197ff1a22a4
+```
+
+watermark image node 핵심값:
+
+```text
+node id: 84
+crop: [0, 0, 54600, 54660]
+original_size_hu: [37128, 37180]
+effect: GrayScale
+brightness: -50
+contrast: 70
+source JPEG: 728x729
+```
+
+`crop` 값은 HU 기준이며 75로 나누면 source pixel 기준 `728x728.8`에 해당한다. core SVG 필터는 grayscale matrix와 brightness/contrast component transfer를 사용했다.
+
+### Stage 2 crop 적용
+
+`RenderTree.ImageNode`에 다음 필드를 추가했다.
+
+- `originalSizeHU`
+- `effect`
+- `brightness`
+- `contrast`
+
+`CGTreeRenderer`는 `crop[0...3]`을 left/top/right/bottom HU로 해석하고, `75.0`으로 나눠 source pixel rect를 계산한다. left/top은 floor, right/bottom은 ceil로 변환한 뒤 source image bounds에 clamp한다. invalid crop은 원본 이미지 draw로 fallback한다.
+
+### Stage 3 effect와 fallback 보강
+
+CoreImage 의존 없이 CoreGraphics bitmap context에서 image adjustment를 수행하도록 구현했다.
+
+- `GrayScale` effect는 luminance 계수 `0.299`, `0.587`, `0.114`를 적용한다.
+- brightness/contrast는 `slope = max(0, 1 + contrast / 100)`, `intercept = brightness / 100 * slope`로 계산한다.
+- `RealPic`, `none`, 빈 effect는 no-op 처리한다.
+- black/white 계열 effect는 전용 샘플이 없어 grayscale fallback으로 처리한다.
+- fit-to-size/stretch 계열과 알 수 없는 fill mode는 bbox 전체 draw fallback을 유지한다.
+
+Stage 2와 Stage 3의 `복학원서.hwp` native PNG hash는 다음처럼 달라졌다.
+
+```text
+Stage 2: d66500abc3f52a2be4744ad54d62cb5a13852a8ac8b7ab93080ad2881967e8ae
+Stage 3: d164965a236b38d28ea79d03de17f0c289aeed91c80768ad6c59dff6339f4e9c
+```
+
+Stage 3 이후 watermark가 풀컬러 표시에서 grayscale 및 brightness/contrast 적용 상태로 바뀌었다.
+
+### Stage 4 대표 샘플 smoke
+
+```bash
+./scripts/render-debug-compare.sh /private/tmp/rhwp-task106-stage4 --page 1 samples/복학원서.hwp samples/20250130-hongbo.hwp samples/aift.hwp
+```
+
+summary 핵심값:
+
+| 샘플 | PageCount | NativePNGSize | NativeNonWhitePixels | TextRuns | HangulRuns | MissingHangulGlyphs |
+|------|-----------|---------------|----------------------|----------|------------|----------------------|
+| `복학원서.hwp` | 1 | `794x1123` | 261727 | 102 | 25 | 0 |
+| `20250130-hongbo.hwp` | 4 | `794x1123` | 84406 | 60 | 35 | 0 |
+| `aift.hwp` | 77 | `794x1123` | 132970 | 25 | 15 | 0 |
+
+Stage 3/Stage 4의 `복학원서.hwp` native PNG hash는 동일했다.
+
+```text
+d164965a236b38d28ea79d03de17f0c289aeed91c80768ad6c59dff6339f4e9c
+```
+
+### Stage 5 통합 검증
+
+bridge 경계 검증:
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+기본 native render smoke:
+
+```text
+OK KTX.hwp: page=1 size=1123x794 textRuns=436 hangulRuns=76 hangulScalars=209 nonWhitePixels=452058
+OK request.hwp: page=1 size=567x794 textRuns=104 hangulRuns=36 hangulScalars=309 nonWhitePixels=67872
+OK exam_kor.hwp: page=1 size=1123x1588 textRuns=133 hangulRuns=86 hangulScalars=1368 nonWhitePixels=176212
+```
+
+Xcode project 재생성과 HostApp Debug build도 통과했다.
+
+```text
+Created project at /Users/melee/Documents/projects/rhwp-mac-task106/AlhangeulMac.xcodeproj
+** BUILD SUCCEEDED ** [11.031 sec]
+```
+
+## 검증 요약
+
+```text
+./scripts/check-no-appkit.sh
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+```text
+./scripts/validate-stage3-render.sh
+OK KTX.hwp: page=1 size=1123x794 textRuns=436 hangulRuns=76 hangulScalars=209 nonWhitePixels=452058
+OK request.hwp: page=1 size=567x794 textRuns=104 hangulRuns=36 hangulScalars=309 nonWhitePixels=67872
+OK exam_kor.hwp: page=1 size=1123x1588 textRuns=133 hangulRuns=86 hangulScalars=1368 nonWhitePixels=176212
+```
+
+```text
+xcodegen generate
+Created project at /Users/melee/Documents/projects/rhwp-mac-task106/AlhangeulMac.xcodeproj
+```
+
+```text
+xcodebuild -project AlhangeulMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData CODE_SIGNING_ALLOWED=NO build
+** BUILD SUCCEEDED ** [11.031 sec]
+```
+
+`git diff --check`도 통과했다.
+
+## 제한 사항
+
+- `render-debug-compare.sh`의 optional core SVG rasterize/pixel diff는 로컬 `qlmanage` sandbox 오류로 생성되지 않았다.
+- black/white 계열 effect는 전용 샘플이 없어 grayscale fallback으로 남겼다.
+- fill mode 전체 parity는 이번 #106 범위가 아니며, 미지원 mode는 bbox draw fallback을 유지한다.
+- WMF/BMP/PCX 변환 정책은 이번 #106 범위가 아니다.
+
+## 잔여 위험
+
+- grayscale과 brightness/contrast는 core SVG 동작을 기준으로 근사했지만, 모든 색공간/알파 조합의 pixel parity를 보장하는 수준의 diff 검증은 하지 못했다.
+- crop 단위는 이번 기준 샘플과 core SVG 출력을 근거로 HU/75 source pixel 변환으로 확정했다. 다른 이미지 유형에서 core와 다른 unit을 내보내는 사례가 있으면 별도 보정이 필요하다.
+
+## 결론
+
+Issue #106의 목표인 Swift native renderer 이미지 `crop`, `effect`, `brightness`, `contrast` 보강은 완료됐다.
+
+`복학원서.hwp` watermark는 더 이상 풀컬러 원본으로만 렌더되지 않고, render tree의 crop source rect와 grayscale/brightness/contrast 값이 native renderer에 반영된다. HostApp Debug build와 bridge 경계 검증도 통과했다.

--- a/mydocs/working/task_m015_106_stage1.md
+++ b/mydocs/working/task_m015_106_stage1.md
@@ -1,0 +1,130 @@
+# Task M015 #106 Stage 1 완료 보고서
+
+## 단계 목적
+
+`samples/복학원서.hwp`에서 Swift native renderer 이미지 출력이 core SVG와 달라지는 기준 상태를 재현하고, Stage 2/3 구현에 필요한 이미지 필드와 단위 해석을 확정했다.
+
+이번 단계는 source code 변경 없이 render debug 산출물과 기존 Swift 구현 상태만 조사했다.
+
+## 산출물
+
+| 구분 | 경로 또는 값 | 요약 |
+|------|--------------|------|
+| 기준 샘플 | `samples/복학원서.hwp` | SHA-256 `da81b4010331bcac290f900c7cf224c97ee8355399614725ce46c197ff1a22a4` |
+| render debug 출력 | `/private/tmp/rhwp-task106-stage1` | render tree JSON, core SVG, native PNG, summary 생성 |
+| 단계 보고서 | `mydocs/working/task_m015_106_stage1.md` | Stage 1 조사 결과 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+문서 본문 또는 코드 본문은 변경하지 않았다.
+
+분리 worktree에는 render-debug 실행에 필요한 generated `Frameworks/` 산출물이 없어, 기존 worktree의 generated `Frameworks/`를 복사해 검증에 사용했다. 해당 산출물은 git 추적 대상이 아니며 이번 단계 커밋 범위에 포함하지 않는다.
+
+## 조사 결과
+
+`render-debug-compare.sh` summary 핵심값:
+
+| 항목 | 값 |
+|------|----|
+| PageCount | 1 |
+| PageSizePt | `793.7x1122.5` |
+| RenderTreeJSONBytes | 189498 |
+| CoreSVGBytes | 380803 |
+| NativePNGSize | `794x1123` |
+| NativeNonWhitePixels | 154266 |
+| TextRuns / HangulRuns | `102 / 25` |
+| MissingHangulGlyphs | 0 |
+| Diff | `not generated` |
+| DiffReason | `qlmanage rasterize failed; see ...core.svg.qlmanage.log` |
+
+render tree의 이미지 노드는 2개다.
+
+| id | bin | bbox | crop | original_size_hu | effect | brightness | contrast | 판단 |
+|----|-----|------|------|------------------|--------|------------|----------|------|
+| 84 | 2 | `137.7067,270.24,495.04,495.7333` | `[0,0,54600,54660]` | `[37128,37180]` | `GrayScale` | -50 | 70 | 워터마크 대상 |
+| 7 | 1 | `65.4933,49.0133,77.0133,87.8933` | `[0,0,65640,74940]` | `[5776,6592]` | `RealPic` | 0 | 0 | 상단 소형 이미지, 이번 효과 보강의 주 대상 아님 |
+
+워터마크 이미지(id 84)의 crop 값은 75 HU/px 기준으로 `54600 / 75 = 728`, `54660 / 75 = 728.8`이다. core SVG에 embedded 된 JPEG는 `728x729`로 확인되어, crop source rect 계산은 crop HU 값을 75로 나눈 뒤 원본 pixel bounds로 clamp하는 방향이 맞다.
+
+`original_size_hu`는 bbox와 같은 display size 계열 값으로 보인다. 워터마크 bbox `495.04x495.7333`에 75를 곱하면 `37128x37180`으로 render tree의 `original_size_hu`와 일치한다. 따라서 Stage 2의 crop source rect는 `original_size_hu`가 아니라 `crop / 75`와 실제 `CGImage` pixel 크기를 기준으로 계산한다.
+
+core SVG는 워터마크 이미지에 다음 필터를 적용한다.
+
+```xml
+<filter id="rhwp-img-grayscale"><feColorMatrix type="matrix" values="0.299 0.587 0.114 0 0 0.299 0.587 0.114 0 0 0.299 0.587 0.114 0 0 0 0 0 1 0"/></filter>
+<filter id="rhwp-img-bc-b-50c70"><feComponentTransfer><feFuncR type="linear" slope="1.7000" intercept="-0.8500"/><feFuncG type="linear" slope="1.7000" intercept="-0.8500"/><feFuncB type="linear" slope="1.7000" intercept="-0.8500"/></feComponentTransfer></filter>
+```
+
+Swift 현재 구현의 누락 지점:
+
+- `RenderTree.swift`의 `ImageNode`는 `effect`, `brightness`, `contrast`, `original_size_hu`를 디코딩하지 않는다.
+- `CGTreeRenderer.renderImage`는 `crop`을 draw에 적용하지 않고 원본 `CGImage` 전체를 bbox에 그린다.
+- `CGTreeRenderer.renderImage`는 색상 effect 또는 brightness/contrast 필터를 적용하지 않는다.
+
+Stage 2 구현 방향:
+
+- `ImageNode`에 `effect`, `brightness`, `contrast`, `originalSizeHU` optional 필드를 추가한다.
+- source crop rect는 `crop` 4개 값을 75로 나눈 pixel 좌표로 계산하고, 원본 이미지 bounds로 clamp한다.
+- crop rect가 비정상이거나 `cropping(to:)`가 실패하면 기존 전체 이미지 draw로 fallback한다.
+
+Stage 3 구현 방향:
+
+- `GrayScale`은 core SVG와 같은 luminance matrix 방향으로 처리한다.
+- brightness/contrast는 core SVG의 `feComponentTransfer`와 같은 방향으로 slope/intercept를 적용한다. 현재 샘플 기준은 `contrast=70 -> slope 1.7`, `brightness=-50 -> intercept -0.85`다.
+- `RealPic`은 보정 없이 원본 표시로 취급한다.
+
+## 검증 결과
+
+작업 브랜치 상태 확인:
+
+```text
+## local/task106...origin/devel [ahead 2]
+```
+
+샘플 hash:
+
+```text
+da81b4010331bcac290f900c7cf224c97ee8355399614725ce46c197ff1a22a4  samples/복학원서.hwp
+```
+
+render debug 실행:
+
+```text
+OK 복학원서.hwp: page=1 renderTreeJSON=/private/tmp/rhwp-task106-stage1/...-render-tree.json coreSVG=/private/tmp/rhwp-task106-stage1/...-core.svg nativePNG=/private/tmp/rhwp-task106-stage1/...-native.png summary=/private/tmp/rhwp-task106-stage1/...-summary.txt
+```
+
+필수 산출물 확인:
+
+```text
+test -s render-tree.json: 통과
+test -s core.svg: 통과
+test -s native.png: 통과
+test -s summary.txt: 통과
+```
+
+이미지 source 확인:
+
+```text
+core-image-1: JPEG 728x729
+core-image-2: PCX bounding box [0, 0] - [877, 1000], 1-bit colour
+```
+
+`git diff --check`:
+
+```text
+통과
+```
+
+## 잔여 위험
+
+- core SVG rasterize와 pixel diff는 `qlmanage` sandbox 오류로 생성되지 않았다. 필수 산출물인 render tree JSON, core SVG, native PNG, summary는 생성됐다.
+- brightness/contrast 수식은 core SVG 필터의 slope/intercept 방향으로 맞출 수 있으나, 색공간과 alpha 처리 때문에 완전 pixel parity는 Stage 3 검증에서 별도 확인이 필요하다.
+- 상단 소형 이미지(id 7)는 core SVG에서 PCX로 확인됐다. 이번 이슈의 주 대상은 워터마크 crop/effect/brightness/contrast이며, PCX 변환 정책 재설계는 수행계획서 제외 범위다.
+
+## 다음 단계 영향
+
+Stage 2에서는 `RenderTree.swift`와 `CGTreeRenderer.swift`를 변경해 이미지 필드 디코딩과 crop source rect 적용을 구현한다. 이 단계에서는 색상 effect를 아직 적용하지 않고, crop과 draw 좌표 안정성만 검증한다.
+
+## 승인 요청
+
+Stage 1 완료를 승인하고 Stage 2 `ImageNode 디코딩과 crop source rect 적용`으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m015_106_stage2.md
+++ b/mydocs/working/task_m015_106_stage2.md
@@ -1,0 +1,144 @@
+# Task M015 #106 Stage 2 완료 보고서
+
+## 단계 목적
+
+`ImageNode`가 Stage 1에서 확인한 이미지 효과 관련 필드를 디코딩하도록 보강하고, `CGTreeRenderer`가 이미지 `crop` 값을 source pixel rect로 변환해 draw에 적용하도록 구현했다.
+
+이번 단계는 색상 effect 적용 전 단계다. `GrayScale`, `brightness`, `contrast`, `fill_mode` 렌더 보정은 Stage 3 범위로 남겼다.
+
+## 산출물
+
+| 파일 | 요약 |
+|------|------|
+| `Sources/RhwpCoreBridge/RenderTree.swift` | `ImageNode`에 `originalSizeHU`, `effect`, `brightness`, `contrast` optional 디코딩 필드 추가 |
+| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | `crop` HU 값을 75 HU/px 기준 source pixel rect로 변환하고 `CGImage.cropping(to:)` 적용 |
+| `mydocs/working/task_m015_106_stage2.md` | Stage 2 구현과 검증 결과 |
+
+변경량:
+
+```text
+Sources/RhwpCoreBridge/CGTreeRenderer.swift | 23 ++++++++++++++++++++++-
+Sources/RhwpCoreBridge/RenderTree.swift     |  7 ++++++-
+2 files changed, 28 insertions(+), 2 deletions(-)
+```
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Swift renderer 공통 계층 2개 파일만 변경했다. HostApp, Quick Look, Thumbnail 호출부는 변경하지 않았다.
+
+기존 이미지 로딩 캐시는 원본 `binDataId` 기준으로 유지했고, crop 결과는 draw 호출 안에서만 계산한다. crop이 없거나 길이가 4가 아니거나 source rect가 비정상이면 기존 전체 이미지 draw로 fallback한다.
+
+## 구현 내용
+
+`ImageNode` 디코딩:
+
+- `original_size_hu` -> `originalSizeHU`
+- `effect`
+- `brightness`
+- `contrast`
+
+모든 새 필드는 optional로 두어 기존 render tree와 필드 누락 문서를 안전하게 처리한다.
+
+`CGTreeRenderer` crop 처리:
+
+- `imageCropUnitsPerPixel = 75.0` 상수를 추가했다.
+- `crop[0...3]`을 각각 left/top/right/bottom HU 값으로 보고 pixel 단위로 변환한다.
+- left/top은 `floor`, right/bottom은 `ceil`을 사용해 Stage 1에서 확인한 `54660 / 75 = 728.8 -> 729px` 케이스를 보존한다.
+- 변환 rect는 실제 `CGImage` width/height로 clamp한다.
+- `CGImage.cropping(to:)`가 실패하면 원본 image를 그대로 그린다.
+
+주요 코드 위치:
+
+- `Sources/RhwpCoreBridge/RenderTree.swift:297`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:11`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:251`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:281`
+
+## 검증 결과
+
+작업 브랜치 상태:
+
+```text
+## local/task106...origin/devel [ahead 3]
+ M Sources/RhwpCoreBridge/CGTreeRenderer.swift
+ M Sources/RhwpCoreBridge/RenderTree.swift
+```
+
+변경 diff 확인:
+
+```text
+git diff -- Sources/RhwpCoreBridge/RenderTree.swift Sources/RhwpCoreBridge/CGTreeRenderer.swift
+```
+
+결과: `ImageNode` optional 필드와 `croppedImage(for:crop:)` helper 변경만 확인했다.
+
+AppKit/UIKit 의존 금지 검증:
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+render debug 실행:
+
+```text
+./scripts/render-debug-compare.sh /private/tmp/rhwp-task106-stage2 --page 1 samples/복학원서.hwp
+```
+
+결과:
+
+```text
+OK 복학원서.hwp: page=1 renderTreeJSON=/private/tmp/rhwp-task106-stage2/...-render-tree.json coreSVG=/private/tmp/rhwp-task106-stage2/...-core.svg nativePNG=/private/tmp/rhwp-task106-stage2/...-native.png summary=/private/tmp/rhwp-task106-stage2/...-summary.txt
+```
+
+summary 핵심값:
+
+| 항목 | 값 |
+|------|----|
+| PageCount | 1 |
+| PageSizePt | `793.7x1122.5` |
+| RenderTreeJSONBytes | 189498 |
+| CoreSVGBytes | 380803 |
+| NativePNGSize | `794x1123` |
+| NativeNonWhitePixels | 154266 |
+| TextRuns / HangulRuns | `102 / 25` |
+| MissingHangulGlyphs | 0 |
+| Diff | `not generated` |
+| DiffReason | `qlmanage rasterize failed; see ...core.svg.qlmanage.log` |
+
+필수 산출물 확인:
+
+```text
+test -s render-tree.json: 통과
+test -s core.svg: 통과
+test -s native.png: 통과
+test -s summary.txt: 통과
+```
+
+PNG 크기 확인:
+
+```text
+pixelWidth: 794
+pixelHeight: 1123
+```
+
+whitespace 검증:
+
+```text
+git diff --check -- Sources/RhwpCoreBridge/RenderTree.swift Sources/RhwpCoreBridge/CGTreeRenderer.swift
+```
+
+결과: 통과.
+
+## 잔여 위험
+
+- `복학원서.hwp` 워터마크 crop은 실제 원본 전체 범위와 거의 일치하므로, Stage 2 native non-white 값은 Stage 1과 동일하다. crop helper의 실제 non-zero offset 케이스는 대표 샘플이나 후속 fixture에서 추가 확인이 필요하다.
+- 색상 effect를 아직 적용하지 않았으므로 워터마크는 여전히 풀컬러에 가깝게 보인다. 이는 Stage 3 범위다.
+- `qlmanage` sandbox 오류로 pixel diff는 생성되지 않았다. 필수 산출물은 모두 생성됐다.
+
+## 다음 단계 영향
+
+Stage 3에서는 이미 디코딩된 `effect`, `brightness`, `contrast` 값을 사용해 grayscale 및 brightness/contrast 보정을 적용한다. CoreImage를 선택할 경우 render-debug/validate 스크립트의 framework 링크 옵션도 함께 갱신해야 한다.
+
+## 승인 요청
+
+Stage 2 완료를 승인하고 Stage 3 `이미지 effect와 fill mode fallback 보강`으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m015_106_stage3.md
+++ b/mydocs/working/task_m015_106_stage3.md
@@ -1,0 +1,131 @@
+# Task M015 #106 Stage 3 완료 보고서
+
+## 단계 목적
+
+Stage 2에서 디코딩한 이미지 `effect`, `brightness`, `contrast`를 Swift native renderer에 반영했다. `fill_mode`는 현재 샘플과 기존 동작을 기준으로 `FitToSize`/stretch 계열만 명시 지원하고, 미지원 값은 기존 bbox 전체 draw로 fallback하도록 정리했다.
+
+## 산출물
+
+| 파일 | 요약 |
+|------|------|
+| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | crop 이후 이미지 effect/brightness/contrast 보정 helper 추가, fill mode fallback 명시 |
+| `mydocs/working/task_m015_106_stage3.md` | Stage 3 구현과 검증 결과 |
+
+변경량:
+
+```text
+Sources/RhwpCoreBridge/CGTreeRenderer.swift | 142 +++++++++++++++++++++++++++-
+1 file changed, 140 insertions(+), 2 deletions(-)
+```
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Swift 공통 renderer의 이미지 draw 경로만 변경했다. `RenderTree.swift` 모델은 Stage 2에서 이미 확장했으므로 이번 단계에서 추가 변경하지 않았다.
+
+CoreImage 사용을 검토했으나 현재 로컬 실행 환경에서 `CIContext.createCGImage`가 `nil`을 반환해 결과가 원본 이미지로 fallback되는 문제가 있었다. 최종 구현은 추가 framework 링크 없이 CoreGraphics bitmap context에서 RGB 값을 직접 보정하는 방식으로 정리했다.
+
+## 구현 내용
+
+이미지 처리 순서는 다음과 같다.
+
+1. 원본 `CGImage`를 `binDataId` 기준 캐시에서 가져온다.
+2. Stage 2의 crop source rect를 적용한다.
+3. `effect`, `brightness`, `contrast`가 있으면 RGBA bitmap context에 그린 뒤 pixel 단위로 보정한다.
+4. 기존 y-flip draw 보정을 유지해 bbox 안에 그린다.
+
+보정 정책:
+
+- `GrayScale`/`gray`/`greyscale` 계열은 core SVG와 같은 luminance 계수 `0.299, 0.587, 0.114`로 grayscale 처리한다.
+- `brightness`/`contrast`는 Stage 1에서 확인한 core SVG `feComponentTransfer` 방향에 맞춰 `slope = 1 + contrast / 100`, `intercept = brightness / 100 * slope`로 적용한다.
+- `RealPic`, `none`, 빈 effect는 원본 색상을 유지한다.
+- black-white 계열 문자열은 현재 dedicated sample이 없으므로 crash 없이 grayscale로 fallback한다.
+- `fill_mode`의 `FitToSize`, `stretch`, `stretch_to_fit` 계열은 기존처럼 bbox 전체 draw로 처리하고, 미지원 값도 bbox draw fallback으로 둔다.
+
+주요 코드 위치:
+
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:268` 이미지 준비 후 draw
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:305` 이미지 보정 진입점
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:351` pixel 보정 loop
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:401` effect 문자열 정규화
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:422` fill mode fallback
+
+## 검증 결과
+
+작업 브랜치 상태:
+
+```text
+## local/task106...origin/devel [ahead 4]
+ M Sources/RhwpCoreBridge/CGTreeRenderer.swift
+```
+
+AppKit/UIKit 의존 금지 검증:
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+render debug 실행:
+
+```text
+./scripts/render-debug-compare.sh /private/tmp/rhwp-task106-stage3 --page 1 samples/복학원서.hwp
+```
+
+결과:
+
+```text
+OK 복학원서.hwp: page=1 renderTreeJSON=/private/tmp/rhwp-task106-stage3/...-render-tree.json coreSVG=/private/tmp/rhwp-task106-stage3/...-core.svg nativePNG=/private/tmp/rhwp-task106-stage3/...-native.png summary=/private/tmp/rhwp-task106-stage3/...-summary.txt
+```
+
+summary 핵심값:
+
+| 항목 | Stage 2 | Stage 3 |
+|------|---------|---------|
+| NativePNGSize | `794x1123` | `794x1123` |
+| NativeNonWhitePixels | 154266 | 261727 |
+| TextRuns / HangulRuns | `102 / 25` | `102 / 25` |
+| MissingHangulGlyphs | 0 | 0 |
+| Diff | `not generated` | `not generated` |
+
+PNG hash:
+
+| 단계 | SHA-256 |
+|------|---------|
+| Stage 2 native PNG | `d66500abc3f52a2be4744ad54d62cb5a13852a8ac8b7ab93080ad2881967e8ae` |
+| Stage 3 native PNG | `d164965a236b38d28ea79d03de17f0c289aeed91c80768ad6c59dff6339f4e9c` |
+
+필수 산출물 확인:
+
+```text
+test -s render-tree.json: 통과
+test -s core.svg: 통과
+test -s native.png: 통과
+test -s summary.txt: 통과
+```
+
+시각 확인:
+
+- Stage 2 native PNG의 워터마크는 풀컬러 붉은 seal로 표시됐다.
+- Stage 3 native PNG의 워터마크는 grayscale 및 brightness/contrast 보정이 적용된 흑백 계열 seal로 표시됐다.
+- 이미지가 상하 반전되거나 bbox 밖으로 밀리는 문제는 관찰되지 않았다.
+
+whitespace 검증:
+
+```text
+git diff --check -- Sources/RhwpCoreBridge/RenderTree.swift Sources/RhwpCoreBridge/CGTreeRenderer.swift scripts/render-debug-compare.sh scripts/validate-stage3-render.sh
+```
+
+결과: 통과.
+
+## 잔여 위험
+
+- `qlmanage` sandbox 오류로 core SVG rasterize와 pixel diff는 생성되지 않았다. 필수 산출물인 render tree JSON, core SVG, native PNG, summary는 생성됐다.
+- black-white effect는 dedicated sample이 없어 grayscale fallback으로 처리했다. threshold parity는 별도 샘플 확인 후 보강하는 편이 안전하다.
+- Stage 3 검증은 `복학원서.hwp` 중심이다. 다른 이미지 포함 샘플의 회귀 확인은 Stage 4에서 수행한다.
+
+## 다음 단계 영향
+
+Stage 4에서는 `복학원서.hwp`, `samples/20250130-hongbo.hwp`, `samples/aift.hwp`를 render-debug 대상으로 실행해 대표 이미지 샘플의 non-blank와 기존 이미지 회귀 여부를 확인한다.
+
+## 승인 요청
+
+Stage 3 완료를 승인하고 Stage 4 `대표 이미지 샘플 render smoke 검증`으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m015_106_stage4.md
+++ b/mydocs/working/task_m015_106_stage4.md
@@ -1,0 +1,102 @@
+# Task M015 #106 Stage 4 완료 보고서
+
+## 단계 목적
+
+Stage 3 이미지 crop/effect/brightness/contrast 보강 이후 대표 이미지 포함 샘플에서 render-debug 필수 산출물이 정상 생성되고 native PNG가 non-blank인지 확인했다.
+
+이번 단계는 source code 변경 없이 검증 산출물과 summary 값을 기록했다.
+
+## 산출물
+
+| 구분 | 경로 또는 값 | 요약 |
+|------|--------------|------|
+| render debug 출력 | `/private/tmp/rhwp-task106-stage4` | 샘플 3개 render tree JSON, core SVG, native PNG, summary 생성 |
+| 단계 보고서 | `mydocs/working/task_m015_106_stage4.md` | Stage 4 검증 결과 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+코드와 제품 문서는 변경하지 않았다. 이번 단계의 저장소 변경은 단계 보고서 추가뿐이다.
+
+## 검증 결과
+
+작업 브랜치 상태:
+
+```text
+## local/task106...origin/devel [ahead 5]
+```
+
+render debug 실행:
+
+```bash
+./scripts/render-debug-compare.sh /private/tmp/rhwp-task106-stage4 --page 1 samples/복학원서.hwp samples/20250130-hongbo.hwp samples/aift.hwp
+```
+
+결과:
+
+```text
+OK 복학원서.hwp: page=1 renderTreeJSON=... coreSVG=... nativePNG=... summary=...
+OK 20250130-hongbo.hwp: page=1 renderTreeJSON=... coreSVG=... nativePNG=... summary=...
+OK aift.hwp: page=1 renderTreeJSON=... coreSVG=... nativePNG=... summary=...
+```
+
+summary 핵심값:
+
+| 샘플 | PageCount | NativePNGSize | NativeNonWhitePixels | TextRuns | HangulRuns | MissingHangulGlyphs | Diff |
+|------|-----------|---------------|----------------------|----------|------------|----------------------|------|
+| `복학원서.hwp` | 1 | `794x1123` | 261727 | 102 | 25 | 0 | not generated |
+| `20250130-hongbo.hwp` | 4 | `794x1123` | 84406 | 60 | 35 | 0 | not generated |
+| `aift.hwp` | 77 | `794x1123` | 132970 | 25 | 15 | 0 | not generated |
+
+필수 산출물 확인:
+
+| 샘플 | render tree JSON | core SVG | native PNG | summary |
+|------|------------------|----------|------------|---------|
+| `복학원서.hwp` | 생성 | 생성 | 생성 | 생성 |
+| `20250130-hongbo.hwp` | 생성 | 생성 | 생성 | 생성 |
+| `aift.hwp` | 생성 | 생성 | 생성 | 생성 |
+
+native PNG hash:
+
+| 샘플 | SHA-256 |
+|------|---------|
+| `복학원서.hwp` | `d164965a236b38d28ea79d03de17f0c289aeed91c80768ad6c59dff6339f4e9c` |
+| `20250130-hongbo.hwp` | `f40bf21406a4d8a2ab1ff764b4f410c145090d11357341b1de93d4f55b2c59fb` |
+| `aift.hwp` | `50489f767d0abd5b2a06cfd1430f2e4b3d225f7217b010a43e71879d5208dc2a` |
+
+`복학원서.hwp` Stage 3/Stage 4 native PNG hash는 동일하다.
+
+```text
+Stage 3: d164965a236b38d28ea79d03de17f0c289aeed91c80768ad6c59dff6339f4e9c
+Stage 4: d164965a236b38d28ea79d03de17f0c289aeed91c80768ad6c59dff6339f4e9c
+```
+
+이는 Stage 4의 `복학원서.hwp` 재검증이 Stage 3 결과와 재현 가능함을 의미한다. 워터마크는 Stage 2의 풀컬러 표시에서 Stage 3/4의 grayscale 및 brightness/contrast 적용 상태로 바뀐 상태가 유지됐다.
+
+PNG 크기 확인:
+
+```text
+복학원서.hwp: pixelWidth 794, pixelHeight 1123
+20250130-hongbo.hwp: pixelWidth 794, pixelHeight 1123
+aift.hwp: pixelWidth 794, pixelHeight 1123
+```
+
+whitespace 검증:
+
+```bash
+git diff --check -- mydocs/working/task_m015_106_stage4.md
+```
+
+결과: 통과.
+
+## 잔여 위험
+
+- `qlmanage` sandbox 오류로 core SVG rasterize와 pixel diff는 생성되지 않았다. 각 summary의 `DiffReason`은 `qlmanage rasterize failed`로 기록됐다. 필수 산출물은 모두 생성됐다.
+- Stage 4는 대표 샘플 3개 기반 smoke 검증이다. 모든 이미지 effect/fill mode의 완전 parity는 수행계획서 제외 범위이며, 미지원 fill mode는 bbox draw fallback으로 남아 있다.
+
+## 다음 단계 영향
+
+Stage 5에서는 `check-no-appkit`, 기본 render smoke, HostApp Debug build를 수행하고 최종 보고서와 오늘할일을 정리한다.
+
+## 승인 요청
+
+Stage 4 완료를 승인하고 Stage 5 `통합 검증과 최종 보고`로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m015_106_stage5.md
+++ b/mydocs/working/task_m015_106_stage5.md
@@ -1,0 +1,99 @@
+# Task M015 #106 Stage 5 완료 보고서
+
+## 단계 목적
+
+HostApp, Quick Look, Thumbnail 공통 renderer 변경으로서 기본 bridge 경계 검증, native render smoke, HostApp Debug build를 다시 실행했다.
+
+이번 단계는 source code 변경 없이 통합 검증 결과, 최종 보고서, 오늘할일 완료 상태를 정리했다.
+
+## 산출물
+
+| 구분 | 경로 또는 값 | 요약 |
+|------|--------------|------|
+| 단계 보고서 | `mydocs/working/task_m015_106_stage5.md` | Stage 5 통합 검증 결과 |
+| 최종 보고서 | `mydocs/report/task_m015_106_report.md` | #106 전체 구현/검증/잔여 위험 정리 |
+| 오늘할일 | `mydocs/orders/20260501.md` | #106 완료 상태 갱신 |
+| render smoke 출력 | `output/stage3-render` | 기본 native render pipeline smoke 산출물 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Stage 5에서 renderer source code는 변경하지 않았다. 저장소 변경은 Stage 5 보고서, 최종 보고서, 오늘할일 완료 표시뿐이다.
+
+## 검증 결과
+
+작업 브랜치 상태:
+
+```text
+## local/task106...origin/devel [ahead 6]
+```
+
+bridge 경계 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+```
+
+결과:
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+기본 native render smoke:
+
+```bash
+./scripts/validate-stage3-render.sh
+```
+
+결과:
+
+```text
+OK KTX.hwp: page=1 size=1123x794 textRuns=436 hangulRuns=76 hangulScalars=209 nonWhitePixels=452058 png=/Users/melee/Documents/projects/rhwp-mac-task106/output/stage3-render/KTX-page1.png
+OK request.hwp: page=1 size=567x794 textRuns=104 hangulRuns=36 hangulScalars=309 nonWhitePixels=67872 png=/Users/melee/Documents/projects/rhwp-mac-task106/output/stage3-render/request-page1.png
+OK exam_kor.hwp: page=1 size=1123x1588 textRuns=133 hangulRuns=86 hangulScalars=1368 nonWhitePixels=176212 png=/Users/melee/Documents/projects/rhwp-mac-task106/output/stage3-render/exam_kor-page1.png
+```
+
+Xcode project 재생성:
+
+```bash
+xcodegen generate
+```
+
+결과:
+
+```text
+Created project at /Users/melee/Documents/projects/rhwp-mac-task106/AlhangeulMac.xcodeproj
+```
+
+HostApp Debug build:
+
+```bash
+xcodebuild -project AlhangeulMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData CODE_SIGNING_ALLOWED=NO build
+```
+
+결과:
+
+```text
+** BUILD SUCCEEDED ** [11.031 sec]
+```
+
+빌드 중 다음 warning은 관찰됐지만 실패 조건은 아니었다.
+
+```text
+IDERunDestination: Supported platforms for the buildables in the current scheme is empty.
+Metadata extraction skipped. No AppIntents.framework dependency found.
+```
+
+## 잔여 위험
+
+- `render-debug-compare.sh`의 optional core SVG rasterize/pixel diff는 로컬 `qlmanage` sandbox 오류로 생성되지 않았다. 필수 산출물과 native PNG summary는 생성됐다.
+- black/white 계열 effect는 전용 샘플이 없어 grayscale fallback으로 남겼다. threshold parity는 별도 샘플 확보 후 다루는 것이 맞다.
+- fill mode 전체 parity와 WMF/BMP/PCX 변환 정책은 이번 #106 범위가 아니다.
+
+## 다음 단계 영향
+
+최종 보고서 승인 후 PR 준비 단계로 넘어갈 수 있다.
+
+## 승인 요청
+
+Stage 5 완료와 최종 보고서를 승인하고 PR 준비로 진행해도 되는지 승인 요청한다.


### PR DESCRIPTION
## 요약

- Swift native renderer가 render tree의 이미지 `crop`, `effect`, `brightness`, `contrast`를 반영하도록 보강했습니다.
- `samples/복학원서.hwp`의 중앙 인장 이미지가 풀컬러 원본으로 렌더되던 상태에서 grayscale 및 brightness/contrast 적용 상태로 개선됐습니다.
- 이미지 crop은 HWPUNIT 기반 source rect를 source pixel rect로 변환해 `CGImage.cropping(to:)`에 적용합니다.
- 이번 범위 밖인 워터마크 alpha/투명키/JPEG 배경 문제는 후속 이슈 #116으로 분리했습니다.

## 변경 내역

- **Stage 1**: [task_m015_106_stage1.md](https://github.com/postmelee/alhangeul-macos/blob/4686b9aab2f27958b4adef738762b064ca8cc801/mydocs/working/task_m015_106_stage1.md) / [51264f8](https://github.com/postmelee/alhangeul-macos/commit/51264f88dae750b43420311147bf45f6fd9bc106) - `복학원서.hwp` 이미지 노드와 core SVG 기준값을 확정했습니다.
- **Stage 2**: [task_m015_106_stage2.md](https://github.com/postmelee/alhangeul-macos/blob/4686b9aab2f27958b4adef738762b064ca8cc801/mydocs/working/task_m015_106_stage2.md) / [72efc17](https://github.com/postmelee/alhangeul-macos/commit/72efc17bf529c134b6935a69f728315d18bc3f08) - 이미지 crop source rect 적용을 구현했습니다.
- **Stage 3**: [task_m015_106_stage3.md](https://github.com/postmelee/alhangeul-macos/blob/4686b9aab2f27958b4adef738762b064ca8cc801/mydocs/working/task_m015_106_stage3.md) / [9f293b3](https://github.com/postmelee/alhangeul-macos/commit/9f293b3b740c8c48b833f7891a16b9d16208a62c) - grayscale, brightness/contrast, fill mode fallback을 보강했습니다.
- **Stage 4**: [task_m015_106_stage4.md](https://github.com/postmelee/alhangeul-macos/blob/4686b9aab2f27958b4adef738762b064ca8cc801/mydocs/working/task_m015_106_stage4.md) / [3a0134b](https://github.com/postmelee/alhangeul-macos/commit/3a0134b08cc393a6fe8c4be485309cb670ca38cf) - 대표 샘플 native render smoke를 수행했습니다.
- **Stage 5**: [task_m015_106_stage5.md](https://github.com/postmelee/alhangeul-macos/blob/4686b9aab2f27958b4adef738762b064ca8cc801/mydocs/working/task_m015_106_stage5.md) / [d128e7c](https://github.com/postmelee/alhangeul-macos/commit/d128e7c91f2f19ce4b2d2051737cd6a6d4c35053) - 통합 검증과 최종 보고서를 정리했습니다.
- **Review 반영**: [4686b9a](https://github.com/postmelee/alhangeul-macos/commit/4686b9aab2f27958b4adef738762b064ca8cc801) - premultiplied alpha 보정과 최종 보고서 표 형식을 반영했습니다.

## 핵심 리뷰 포인트

- `RenderTree.ImageNode`의 optional 필드 decode가 기존 render tree와 하위 호환되는지 확인이 필요합니다.
- `CGTreeRenderer`의 crop 변환이 left/top floor, right/bottom ceil, bounds clamp 순서로 안전하게 동작하는지 봐 주세요.
- `applyImageAdjustments`는 기존 alpha를 보존하면서 premultiplied RGBA를 straight color로 풀어 RGB 보정을 적용한 뒤 다시 premultiply합니다. transparent key와 watermark opacity는 후속 #116에서 다룹니다.

## 검증

- [x] `git diff --check`
- [x] `./scripts/check-no-appkit.sh`
- [x] `xcodegen generate`
- [x] `xcodebuild -project AlhangeulMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData CODE_SIGNING_ALLOWED=NO build`
- [x] `./scripts/validate-stage3-render.sh`
- [x] `./scripts/render-debug-compare.sh /private/tmp/rhwp-task106-stage4 --page 1 samples/복학원서.hwp samples/20250130-hongbo.hwp samples/aift.hwp`
- [x] Release package build and local app replacement smoke: `./scripts/package-release.sh 0.1.0`, `/Users/melee/Applications/AlhangeulMac.app` 교체, app/extension code signing 및 PlugInKit 등록 확인

## 문서

- 수행 계획서: [task_m015_106.md](https://github.com/postmelee/alhangeul-macos/blob/4686b9aab2f27958b4adef738762b064ca8cc801/mydocs/plans/task_m015_106.md)
- 구현 계획서: [task_m015_106_impl.md](https://github.com/postmelee/alhangeul-macos/blob/4686b9aab2f27958b4adef738762b064ca8cc801/mydocs/plans/task_m015_106_impl.md)
- 최종 보고서: [task_m015_106_report.md](https://github.com/postmelee/alhangeul-macos/blob/4686b9aab2f27958b4adef738762b064ca8cc801/mydocs/report/task_m015_106_report.md)

## 관련 이슈

Closes #106
Refs #116
Refs https://github.com/edwardkim/rhwp/issues/421
Refs https://github.com/edwardkim/rhwp/issues/514

## 남은 리스크

- `복학원서.hwp` 중앙 JPEG 워터마크의 alpha/투명키/밝기-대비 Hancom parity는 아직 남아 있습니다. 후속 #116에서 core 의미 확장과 Swift 적용 범위를 함께 다룹니다.
- black/white 계열 effect는 전용 샘플이 없어 grayscale fallback입니다.
- optional core SVG rasterize/pixel diff는 로컬 `qlmanage` sandbox 오류로 생성하지 못했습니다.
