### PR TITLE
Task #123: native renderer clip 정책 devel-webview 적용

### DIFF
--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -9,10 +9,12 @@ import ImageIO
 
 class CGTreeRenderer {
     private let imageCropUnitsPerPixel = 75.0
+    private let tableCellClipRightSlack = 4.0
 
     private var imageCache: [UInt16: CGImage] = [:]
     private weak var document: RhwpDocument?
 
+    private var pageBounds: BBox?
     private var pageHeight: Double = 0
 
     func render(tree: RenderNode, in context: CGContext, pageHeight: Double, document: RhwpDocument?) {
@@ -23,6 +25,7 @@ class CGTreeRenderer {
             clearCache()
         }
         self.document = document
+        self.pageBounds = tree.bbox
         self.pageHeight = pageHeight
         // 호출 측은 좌상단 원점 좌표계로 CGContext를 전달한다.
         // 렌더 트리의 좌표(좌상단 원점)를 그대로 사용할 수 있다.
@@ -61,24 +64,10 @@ class CGTreeRenderer {
             renderPageBackground(bg, bbox: node.bbox, in: ctx)
 
         case .body(let body):
-            if let clip = body.clipRect {
-                ctx.saveGState()
-                ctx.clip(to: cgRect(clip))
-                renderChildren(node, in: ctx)
-                ctx.restoreGState()
-            } else {
-                renderChildren(node, in: ctx)
-            }
+            renderBody(body, node: node, in: ctx)
 
         case .tableCell(let cell):
-            if cell.clip {
-                ctx.saveGState()
-                ctx.clip(to: cgRect(node.bbox))
-                renderChildren(node, in: ctx)
-                ctx.restoreGState()
-            } else {
-                renderChildren(node, in: ctx)
-            }
+            renderTableCell(cell, node: node, in: ctx)
 
         case .rectangle(let rect):
             renderRectangle(rect, bbox: node.bbox, in: ctx)
@@ -122,10 +111,130 @@ class CGTreeRenderer {
         }
     }
 
+    private func renderTableCell(_ cell: TableCellNode, node: RenderNode, in ctx: CGContext) {
+        guard cell.clip else {
+            renderChildren(node, in: ctx)
+            return
+        }
+
+        ctx.saveGState()
+        ctx.clip(to: tableCellClipRect(for: node.bbox))
+        renderChildren(node, in: ctx)
+        ctx.restoreGState()
+    }
+
+    private func tableCellClipRect(for bbox: BBox) -> CGRect {
+        CGRect(
+            x: bbox.x,
+            y: bbox.y,
+            width: max(0, bbox.width + tableCellClipRightSlack),
+            height: bbox.height
+        )
+    }
+
     private func renderChildren(_ node: RenderNode, in ctx: CGContext) {
         for child in node.children {
             renderNode(child, in: ctx)
         }
+    }
+
+    private func renderBody(_ body: BodyNode, node: RenderNode, in ctx: CGContext) {
+        guard let clip = body.clipRect else {
+            renderChildren(node, in: ctx)
+            return
+        }
+
+        ctx.saveGState()
+        ctx.clip(to: cgRect(clip))
+        renderChildren(node, in: ctx)
+        ctx.restoreGState()
+
+        renderBodyOverflowControls(node, bodyClip: clip, in: ctx)
+    }
+
+    private func renderBodyOverflowControls(_ bodyNode: RenderNode, bodyClip: BBox, in ctx: CGContext) {
+        let candidates = bodyOverflowReplayCandidates(in: bodyNode, bodyClip: bodyClip)
+        guard !candidates.isEmpty else { return }
+
+        ctx.saveGState()
+        ctx.clip(to: bodyOverflowReplayClipRect(bodyClip))
+        for candidate in candidates {
+            renderNode(candidate, in: ctx)
+        }
+        ctx.restoreGState()
+    }
+
+    private func bodyOverflowReplayCandidates(in bodyNode: RenderNode, bodyClip: BBox) -> [RenderNode] {
+        let bodyLeft = bodyClip.x
+        let bodyRight = bodyClip.x + bodyClip.width
+        var candidates: [RenderNode] = []
+
+        for child in bodyNode.children {
+            if case .column(_) = child.nodeType {
+                candidates.append(
+                    contentsOf: child.children.filter {
+                        isBodyOverflowReplayCandidate($0, bodyLeft: bodyLeft, bodyRight: bodyRight)
+                    }
+                )
+            } else if isBodyOverflowReplayCandidate(child, bodyLeft: bodyLeft, bodyRight: bodyRight) {
+                candidates.append(child)
+            }
+        }
+
+        return candidates
+    }
+
+    private func isBodyOverflowReplayCandidate(
+        _ node: RenderNode,
+        bodyLeft: Double,
+        bodyRight: Double
+    ) -> Bool {
+        guard node.visible, isBodyOverflowControlNode(node) else {
+            return false
+        }
+        return horizontallyOverflows(node.bbox, left: bodyLeft, right: bodyRight)
+    }
+
+    private func isBodyOverflowControlNode(_ node: RenderNode) -> Bool {
+        switch node.nodeType {
+        case .table(_),
+             .line(_),
+             .rectangle(_),
+             .ellipse(_),
+             .path(_),
+             .image(_),
+             .group(_),
+             .textBox,
+             .equation(_),
+             .formObject(_):
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func horizontallyOverflows(_ bbox: BBox, left: Double, right: Double) -> Bool {
+        bbox.x < left || bbox.x + bbox.width > right
+    }
+
+    private func bodyOverflowReplayClipRect(_ bodyClip: BBox) -> CGRect {
+        let pageRect: CGRect
+        if let pageBounds {
+            pageRect = cgRect(pageBounds)
+        } else {
+            pageRect = CGRect(
+                x: 0,
+                y: 0,
+                width: CGFloat(max(bodyClip.x + bodyClip.width, 0)),
+                height: CGFloat(max(pageHeight, bodyClip.y + bodyClip.height))
+            )
+        }
+        return CGRect(
+            x: pageRect.minX,
+            y: CGFloat(bodyClip.y),
+            width: pageRect.width,
+            height: CGFloat(bodyClip.height)
+        )
     }
 
     // MARK: - 사각형


### PR DESCRIPTION
## 요약

- `devel`에 적용한 Swift native renderer clip 정책을 `devel-webview`에도 선별 적용했습니다.
- `devel-webview`의 WKWebView HostApp 구조와 bundled font resolver 변경은 보존했습니다.
- 변경 파일은 `Sources/RhwpCoreBridge/CGTreeRenderer.swift` 한 개입니다.

## 적용 내용

- Body clip 내부 일반 렌더링 이후 body 좌우 overflow control replay pass 추가
- replay 대상 control whitelist 적용
- `TableCell.clip` 우측 폭에 `4.0pt` 여유 적용

## 검증

```text
./scripts/check-no-appkit.sh
OK: shared Swift code has no AppKit/UIKit dependencies
```

```text
./scripts/validate-stage3-render.sh
OK KTX.hwp: page=1 size=1123x794 textRuns=436 hangulRuns=76 hangulScalars=209 nonWhitePixels=452141
OK request.hwp: page=1 size=567x794 textRuns=104 hangulRuns=36 hangulScalars=309 nonWhitePixels=67892
OK exam_kor.hwp: page=1 size=1123x1588 textRuns=133 hangulRuns=86 hangulScalars=1368 nonWhitePixels=175781
```

```text
./scripts/validate-stage3-render.sh /private/tmp/rhwp-task123-webview-smoke samples/basic/KTX.hwp samples/basic/request.hwp samples/exam_kor.hwp
OK KTX.hwp: nonWhitePixels=452141
OK request.hwp: nonWhitePixels=67892
OK exam_kor.hwp: nonWhitePixels=175781
```

```text
xcodebuild -project AlhangeulMac.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData CODE_SIGNING_ALLOWED=NO build
** BUILD SUCCEEDED ** [13.213 sec]
```

## 참고

- `devel` 대상 문서/최종 보고서 변경은 별도 PR `publish/task123-devel`에 포함했습니다.
