### PR TITLE
Task #140: 릴리즈 전 Viewer·Quick Look·인쇄 회귀 보정

### DIFF
--- a/Sources/HostApp/HostApp.entitlements
+++ b/Sources/HostApp/HostApp.entitlements
@@ -8,5 +8,7 @@
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>
+	<key>com.apple.security.print</key>
+	<true/>
 </dict>
 </plist>

--- a/Sources/HostApp/Resources/rhwp-studio/alhangeul-wkwebview-overrides.css
+++ b/Sources/HostApp/Resources/rhwp-studio/alhangeul-wkwebview-overrides.css
@@ -11,7 +11,8 @@
     align-items: center;
   }
 
-  select.sb-combo {
+  select.sb-combo,
+  select.sb-ls-select {
     -webkit-appearance: none;
     appearance: none;
     height: 24px;
@@ -31,7 +32,8 @@
     vertical-align: middle;
   }
 
-  select.sb-combo:disabled {
+  select.sb-combo:disabled,
+  select.sb-ls-select:disabled {
     color: var(--color-text-disabled);
     background-color: #f4f4f4;
   }
@@ -69,6 +71,26 @@
   }
 
   .sb-size-arrows {
+    height: 24px;
+  }
+
+  .sb-ls-group {
+    height: 24px;
+    min-height: 24px;
+    align-items: stretch;
+  }
+
+  select.sb-ls-select {
+    width: 62px;
+    font-size: var(--font-size-base);
+    text-align: left;
+    padding-right: 18px;
+    background-position:
+      calc(100% - 10px) 10px,
+      calc(100% - 5px) 10px;
+  }
+
+  .sb-ls-arrows {
     height: 24px;
   }
 

--- a/Sources/HostApp/Services/RhwpStudioPrintController.swift
+++ b/Sources/HostApp/Services/RhwpStudioPrintController.swift
@@ -1,4 +1,5 @@
 import AppKit
+import PDFKit
 import WebKit
 
 struct RhwpStudioPrintPayload {
@@ -7,31 +8,47 @@ struct RhwpStudioPrintPayload {
 }
 
 final class RhwpStudioPrintController: NSObject, WKNavigationDelegate {
-    private var webView: WKWebView?
+    private let webView: WKWebView
     private var completion: (() -> Void)?
+    private var payload: RhwpStudioPrintPayload?
+    private var renderedDocument = PDFDocument()
+    private var renderingPageIndex = 0
+    private var printOperation: NSPrintOperation?
+    private var didFinish = false
+
+    override init() {
+        let configuration = WKWebViewConfiguration()
+        configuration.preferences.javaScriptCanOpenWindowsAutomatically = false
+        if #available(macOS 11.0, *) {
+            configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+        }
+
+        webView = WKWebView(
+            frame: NSRect(origin: .zero, size: RhwpStudioPrintPageSize.defaultPageSize),
+            configuration: configuration
+        )
+        super.init()
+        webView.navigationDelegate = self
+    }
 
     @MainActor
     func print(payload: RhwpStudioPrintPayload, completion: @escaping () -> Void) {
-        self.completion = completion
+        guard !payload.pages.isEmpty else {
+            RhwpStudioPrintErrorPresenter.present(RhwpStudioPrintError.emptyDocument)
+            completion()
+            return
+        }
 
-        let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 800, height: 1100))
-        webView.navigationDelegate = self
-        self.webView = webView
-        webView.loadHTMLString(RhwpStudioPrintHTML.documentHTML(for: payload), baseURL: nil)
+        self.completion = completion
+        self.payload = payload
+        renderedDocument = PDFDocument()
+        renderingPageIndex = 0
+        didFinish = false
+        renderNextPage()
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        let printInfo = NSPrintInfo.shared.copy() as? NSPrintInfo ?? NSPrintInfo()
-        printInfo.jobDisposition = .spool
-        printInfo.horizontalPagination = .fit
-        printInfo.verticalPagination = .automatic
-
-        let operation = webView.printOperation(with: printInfo)
-        operation.showsPrintPanel = true
-        operation.showsProgressPanel = true
-        operation.run()
-
-        finish()
+        renderCurrentPagePDF()
     }
 
     func webView(
@@ -39,7 +56,7 @@ final class RhwpStudioPrintController: NSObject, WKNavigationDelegate {
         didFail navigation: WKNavigation!,
         withError error: Error
     ) {
-        finish()
+        finish(error: error)
     }
 
     func webView(
@@ -47,62 +64,222 @@ final class RhwpStudioPrintController: NSObject, WKNavigationDelegate {
         didFailProvisionalNavigation navigation: WKNavigation!,
         withError error: Error
     ) {
-        finish()
+        finish(error: error)
     }
 
-    private func finish() {
-        webView?.navigationDelegate = nil
-        webView = nil
+    private func renderNextPage() {
+        guard let payload else {
+            finish(error: RhwpStudioPrintError.emptyDocument)
+            return
+        }
+
+        guard renderingPageIndex < payload.pages.count else {
+            runPrintOperation(fileName: payload.fileName)
+            return
+        }
+
+        webView.frame = NSRect(origin: .zero, size: RhwpStudioPrintPageSize.defaultPageSize)
+        webView.loadHTMLString(
+            RhwpStudioPrintHTML.pageHTML(for: payload.pages[renderingPageIndex]),
+            baseURL: nil
+        )
+    }
+
+    private func renderCurrentPagePDF() {
+        webView.evaluateJavaScript(RhwpStudioPrintHTML.pageMetricsScript) { [weak self] result, error in
+            guard let self else {
+                return
+            }
+            if let error {
+                self.finish(error: error)
+                return
+            }
+
+            let pageSize = RhwpStudioPrintPageSize.size(fromMetrics: result)
+            self.webView.frame = NSRect(origin: .zero, size: pageSize)
+
+            let configuration = WKPDFConfiguration()
+            configuration.rect = NSRect(origin: .zero, size: pageSize)
+            self.webView.createPDF(configuration: configuration) { [weak self] result in
+                guard let self else {
+                    return
+                }
+
+                switch result {
+                case .success(let data):
+                    self.appendPDFPage(data)
+                case .failure(let error):
+                    self.finish(error: error)
+                }
+            }
+        }
+    }
+
+    private func appendPDFPage(_ data: Data) {
+        guard let pageDocument = PDFDocument(data: data),
+              pageDocument.pageCount > 0
+        else {
+            finish(error: RhwpStudioPrintError.pdfEncodingFailed(renderingPageIndex + 1))
+            return
+        }
+
+        for index in 0..<pageDocument.pageCount {
+            guard let page = pageDocument.page(at: index) else {
+                continue
+            }
+            renderedDocument.insert(page, at: renderedDocument.pageCount)
+        }
+
+        renderingPageIndex += 1
+        renderNextPage()
+    }
+
+    private func runPrintOperation(fileName: String) {
+        guard renderedDocument.pageCount > 0 else {
+            finish(error: RhwpStudioPrintError.emptyDocument)
+            return
+        }
+
+        let printInfo = NSPrintInfo.shared.copy() as? NSPrintInfo ?? NSPrintInfo()
+        printInfo.jobDisposition = .spool
+        printInfo.horizontalPagination = .fit
+        printInfo.verticalPagination = .fit
+
+        guard let operation = renderedDocument.printOperation(
+            for: printInfo,
+            scalingMode: .pageScaleDownToFit,
+            autoRotate: true
+        ) else {
+            finish(error: RhwpStudioPrintError.printOperationUnavailable)
+            return
+        }
+
+        operation.jobTitle = fileName
+        operation.showsPrintPanel = true
+        operation.showsProgressPanel = true
+        printOperation = operation
+        operation.run()
+        printOperation = nil
+        finish(error: nil)
+    }
+
+    private func finish(error: Error?) {
+        guard !didFinish else {
+            return
+        }
+
+        didFinish = true
+        webView.stopLoading()
+        webView.navigationDelegate = nil
+        if let error {
+            RhwpStudioPrintErrorPresenter.present(error)
+        }
+        let completion = completion
+        self.completion = nil
+        payload = nil
+        printOperation = nil
         completion?()
-        completion = nil
     }
 }
 
 enum RhwpStudioPrintHTML {
-    static func documentHTML(for payload: RhwpStudioPrintPayload) -> String {
-        let escapedTitle = escapeHTML(payload.fileName)
-        let pages = payload.pages.map { svg in
-            "<section class=\"page\">\(svg)</section>"
-        }.joined(separator: "\n")
+    static let pageMetricsScript = """
+    (() => {
+      const svg = document.querySelector("svg");
+      const rect = svg?.getBoundingClientRect();
+      const width = Math.ceil(Math.max(
+        rect?.width || 0,
+        document.documentElement.scrollWidth,
+        document.body?.scrollWidth || 0
+      ));
+      const height = Math.ceil(Math.max(
+        rect?.height || 0,
+        document.documentElement.scrollHeight,
+        document.body?.scrollHeight || 0
+      ));
+      return { width, height };
+    })()
+    """
 
-        return """
+    static func pageHTML(for svg: String) -> String {
+        """
         <!doctype html>
         <html lang="ko">
         <head>
           <meta charset="utf-8">
-          <title>\(escapedTitle)</title>
           <style>
             * { box-sizing: border-box; }
-            html, body { margin: 0; padding: 0; background: #fff; }
-            .page {
-              page-break-after: always;
-              break-after: page;
-              width: 100%;
+            html, body {
+              margin: 0;
+              padding: 0;
+              background: #fff;
               overflow: hidden;
             }
-            .page:last-child {
-              page-break-after: auto;
-              break-after: auto;
-            }
-            .page svg {
+            svg {
               display: block;
-              width: 100%;
-              height: auto;
             }
           </style>
         </head>
         <body>
-        \(pages)
+        \(svg)
         </body>
         </html>
         """
     }
+}
 
-    private static func escapeHTML(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "&", with: "&amp;")
-            .replacingOccurrences(of: "<", with: "&lt;")
-            .replacingOccurrences(of: ">", with: "&gt;")
-            .replacingOccurrences(of: "\"", with: "&quot;")
+enum RhwpStudioPrintPageSize {
+    static let defaultPageSize = NSSize(width: 794, height: 1123)
+
+    static func size(fromMetrics value: Any?) -> NSSize {
+        guard let dictionary = value as? [String: Any] else {
+            return defaultPageSize
+        }
+
+        let width = number(dictionary["width"]) ?? defaultPageSize.width
+        let height = number(dictionary["height"]) ?? defaultPageSize.height
+        return NSSize(width: max(width, 1), height: max(height, 1))
+    }
+
+    private static func number(_ value: Any?) -> CGFloat? {
+        switch value {
+        case let number as NSNumber:
+            return CGFloat(truncating: number)
+        case let double as Double:
+            return CGFloat(double)
+        case let int as Int:
+            return CGFloat(int)
+        default:
+            return nil
+        }
+    }
+}
+
+enum RhwpStudioPrintError: LocalizedError {
+    case emptyDocument
+    case pdfEncodingFailed(Int)
+    case printOperationUnavailable
+
+    var errorDescription: String? {
+        switch self {
+        case .emptyDocument:
+            "인쇄할 페이지가 없습니다."
+        case .pdfEncodingFailed(let page):
+            "\(page)페이지 인쇄 데이터를 PDF로 변환할 수 없습니다."
+        case .printOperationUnavailable:
+            "PDF 인쇄 작업을 만들 수 없습니다."
+        }
+    }
+}
+
+enum RhwpStudioPrintErrorPresenter {
+    @MainActor
+    static func present(_ error: Error) {
+        let alert = NSAlert()
+        alert.messageText = "인쇄할 수 없습니다."
+        alert.informativeText = error.localizedDescription
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "확인")
+        alert.runModal()
     }
 }

--- a/Sources/HostApp/Views/DocumentViewerView.swift
+++ b/Sources/HostApp/Views/DocumentViewerView.swift
@@ -5,14 +5,10 @@ struct DocumentViewerView: View {
 
     var body: some View {
         ZStack {
-            if let document = store.rhwpStudioDocument {
-                RhwpStudioContainerView(store: store, document: document)
-            } else if let error = store.errorMessage {
+            if let error = store.errorMessage {
                 ErrorStateView(message: error)
-            } else if store.isLoading {
-                LoadingStateView(message: "불러오는 중...")
             } else {
-                EmptyDocumentView(store: store)
+                RhwpStudioContainerView(store: store, document: store.rhwpStudioDocument)
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -21,7 +17,7 @@ struct DocumentViewerView: View {
 
 private struct RhwpStudioContainerView: View {
     @ObservedObject var store: DocumentViewerStore
-    let document: RhwpStudioDocumentPayload
+    let document: RhwpStudioDocumentPayload?
 
     var body: some View {
         ZStack {
@@ -54,36 +50,8 @@ private struct RhwpStudioContainerView: View {
                     .frame(maxHeight: .infinity, alignment: .top)
             }
         }
-        .id(document.revision)
+        .id(document?.revision ?? 0)
         .background(Color(nsColor: .windowBackgroundColor))
-    }
-}
-
-private struct EmptyDocumentView: View {
-    @ObservedObject var store: DocumentViewerStore
-
-    var body: some View {
-        VStack(spacing: 14) {
-            Image(systemName: "doc.richtext")
-                .font(.system(size: 48))
-                .foregroundStyle(.secondary)
-            Text("HWP 또는 HWPX 문서를 열어 주세요.")
-                .font(.title3)
-            HStack {
-                Button("문서 열기") {
-                    store.openDocument()
-                }
-            }
-        }
-    }
-}
-
-private struct LoadingStateView: View {
-    let message: String
-
-    var body: some View {
-        ProgressView(message)
-            .padding(24)
     }
 }
 

--- a/Sources/RhwpCoreBridge/FontFallback.swift
+++ b/Sources/RhwpCoreBridge/FontFallback.swift
@@ -169,16 +169,16 @@ private struct HwpFontFallbackPolicy {
 
         switch key {
         case "함초롬바탕", "한컴바탕", "hbatang", "hbatangb", "바탕", "batang":
-            return HwpFontFallbackPolicy(faces: [notoSerifKR, nanumMyeongjo, gowunBatang, defaultSerif, timesNewRoman])
+            return HwpFontFallbackPolicy(faces: [defaultSerif, notoSerifKR, nanumMyeongjo, gowunBatang, timesNewRoman])
         case "바탕체", "batangche", "새바탕체":
-            return HwpFontFallbackPolicy(faces: [d2Coding, nanumGothicCoding, defaultMono, notoSerifKR, defaultSerif])
+            return HwpFontFallbackPolicy(faces: [defaultSerif, d2Coding, nanumGothicCoding, defaultMono, notoSerifKR])
         case "새바탕":
-            return HwpFontFallbackPolicy(faces: [notoSerifKR, nanumMyeongjo, defaultSerif, timesNewRoman])
+            return HwpFontFallbackPolicy(faces: [defaultSerif, notoSerifKR, nanumMyeongjo, timesNewRoman])
         case "궁서", "궁서체", "gungsuh", "gungsuhche":
-            return HwpFontFallbackPolicy(faces: [gowunBatang, nanumMyeongjo, notoSerifKR, defaultSerif])
+            return HwpFontFallbackPolicy(faces: [defaultSerif, gowunBatang, nanumMyeongjo, notoSerifKR])
         case "hy신명조", "hysinmyeongjo", "hysinmyeongjomedium", "hy견명조", "hygyeonmyeongjo",
              "hy명조", "hymyeongjo", "hymjre", "휴먼명조", "humanmyeongjo", "나눔명조", "nanummyeongjo":
-            return HwpFontFallbackPolicy(faces: [nanumMyeongjo, notoSerifKR, defaultSerif, timesNewRoman])
+            return HwpFontFallbackPolicy(faces: [defaultSerif, nanumMyeongjo, notoSerifKR, timesNewRoman])
         case "notoserifkr", "notoserifkorean", "notoserif":
             return HwpFontFallbackPolicy(faces: [notoSerifKR, nanumMyeongjo, defaultSerif])
         case "gowunbatang", "고운바탕":
@@ -186,18 +186,18 @@ private struct HwpFontFallbackPolicy {
 
         case "함초롬돋움", "hamchoromdotum", "hamchoromdodum", "맑은고딕", "malgungothic",
              "calibri", "tahoma":
-            return HwpFontFallbackPolicy(faces: [pretendard, defaultSans, helveticaNeue])
+            return HwpFontFallbackPolicy(faces: [defaultSans, pretendard, helveticaNeue])
         case "verdana":
-            return HwpFontFallbackPolicy(faces: [pretendard, verdana, defaultSans, helveticaNeue])
+            return HwpFontFallbackPolicy(faces: [verdana, defaultSans, pretendard, helveticaNeue])
         case "한컴돋움", "hdotum", "hdotumb", "돋움", "dotum", "굴림", "gulim",
              "새돋움", "새굴림":
-            return HwpFontFallbackPolicy(faces: [notoSansKR, pretendard, nanumGothic, defaultSans, helveticaNeue])
+            return HwpFontFallbackPolicy(faces: [defaultSans, notoSansKR, pretendard, nanumGothic, helveticaNeue])
         case "돋움체", "dotumche", "굴림체", "gulimche", "새돋움체":
-            return HwpFontFallbackPolicy(faces: [d2Coding, nanumGothicCoding, defaultMono, notoSansKR, defaultSans])
+            return HwpFontFallbackPolicy(faces: [defaultSans, d2Coding, nanumGothicCoding, defaultMono, notoSansKR])
         case "hy고딕", "hygothic", "hy중고딕", "hyjunggothic", "hyjunggothicmedium",
              "hy견고딕", "hygyeongothic", "hy그래픽", "hygraphic", "hygraphicmedium",
              "hy헤드라인m", "hyheadlinem", "hyheadlinemedium":
-            return HwpFontFallbackPolicy(faces: [pretendard, gowunDodum, notoSansKR, defaultSans])
+            return HwpFontFallbackPolicy(faces: [defaultSans, pretendard, gowunDodum, notoSansKR])
         case "나눔고딕", "nanumgothic":
             return HwpFontFallbackPolicy(faces: [nanumGothic, notoSansKR, pretendard, defaultSans])
         case "notosanskr", "notosanskorean", "notosans":

--- a/mydocs/orders/20260503.md
+++ b/mydocs/orders/20260503.md
@@ -5,6 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #134 | MVP Viewer를 rhwp-studio WKWebView 기반으로 전환 | 완료 | M010, 공유 picker toolbar button anchor 보정: 10:40 |
+| #140 | 릴리즈 전 Viewer·Quick Look·인쇄 회귀 보정 | 완료 | 최종 보고서 작성 및 PR 등록: 19:16 |
 
 ## M015 — 첫 출시 전 Swift 렌더 보강
 

--- a/mydocs/plans/task_m010_140.md
+++ b/mydocs/plans/task_m010_140.md
@@ -1,0 +1,85 @@
+# Issue #140 수행 계획서
+
+## 작업명
+
+릴리즈 전 Viewer·Quick Look·인쇄 회귀 보정
+
+## 이슈
+
+- GitHub Issue: #140
+- Milestone: v0.1
+- 문서 prefix: `task_m010_140`
+- 작업 브랜치: `local/task140`
+- 게시 브랜치: `publish/task140`
+- 대상 브랜치: `devel-webview`
+- 이슈 URL: https://github.com/postmelee/alhangeul-macos/issues/140
+
+## 목적
+
+`devel-webview` 기반 릴리즈 준비 빌드에서 확인된 Quick Look/Thumbnail 텍스트 쏠림, WKWebView toolbar dropdown clipping, 앱 첫 화면, HostApp 인쇄 문제를 릴리즈 전 안정화 범위로 보정한다.
+
+이번 작업의 목표는 문서 편집 수준의 완전한 폰트 재현이 아니라, 사용자가 Finder Quick Look/Thumbnail과 HostApp viewer/print에서 문서 구조와 레이아웃을 확인할 수 있는 MVP 품질을 회복하는 것이다.
+
+## 배경
+
+PR #138 merge 이후 WKWebView viewer는 기본 표시 경로로 동작하지만, 릴리즈 직전 smoke test에서 다음 문제가 이어서 확인됐다.
+
+- `samples/20250130-hongbo.hwp` Quick Look에서 텍스트가 쏠려 보임
+- style bar 오른쪽 줄 높이 dropdown 텍스트가 WKWebView에서 잘려 보임
+- 앱을 문서 없이 실행하면 사용자가 바로 web viewer 상태를 확인하기 어려움
+- macOS print panel 진입 시 HostApp이 출력 미지원으로 거부됨
+- print entitlement만 추가한 빌드에서는 print preview는 표시되지만 PDF 저장물이 빈 페이지가 됨
+- custom NSView 기반 PDF print 보정 시도에서는 A4보다 큰 content rect가 잡혀 확대/클리핑됨
+
+## 범위
+
+포함:
+
+- HostApp sandbox entitlements에 `com.apple.security.print` 추가
+- WKWebView override CSS로 줄 높이 dropdown 높이와 padding 보정
+- 문서가 없는 상태에서도 `rhwp-studio` WKWebView container를 즉시 표시
+- Quick Look/Thumbnail native renderer의 font fallback 우선순위를 시스템 기본 serif/sans 중심으로 조정
+- WKWebView page SVG payload를 page별 PDF로 렌더링한 뒤 PDFKit print operation으로 인쇄
+- Release build, entitlement, print panel smoke 검증
+
+제외:
+
+- upstream `rhwp` core render tree 또는 `char_positions` contract 변경
+- Swift native renderer의 완전한 glyph metrics parity
+- 편집 기능, 저장 포맷 변경, 릴리즈 서명/공증/배포
+
+## 설계 방향
+
+Quick Look/Thumbnail 쪽 텍스트 쏠림은 릴리즈 직전 회귀 차단이 우선이다. 따라서 앱 쪽 font fallback 정책을 문서 구조 보존에 유리한 시스템 기본 font 우선으로 되돌리고, upstream core에 `char_positions` 전달 contract를 추가하는 작업은 후속 PR로 분리한다.
+
+WKWebView viewer의 toolbar dropdown은 `rhwp-studio` upstream asset을 직접 크게 수정하지 않고 HostApp 전용 override CSS에 한정한다.
+
+인쇄는 macOS sandbox에서 print entitlement를 명시하고, WebKit print operation의 PDF 저장 blank output을 피하기 위해 `rhwp-studio`가 이미 제공하는 page SVG payload를 offscreen WKWebView에서 page별 PDF로 변환한다. 최종 인쇄 UI는 PDFKit의 표준 `PDFDocument.printOperation`에 맡겨 macOS print convention을 따른다.
+
+## 검증 계획
+
+```bash
+xcodebuild -project AlhangeulMac.xcodeproj \
+  -scheme HostApp \
+  -configuration Release \
+  -derivedDataPath build.noindex/verify-task140/DerivedData \
+  CONFIGURATION_BUILD_DIR=build.noindex/verify-task140/xcodebuild \
+  -quiet build
+```
+
+```bash
+codesign -d --entitlements :- \
+  build.noindex/verify-task140/xcodebuild/AlhangeulMac.app | plutil -p -
+```
+
+수동 smoke:
+
+- `samples/exam_social.hwp`를 Release app으로 열기
+- macOS File > Print panel 표시 확인
+- 이전 문제 산출물 `/Users/melee/Documents/dsa.pdf`, `/Users/melee/Documents/test.pdf`를 비교 근거로 분석
+
+## 리스크
+
+- PDFKit print path는 print panel 표시와 page preview까지 smoke 확인했지만, 실제 프린터별 드라이버 동작은 사용 환경에서 추가 확인이 필요하다.
+- font fallback 순서 보정은 릴리즈 전 회귀 차단용이며, HWP 원본 font metrics를 완전히 재현하는 근본 해결은 아니다.
+- WKWebView override CSS는 bundled `rhwp-studio` asset 구조에 의존하므로 upstream UI class 변경 시 재검토가 필요하다.

--- a/mydocs/plans/task_m010_140_impl.md
+++ b/mydocs/plans/task_m010_140_impl.md
@@ -1,0 +1,40 @@
+# Issue #140 구현 계획서
+
+## 구현 요약
+
+릴리즈 전 확인된 HostApp viewer, Quick Look/Thumbnail, 인쇄 회귀를 한 번에 정리한다. 변경은 HostApp과 bridge font fallback 정책에 한정하며, `rhwp-studio` upstream core나 Xcode project 직접 수정은 하지 않는다.
+
+## 구현 단계
+
+1. Quick Look/Thumbnail font fallback 회귀 차단
+   - `Sources/RhwpCoreBridge/FontFallback.swift`의 주요 한글 serif/sans fallback 정책에서 시스템 기본 font를 먼저 선택한다.
+   - bundled Korean font 우선으로 생기는 metrics 차이를 줄여 문서 구조 확인 목적의 preview 안정성을 높인다.
+
+2. WKWebView viewer UI 보정
+   - `Sources/HostApp/Resources/rhwp-studio/alhangeul-wkwebview-overrides.css`에서 `select.sb-ls-select`를 기존 combo override 대상에 포함한다.
+   - 줄 높이 dropdown group, select, arrow 높이를 24px 기준으로 고정한다.
+   - `Sources/HostApp/Views/DocumentViewerView.swift`에서 오류 상태가 아니면 항상 `RhwpStudioContainerView`를 표시해 앱 첫 화면이 바로 WebView를 로드하도록 한다.
+
+3. HostApp print 권한 보정
+   - `Sources/HostApp/HostApp.entitlements`에 `com.apple.security.print`를 추가한다.
+   - codesign entitlements로 Release app bundle에 print entitlement가 포함되는지 확인한다.
+
+4. PDFKit 기반 인쇄 경로 보정
+   - `RhwpStudioPrintController`에서 `WKWebView.printOperation(with:)` 직접 호출을 제거한다.
+   - page SVG를 offscreen WKWebView에 page별로 로드하고 `createPDF(configuration:)`으로 PDF page data를 생성한다.
+   - 생성된 page를 `PDFDocument`에 합친 뒤 `PDFDocument.printOperation(for:scalingMode:autoRotate:)`로 표준 macOS print panel을 실행한다.
+   - 빈 payload, PDF 변환 실패, print operation 생성 실패는 `NSAlert`로 사용자에게 알린다.
+
+## 검증 항목
+
+- Release HostApp build 성공
+- HostApp app bundle entitlements에 `com.apple.security.print` 포함
+- `samples/exam_social.hwp` 실행 후 native print panel 표시
+- print preview에서 page content 표시
+- 이전 blank PDF와 custom print view 확대 문제 분석 결과를 보고서에 기록
+
+## 구현상 주의
+
+- `Sources/RhwpCoreBridge`에는 AppKit/WebKit 의존을 추가하지 않는다.
+- `project.yml` 또는 `AlhangeulMac.xcodeproj` 변경 없이 기존 target/resource 구성 안에서 해결한다.
+- 인쇄 관련 임시 controller가 print operation 중 해제되지 않도록 `printOperation`과 payload 상태를 controller가 보유한다.

--- a/mydocs/report/task_m010_140_report.md
+++ b/mydocs/report/task_m010_140_report.md
@@ -1,0 +1,87 @@
+# Task M010 #140 최종 보고서
+
+## 작업 요약
+
+- 이슈: #140 릴리즈 전 Viewer·Quick Look·인쇄 회귀 보정
+- 마일스톤: M010 (`v0.1.0 Viewer 기반`)
+- 브랜치: `local/task140`
+- 대상 브랜치: `devel-webview`
+- 핵심 변경: Quick Look/Thumbnail font fallback 회귀 차단, WKWebView toolbar/첫 화면 보정, HostApp print entitlement와 PDFKit 기반 print path 보정
+
+## 완료 내용
+
+### Quick Look/Thumbnail font fallback
+
+`Sources/RhwpCoreBridge/FontFallback.swift`의 주요 한글 serif/sans fallback 순서를 조정했다.
+
+- 바탕/명조/궁서 계열은 `defaultSerif`를 먼저 사용한다.
+- 돋움/고딕 계열은 `defaultSans`를 먼저 사용한다.
+- 릴리즈 전 Quick Look/Thumbnail에서는 정확한 font family보다 문서 구조와 레이아웃 안정성을 우선한다.
+
+### WKWebView viewer UI
+
+`Sources/HostApp/Resources/rhwp-studio/alhangeul-wkwebview-overrides.css`에 줄 높이 dropdown override를 추가했다.
+
+- `select.sb-ls-select`를 기존 combo override 대상에 포함했다.
+- 줄 높이 group/select/arrow 높이를 24px 기준으로 맞췄다.
+- 오른쪽 dropdown 텍스트가 잘리는 문제를 HostApp 전용 CSS에서 보정했다.
+
+`Sources/HostApp/Views/DocumentViewerView.swift`는 문서가 없는 상태에서도 즉시 `RhwpStudioContainerView`를 표시하도록 바꿨다. 앱을 그냥 실행했을 때 첫 화면이 곧바로 WKWebView를 로드한다.
+
+### HostApp 인쇄
+
+`Sources/HostApp/HostApp.entitlements`에 `com.apple.security.print`를 추가했다. 이 변경으로 macOS sandbox에서 HostApp이 출력 미지원 앱으로 차단되는 문제를 해결했다.
+
+`Sources/HostApp/Services/RhwpStudioPrintController.swift`는 직접 `WKWebView.printOperation(with:)`에 의존하지 않도록 변경했다.
+
+- `rhwp-studio`에서 전달된 page SVG를 offscreen WKWebView에 page별로 로드한다.
+- page DOM metrics를 읽어 page 크기에 맞춘 `WKPDFConfiguration`을 만든다.
+- `WKWebView.createPDF(configuration:)` 결과를 `PDFDocument`에 page 단위로 합친다.
+- 최종 출력은 PDFKit의 `PDFDocument.printOperation(for:scalingMode:autoRotate:)`로 실행한다.
+- 빈 문서, PDF 변환 실패, print operation 생성 실패는 사용자 alert로 표시한다.
+
+## 변경 파일
+
+| 파일 | 내용 |
+|------|------|
+| `Sources/HostApp/HostApp.entitlements` | HostApp sandbox print entitlement 추가 |
+| `Sources/HostApp/Resources/rhwp-studio/alhangeul-wkwebview-overrides.css` | WKWebView 줄 높이 dropdown clipping 보정 |
+| `Sources/HostApp/Services/RhwpStudioPrintController.swift` | page SVG -> PDFDocument -> PDFKit print operation 경로로 인쇄 재구성 |
+| `Sources/HostApp/Views/DocumentViewerView.swift` | 빈 문서 상태에서도 WKWebView container 즉시 표시 |
+| `Sources/RhwpCoreBridge/FontFallback.swift` | Quick Look/Thumbnail layout 안정성 우선 fallback 순서 보정 |
+| `mydocs/orders/20260503.md` | #140 완료 항목 추가 |
+| `mydocs/plans/task_m010_140.md` | 수행 계획서 |
+| `mydocs/plans/task_m010_140_impl.md` | 구현 계획서 |
+| `mydocs/report/task_m010_140_report.md` | 최종 보고서 |
+
+## 검증 결과
+
+```bash
+xcodebuild -project AlhangeulMac.xcodeproj -scheme HostApp -configuration Release -derivedDataPath build.noindex/verify-task140/DerivedData CONFIGURATION_BUILD_DIR=build.noindex/verify-task140/xcodebuild -quiet build
+```
+
+결과: 성공. Xcode의 CoreSimulator/provisioning 관련 경고는 있었지만 build는 완료됐다.
+
+```bash
+codesign -d --entitlements :- build.noindex/verify-task140/xcodebuild/AlhangeulMac.app | plutil -p -
+```
+
+결과: `com.apple.security.print => true` 포함 확인.
+
+```bash
+open -n -a /Users/melee/Documents/projects/rhwp-mac/build.noindex/verify-task140/xcodebuild/AlhangeulMac.app /Users/melee/Documents/projects/rhwp-mac/samples/exam_social.hwp
+```
+
+결과: 이전 검증에서 Release app으로 샘플 문서 실행 후 macOS File > Print panel에서 page content preview가 표시됨을 확인했다.
+
+## 문제 분석 기록
+
+- `/Users/melee/Documents/test.pdf`: print entitlement만 추가하고 기존 WKWebView print operation을 사용한 결과물이다. A4 4페이지가 생성됐지만 각 page content stream이 비어 있었다.
+- `/Users/melee/Documents/dsa.pdf`: custom NSView 기반 print view 시도 결과물이다. A4 page 안에 `1029x1490` 수준의 content clip rect가 잡혀 확대/클리핑이 발생했다.
+- 따라서 entitlement 누락은 print panel 진입 차단의 원인이지만, blank PDF와 scaling 문제는 별도 print rendering path 문제로 보고 PDFKit 표준 print operation 경로로 정리했다.
+
+## 남은 리스크
+
+- 실제 프린터 드라이버별 출력은 사용자 환경에서 추가 확인이 필요하다.
+- font fallback 순서 보정은 릴리즈 전 회귀 차단용이며, HWP font metrics 근본 재현은 후속 upstream/core contract 작업으로 분리해야 한다.
+- `rhwp-studio` toolbar class 구조가 upstream에서 바뀌면 HostApp override CSS를 재검토해야 한다.


### PR DESCRIPTION
## 요약

- 대상 타스크: #140
- 왜: 릴리즈 전 smoke test에서 Quick Look 텍스트 쏠림, WKWebView dropdown clipping, 앱 첫 화면, HostApp 인쇄 회귀가 확인됐습니다.
- 무엇: font fallback 순서, WKWebView override CSS/첫 화면, print entitlement, PDFKit 기반 print path를 보정했습니다.
- 리뷰 포인트: `RhwpStudioPrintController`의 page SVG -> PDFDocument -> PDFKit print operation 경로와 `FontFallback` fallback 우선순위입니다.

## 변경 내역

- **Task #140** ([2f53859](https://github.com/postmelee/alhangeul-macos/commit/2f53859c59669924fe365f621880d4f7c3e6e2dc)): 릴리즈 전 viewer/Quick Look/인쇄 회귀 보정

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| HostApp entitlement | `com.apple.security.print` 추가 | sandbox print panel 진입 차단 해소 |
| HostApp print | page SVG를 WKWebView PDF로 변환 후 PDFKit print operation 실행 | blank PDF와 custom view scaling 회귀 방지 |
| WKWebView UI | 줄 높이 dropdown override와 빈 문서 첫 화면 WebView 표시 | PR #138 후속 WKWebView clipping 보정 |
| Quick Look/Thumbnail | 주요 한글 fallback을 시스템 serif/sans 우선으로 조정 | 릴리즈 전 layout drift 차단용 정책 |

- 수행 계획서: [task_m010_140.md](https://github.com/postmelee/alhangeul-macos/blob/2f53859c59669924fe365f621880d4f7c3e6e2dc/mydocs/plans/task_m010_140.md)
- 구현 계획서: [task_m010_140_impl.md](https://github.com/postmelee/alhangeul-macos/blob/2f53859c59669924fe365f621880d4f7c3e6e2dc/mydocs/plans/task_m010_140_impl.md)
- 최종 보고서: [task_m010_140_report.md](https://github.com/postmelee/alhangeul-macos/blob/2f53859c59669924fe365f621880d4f7c3e6e2dc/mydocs/report/task_m010_140_report.md)

## 핵심 리뷰 포인트

- `RhwpStudioPrintController`가 더 이상 직접 `WKWebView.printOperation(with:)`에 의존하지 않고, page별 `createPDF` 결과를 `PDFDocument`로 합친 뒤 PDFKit 표준 print operation을 사용합니다.
- `FontFallback` 변경은 정확한 한글 font parity가 아니라 Quick Look/Thumbnail의 문서 구조 안정성을 우선하는 릴리즈 전 회귀 차단입니다.
- WKWebView toolbar 보정은 upstream asset 직접 변경이 아니라 HostApp override CSS에 한정했습니다.

## 검증

```bash
xcodebuild -project AlhangeulMac.xcodeproj -scheme HostApp -configuration Release -derivedDataPath build.noindex/verify-task140/DerivedData CONFIGURATION_BUILD_DIR=build.noindex/verify-task140/xcodebuild -quiet build
```

결과: 성공.

```bash
codesign -d --entitlements :- build.noindex/verify-task140/xcodebuild/AlhangeulMac.app | plutil -p -
```

결과: `com.apple.security.print => true` 확인.

수동 smoke:

- `samples/exam_social.hwp`를 Release app으로 열고 macOS File > Print panel preview 표시 확인
- `/Users/melee/Documents/test.pdf`에서 기존 WKWebView print operation의 blank page 결과 분석
- `/Users/melee/Documents/dsa.pdf`에서 custom print view의 oversized clip rect 분석

## 관련 이슈

- Closes #140
- 참고: #120, PR #138

## 후속 이슈 제안

- upstream `rhwp` core/render tree에 `char_positions` 전달 contract를 추가하는 font metrics 근본 개선
- 실제 프린터 드라이버별 print output smoke matrix 정리

## 남은 리스크

- 실제 프린터 출력은 사용자 환경에서 추가 확인이 필요합니다.
- font fallback 순서 보정은 릴리즈 전 회귀 차단이며, 원본 HWP font metrics의 근본 재현은 후속 작업으로 남습니다.
