### PR TITLE
Task #109: devel-webview Quick Look renderer style 백포트

### DIFF
--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -2105,14 +2105,18 @@ class CGTreeRenderer {
     }
 
     private func applyPatternFill(_ pattern: PatternFillInfo, style: ShapeStyle, path: CGPath, in ctx: CGContext) {
+        let alpha = clampedAlpha(style.opacity)
+
         ctx.saveGState()
         applyShadow(style.shadow, in: ctx)
         ctx.addPath(path)
+        ctx.setAlpha(alpha)
         ctx.setFillColor(colorRefToCGColor(pattern.backgroundColor))
         ctx.fillPath()
         ctx.restoreGState()
 
         ctx.saveGState()
+        ctx.setAlpha(alpha)
         ctx.addPath(path)
         ctx.clip()
         drawPatternLines(pattern, bounds: path.boundingBoxOfPath, in: ctx)

--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -10,12 +10,26 @@ import ImageIO
 class CGTreeRenderer {
     private let imageCropUnitsPerPixel = 75.0
     private let tableCellClipRightSlack = 4.0
+    private let pathEpsilon = 0.000001
 
     private var imageCache: [UInt16: CGImage] = [:]
     private weak var document: RhwpDocument?
 
     private var pageBounds: BBox?
     private var pageHeight: Double = 0
+
+    private struct BuiltPath {
+        let path: CGPath
+        let firstPoint: CGPoint?
+        let lastPoint: CGPoint?
+        let firstTangent: CGVector?
+        let lastTangent: CGVector?
+    }
+
+    private enum ArcSegment {
+        case line(CGPoint)
+        case curve(CGPoint, CGPoint, CGPoint)
+    }
 
     func render(tree: RenderNode, in context: CGContext, pageHeight: Double, document: RhwpDocument?) {
         HwpBundledFontRegistry.ensureRegistered()
@@ -252,8 +266,8 @@ class CGTreeRenderer {
             path = CGPath(rect: r, transform: nil)
         }
 
-        // 그라데이션 채우기
         if let grad = rect.gradient {
+            applyShapeShadowSilhouette(rect.style, path: path, fallbackColor: grad.colors.first, in: ctx)
             ctx.addPath(path)
             ctx.clip()
             drawGradient(grad, in: r, ctx: ctx)
@@ -261,7 +275,7 @@ class CGTreeRenderer {
             applyShapeStyleFill(rect.style, path: path, in: ctx)
         }
 
-        applyShapeStyleStroke(rect.style, path: path, in: ctx)
+        applyShapeStyleStroke(rect.style, path: path, includeShadow: rect.gradient == nil && !hasShapeFill(rect.style), in: ctx)
         ctx.restoreGState()
     }
 
@@ -272,14 +286,21 @@ class CGTreeRenderer {
         applyTransform(line.transform, bbox: bbox, in: ctx)
 
         let style = line.style
+        let start = CGPoint(x: line.x1, y: line.y1)
+        let end = CGPoint(x: line.x2, y: line.y2)
+        let strokeLine = adjustedLineForArrows(start: start, end: end, style: style)
 
+        ctx.saveGState()
+        applyShadow(style.shadow, in: ctx)
         ctx.setStrokeColor(colorRefToCGColor(style.color))
         ctx.setLineWidth(CGFloat(max(style.width, 0.5)))
         applyDash(style.dash, in: ctx)
 
-        ctx.move(to: CGPoint(x: line.x1, y: line.y1))
-        ctx.addLine(to: CGPoint(x: line.x2, y: line.y2))
+        ctx.move(to: strokeLine.start)
+        ctx.addLine(to: strokeLine.end)
         ctx.strokePath()
+        drawLineArrows(start: start, end: end, style: style, in: ctx)
+        ctx.restoreGState()
 
         ctx.restoreGState()
     }
@@ -294,6 +315,7 @@ class CGTreeRenderer {
         let path = CGPath(ellipseIn: r, transform: nil)
 
         if let grad = ell.gradient {
+            applyShapeShadowSilhouette(ell.style, path: path, fallbackColor: grad.colors.first, in: ctx)
             ctx.addPath(path)
             ctx.clip()
             drawGradient(grad, in: r, ctx: ctx)
@@ -301,7 +323,7 @@ class CGTreeRenderer {
             applyShapeStyleFill(ell.style, path: path, in: ctx)
         }
 
-        applyShapeStyleStroke(ell.style, path: path, in: ctx)
+        applyShapeStyleStroke(ell.style, path: path, includeShadow: ell.gradient == nil && !hasShapeFill(ell.style), in: ctx)
         ctx.restoreGState()
     }
 
@@ -311,9 +333,11 @@ class CGTreeRenderer {
         ctx.saveGState()
         applyTransform(pathNode.transform, bbox: bbox, in: ctx)
 
-        let cgPath = buildCGPath(pathNode.commands)
+        let builtPath = buildCGPath(pathNode.commands)
+        let cgPath = builtPath.path
 
         if let grad = pathNode.gradient {
+            applyShapeShadowSilhouette(pathNode.style, path: cgPath, fallbackColor: grad.colors.first, in: ctx)
             ctx.addPath(cgPath)
             ctx.clip()
             drawGradient(grad, in: cgRect(bbox), ctx: ctx)
@@ -323,37 +347,150 @@ class CGTreeRenderer {
 
         // 패스 노드는 lineStyle이 있으면 그것을 사용
         if let ls = pathNode.lineStyle {
+            ctx.saveGState()
+            applyShadow(ls.shadow, in: ctx)
             ctx.addPath(cgPath)
             ctx.setStrokeColor(colorRefToCGColor(ls.color))
             ctx.setLineWidth(CGFloat(max(ls.width, 0.5)))
             applyDash(ls.dash, in: ctx)
             ctx.strokePath()
+            drawConnectorArrows(for: pathNode, builtPath: builtPath, in: ctx)
+            ctx.restoreGState()
         } else {
-            applyShapeStyleStroke(pathNode.style, path: cgPath, in: ctx)
+            applyShapeStyleStroke(pathNode.style, path: cgPath, includeShadow: pathNode.gradient == nil && !hasShapeFill(pathNode.style), in: ctx)
         }
 
         ctx.restoreGState()
     }
 
-    private func buildCGPath(_ commands: [PathCommand]) -> CGPath {
+    private func buildCGPath(_ commands: [PathCommand]) -> BuiltPath {
         let path = CGMutablePath()
+        var currentPoint: CGPoint?
+        var subpathStart: CGPoint?
+        var firstPoint: CGPoint?
+        var lastPoint: CGPoint?
+        var firstTangent: CGVector?
+        var lastTangent: CGVector?
+
+        func notePoint(_ point: CGPoint) {
+            if firstPoint == nil {
+                firstPoint = point
+            }
+            lastPoint = point
+        }
+
+        func noteSegment(from start: CGPoint, to end: CGPoint, startControl: CGPoint? = nil, endControl: CGPoint? = nil) {
+            if firstPoint == nil {
+                firstPoint = start
+            }
+
+            if firstTangent == nil {
+                let target = startControl ?? end
+                let tangent = vector(from: start, to: target)
+                if !isZeroVector(tangent) {
+                    firstTangent = tangent
+                }
+            }
+
+            let tangentSource = endControl ?? start
+            let tangent = vector(from: tangentSource, to: end)
+            if !isZeroVector(tangent) {
+                lastTangent = tangent
+            }
+
+            lastPoint = end
+        }
+
         for cmd in commands {
             switch cmd {
             case .moveTo(let x, let y):
-                path.move(to: CGPoint(x: x, y: y))
+                let point = CGPoint(x: x, y: y)
+                path.move(to: point)
+                currentPoint = point
+                subpathStart = point
+                notePoint(point)
             case .lineTo(let x, let y):
-                path.addLine(to: CGPoint(x: x, y: y))
+                let end = CGPoint(x: x, y: y)
+                guard let start = currentPoint else {
+                    path.move(to: end)
+                    currentPoint = end
+                    subpathStart = end
+                    notePoint(end)
+                    continue
+                }
+                path.addLine(to: end)
+                noteSegment(from: start, to: end)
+                currentPoint = end
             case .curveTo(let x1, let y1, let x2, let y2, let x, let y):
+                let end = CGPoint(x: x, y: y)
+                guard let start = currentPoint else {
+                    path.move(to: end)
+                    currentPoint = end
+                    subpathStart = end
+                    notePoint(end)
+                    continue
+                }
+                let control1 = CGPoint(x: x1, y: y1)
+                let control2 = CGPoint(x: x2, y: y2)
                 path.addCurve(to: CGPoint(x: x, y: y),
-                              control1: CGPoint(x: x1, y: y1),
-                              control2: CGPoint(x: x2, y: y2))
-            case .arcTo(_, _, _, _, _, let x, let y):
-                path.addLine(to: CGPoint(x: x, y: y))
+                              control1: control1,
+                              control2: control2)
+                noteSegment(from: start, to: end, startControl: control1, endControl: control2)
+                currentPoint = end
+            case .arcTo(let rx, let ry, let xRotation, let largeArc, let sweep, let x, let y):
+                let end = CGPoint(x: x, y: y)
+                guard let start = currentPoint else {
+                    path.move(to: end)
+                    currentPoint = end
+                    subpathStart = end
+                    notePoint(end)
+                    continue
+                }
+                let segments = arcSegments(
+                    from: start,
+                    rx: rx,
+                    ry: ry,
+                    xRotation: xRotation,
+                    largeArc: largeArc,
+                    sweep: sweep,
+                    to: end
+                )
+                if segments.isEmpty {
+                    currentPoint = end
+                    continue
+                }
+                for segment in segments {
+                    switch segment {
+                    case .line(let lineEnd):
+                        path.addLine(to: lineEnd)
+                        noteSegment(from: currentPoint ?? start, to: lineEnd)
+                        currentPoint = lineEnd
+                    case .curve(let control1, let control2, let curveEnd):
+                        path.addCurve(to: curveEnd, control1: control1, control2: control2)
+                        noteSegment(
+                            from: currentPoint ?? start,
+                            to: curveEnd,
+                            startControl: control1,
+                            endControl: control2
+                        )
+                        currentPoint = curveEnd
+                    }
+                }
             case .closePath:
                 path.closeSubpath()
+                if let start = currentPoint, let end = subpathStart {
+                    noteSegment(from: start, to: end)
+                    currentPoint = end
+                }
             }
         }
-        return path
+        return BuiltPath(
+            path: path,
+            firstPoint: firstPoint,
+            lastPoint: lastPoint,
+            firstTangent: firstTangent,
+            lastTangent: lastTangent
+        )
     }
 
     // MARK: - 이미지
@@ -847,8 +984,24 @@ class CGTreeRenderer {
         guard !run.text.isEmpty else { return }
 
         let style = run.style
-        let fontSize = CGFloat(style.fontSize)
-        guard fontSize > 0 else { return }
+        let baseFontSize = CGFloat(style.fontSize)
+        guard baseFontSize > 0 else { return }
+        let fontSize = effectiveTextRunFontSize(style: style, baseFontSize: baseFontSize)
+        let baselineShift = textRunBaselineShift(style: style, baseFontSize: baseFontSize)
+        let rotation = normalizedTextRunRotation(run)
+
+        if abs(rotation) > pathEpsilon || run.isVertical {
+            renderCenteredTextRun(
+                run,
+                bbox: bbox,
+                style: style,
+                fontSize: fontSize,
+                baselineShift: baselineShift,
+                rotation: rotation,
+                in: ctx
+            )
+            return
+        }
 
         ctx.saveGState()
 
@@ -884,14 +1037,46 @@ class CGTreeRenderer {
         // Core Text 좌하단 좌표계에서 베이스라인 위치
         // bbox 내부 좌표: baseline은 bbox.y 상단으로부터의 거리
         // Core Text Y: bbox 하단(0)으로부터 위로 = bbox.height - baseline
-        let textY = CGFloat(bbox.height) - CGFloat(run.baseline)
+        let textY = CGFloat(bbox.height) - CGFloat(run.baseline) + baselineShift
+
+        if style.shadowType > 0 {
+            let shadowAttributes = makeTextRunAttributes(
+                style: style,
+                font: font,
+                colorOverride: style.shadowColor
+            )
+            let shadowLine = CTLineCreateWithAttributedString(
+                NSAttributedString(string: run.text, attributes: shadowAttributes)
+            )
+            let shadowLayout = makeTextRunLayoutPlan(
+                text: run.text,
+                style: style,
+                bbox: bbox,
+                line: shadowLine,
+                attributes: shadowAttributes,
+                charPositions: run.charPositions
+            )
+            drawTextLine(
+                shadowLine,
+                layout: shadowLayout,
+                style: style,
+                attributes: shadowAttributes,
+                x: CGFloat(style.shadowOffsetX),
+                y: textY - CGFloat(style.shadowOffsetY),
+                in: ctx
+            )
+        }
+
+        drawTextTabLeaders(style: style, fontSize: fontSize, y: textY, in: ctx)
         drawTextLine(line, layout: layout, style: style, attributes: attributes, y: textY, in: ctx)
+        drawTextEmphasisDots(text: run.text, line: line, layout: layout, style: style, fontSize: fontSize, y: textY, in: ctx)
 
         ctx.restoreGState()
 
         // 밑줄 (페이지 좌표계, 전체 Y반전 상태)
         if style.underline != "None" {
-            let ulY = CGFloat(bbox.y) + CGFloat(run.baseline) + fontSize * 0.15
+            let baselineY = CGFloat(bbox.y) + CGFloat(run.baseline) - baselineShift
+            let ulY = baselineY + fontSize * 0.15
             drawTextDecoration(
                 in: ctx, x: CGFloat(bbox.x), y: ulY, width: CGFloat(bbox.width),
                 shape: style.underlineShape,
@@ -901,7 +1086,13 @@ class CGTreeRenderer {
 
         // 취소선
         if style.strikethrough {
-            let stY = CGFloat(bbox.y) + CGFloat(bbox.height) / 2
+            let stY: CGFloat
+            if style.superscript || style.subscript {
+                let baselineY = CGFloat(bbox.y) + CGFloat(run.baseline) - baselineShift
+                stY = baselineY - fontSize * 0.3
+            } else {
+                stY = CGFloat(bbox.y) + CGFloat(bbox.height) / 2
+            }
             drawTextDecoration(
                 in: ctx, x: CGFloat(bbox.x), y: stY, width: CGFloat(bbox.width),
                 shape: style.strikeShape,
@@ -909,6 +1100,81 @@ class CGTreeRenderer {
             )
         }
 
+        ctx.restoreGState()
+    }
+
+    private func renderCenteredTextRun(
+        _ run: TextRunNode,
+        bbox: BBox,
+        style: TextStyle,
+        fontSize: CGFloat,
+        baselineShift: CGFloat,
+        rotation: Double,
+        in ctx: CGContext
+    ) {
+        ctx.saveGState()
+
+        if style.shadeColor != 0x00FFFFFF && style.shadeColor != 0 {
+            ctx.setFillColor(colorRefToCGColor(style.shadeColor).copy(alpha: 0.3)!)
+            ctx.fill(cgRect(bbox))
+        }
+
+        if abs(rotation) > pathEpsilon {
+            applyTextRunRotation(rotation, bbox: bbox, in: ctx)
+        }
+
+        ctx.saveGState()
+        ctx.translateBy(x: CGFloat(bbox.x), y: CGFloat(bbox.y + bbox.height))
+        ctx.scaleBy(x: 1, y: -1)
+
+        let font = makeTextRunFont(style: style, fontSize: fontSize)
+        let attributes = makeTextRunAttributes(style: style, font: font)
+        let line = CTLineCreateWithAttributedString(NSAttributedString(string: run.text, attributes: attributes))
+        let layout = makeTextRunLayoutPlan(
+            text: run.text,
+            style: style,
+            bbox: bbox,
+            line: line,
+            attributes: attributes,
+            charPositions: run.charPositions
+        )
+        let metrics = textRunTypographicMetrics(line)
+        let visualWidth = textRunVisualWidth(line, layout: layout, attributes: attributes)
+        let textX = (CGFloat(bbox.width) - visualWidth) / 2
+        let textY = CGFloat(bbox.height) / 2 - (metrics.ascent - metrics.descent) / 2 + baselineShift
+
+        if style.shadowType > 0 {
+            let shadowAttributes = makeTextRunAttributes(
+                style: style,
+                font: font,
+                colorOverride: style.shadowColor
+            )
+            let shadowLine = CTLineCreateWithAttributedString(
+                NSAttributedString(string: run.text, attributes: shadowAttributes)
+            )
+            let shadowLayout = makeTextRunLayoutPlan(
+                text: run.text,
+                style: style,
+                bbox: bbox,
+                line: shadowLine,
+                attributes: shadowAttributes,
+                charPositions: run.charPositions
+            )
+            drawTextLine(
+                shadowLine,
+                layout: shadowLayout,
+                style: style,
+                attributes: shadowAttributes,
+                x: textX + CGFloat(style.shadowOffsetX),
+                y: textY - CGFloat(style.shadowOffsetY),
+                in: ctx
+            )
+        }
+
+        drawTextLine(line, layout: layout, style: style, attributes: attributes, x: textX, y: textY, in: ctx)
+        drawTextEmphasisDots(text: run.text, line: line, layout: layout, style: style, fontSize: fontSize, y: textY, in: ctx)
+
+        ctx.restoreGState()
         ctx.restoreGState()
     }
 
@@ -928,10 +1194,44 @@ class CGTreeRenderer {
         return font
     }
 
-    private func makeTextRunAttributes(style: TextStyle, font: CTFont) -> [NSAttributedString.Key: Any] {
+    private func normalizedTextRunRotation(_ run: TextRunNode) -> Double {
+        guard let rotation = run.rotation, rotation.isFinite else { return 0 }
+        return rotation.truncatingRemainder(dividingBy: 360)
+    }
+
+    private func applyTextRunRotation(_ rotation: Double, bbox: BBox, in ctx: CGContext) {
+        let cx = CGFloat(bbox.x + bbox.width / 2)
+        let cy = CGFloat(bbox.y + bbox.height / 2)
+        ctx.translateBy(x: cx, y: cy)
+        ctx.rotate(by: CGFloat(rotation * .pi / 180))
+        ctx.translateBy(x: -cx, y: -cy)
+    }
+
+    private func effectiveTextRunFontSize(style: TextStyle, baseFontSize: CGFloat) -> CGFloat {
+        if style.superscript || style.subscript {
+            return baseFontSize * 0.7
+        }
+        return baseFontSize
+    }
+
+    private func textRunBaselineShift(style: TextStyle, baseFontSize: CGFloat) -> CGFloat {
+        if style.superscript {
+            return baseFontSize * 0.3
+        }
+        if style.subscript {
+            return -baseFontSize * 0.15
+        }
+        return 0
+    }
+
+    private func makeTextRunAttributes(
+        style: TextStyle,
+        font: CTFont,
+        colorOverride: UInt32? = nil
+    ) -> [NSAttributedString.Key: Any] {
         var attributes: [NSAttributedString.Key: Any] = [
             coreTextFontKey: font,
-            coreTextForegroundColorKey: colorRefToCGColor(style.color),
+            coreTextForegroundColorKey: colorRefToCGColor(colorOverride ?? style.color),
         ]
 
         if style.letterSpacing != 0 {
@@ -1071,26 +1371,60 @@ class CGTreeRenderer {
         layout: TextRunLayoutPlan,
         style: TextStyle,
         attributes: [NSAttributedString.Key: Any],
+        x: CGFloat = 0,
         y: CGFloat,
         in ctx: CGContext
     ) {
         switch layout.strategy {
         case .line:
-            ctx.textPosition = CGPoint(x: 0, y: y)
+            ctx.textPosition = CGPoint(x: x, y: y)
             CTLineDraw(line, ctx)
         case .clusters:
             guard let clusterPlan = layout.clusterPlan else {
-                ctx.textPosition = CGPoint(x: 0, y: y)
+                ctx.textPosition = CGPoint(x: x, y: y)
                 CTLineDraw(line, ctx)
                 return
             }
-            drawTextClusters(clusterPlan.clusters, style: style, attributes: attributes, y: y, in: ctx)
+            drawTextClusters(clusterPlan.clusters, style: style, attributes: attributes, xOffset: x, y: y, in: ctx)
         case .scaledLine(let scale):
             ctx.saveGState()
             ctx.scaleBy(x: scale, y: 1)
-            ctx.textPosition = CGPoint(x: 0, y: y)
+            ctx.textPosition = CGPoint(x: x / scale, y: y)
             CTLineDraw(line, ctx)
             ctx.restoreGState()
+        }
+    }
+
+    private func textRunTypographicMetrics(_ line: CTLine) -> TextRunTypographicMetrics {
+        var ascent: CGFloat = 0
+        var descent: CGFloat = 0
+        var leading: CGFloat = 0
+        let width = CGFloat(CTLineGetTypographicBounds(line, &ascent, &descent, &leading))
+        return TextRunTypographicMetrics(width: width, ascent: ascent, descent: descent, leading: leading)
+    }
+
+    private func textRunVisualWidth(
+        _ line: CTLine,
+        layout: TextRunLayoutPlan,
+        attributes: [NSAttributedString.Key: Any]
+    ) -> CGFloat {
+        let lineWidth = textRunTypographicMetrics(line).width
+        switch layout.strategy {
+        case .line:
+            return lineWidth
+        case .scaledLine(let scale):
+            return lineWidth * scale
+        case .clusters:
+            guard let clusters = layout.clusterPlan?.clusters else {
+                return lineWidth
+            }
+
+            var maxX: CGFloat = 0
+            for cluster in clusters where isDrawableTextCluster(cluster.text) {
+                let clusterLine = cluster.line ?? makeTextRunClusterLine(cluster.text, attributes: attributes)
+                maxX = max(maxX, cluster.x + measureTextRunClusterWidth(clusterLine))
+            }
+            return maxX > 0 ? maxX : lineWidth
         }
     }
 
@@ -1149,15 +1483,20 @@ class CGTreeRenderer {
         spans.reserveCapacity(text.count)
 
         var scalarOffset = 0
+        var utf16Offset = 0
         for character in text {
             let clusterText = String(character)
             let scalarCount = clusterText.unicodeScalars.count
+            let utf16Count = clusterText.utf16.count
             spans.append(TextRunClusterSpan(
                 text: clusterText,
                 scalarStart: scalarOffset,
-                scalarEnd: scalarOffset + scalarCount
+                scalarEnd: scalarOffset + scalarCount,
+                utf16Start: utf16Offset,
+                utf16End: utf16Offset + utf16Count
             ))
             scalarOffset += scalarCount
+            utf16Offset += utf16Count
         }
 
         return spans
@@ -1470,11 +1809,12 @@ class CGTreeRenderer {
         _ clusters: [TextRunCluster],
         style: TextStyle,
         attributes: [NSAttributedString.Key: Any],
+        xOffset: CGFloat = 0,
         y: CGFloat,
         in ctx: CGContext
     ) {
         for cluster in clusters where isDrawableTextCluster(cluster.text) {
-            drawTextCluster(cluster, style: style, attributes: attributes, y: y, in: ctx)
+            drawTextCluster(cluster, style: style, attributes: attributes, xOffset: xOffset, y: y, in: ctx)
         }
     }
 
@@ -1482,22 +1822,174 @@ class CGTreeRenderer {
         _ cluster: TextRunCluster,
         style: TextStyle,
         attributes: [NSAttributedString.Key: Any],
+        xOffset: CGFloat = 0,
         y: CGFloat,
         in ctx: CGContext
     ) {
         let line = cluster.line ?? makeTextRunClusterLine(cluster.text, attributes: attributes)
+        let x = cluster.x + xOffset
 
         if needsHalfwidthPunctuationScale(cluster.text, style: style) {
             ctx.saveGState()
-            ctx.translateBy(x: cluster.x, y: y)
+            ctx.translateBy(x: x, y: y)
             ctx.scaleBy(x: 0.5, y: 1)
             ctx.textPosition = .zero
             CTLineDraw(line, ctx)
             ctx.restoreGState()
         } else {
-            ctx.textPosition = CGPoint(x: cluster.x, y: y)
+            ctx.textPosition = CGPoint(x: x, y: y)
             CTLineDraw(line, ctx)
         }
+    }
+
+    private func drawTextEmphasisDots(
+        text: String,
+        line: CTLine,
+        layout: TextRunLayoutPlan,
+        style: TextStyle,
+        fontSize: CGFloat,
+        y: CGFloat,
+        in ctx: CGContext
+    ) {
+        guard let dot = emphasisDotText(style.emphasisDot) else { return }
+
+        let dotSize = max(fontSize * 0.3, 1)
+        let dotFont = resolveAppleFont(
+            hwpFontFamily: style.fontFamily,
+            bold: false,
+            italic: false,
+            size: dotSize
+        )
+        let attributes: [NSAttributedString.Key: Any] = [
+            coreTextFontKey: dotFont,
+            coreTextForegroundColorKey: colorRefToCGColor(style.color),
+        ]
+        let dotLine = CTLineCreateWithAttributedString(NSAttributedString(string: dot, attributes: attributes))
+        let dotWidth = CGFloat(CTLineGetTypographicBounds(dotLine, nil, nil, nil))
+        let dotY = y + fontSize * 1.05
+        let ratio = CGFloat(style.ratio > 0 ? style.ratio : 1)
+
+        for position in textRunVisualClusterPositions(text: text, line: line, layout: layout) {
+            guard isDrawableTextCluster(position.text) else { continue }
+            let dotX = position.x + fontSize * ratio * 0.5 - dotWidth / 2
+            ctx.textPosition = CGPoint(x: dotX, y: dotY)
+            CTLineDraw(dotLine, ctx)
+        }
+    }
+
+    private func emphasisDotText(_ value: UInt8) -> String? {
+        switch value {
+        case 1:
+            return "●"
+        case 2:
+            return "○"
+        case 3:
+            return "ˇ"
+        case 4:
+            return "˜"
+        case 5:
+            return "･"
+        case 6:
+            return "˸"
+        default:
+            return nil
+        }
+    }
+
+    private func textRunVisualClusterPositions(
+        text: String,
+        line: CTLine,
+        layout: TextRunLayoutPlan
+    ) -> [(text: String, x: CGFloat)] {
+        let spans = splitTextRunClusters(text)
+        if let clusterPlan = layout.clusterPlan,
+           clusterPlan.clusters.count == spans.count {
+            return zip(spans, clusterPlan.clusters).map { ($0.text, $1.x) }
+        }
+
+        return spans.map { span in
+            let rawX = CGFloat(CTLineGetOffsetForStringIndex(line, span.utf16Start, nil))
+            switch layout.strategy {
+            case .scaledLine(let scale):
+                return (span.text, rawX * scale)
+            case .line, .clusters:
+                return (span.text, rawX)
+            }
+        }
+    }
+
+    private func drawTextTabLeaders(style: TextStyle, fontSize: CGFloat, y: CGFloat, in ctx: CGContext) {
+        guard !style.tabLeaders.isEmpty else { return }
+
+        let leaderY = y + fontSize * 0.35
+        let color = colorRefToCGColor(style.color)
+
+        ctx.saveGState()
+        ctx.setStrokeColor(color)
+        for leader in style.tabLeaders {
+            guard leader.fillType != 0 else { continue }
+            let x1 = CGFloat(leader.startX)
+            let x2 = CGFloat(leader.endX)
+            guard x2 > x1 else { continue }
+            drawTextTabLeader(fillType: leader.fillType, x1: x1, x2: x2, y: leaderY, in: ctx)
+        }
+        ctx.restoreGState()
+    }
+
+    private func drawTextTabLeader(fillType: UInt8, x1: CGFloat, x2: CGFloat, y: CGFloat, in ctx: CGContext) {
+        switch fillType {
+        case 1:
+            drawTextLeaderLine(x1: x1, x2: x2, y: y, width: 0.5, dash: [], in: ctx)
+        case 2:
+            drawTextLeaderLine(x1: x1, x2: x2, y: y, width: 0.5, dash: [3, 3], in: ctx)
+        case 3:
+            ctx.setLineCap(.round)
+            drawTextLeaderLine(x1: x1, x2: x2, y: y, width: 1.0, dash: [0.1, 3.0], in: ctx)
+            ctx.setLineCap(.butt)
+        case 4:
+            drawTextLeaderLine(x1: x1, x2: x2, y: y, width: 0.5, dash: [6, 2, 1, 2], in: ctx)
+        case 5:
+            drawTextLeaderLine(x1: x1, x2: x2, y: y, width: 0.5, dash: [6, 2, 1, 2, 1, 2], in: ctx)
+        case 6:
+            drawTextLeaderLine(x1: x1, x2: x2, y: y, width: 0.5, dash: [8, 4], in: ctx)
+        case 7:
+            ctx.setLineCap(.round)
+            drawTextLeaderLine(x1: x1, x2: x2, y: y, width: 0.7, dash: [0.1, 2.5], in: ctx)
+            ctx.setLineCap(.butt)
+        case 8:
+            drawTextLeaderLine(x1: x1, x2: x2, y: y - 1.0, width: 0.3, dash: [], in: ctx)
+            drawTextLeaderLine(x1: x1, x2: x2, y: y + 1.0, width: 0.3, dash: [], in: ctx)
+        case 9:
+            drawTextLeaderLine(x1: x1, x2: x2, y: y - 1.2, width: 0.3, dash: [], in: ctx)
+            drawTextLeaderLine(x1: x1, x2: x2, y: y + 0.8, width: 0.8, dash: [], in: ctx)
+        case 10:
+            drawTextLeaderLine(x1: x1, x2: x2, y: y - 0.8, width: 0.8, dash: [], in: ctx)
+            drawTextLeaderLine(x1: x1, x2: x2, y: y + 1.2, width: 0.3, dash: [], in: ctx)
+        case 11:
+            drawTextLeaderLine(x1: x1, x2: x2, y: y - 2.0, width: 0.3, dash: [], in: ctx)
+            drawTextLeaderLine(x1: x1, x2: x2, y: y, width: 0.8, dash: [], in: ctx)
+            drawTextLeaderLine(x1: x1, x2: x2, y: y + 2.0, width: 0.3, dash: [], in: ctx)
+        default:
+            drawTextLeaderLine(x1: x1, x2: x2, y: y, width: 0.5, dash: [1, 2], in: ctx)
+        }
+    }
+
+    private func drawTextLeaderLine(
+        x1: CGFloat,
+        x2: CGFloat,
+        y: CGFloat,
+        width: CGFloat,
+        dash: [CGFloat],
+        in ctx: CGContext
+    ) {
+        ctx.saveGState()
+        ctx.setLineWidth(width)
+        ctx.setLineDash(phase: 0, lengths: dash)
+        ctx.beginPath()
+        ctx.move(to: CGPoint(x: x1, y: y))
+        ctx.addLine(to: CGPoint(x: x2, y: y))
+        ctx.strokePath()
+        ctx.restoreGState()
     }
 
     private func isDrawableTextCluster(_ cluster: String) -> Bool {
@@ -1568,33 +2060,150 @@ class CGTreeRenderer {
 
     private func applyShapeStyleFill(_ style: ShapeStyle, path: CGPath, in ctx: CGContext) {
         if let pattern = style.pattern {
-            // 패턴 채우기 (M3에서 정확한 패턴 구현)
-            if let bgColor = UInt32(exactly: pattern.backgroundColor) {
-                ctx.addPath(path)
-                ctx.setFillColor(colorRefToCGColor(bgColor))
-                ctx.fillPath()
-            }
+            applyPatternFill(pattern, style: style, path: path, in: ctx)
         } else if let fillColor = style.fillColor {
+            ctx.saveGState()
+            applyShadow(style.shadow, in: ctx)
             ctx.addPath(path)
-            ctx.setAlpha(CGFloat(style.opacity))
+            ctx.setAlpha(clampedAlpha(style.opacity))
             ctx.setFillColor(colorRefToCGColor(fillColor))
             ctx.fillPath()
-            ctx.setAlpha(1.0)
+            ctx.restoreGState()
         }
     }
 
-    private func applyShapeStyleStroke(_ style: ShapeStyle, path: CGPath, in ctx: CGContext) {
+    private func applyShapeStyleStroke(_ style: ShapeStyle, path: CGPath, includeShadow: Bool = true, in ctx: CGContext) {
         if let strokeColor = style.strokeColor, style.strokeWidth > 0 {
+            ctx.saveGState()
+            if includeShadow {
+                applyShadow(style.shadow, in: ctx)
+            }
             ctx.addPath(path)
             ctx.setStrokeColor(colorRefToCGColor(strokeColor))
             ctx.setLineWidth(CGFloat(max(style.strokeWidth, 0.5)))
             applyDash(style.strokeDash, in: ctx)
             ctx.strokePath()
+            ctx.restoreGState()
         }
     }
 
+    private func hasShapeFill(_ style: ShapeStyle) -> Bool {
+        style.pattern != nil || style.fillColor != nil
+    }
+
+    private func applyShapeShadowSilhouette(_ style: ShapeStyle, path: CGPath, fallbackColor: UInt32?, in ctx: CGContext) {
+        guard style.shadow != nil else { return }
+        let color = style.fillColor ?? fallbackColor ?? style.strokeColor ?? 0
+
+        ctx.saveGState()
+        applyShadow(style.shadow, in: ctx)
+        ctx.addPath(path)
+        ctx.setAlpha(clampedAlpha(style.opacity))
+        ctx.setFillColor(colorRefToCGColor(color))
+        ctx.fillPath()
+        ctx.restoreGState()
+    }
+
+    private func applyPatternFill(_ pattern: PatternFillInfo, style: ShapeStyle, path: CGPath, in ctx: CGContext) {
+        ctx.saveGState()
+        applyShadow(style.shadow, in: ctx)
+        ctx.addPath(path)
+        ctx.setFillColor(colorRefToCGColor(pattern.backgroundColor))
+        ctx.fillPath()
+        ctx.restoreGState()
+
+        ctx.saveGState()
+        ctx.addPath(path)
+        ctx.clip()
+        drawPatternLines(pattern, bounds: path.boundingBoxOfPath, in: ctx)
+        ctx.restoreGState()
+    }
+
+    private func drawPatternLines(_ pattern: PatternFillInfo, bounds: CGRect, in ctx: CGContext) {
+        guard !bounds.isNull, !bounds.isInfinite, bounds.width > 0, bounds.height > 0 else { return }
+
+        let tile: CGFloat = 6
+        let minX = floor(bounds.minX / tile) * tile - tile
+        let maxX = ceil(bounds.maxX / tile) * tile + tile
+        let minY = floor(bounds.minY / tile) * tile - tile
+        let maxY = ceil(bounds.maxY / tile) * tile + tile
+
+        ctx.saveGState()
+        ctx.setStrokeColor(colorRefToCGColor(pattern.patternColor))
+        ctx.setLineWidth(1.0)
+        ctx.setLineDash(phase: 0, lengths: [])
+
+        switch pattern.patternType {
+        case 0:
+            strideValues(from: minY + tile / 2, through: maxY, by: tile) { y in
+                drawLine(from: CGPoint(x: minX, y: y), to: CGPoint(x: maxX, y: y), in: ctx)
+            }
+        case 1:
+            strideValues(from: minX + tile / 2, through: maxX, by: tile) { x in
+                drawLine(from: CGPoint(x: x, y: minY), to: CGPoint(x: x, y: maxY), in: ctx)
+            }
+        case 2:
+            strideValues(from: minX - (maxY - minY), through: maxX + tile, by: tile) { x in
+                drawLine(from: CGPoint(x: x + tile, y: minY), to: CGPoint(x: x, y: minY + tile), in: ctx)
+                drawLine(from: CGPoint(x: x + maxY - minY, y: minY), to: CGPoint(x: x, y: maxY), in: ctx)
+            }
+        case 3:
+            strideValues(from: minX - tile, through: maxX + (maxY - minY), by: tile) { x in
+                drawLine(from: CGPoint(x: x, y: minY), to: CGPoint(x: x + maxY - minY, y: maxY), in: ctx)
+            }
+        case 4:
+            strideValues(from: minY + tile / 2, through: maxY, by: tile) { y in
+                drawLine(from: CGPoint(x: minX, y: y), to: CGPoint(x: maxX, y: y), in: ctx)
+            }
+            strideValues(from: minX + tile / 2, through: maxX, by: tile) { x in
+                drawLine(from: CGPoint(x: x, y: minY), to: CGPoint(x: x, y: maxY), in: ctx)
+            }
+        case 5:
+            strideValues(from: minX - tile, through: maxX + (maxY - minY), by: tile) { x in
+                drawLine(from: CGPoint(x: x, y: minY), to: CGPoint(x: x + maxY - minY, y: maxY), in: ctx)
+            }
+            strideValues(from: minX - (maxY - minY), through: maxX + tile, by: tile) { x in
+                drawLine(from: CGPoint(x: x + maxY - minY, y: minY), to: CGPoint(x: x, y: maxY), in: ctx)
+            }
+        default:
+            break
+        }
+
+        ctx.restoreGState()
+    }
+
+    private func strideValues(from start: CGFloat, through end: CGFloat, by step: CGFloat, _ body: (CGFloat) -> Void) {
+        guard step > 0 else { return }
+        var value = start
+        while value <= end {
+            body(value)
+            value += step
+        }
+    }
+
+    private func drawLine(from start: CGPoint, to end: CGPoint, in ctx: CGContext) {
+        ctx.beginPath()
+        ctx.move(to: start)
+        ctx.addLine(to: end)
+        ctx.strokePath()
+    }
+
+    private func applyShadow(_ shadow: ShadowStyleInfo?, in ctx: CGContext) {
+        guard let shadow else { return }
+        let opacity = shadow.alpha > 0 ? 1.0 - CGFloat(shadow.alpha) / 255.0 : 1.0
+        ctx.setShadow(
+            offset: CGSize(width: CGFloat(shadow.offsetX), height: CGFloat(shadow.offsetY)),
+            blur: 2.0,
+            color: colorRefToCGColor(shadow.color, alpha: opacity)
+        )
+    }
+
+    private func clampedAlpha(_ value: Double) -> CGFloat {
+        min(1.0, max(0.0, CGFloat(value)))
+    }
+
     private func applyDash(_ dash: String, in ctx: CGContext) {
-        switch dash {
+        switch normalizedDashName(dash) {
         case "Dash":
             ctx.setLineDash(phase: 0, lengths: [6, 3])
         case "Dot":
@@ -1606,6 +2215,501 @@ class CGTreeRenderer {
         default: // Solid
             ctx.setLineDash(phase: 0, lengths: [])
         }
+    }
+
+    private func normalizedDashName(_ dash: String) -> String {
+        switch normalizedStyleKey(dash) {
+        case "dash", "dashed":
+            return "Dash"
+        case "dot", "dotted":
+            return "Dot"
+        case "dashdot", "dashdotted":
+            return "DashDot"
+        case "dashdotdot", "dashdotdotted":
+            return "DashDotDot"
+        default:
+            return "Solid"
+        }
+    }
+
+    private func adjustedLineForArrows(start: CGPoint, end: CGPoint, style: LineStyle) -> (start: CGPoint, end: CGPoint) {
+        guard let metrics = lineMetrics(from: start, to: end) else {
+            return (start, end)
+        }
+
+        let strokeWidth = CGFloat(max(style.width, 0.5))
+        var adjustedStart = start
+        var adjustedEnd = end
+
+        if hasRenderableArrow(style.startArrow) {
+            let size = arrowDimensions(
+                strokeWidth: strokeWidth,
+                lineLength: metrics.length,
+                arrowSize: style.startArrowSize
+            )
+            adjustedStart = offset(start, by: metrics.unit, scale: size.width)
+        }
+
+        if hasRenderableArrow(style.endArrow) {
+            let size = arrowDimensions(
+                strokeWidth: strokeWidth,
+                lineLength: metrics.length,
+                arrowSize: style.endArrowSize
+            )
+            adjustedEnd = offset(end, by: metrics.unit, scale: -size.width)
+        }
+
+        return (adjustedStart, adjustedEnd)
+    }
+
+    private func drawLineArrows(start: CGPoint, end: CGPoint, style: LineStyle, in ctx: CGContext) {
+        guard let metrics = lineMetrics(from: start, to: end) else { return }
+
+        let strokeWidth = CGFloat(max(style.width, 0.5))
+        let color = colorRefToCGColor(style.color)
+
+        if hasRenderableArrow(style.startArrow) {
+            let size = arrowDimensions(
+                strokeWidth: strokeWidth,
+                lineLength: metrics.length,
+                arrowSize: style.startArrowSize
+            )
+            drawArrowHead(
+                tip: start,
+                direction: reversed(metrics.unit),
+                size: size,
+                arrowStyle: style.startArrow,
+                color: color,
+                strokeWidth: strokeWidth,
+                in: ctx
+            )
+        }
+
+        if hasRenderableArrow(style.endArrow) {
+            let size = arrowDimensions(
+                strokeWidth: strokeWidth,
+                lineLength: metrics.length,
+                arrowSize: style.endArrowSize
+            )
+            drawArrowHead(
+                tip: end,
+                direction: metrics.unit,
+                size: size,
+                arrowStyle: style.endArrow,
+                color: color,
+                strokeWidth: strokeWidth,
+                in: ctx
+            )
+        }
+    }
+
+    private func drawConnectorArrows(for pathNode: PathNode, builtPath: BuiltPath, in ctx: CGContext) {
+        guard
+            let style = pathNode.lineStyle,
+            hasRenderableArrow(style.startArrow) || hasRenderableArrow(style.endArrow),
+            let endpoints = connectorEndpoints(pathNode.connectorEndpoints),
+            let metrics = lineMetrics(from: endpoints.start, to: endpoints.end)
+        else {
+            return
+        }
+
+        let strokeWidth = CGFloat(max(style.width, 0.5))
+        let color = colorRefToCGColor(style.color)
+
+        if hasRenderableArrow(style.startArrow) {
+            let direction = normalizedVector(reversed(builtPath.firstTangent ?? metrics.unit))
+                ?? reversed(metrics.unit)
+            let size = arrowDimensions(
+                strokeWidth: strokeWidth,
+                lineLength: metrics.length,
+                arrowSize: style.startArrowSize
+            )
+            drawArrowHead(
+                tip: endpoints.start,
+                direction: direction,
+                size: size,
+                arrowStyle: style.startArrow,
+                color: color,
+                strokeWidth: strokeWidth,
+                in: ctx
+            )
+        }
+
+        if hasRenderableArrow(style.endArrow) {
+            let direction = normalizedVector(builtPath.lastTangent ?? metrics.unit) ?? metrics.unit
+            let size = arrowDimensions(
+                strokeWidth: strokeWidth,
+                lineLength: metrics.length,
+                arrowSize: style.endArrowSize
+            )
+            drawArrowHead(
+                tip: endpoints.end,
+                direction: direction,
+                size: size,
+                arrowStyle: style.endArrow,
+                color: color,
+                strokeWidth: strokeWidth,
+                in: ctx
+            )
+        }
+    }
+
+    private func connectorEndpoints(_ raw: [[Double]]?) -> (start: CGPoint, end: CGPoint)? {
+        guard let raw else { return nil }
+        if raw.count >= 2, raw[0].count >= 2, raw[1].count >= 2 {
+            return (
+                CGPoint(x: raw[0][0], y: raw[0][1]),
+                CGPoint(x: raw[1][0], y: raw[1][1])
+            )
+        }
+        if raw.count == 1, raw[0].count >= 4 {
+            return (
+                CGPoint(x: raw[0][0], y: raw[0][1]),
+                CGPoint(x: raw[0][2], y: raw[0][3])
+            )
+        }
+        return nil
+    }
+
+    private func drawArrowHead(
+        tip: CGPoint,
+        direction: CGVector,
+        size: CGSize,
+        arrowStyle: String,
+        color: CGColor,
+        strokeWidth: CGFloat,
+        in ctx: CGContext
+    ) {
+        guard
+            let style = normalizedArrowStyle(arrowStyle),
+            let direction = normalizedVector(direction),
+            size.width > 0,
+            size.height > 0
+        else {
+            return
+        }
+
+        let along = reversed(direction)
+        let perp = CGVector(dx: direction.dy, dy: -direction.dx)
+        let halfHeight = size.height / 2
+
+        func point(along alongDistance: CGFloat, perp perpDistance: CGFloat) -> CGPoint {
+            CGPoint(
+                x: tip.x + along.dx * alongDistance + perp.dx * perpDistance,
+                y: tip.y + along.dy * alongDistance + perp.dy * perpDistance
+            )
+        }
+
+        func addPolygon(_ points: [CGPoint]) -> CGPath {
+            let path = CGMutablePath()
+            guard let first = points.first else { return path }
+            path.move(to: first)
+            for point in points.dropFirst() {
+                path.addLine(to: point)
+            }
+            path.closeSubpath()
+            return path
+        }
+
+        ctx.saveGState()
+        ctx.setLineDash(phase: 0, lengths: [])
+        ctx.setFillColor(color)
+        ctx.setStrokeColor(color)
+
+        switch style {
+        case "Arrow":
+            let path = addPolygon([
+                tip,
+                point(along: size.width, perp: -halfHeight),
+                point(along: size.width, perp: halfHeight)
+            ])
+            ctx.addPath(path)
+            ctx.fillPath()
+
+        case "ConcaveArrow":
+            let path = addPolygon([
+                tip,
+                point(along: size.width, perp: -halfHeight),
+                point(along: size.width * 0.7, perp: 0),
+                point(along: size.width, perp: halfHeight)
+            ])
+            ctx.addPath(path)
+            ctx.fillPath()
+
+        case "Diamond", "OpenDiamond":
+            let path = addPolygon([
+                point(along: 0, perp: 0),
+                point(along: size.width / 2, perp: -halfHeight),
+                point(along: size.width, perp: 0),
+                point(along: size.width / 2, perp: halfHeight)
+            ])
+            drawArrowPath(path, style: style, color: color, strokeWidth: strokeWidth, in: ctx)
+
+        case "Circle", "OpenCircle":
+            let center = point(along: size.width / 2, perp: 0)
+            let rx = size.width * 0.4
+            let ry = halfHeight * 0.8
+            let rect = CGRect(x: center.x - rx, y: center.y - ry, width: rx * 2, height: ry * 2)
+            drawArrowEllipse(rect, style: style, color: color, strokeWidth: strokeWidth, in: ctx)
+
+        case "Square", "OpenSquare":
+            let path = addPolygon([
+                point(along: 0, perp: -halfHeight),
+                point(along: size.width, perp: -halfHeight),
+                point(along: size.width, perp: halfHeight),
+                point(along: 0, perp: halfHeight)
+            ])
+            drawArrowPath(path, style: style, color: color, strokeWidth: strokeWidth, in: ctx)
+
+        default:
+            break
+        }
+
+        ctx.restoreGState()
+    }
+
+    private func drawArrowPath(
+        _ path: CGPath,
+        style: String,
+        color: CGColor,
+        strokeWidth: CGFloat,
+        in ctx: CGContext
+    ) {
+        if style.hasPrefix("Open") {
+            ctx.addPath(path)
+            ctx.setFillColor(CGColor(gray: 1, alpha: 1))
+            ctx.fillPath()
+            ctx.addPath(path)
+            ctx.setStrokeColor(color)
+            ctx.setLineWidth(max(strokeWidth * 0.3, 0.5))
+            ctx.strokePath()
+        } else {
+            ctx.addPath(path)
+            ctx.setFillColor(color)
+            ctx.fillPath()
+        }
+    }
+
+    private func drawArrowEllipse(
+        _ rect: CGRect,
+        style: String,
+        color: CGColor,
+        strokeWidth: CGFloat,
+        in ctx: CGContext
+    ) {
+        if style.hasPrefix("Open") {
+            ctx.addEllipse(in: rect)
+            ctx.setFillColor(CGColor(gray: 1, alpha: 1))
+            ctx.fillPath()
+            ctx.addEllipse(in: rect)
+            ctx.setStrokeColor(color)
+            ctx.setLineWidth(max(strokeWidth * 0.3, 0.5))
+            ctx.strokePath()
+        } else {
+            ctx.addEllipse(in: rect)
+            ctx.setFillColor(color)
+            ctx.fillPath()
+        }
+    }
+
+    private func normalizedArrowStyle(_ arrowStyle: String) -> String? {
+        switch normalizedStyleKey(arrowStyle) {
+        case "", "none":
+            return nil
+        case "arrow":
+            return "Arrow"
+        case "concavearrow", "concave":
+            return "ConcaveArrow"
+        case "opendiamond":
+            return "OpenDiamond"
+        case "opencircle":
+            return "OpenCircle"
+        case "opensquare":
+            return "OpenSquare"
+        case "diamond":
+            return "Diamond"
+        case "circle":
+            return "Circle"
+        case "square":
+            return "Square"
+        default:
+            return nil
+        }
+    }
+
+    private func hasRenderableArrow(_ arrowStyle: String) -> Bool {
+        normalizedArrowStyle(arrowStyle) != nil
+    }
+
+    private func arrowDimensions(strokeWidth: CGFloat, lineLength: CGFloat, arrowSize: UInt8) -> CGSize {
+        let widthLevel = Int(arrowSize / 3)
+        let lengthLevel = Int(arrowSize % 3)
+        let widthMultiplier: CGFloat
+        switch widthLevel {
+        case 0:
+            widthMultiplier = 1.5
+        case 1:
+            widthMultiplier = 2.5
+        default:
+            widthMultiplier = 3.5
+        }
+
+        let lengthMultiplier: CGFloat
+        switch lengthLevel {
+        case 0:
+            lengthMultiplier = 1.0
+        case 1:
+            lengthMultiplier = 1.5
+        default:
+            lengthMultiplier = 2.0
+        }
+
+        let height = max(strokeWidth * widthMultiplier, 3.0)
+        let width = min(height * lengthMultiplier, lineLength * 0.3)
+        return CGSize(width: width, height: height)
+    }
+
+    private func lineMetrics(from start: CGPoint, to end: CGPoint) -> (length: CGFloat, unit: CGVector)? {
+        let vector = vector(from: start, to: end)
+        let length = sqrt(vector.dx * vector.dx + vector.dy * vector.dy)
+        guard length > CGFloat(pathEpsilon) else { return nil }
+        return (length, CGVector(dx: vector.dx / length, dy: vector.dy / length))
+    }
+
+    private func vector(from start: CGPoint, to end: CGPoint) -> CGVector {
+        CGVector(dx: end.x - start.x, dy: end.y - start.y)
+    }
+
+    private func reversed(_ vector: CGVector) -> CGVector {
+        CGVector(dx: -vector.dx, dy: -vector.dy)
+    }
+
+    private func offset(_ point: CGPoint, by vector: CGVector, scale: CGFloat) -> CGPoint {
+        CGPoint(x: point.x + vector.dx * scale, y: point.y + vector.dy * scale)
+    }
+
+    private func normalizedVector(_ vector: CGVector) -> CGVector? {
+        let length = sqrt(vector.dx * vector.dx + vector.dy * vector.dy)
+        guard length > CGFloat(pathEpsilon) else { return nil }
+        return CGVector(dx: vector.dx / length, dy: vector.dy / length)
+    }
+
+    private func isZeroVector(_ vector: CGVector) -> Bool {
+        abs(vector.dx) <= CGFloat(pathEpsilon) && abs(vector.dy) <= CGFloat(pathEpsilon)
+    }
+
+    private func normalizedStyleKey(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "_", with: "")
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: " ", with: "")
+            .replacingOccurrences(of: "\t", with: "")
+    }
+
+    private func arcSegments(
+        from start: CGPoint,
+        rx initialRx: Double,
+        ry initialRy: Double,
+        xRotation: Double,
+        largeArc: Bool,
+        sweep: Bool,
+        to end: CGPoint
+    ) -> [ArcSegment] {
+        let x1 = Double(start.x)
+        let y1 = Double(start.y)
+        let x2 = Double(end.x)
+        let y2 = Double(end.y)
+
+        if abs(x1 - x2) < pathEpsilon && abs(y1 - y2) < pathEpsilon {
+            return []
+        }
+
+        var rx = abs(initialRx)
+        var ry = abs(initialRy)
+        if rx < pathEpsilon || ry < pathEpsilon {
+            return [.line(end)]
+        }
+
+        let phi = xRotation * Double.pi / 180
+        let cosPhi = cos(phi)
+        let sinPhi = sin(phi)
+
+        let dx = (x1 - x2) / 2
+        let dy = (y1 - y2) / 2
+        let x1Prime = cosPhi * dx + sinPhi * dy
+        let y1Prime = -sinPhi * dx + cosPhi * dy
+
+        let x1PrimeSquared = x1Prime * x1Prime
+        let y1PrimeSquared = y1Prime * y1Prime
+        let lambda = x1PrimeSquared / (rx * rx) + y1PrimeSquared / (ry * ry)
+        if lambda > 1 {
+            let scale = sqrt(lambda)
+            rx *= scale
+            ry *= scale
+        }
+
+        let rxSquared = rx * rx
+        let rySquared = ry * ry
+        let numerator = max(0.0, rxSquared * rySquared - rxSquared * y1PrimeSquared - rySquared * x1PrimeSquared)
+        let denominator = rxSquared * y1PrimeSquared + rySquared * x1PrimeSquared
+        let squareRoot = denominator > 1e-10 ? sqrt(numerator / denominator) : 0
+        let sign = largeArc == sweep ? -1.0 : 1.0
+        let cxPrime = sign * squareRoot * rx * y1Prime / ry
+        let cyPrime = sign * squareRoot * (-ry * x1Prime) / rx
+
+        let cx = cosPhi * cxPrime - sinPhi * cyPrime + (x1 + x2) / 2
+        let cy = sinPhi * cxPrime + cosPhi * cyPrime + (y1 + y2) / 2
+
+        let theta1 = atan2((y1Prime - cyPrime) / ry, (x1Prime - cxPrime) / rx)
+        let theta2 = atan2((-y1Prime - cyPrime) / ry, (-x1Prime - cxPrime) / rx)
+        var deltaTheta = theta2 - theta1
+
+        if !sweep && deltaTheta > 0 {
+            deltaTheta -= 2 * Double.pi
+        }
+        if sweep && deltaTheta < 0 {
+            deltaTheta += 2 * Double.pi
+        }
+
+        let segmentCount = max(1, Int(ceil(abs(deltaTheta) / (Double.pi / 2 + 0.001))))
+        let segmentAngle = deltaTheta / Double(segmentCount)
+        var segments: [ArcSegment] = []
+
+        for index in 0..<segmentCount {
+            let t1 = theta1 + segmentAngle * Double(index)
+            let t2 = theta1 + segmentAngle * Double(index + 1)
+            let alpha = 4.0 / 3.0 * tan(segmentAngle / 4.0)
+
+            let cosT1 = cos(t1)
+            let sinT1 = sin(t1)
+            let cosT2 = cos(t2)
+            let sinT2 = sin(t2)
+
+            let ep1x = cosT1 - alpha * sinT1
+            let ep1y = sinT1 + alpha * cosT1
+            let ep2x = cosT2 + alpha * sinT2
+            let ep2y = sinT2 - alpha * cosT2
+
+            let cp1x = rx * ep1x
+            let cp1y = ry * ep1y
+            let cp2x = rx * ep2x
+            let cp2y = ry * ep2y
+            let endX = rx * cosT2
+            let endY = ry * sinT2
+
+            segments.append(.curve(
+                CGPoint(x: cosPhi * cp1x - sinPhi * cp1y + cx,
+                        y: sinPhi * cp1x + cosPhi * cp1y + cy),
+                CGPoint(x: cosPhi * cp2x - sinPhi * cp2y + cx,
+                        y: sinPhi * cp2x + cosPhi * cp2y + cy),
+                CGPoint(x: cosPhi * endX - sinPhi * endY + cx,
+                        y: sinPhi * endX + cosPhi * endY + cy)
+            ))
+        }
+
+        return segments
     }
 
     private func applyTransform(_ transform: ShapeTransform, bbox: BBox, in ctx: CGContext) {
@@ -1660,10 +2764,14 @@ class CGTreeRenderer {
 
     /// HWP ColorRef (0x00BBGGRR) → CGColor
     private func colorRefToCGColor(_ ref: UInt32) -> CGColor {
+        colorRefToCGColor(ref, alpha: 1.0)
+    }
+
+    private func colorRefToCGColor(_ ref: UInt32, alpha: CGFloat) -> CGColor {
         let r = CGFloat(ref & 0xFF) / 255.0
         let g = CGFloat((ref >> 8) & 0xFF) / 255.0
         let b = CGFloat((ref >> 16) & 0xFF) / 255.0
-        return CGColor(red: r, green: g, blue: b, alpha: 1.0)
+        return CGColor(red: r, green: g, blue: b, alpha: clampedAlpha(Double(alpha)))
     }
 
     private var coreTextForegroundColorKey: NSAttributedString.Key {
@@ -1698,6 +2806,13 @@ private struct TextRunSpacingEstimate {
     }
 }
 
+private struct TextRunTypographicMetrics {
+    let width: CGFloat
+    let ascent: CGFloat
+    let descent: CGFloat
+    let leading: CGFloat
+}
+
 private enum TextRunDrawStrategy {
     case line
     case scaledLine(CGFloat)
@@ -1724,6 +2839,8 @@ private struct TextRunClusterSpan {
     let text: String
     let scalarStart: Int
     let scalarEnd: Int
+    let utf16Start: Int
+    let utf16End: Int
 }
 
 private struct TextRunTabStop {


### PR DESCRIPTION
## 요약

- 대상 타스크: #109 Swift native renderer style parity 보강의 `devel-webview` 백포트
- 왜: `devel-webview`의 HostApp 문서 화면은 WKWebView/rhwp-studio 경로라 직접 영향은 없지만, Quick Look Preview와 Thumbnail은 공용 native `CGTreeRenderer`를 사용하므로 동일한 렌더링 품질 개선이 필요함
- 무엇: #161의 `CGTreeRenderer` 도형/텍스트 스타일 처리 보강을 `devel-webview`에 소스 범위로 백포트
- 리뷰 포인트: WebView 화면 경로를 건드리지 않았고, Quick Look/Thumbnail 공용 renderer 변경만 포함했는지 확인

## 변경 내역

- **[백포트](https://github.com/postmelee/alhangeul-macos/commit/a2024982cbb535205f9a2cabfac883455ac924ba)** ([a202498](https://github.com/postmelee/alhangeul-macos/commit/a2024982cbb535205f9a2cabfac883455ac924ba)): `devel` 대상 PR #161의 native `CGTreeRenderer` style parity 변경을 `devel-webview`에 적용
- **[리뷰 반영](https://github.com/postmelee/alhangeul-macos/commit/65805f8416d5d32a95545342a9cd84ff7dbbd149)** ([65805f8](https://github.com/postmelee/alhangeul-macos/commit/65805f8416d5d32a95545342a9cd84ff7dbbd149)): pattern fill의 background fill과 pattern line stroke에 `ShapeStyle.opacity` 반영

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | 도형 stroke/fill/shadow/pattern 및 텍스트 style/transform 처리 보강 | Quick Look/Thumbnail 공용 renderer 변경으로 한정됐는지 |
| `devel-webview` HostApp | WKWebView/rhwp-studio 화면 경로 변경 없음 | webview 배포 준비 흐름에 직접 UI 회귀가 없는지 |
| Xcode project | 이 브랜치의 생성 project인 `Alhangeul.xcodeproj` 기준 검증 | `AlhangeulMac.xcodeproj`가 아닌 branch-local project 명칭 사용 |

## 핵심 리뷰 포인트

- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`에 AppKit/UIKit/WebKit 직접 의존을 추가하지 않았는지
- `devel-webview`의 HostApp WKWebView 문서 화면 코드와 plist/package 설정을 건드리지 않았는지
- #161과 동일한 native renderer 변경이 Quick Look Preview/Thumbnail 산출물에만 기대 효과를 주는지

## 검증

- `./scripts/check-no-appkit.sh`
- `./scripts/validate-stage3-render.sh /private/tmp/rhwp-task109-webview-smoke samples/basic/BookReview.hwp samples/basic/KTX.hwp samples/basic/request.hwp samples/exam_kor.hwp`
- `./scripts/validate-stage3-render.sh /private/tmp/rhwp-task109-webview-opacity-smoke samples/basic/BookReview.hwp samples/basic/KTX.hwp samples/basic/request.hwp samples/exam_kor.hwp`
- `./scripts/render-debug-compare.sh /private/tmp/rhwp-task109-webview-bokhak samples/복학원서.hwp`
- `./scripts/render-debug-compare.sh /private/tmp/rhwp-task109-webview-hongbo samples/20250130-hongbo.hwp`
- `xcodegen generate`
- `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-webview CODE_SIGNING_ALLOWED=NO build`

## 관련 이슈

- #109
- #161: `devel` 대상 원본 PR

## 후속 이슈 제안

- upstream/repo 공용 style fixture 생성: pattern/shadow 도형, text shadow, emphasis dot, tab leader, rotation, vertical text 포함

## 남은 리스크

- 이 PR은 `devel-webview`의 Quick Look/Thumbnail native renderer 백포트이며, HostApp의 WKWebView/rhwp-studio 문서 화면 품질을 직접 개선하지 않는다.
- 저장소 실제 샘플에 pattern/shadow 등 일부 style fixture가 부족해 #161의 synthetic render tree 검증 결과를 함께 근거로 삼는다.
- CoreGraphics/CoreText와 WebCanvas/SVG rasterization은 픽셀 단위 완전 일치가 아닐 수 있다.
