### PR TITLE
Task #218: v0.1.1 release 실패 사례 troubleshooting 문서화

### DIFF
--- a/mydocs/manual/release_distribution_guide.md
+++ b/mydocs/manual/release_distribution_guide.md
@@ -28,6 +28,14 @@
 
 릴리즈별 실제 결정, SHA256, 검증 기록은 [`mydocs/release/`](../release/)에 남긴다. 환경 스냅샷은 [`release_environment.md`](../tech/release_environment.md)에 둔다. 실패 증상, 재현 조건, 원인, 재발 방지 절차가 모인 경우에만 `mydocs/troubleshootings/`로 분리한다.
 
+## 문제 해결 기록
+
+반복 가능한 release workflow 실패는 매뉴얼 본문에 사례를 길게 복제하지 않고 `mydocs/troubleshootings/` 아래에 별도 문서로 둔다.
+
+| 문서 | 읽는 시점 | 내용 |
+|------|-----------|------|
+| [`release_v0_1_1_workflow_failures.md`](../troubleshootings/release_v0_1_1_workflow_failures.md) | `v0.1.1` release workflow와 같은 계열의 GitHub Actions, Developer ID, notarization, Sparkle signing, Rust staticlib 실패를 진단할 때 | `GH_TOKEN`, `$GITHUB_OUTPUT`, `cbindgen`, `librhwp.a` hash mismatch, notarization log, Sparkle nested signing, extension entitlement 실패 사례 |
+
 ## 현재 release 자산
 
 - `scripts/package-release.sh`: Release configuration 개발/검증용 zip 생성

--- a/mydocs/manual/release_signing_notarization_guide.md
+++ b/mydocs/manual/release_signing_notarization_guide.md
@@ -86,4 +86,5 @@ spctl --assess --type open --context context:primary-signature --verbose build.n
 
 - credential 조회 실패는 `release_environment.md`의 환경 식별자와 실제 Keychain/workflow 환경을 먼저 대조한다.
 - app/DMG staple 실패, Gatekeeper 차단, notarization rejection은 release report에 실제 command, 대상 파일, 오류 요약을 기록한다.
+- Sparkle nested component signing, app extension entitlement, notary log 부족이 의심되면 [`release_v0_1_1_workflow_failures.md`](../troubleshootings/release_v0_1_1_workflow_failures.md)의 `v0.1.1` release workflow 실패 사례를 함께 확인한다.
 - 반복 가능한 실패 증상, 재현 조건, 원인, 재발 방지 절차가 정리되면 `mydocs/troubleshootings/`에 별도 문서로 승격한다.

--- a/mydocs/orders/20260511.md
+++ b/mydocs/orders/20260511.md
@@ -13,7 +13,7 @@
 | #223 | 그림 선택 후 Space 입력 시 WKWebView viewer runtime error 발생 | 완료 | 완료: 12:55 |
 | #205 | 앱 버전과 bundled rhwp provenance 표기 정책 정리 | 완료 | 완료: 11:59 |
 | #227 | Rust bridge staticlib artifact 검증 정책 재정의 | 완료 | 완료: 13:08, 최종 보고서 작성 |
-| #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 진행중 | M019 Stage 3 완료 보고서 승인 대기 |
+| #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 완료 | 완료: 13:30, 최종 보고서 승인 대기 |
 
 ## M020 — v0.2 Mac 통합 확장
 

--- a/mydocs/orders/20260511.md
+++ b/mydocs/orders/20260511.md
@@ -13,7 +13,7 @@
 | #223 | 그림 선택 후 Space 입력 시 WKWebView viewer runtime error 발생 | 완료 | 완료: 12:55 |
 | #205 | 앱 버전과 bundled rhwp provenance 표기 정책 정리 | 완료 | 완료: 11:59 |
 | #227 | Rust bridge staticlib artifact 검증 정책 재정의 | 완료 | 완료: 13:08, 최종 보고서 작성 |
-| #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 진행중 | M019, 구현계획서 작성 후 승인 대기 |
+| #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 진행중 | M019 Stage 1 완료 보고서 승인 대기 |
 
 ## M020 — v0.2 Mac 통합 확장
 

--- a/mydocs/orders/20260511.md
+++ b/mydocs/orders/20260511.md
@@ -13,7 +13,7 @@
 | #223 | 그림 선택 후 Space 입력 시 WKWebView viewer runtime error 발생 | 완료 | 완료: 12:55 |
 | #205 | 앱 버전과 bundled rhwp provenance 표기 정책 정리 | 완료 | 완료: 11:59 |
 | #227 | Rust bridge staticlib artifact 검증 정책 재정의 | 완료 | 완료: 13:08, 최종 보고서 작성 |
-| #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 진행중 | M019, 수행계획서 작성 후 승인 대기 |
+| #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 진행중 | M019, 구현계획서 작성 후 승인 대기 |
 
 ## M020 — v0.2 Mac 통합 확장
 

--- a/mydocs/orders/20260511.md
+++ b/mydocs/orders/20260511.md
@@ -13,7 +13,7 @@
 | #223 | 그림 선택 후 Space 입력 시 WKWebView viewer runtime error 발생 | 완료 | 완료: 12:55 |
 | #205 | 앱 버전과 bundled rhwp provenance 표기 정책 정리 | 완료 | 완료: 11:59 |
 | #227 | Rust bridge staticlib artifact 검증 정책 재정의 | 완료 | 완료: 13:08, 최종 보고서 작성 |
-| #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 진행중 | M019 Stage 1 완료 보고서 승인 대기 |
+| #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 진행중 | M019 Stage 2 완료 보고서 승인 대기 |
 
 ## M020 — v0.2 Mac 통합 확장
 

--- a/mydocs/orders/20260511.md
+++ b/mydocs/orders/20260511.md
@@ -13,7 +13,7 @@
 | #223 | 그림 선택 후 Space 입력 시 WKWebView viewer runtime error 발생 | 완료 | 완료: 12:55 |
 | #205 | 앱 버전과 bundled rhwp provenance 표기 정책 정리 | 완료 | 완료: 11:59 |
 | #227 | Rust bridge staticlib artifact 검증 정책 재정의 | 완료 | 완료: 13:08, 최종 보고서 작성 |
-| #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 진행중 | M019 Stage 2 완료 보고서 승인 대기 |
+| #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 진행중 | M019 Stage 3 완료 보고서 승인 대기 |
 
 ## M020 — v0.2 Mac 통합 확장
 

--- a/mydocs/orders/20260511.md
+++ b/mydocs/orders/20260511.md
@@ -13,6 +13,7 @@
 | #223 | 그림 선택 후 Space 입력 시 WKWebView viewer runtime error 발생 | 완료 | 완료: 12:55 |
 | #205 | 앱 버전과 bundled rhwp provenance 표기 정책 정리 | 완료 | 완료: 11:59 |
 | #227 | Rust bridge staticlib artifact 검증 정책 재정의 | 완료 | 완료: 13:08, 최종 보고서 작성 |
+| #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 진행중 | M019, 수행계획서 작성 후 승인 대기 |
 
 ## M020 — v0.2 Mac 통합 확장
 

--- a/mydocs/plans/task_m019_218.md
+++ b/mydocs/plans/task_m019_218.md
@@ -1,0 +1,117 @@
+# Task M019 #218 수행계획서
+
+## 목적
+
+`v0.1.1` public release 실행 중 실제로 발생한 GitHub Actions, signing, notarization, Sparkle signing, CI dependency, Rust staticlib hash 검증 실패를 장기 운영자가 재사용할 수 있는 troubleshooting 문서로 승격한다.
+
+완료 후에는 `#188` Stage 4 보고서만 추적하지 않아도 release maintainer가 같은 계열의 실패를 증상, 재현 조건, 원인, 수정, 예방책 순서로 진단할 수 있어야 한다.
+
+## 배경
+
+`#188`은 `v0.1.1` public release를 준비하고 최종 build `4`를 public DMG와 Sparkle appcast로 게시한 작업이다. 그 과정에서 release workflow가 여러 번 실패했고, `mydocs/working/task_m018_188_stage4.md`에는 run별 실패와 보정이 기록되어 있다.
+
+현재 기록은 stage 보고서 안에 남아 있어 후속 운영자가 특정 장애를 찾기 어렵다. 특히 `GH_TOKEN` 인증, Developer ID certificate import helper 출력, `cbindgen` 누락, `librhwp.a` byte hash mismatch, notarization log 부재, Sparkle nested component signing, Quick Look/Thumbnail extension entitlement 문제는 release runbook과 연결되는 troubleshooting 문서로 분리할 필요가 있다.
+
+동시에 `#220`과 `#227`에서 Rust staticlib hash 검증 정책이 병렬로 재정의되고 있으므로, 본 작업은 `#188`에서 실제 발생한 실패와 당시의 제한적 예외 판단을 문서화하고, 장기 정책 결론은 해당 이슈를 참조하도록 경계를 둔다.
+
+## 범위(포함·제외)
+
+포함:
+
+- `mydocs/troubleshootings/` 아래 `v0.1.1` release workflow 실패 사례 문서 추가
+- 각 실패 항목을 증상, 재현 조건, 원인, 수정, 예방책으로 분리
+- GitHub Actions `GH_TOKEN`/`gh` 인증 실패 사례 정리
+- Developer ID keychain helper stdout/stderr 오염과 `$GITHUB_OUTPUT` format 오류 사례 정리
+- `cbindgen` 누락으로 인한 rhwp lock 검증 실패 사례 정리
+- `librhwp.a` staticlib hash mismatch와 제한적 skip 예외의 운영 판단 정리
+- notary status/log 처리 미흡으로 진단이 어려웠던 notarization 실패 사례 정리
+- Sparkle nested XPC/Autoupdate Developer ID signing/timestamp 누락 사례 정리
+- Quick Look/Thumbnail extension release entitlement와 `get-task-allow` 문제 정리
+- `release_distribution_guide.md` 또는 관련 release manual에서 troubleshooting 문서로 연결
+- 수행계획서, 구현계획서, 단계 보고서, 최종 보고서, 오늘할일 갱신
+
+제외:
+
+- release script 기능 변경
+- release workflow YAML 변경
+- 새 public release 실행
+- notarization submit, signing, GitHub Release 게시, Pages deployment
+- Homebrew tap 배포 작업
+- `#220`/`#227`의 Rust staticlib 검증 정책 최종 결정 대체
+
+## 설계 방향
+
+troubleshooting 문서는 사건 기록이 아니라 운영자가 장애를 분류하고 다음 조치를 결정하는 문서로 작성한다. 따라서 run 번호만 나열하지 않고, 각 항목을 같은 구조로 반복한다.
+
+각 실패 항목은 다음 구조를 기본으로 한다.
+
+- 증상: workflow step, 대표 오류, 관찰된 상태
+- 재현 조건: 어떤 workflow/run/환경에서 발생했는지
+- 원인: 코드나 운영 설정에서 확인된 직접 원인
+- 수정: `#188`에서 적용된 보정
+- 예방책: 다음 release 전에 확인할 체크포인트
+
+문서 상단에는 전체 실패 흐름 표를 두어 `#188` Stage 4의 run별 순서를 빠르게 따라갈 수 있게 한다. 민감 정보는 기록하지 않고, secret 이름과 비밀이 아닌 운영 식별자만 일반화해 쓴다.
+
+Rust staticlib hash 항목은 숨은 우회처럼 쓰지 않는다. `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`은 당시 CI runner/toolchain 차이로 인한 byte-for-byte mismatch를 제한적으로 건너뛰되, source lock, Cargo lock, generated header, FFI symbol 검증은 유지한 판단으로 설명한다. 장기 정책은 `#220`/`#227` 결과를 따르는 것으로 명시한다.
+
+## 예상 변경 파일
+
+- `mydocs/troubleshootings/release_v0_1_1_workflow_failures.md`
+- `mydocs/manual/release_distribution_guide.md`
+- 필요 시 `mydocs/manual/release_signing_notarization_guide.md`
+- `mydocs/orders/20260511.md`
+- `mydocs/plans/task_m019_218.md`
+- `mydocs/plans/task_m019_218_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m019_218_stage{N}.md`
+- `mydocs/report/task_m019_218_report.md`
+
+## 잠정 단계(3~6단계)
+
+1. Stage 1: 실패 사례 inventory와 문서 구조 확정
+   - `#188` Stage 4 보고서, 최종 보고서, release 관련 매뉴얼을 읽고 실제 실패 사례 목록과 진단 구조를 확정한다.
+   - secret/credential 기록 금지 범위와 문서화 가능한 운영 식별자를 분리한다.
+2. Stage 2: troubleshooting 문서 작성
+   - `mydocs/troubleshootings/release_v0_1_1_workflow_failures.md`를 추가한다.
+   - run별 흐름 표와 항목별 증상/재현 조건/원인/수정/예방책을 작성한다.
+3. Stage 3: release 매뉴얼 연결과 검증
+   - release distribution/signing 문서에서 troubleshooting 문서로 연결한다.
+   - staticlib hash 항목이 `#220`/`#227`의 정책 결정을 대체하지 않도록 문구를 조정한다.
+4. Stage 4: 보고와 마무리
+   - 단계 보고서와 최종 보고서에 문서화 범위, 검증 결과, 후속 정책 의존성을 기록한다.
+   - 오늘할일 상태를 완료로 갱신한다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260511.md mydocs/plans/task_m019_218.md
+```
+
+구현 단계 후보:
+
+```bash
+test -f mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+rg -n "GH_TOKEN|Developer ID|cbindgen|staticlib|librhwp.a|ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY|notarization|Sparkle|get-task-allow|entitlement" \
+  mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+rg -n "release_v0_1_1_workflow_failures|troubleshooting|문제 해결|실패 사례" \
+  mydocs/manual/release_distribution_guide.md mydocs/manual/release_signing_notarization_guide.md
+git diff --check
+```
+
+문서 작업이므로 release workflow 실행, notarization submit, signed/notarized DMG 생성, GitHub Release 게시, Pages deployment는 검증 범위에 포함하지 않는다.
+
+## 리스크
+
+- `#220`/`#227`에서 staticlib hash 검증 정책이 바뀌면 본 문서의 해당 항목도 후속 보정이 필요할 수 있다.
+- 실제 실패 로그의 민감 정보와 진단에 필요한 운영 정보의 경계가 흐려질 수 있다. secret 값은 쓰지 않고, secret 이름과 비밀이 아닌 식별자만 일반화한다.
+- troubleshooting 문서가 stage report를 그대로 복제하면 장기 운영 문서로서 찾기 어렵다. 항목별 진단 구조를 유지한다.
+- release script 변경 없이 문서만 추가하므로, 새 validator나 fail-fast 개선은 `#219` 범위로 남는다.
+- public release 실행과 배포 작업은 명시 승인 없이는 수행하지 않는다.
+
+## 승인 요청 사항
+
+1. 위 범위와 4단계 진행 구조 승인
+2. troubleshooting 파일명을 `mydocs/troubleshootings/release_v0_1_1_workflow_failures.md`로 두는 방향 승인
+3. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m019_218_impl.md`) 작성

--- a/mydocs/plans/task_m019_218_impl.md
+++ b/mydocs/plans/task_m019_218_impl.md
@@ -1,0 +1,219 @@
+# Task M019 #218 구현계획서
+
+수행계획서: `mydocs/plans/task_m019_218.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #218 v0.1.1 release workflow 실패 사례 troubleshooting 문서화
+- 마일스톤: M019 (`v0.1.2`)
+- 브랜치: `local/task218`
+- 작업 위치: `/private/tmp/rhwp-mac-task218`
+- 기준 브랜치: `devel-webview`
+- 목표: `#188` public release 실행 중 발생한 workflow/signing/notarization/staticlib 실패 사례를 장기 운영용 troubleshooting 문서로 정리하고 release manual에서 연결한다.
+
+## 현재 전제와 제약
+
+- `#188` Stage 4 보고서에는 run별 실패와 보정이 이미 기록되어 있다.
+- 본 작업은 그 기록을 운영자가 재사용 가능한 troubleshooting 문서로 승격한다.
+- release script, workflow, signing 설정, notarization submit, GitHub Release 게시, Pages deployment는 변경하거나 실행하지 않는다.
+- `#220`과 `#227`에서 Rust staticlib artifact 검증 정책이 병렬로 정리되고 있으므로, 본 작업은 `#188` 당시 판단과 제한적 예외를 기록하고 장기 정책 결론은 해당 이슈로 연결한다.
+- secret 값, certificate payload, app-specific password, token 값, Sparkle private key는 문서에 기록하지 않는다.
+
+## 구현 원칙
+
+- troubleshooting 문서는 stage report 복제가 아니라 진단 절차 문서로 작성한다.
+- 각 실패 사례는 `증상`, `재현 조건`, `원인`, `수정`, `예방책` 구조를 유지한다.
+- 문서 상단에는 run별 실패 흐름 요약 표를 두어 `#188` Stage 4와 대조할 수 있게 한다.
+- release manual에는 긴 사례를 복제하지 않고 troubleshooting 문서로 연결하는 진입점만 추가한다.
+- staticlib hash skip은 숨은 우회가 아니라 CI runner/toolchain 차이에서 `librhwp.a` byte hash만 제한적으로 건너뛰고 source lock, Cargo lock, generated header, FFI symbol 검증은 유지한 운영 판단으로 설명한다.
+
+## Stage 1. 실패 사례 inventory와 구조 확정
+
+### 목표
+
+`#188` 기록과 현재 release manual을 대조해 troubleshooting 문서에 들어갈 실패 사례, 민감 정보 제외 기준, 문서 구조를 확정한다.
+
+### 작업
+
+- `mydocs/working/task_m018_188_stage4.md`의 release workflow 실패 표와 보정 내용을 확인한다.
+- `mydocs/report/task_m018_188_report.md`의 최종 public release 결과와 잔여 위험을 확인한다.
+- `release_distribution_guide.md`와 `release_signing_notarization_guide.md`에서 troubleshooting 연결 위치를 정한다.
+- `scripts/release.sh`, `scripts/build-rust-macos.sh`, `scripts/ci/import-developer-id-certificate.sh`의 관련 함수/환경 변수 이름을 확인한다.
+- Stage 1 보고서에 문서 구조, 포함 항목, 제외 항목, 후속 이슈 연결을 기록한다.
+
+### 예상 변경 파일
+
+- `mydocs/working/task_m019_218_stage1.md`
+
+### 검증
+
+```bash
+rg -n "25632437884|25632495693|25632545387|25632598126|25632780594|25633064531|25633267598|GH_TOKEN|cbindgen|staticlib|Sparkle nested|get-task-allow" \
+  mydocs/working/task_m018_188_stage4.md mydocs/report/task_m018_188_report.md
+rg -n "troubleshooting|문제|notarization|Developer ID|Sparkle|staticlib" \
+  mydocs/manual/release_distribution_guide.md mydocs/manual/release_signing_notarization_guide.md
+git diff --check -- mydocs/working/task_m019_218_stage1.md
+```
+
+### 완료 기준
+
+- Stage 1 보고서에 troubleshooting 문서의 항목 목록과 구조가 확정된다.
+- secret/credential 기록 금지 기준이 명시된다.
+- Stage 1에서는 신규 troubleshooting 본문과 release manual을 아직 변경하지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #218 Stage 1: release 실패 사례 inventory 정리
+```
+
+## Stage 2. troubleshooting 문서 작성
+
+### 목표
+
+`mydocs/troubleshootings/release_v0_1_1_workflow_failures.md`를 추가해 `v0.1.1` release workflow 실패 사례를 운영 문서로 정리한다.
+
+### 작업
+
+- 문서 상단에 대상 release, 관련 이슈, 참조 stage report, 공개 release 결과를 기록한다.
+- run별 실패 흐름 요약 표를 추가한다.
+- 다음 사례를 각각 `증상`, `재현 조건`, `원인`, `수정`, `예방책` 구조로 작성한다.
+  - upstream latest rhwp release 확인 단계의 `GH_TOKEN`/`gh` 인증 실패
+  - Developer ID certificate import helper stdout 오염과 `$GITHUB_OUTPUT` format 오류
+  - runner의 `cbindgen` 누락으로 인한 rhwp lock 검증 실패
+  - `librhwp.a` staticlib byte hash mismatch와 제한적 skip 예외
+  - notarization invalid 상태에서 log 없이 진단이 어려웠던 문제
+  - Sparkle nested XPC/Autoupdate ad-hoc signature와 timestamp 누락
+  - Quick Look/Thumbnail extension `get-task-allow`와 timestamp 누락
+- 문서 하단에 다음 release 전 확인 checklist와 후속 이슈(`#219`, `#220`, `#227`) 연결을 둔다.
+- Stage 2 보고서에 작성된 troubleshooting 범위와 의도적으로 제외한 변경을 기록한다.
+
+### 예상 변경 파일
+
+- `mydocs/troubleshootings/release_v0_1_1_workflow_failures.md`
+- `mydocs/working/task_m019_218_stage2.md`
+
+### 검증
+
+```bash
+test -f mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+rg -n "GH_TOKEN|Developer ID|GITHUB_OUTPUT|cbindgen|librhwp.a|ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY|notarization|Sparkle|get-task-allow|entitlement|#219|#220|#227" \
+  mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+git diff --check -- mydocs/troubleshootings/release_v0_1_1_workflow_failures.md mydocs/working/task_m019_218_stage2.md
+```
+
+### 완료 기준
+
+- troubleshooting 문서가 실제 실패 사례를 항목별 진단 구조로 설명한다.
+- staticlib hash skip이 제한적 운영 판단으로 설명되고, 장기 정책은 후속 이슈로 연결된다.
+- release script/workflow 변경 없이 문서만 추가된다.
+
+### 커밋 메시지
+
+```text
+Task #218 Stage 2: v0.1.1 release 실패 사례 문서화
+```
+
+## Stage 3. release manual 연결과 문서 검증
+
+### 목표
+
+release manual에서 troubleshooting 문서로 진입할 수 있게 연결하고, 문서 간 중복과 정책 충돌을 점검한다.
+
+### 작업
+
+- `release_distribution_guide.md`에 `v0.1.1` release workflow 실패 사례 troubleshooting 문서 링크를 추가한다.
+- 필요하면 `release_signing_notarization_guide.md`에 signing/notarization 실패 진단 참고 링크를 추가한다.
+- release manual에는 사례 세부 내용을 복제하지 않고, 언제 troubleshooting 문서를 참고해야 하는지만 기록한다.
+- staticlib hash 항목이 `#220`/`#227` 정책 결정을 대체하지 않도록 문구를 재확인한다.
+- Stage 3 보고서에 연결 위치와 검증 결과를 기록한다.
+
+### 예상 변경 파일
+
+- `mydocs/manual/release_distribution_guide.md`
+- 필요 시 `mydocs/manual/release_signing_notarization_guide.md`
+- `mydocs/working/task_m019_218_stage3.md`
+
+### 검증
+
+```bash
+rg -n "release_v0_1_1_workflow_failures|v0.1.1 release workflow|troubleshooting|실패 사례|문제 해결" \
+  mydocs/manual/release_distribution_guide.md mydocs/manual/release_signing_notarization_guide.md mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+rg -n "#220|#227|staticlib|ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY" \
+  mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+git diff --check -- mydocs/manual/release_distribution_guide.md mydocs/manual/release_signing_notarization_guide.md mydocs/working/task_m019_218_stage3.md
+```
+
+### 완료 기준
+
+- release distribution guide에서 troubleshooting 문서로 접근할 수 있다.
+- signing/notarization guide는 필요 시 관련 실패 진단 문서로 연결된다.
+- manual 본문과 troubleshooting 문서 사이에 정책 충돌이나 과도한 중복이 없다.
+
+### 커밋 메시지
+
+```text
+Task #218 Stage 3: release troubleshooting 연결 보강
+```
+
+## Stage 4. 최종 정리와 보고
+
+### 목표
+
+전체 문서 변경을 최종 검증하고 오늘할일과 최종 보고서를 정리한다.
+
+### 작업
+
+- troubleshooting 문서와 release manual 링크를 전체 keyword scan으로 확인한다.
+- `mydocs/orders/20260511.md`의 `#218` 상태를 완료로 갱신한다.
+- 최종 보고서 `mydocs/report/task_m019_218_report.md`를 작성한다.
+- Stage 4 보고서를 작성한다.
+- 최종 보고서에 검증 결과, 변경 파일, 후속 이슈 의존성, 실행하지 않은 release 작업을 기록한다.
+
+### 예상 변경 파일
+
+- `mydocs/orders/20260511.md`
+- `mydocs/working/task_m019_218_stage4.md`
+- `mydocs/report/task_m019_218_report.md`
+
+### 검증
+
+```bash
+test -f mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+test -f mydocs/report/task_m019_218_report.md
+rg -n "GH_TOKEN|Developer ID|GITHUB_OUTPUT|cbindgen|librhwp.a|ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY|notarization|Sparkle|get-task-allow|#219|#220|#227" \
+  mydocs/troubleshootings/release_v0_1_1_workflow_failures.md mydocs/report/task_m019_218_report.md
+rg -n "release_v0_1_1_workflow_failures|v0.1.1 release workflow|실패 사례" \
+  mydocs/manual/release_distribution_guide.md mydocs/manual/release_signing_notarization_guide.md
+git diff --check
+git status --short
+```
+
+### 완료 기준
+
+- `#188` Stage 4 보고서를 보지 않아도 주요 release workflow 실패를 진단할 수 있다.
+- release manual에서 troubleshooting 문서로 연결된다.
+- staticlib hash 예외는 제한적 운영 판단과 후속 정책 의존성으로 설명된다.
+- release workflow 실행, notarization submit, public release 게시, Homebrew tap 배포는 수행하지 않았음이 보고서에 명시된다.
+
+### 커밋 메시지
+
+```text
+Task #218 Stage 4: release troubleshooting 최종 정리
+```
+
+## 전체 검증 요약
+
+최종 단계에서는 다음 범위를 모두 확인한다.
+
+```bash
+git diff --check
+rg -n "release_v0_1_1_workflow_failures|GH_TOKEN|Developer ID|cbindgen|librhwp.a|notarization|Sparkle|get-task-allow|#219|#220|#227" \
+  mydocs/troubleshootings/release_v0_1_1_workflow_failures.md \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/release_signing_notarization_guide.md \
+  mydocs/report/task_m019_218_report.md
+git status --short
+```

--- a/mydocs/report/task_m019_218_report.md
+++ b/mydocs/report/task_m019_218_report.md
@@ -1,0 +1,83 @@
+# Task M019 #218 최종 결과 보고서
+
+## 작업 요약
+
+| 항목 | 값 |
+|------|----|
+| 이슈 | [#218 v0.1.1 release workflow 실패 사례 troubleshooting 문서화](https://github.com/postmelee/alhangeul-macos/issues/218) |
+| 마일스톤 | M019 `v0.1.2` |
+| 브랜치 | `local/task218` |
+| 작업 위치 | `/private/tmp/rhwp-mac-task218` |
+| 단계 | Stage 1-4 |
+
+`#188` `v0.1.1` public release 실행 중 발생한 GitHub Actions, Developer ID signing, notarization, Sparkle nested signing, Rust staticlib hash 검증 실패를 troubleshooting 문서로 승격했다. 이제 `#188` Stage 4 보고서만 찾지 않아도 release maintainer가 같은 계열의 실패를 증상, 재현 조건, 원인, 수정, 예방책 순서로 진단할 수 있다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/troubleshootings/release_v0_1_1_workflow_failures.md` | `v0.1.1` release workflow 실패 7건을 진단 문서로 정리 |
+| `mydocs/manual/release_distribution_guide.md` | release troubleshooting 문서 진입점 추가 |
+| `mydocs/manual/release_signing_notarization_guide.md` | Sparkle nested signing, extension entitlement, notary log 문제 진단 시 troubleshooting 문서 참조 추가 |
+| `mydocs/plans/task_m019_218.md` | 수행계획서 |
+| `mydocs/plans/task_m019_218_impl.md` | 구현계획서 |
+| `mydocs/working/task_m019_218_stage1.md` | 실패 사례 inventory와 문서 구조 확정 |
+| `mydocs/working/task_m019_218_stage2.md` | troubleshooting 문서 작성 보고 |
+| `mydocs/working/task_m019_218_stage3.md` | release manual 연결 보고 |
+| `mydocs/working/task_m019_218_stage4.md` | 최종 검증 보고 |
+| `mydocs/orders/20260511.md` | `#218` 진행 상태와 완료 상태 기록 |
+
+## 문서화한 실패 사례
+
+| 사례 | 정리 내용 |
+|------|----------|
+| `GH_TOKEN` 누락 | `gh` CLI를 사용하는 release workflow에서 `GH_TOKEN: ${{ github.token }}` 전달 필요 |
+| Developer ID certificate import | `$GITHUB_OUTPUT`에 쓸 helper stdout은 keychain path만 남기고 `security` 출력은 stderr로 분리 |
+| `cbindgen` 누락 | GitHub macOS runner에 `cbindgen`이 없을 수 있으므로 release/rehearsal workflow에서 필요 시 설치 |
+| `librhwp.a` staticlib hash mismatch | `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`은 staticlib byte hash만 제한적으로 skip하고 source/header/symbol 검증은 유지 |
+| notarization log 부족 | notary JSON status와 submission log를 출력해 `Invalid` 상태 원인을 진단 |
+| Sparkle nested signing | XPC/Updater/Autoupdate nested component를 Developer ID/timestamp로 재서명 |
+| app extension entitlement | Quick Look/Thumbnail extension의 `get-task-allow` 제거와 배포용 entitlements 재서명 |
+
+## 검증 결과
+
+| 검증 | 결과 |
+|------|------|
+| troubleshooting 문서 존재 | OK |
+| 핵심 키워드 확인 | OK |
+| release manual 링크 확인 | OK |
+| `#219`, `#220`, `#227` 후속 이슈 연결 | OK |
+| `git diff --check` | OK |
+
+최종 검증 명령:
+
+```bash
+test -f mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+test -f mydocs/report/task_m019_218_report.md
+rg -n "GH_TOKEN|Developer ID|GITHUB_OUTPUT|cbindgen|librhwp.a|ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY|notarization|Sparkle|get-task-allow|#219|#220|#227" \
+  mydocs/troubleshootings/release_v0_1_1_workflow_failures.md mydocs/report/task_m019_218_report.md
+rg -n "release_v0_1_1_workflow_failures|v0.1.1 release workflow|실패 사례" \
+  mydocs/manual/release_distribution_guide.md mydocs/manual/release_signing_notarization_guide.md
+git diff --check
+git status --short
+```
+
+## 제외한 작업
+
+- release script 기능 변경
+- release workflow YAML 변경
+- notarization submit 또는 signing 실행
+- GitHub Release 게시
+- Pages deployment
+- Homebrew tap 배포
+- Rust staticlib hash 장기 정책 확정
+
+## 잔여 위험과 후속 작업
+
+- staticlib hash skip 허용 조건과 장기 검증 기준은 `#220`, `#227` 결과를 따라야 한다.
+- Sparkle nested component discovery, app extension entitlement/timestamp preflight는 `#219`에서 validator로 보강한다.
+- 본 작업은 troubleshooting 문서화만 수행했으므로 새 release run의 실제 성공을 보장하지 않는다. 다음 public release에서는 release workflow와 signing/notarization 검증을 별도로 수행해야 한다.
+
+## 작업지시자 승인 요청
+
+`#218` 작업은 troubleshooting 문서 작성, release manual 연결, 최종 검증까지 완료됐다. 이 최종 보고서 승인 후 PR 게시 절차로 넘어갈 수 있다.

--- a/mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+++ b/mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
@@ -1,0 +1,346 @@
+# v0.1.1 release workflow 실패 사례 troubleshooting
+
+## 목적
+
+`v0.1.1` public release 실행 중 발생한 GitHub Actions, Developer ID signing, notarization, Sparkle nested signing, Rust bridge 검증 실패를 장기 운영자가 재사용할 수 있는 진단 문서로 정리한다.
+
+이 문서는 `#188` Stage 4 보고서의 사건 기록을 운영 절차로 재구성한 것이다. release script나 workflow의 현재 구현이 바뀌어도, 같은 계열의 실패가 다시 발생하면 증상, 재현 조건, 원인, 수정, 예방책 순서로 먼저 대조한다.
+
+## 대상 release와 참조 자료
+
+| 항목 | 값 |
+|------|----|
+| 관련 이슈 | [#188](https://github.com/postmelee/alhangeul-macos/issues/188), [#218](https://github.com/postmelee/alhangeul-macos/issues/218) |
+| 원본 stage report | `mydocs/working/task_m018_188_stage4.md` |
+| 최종 report | `mydocs/report/task_m018_188_report.md` |
+| 초기 public success run | `25633522344` |
+| 최종 public release run | `25645869039` |
+| 최종 public release | `v0.1.1` build `4` |
+
+기록하지 않는 값:
+
+- Apple ID password
+- app-specific password
+- App Store Connect API private key
+- exported signing identity `.p12` payload와 password
+- Keychain credential payload
+- Sparkle EdDSA private key
+- GitHub token 값
+- notarization credential 원문
+
+문서에는 workflow variable/secret 이름, run 번호, 실패 step 이름, public run URL, script/function 이름만 기록한다.
+
+## 전체 실패 흐름
+
+| run | 실패 지점 | 대표 증상 | 적용된 보정 |
+|-----|-----------|-----------|-------------|
+| [`25632437884`](https://github.com/postmelee/alhangeul-macos/actions/runs/25632437884) | upstream latest rhwp release 확인 | `gh` 인증 실패 | release workflow에 `GH_TOKEN: ${{ github.token }}` 복구 |
+| [`25632495693`](https://github.com/postmelee/alhangeul-macos/actions/runs/25632495693) | Developer ID certificate import | `$GITHUB_OUTPUT` format 오류 | helper stdout에는 keychain path만 남기고 `security` 출력은 stderr로 이동 |
+| [`25632545387`](https://github.com/postmelee/alhangeul-macos/actions/runs/25632545387) | rhwp lock verify | runner에 `cbindgen` 없음 | release/rehearsal workflow에서 필요 시 `brew install cbindgen` |
+| [`25632598126`](https://github.com/postmelee/alhangeul-macos/actions/runs/25632598126) | rhwp staticlib hash verify | `librhwp.a` hash/size mismatch | CI에서는 staticlib byte hash만 제한적으로 skip |
+| [`25632780594`](https://github.com/postmelee/alhangeul-macos/actions/runs/25632780594) | app notarization | notary status `Invalid`, 상세 log 부족 | notary JSON status 파싱과 submission log 출력 |
+| [`25633064531`](https://github.com/postmelee/alhangeul-macos/actions/runs/25633064531) | app notarization | Sparkle nested component signature/timestamp 문제 | Sparkle nested component Developer ID/timestamp signing |
+| [`25633267598`](https://github.com/postmelee/alhangeul-macos/actions/runs/25633267598) | app notarization | Quick Look/Thumbnail extension entitlement/timestamp 문제 | app extension 배포용 entitlements 재서명 |
+| [`25633522344`](https://github.com/postmelee/alhangeul-macos/actions/runs/25633522344) | 없음 | initial public workflow 성공 | `v0.1.1` build `2` 게시 |
+
+## 1. `GH_TOKEN` 누락으로 `gh` 인증 실패
+
+### 증상
+
+`Release Publish DMG` workflow의 upstream latest `rhwp` release 확인 단계에서 `gh` 명령이 인증 실패로 중단된다.
+
+대표 판단:
+
+- 실패 run: `25632437884`
+- 실패 지점: upstream latest `rhwp` release 확인
+- 관련 workflow: `.github/workflows/release-publish.yml`
+
+### 재현 조건
+
+GitHub Actions workflow에서 `gh` CLI를 사용하지만 job 또는 step 환경에 `GH_TOKEN`이 설정되어 있지 않다. `github.token`은 자동으로 모든 subprocess에 전달되는 값이 아니므로, `gh`가 읽을 환경 변수로 명시해야 한다.
+
+### 원인
+
+release workflow에서 `GH_TOKEN`을 제거하면서 `gh` 인증 기반 조회가 실패했다. upstream release guard는 public API처럼 보이더라도 `gh` CLI 실행 경로에서는 인증 환경을 요구한다.
+
+### 수정
+
+release publish workflow env에 다음 값을 복구했다.
+
+```yaml
+GH_TOKEN: ${{ github.token }}
+```
+
+### 예방책
+
+- workflow에서 `gh` CLI를 쓰는 step은 `GH_TOKEN` 전달 여부를 확인한다.
+- token 값을 로그나 문서에 기록하지 않는다.
+- workflow 변경 후에는 `rg -n "GH_TOKEN|gh " .github/workflows`로 인증 사용 지점을 함께 점검한다.
+
+## 2. certificate import helper stdout 오염
+
+### 증상
+
+Developer ID certificate import step에서 `$GITHUB_OUTPUT` format 오류가 발생한다.
+
+대표 판단:
+
+- 실패 run: `25632495693`
+- 실패 지점: Developer ID certificate import
+- 관련 helper: `scripts/ci/import-developer-id-certificate.sh`
+
+### 재현 조건
+
+workflow step이 helper stdout을 command substitution으로 받아 `GITHUB_OUTPUT`에 쓰는데, helper stdout에 keychain path 외의 `security` command 출력이 섞인다.
+
+### 원인
+
+GitHub Actions output file은 `key=value` 형식 또는 heredoc 형식을 기대한다. keychain path 하나만 받아야 하는 흐름에 `security create-keychain`, `security import`, `security list-keychains` 같은 command output이 stdout으로 섞이면 output parser가 실패한다.
+
+### 수정
+
+helper는 `security` 출력과 진단 메시지를 stderr로 보내고, stdout에는 keychain path만 남기도록 보정했다.
+
+현재 기준:
+
+- required env: `DEVELOPER_ID_APPLICATION_P12_BASE64`, `DEVELOPER_ID_APPLICATION_P12_PASSWORD`, `RELEASE_KEYCHAIN_PASSWORD`
+- stdout: temporary keychain path
+- stderr: `security` command output
+
+### 예방책
+
+- GitHub Actions output으로 사용할 값은 stdout에 단일 값만 남긴다.
+- 진단 출력은 stderr로 보낸다.
+- helper 변경 후에는 workflow step의 command substitution 사용 여부를 확인한다.
+- `.p12` payload, password, keychain credential 값은 문서와 로그에 남기지 않는다.
+
+## 3. runner에 `cbindgen` 없음
+
+### 증상
+
+`./scripts/build-rust-macos.sh --verify-lock` 실행 중 `cbindgen` command가 없어 rhwp lock verify가 실패한다.
+
+대표 판단:
+
+- 실패 run: `25632545387`
+- 실패 지점: rhwp lock verify
+- 관련 script: `scripts/build-rust-macos.sh`
+
+### 재현 조건
+
+GitHub-hosted macOS runner에 Rust toolchain은 있지만 `cbindgen`이 사전 설치되어 있지 않다. `build-rust-macos.sh`는 generated header와 FFI symbol snapshot을 검증하기 위해 `cbindgen`을 필수 도구로 요구한다.
+
+### 원인
+
+release workflow가 local 개발 환경의 `cbindgen` 설치 상태를 runner에도 있다고 가정했다. 하지만 GitHub-hosted runner image에는 해당 도구가 없을 수 있다.
+
+### 수정
+
+release/rehearsal workflow에서 `cbindgen`이 없으면 설치하도록 보정했다.
+
+대표 흐름:
+
+```bash
+if ! command -v cbindgen >/dev/null 2>&1; then
+  brew install cbindgen
+fi
+```
+
+### 예방책
+
+- `scripts/build-rust-macos.sh`의 `require_tool` 목록을 workflow 준비 step과 함께 점검한다.
+- runner image 업데이트 이후에도 `cbindgen` presence를 가정하지 않는다.
+- dependency 설치 step은 release publish와 rehearsal 양쪽에 함께 반영한다.
+
+## 4. `librhwp.a` staticlib byte hash mismatch
+
+### 증상
+
+`Frameworks/universal/librhwp.a`의 sha256 또는 size가 `rhwp-core.lock`에 기록된 값과 달라져 `--verify-lock`이 실패한다.
+
+대표 판단:
+
+- 실패 run: `25632598126`
+- 실패 지점: rhwp staticlib hash verify
+- 관련 artifact: `Frameworks/universal/librhwp.a`
+- 관련 env: `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY`
+
+### 재현 조건
+
+같은 `rhwp` source commit과 같은 RustBridge source를 사용해도 GitHub macOS runner, Rust compiler, Xcode/linker/ar, build path, dependency build 환경 차이로 static archive byte layout이 달라진다.
+
+### 원인
+
+`rhwp-core.lock`은 staticlib artifact의 byte hash/size까지 기록하고 있었다. 그러나 CI runner/toolchain 차이에서 `librhwp.a`의 byte-for-byte reproducibility가 안정적으로 보장되지 않았다.
+
+### 수정
+
+`#188`에서는 release를 진행하기 위한 제한적 예외로 staticlib byte hash/size 검증만 건너뛰었다.
+
+유지한 검증:
+
+- `rhwp` source lock
+- `Cargo.lock`의 resolved commit
+- generated header
+- FFI symbol snapshot
+
+적용된 환경 변수:
+
+```bash
+ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1
+```
+
+`scripts/build-rust-macos.sh`는 해당 env가 `1`일 때 `Frameworks/universal/librhwp.a` byte hash만 skip하고, 경고와 함께 다른 검증은 유지한다.
+
+### 예방책
+
+- 이 env는 전체 rhwp 검증 skip이 아니다. staticlib byte hash에만 적용한다.
+- release 판단에서 이 예외를 쓰면 report에 이유와 유지된 검증 범위를 기록한다.
+- 장기 정책은 [#220](https://github.com/postmelee/alhangeul-macos/issues/220)과 [#227](https://github.com/postmelee/alhangeul-macos/issues/227)의 결론을 따른다.
+- core/FFI/ABI 변경이 있는 PR에서는 generated header와 `rhwp-ffi-symbols.txt` 검증 결과를 반드시 확인한다.
+
+## 5. notarization invalid 후 log 부족
+
+### 증상
+
+notary submit 결과가 `Invalid`인데 상세 notarization log 없이 이후 단계로 진행하거나 stapling 단계에서 실패한다.
+
+대표 판단:
+
+- 실패 run: `25632780594`
+- 실패 지점: app notarization
+- 관련 script: `scripts/release.sh`
+- 관련 function: `submit_for_notarization`, `print_notary_log`
+
+### 재현 조건
+
+`xcrun notarytool submit --wait --output-format json` 실행 결과를 제출 성공 여부만으로 판단하고, JSON의 `status`가 `Accepted`인지 별도로 확인하지 않는다. submission id가 있는데도 `notarytool log`를 출력하지 않으면 원인 진단이 늦어진다.
+
+### 원인
+
+notary command exit code와 notarization status를 분리해 처리하지 않았고, rejection/invalid 상태에서 notary log를 가져오는 진단 경로가 부족했다.
+
+### 수정
+
+`scripts/release.sh`에서 다음을 보강했다.
+
+- notary result JSON에서 `id`와 `status` 추출
+- status가 `Accepted`가 아니면 JSON 출력
+- submission id가 있으면 `xcrun notarytool log` 출력
+- app bundle과 DMG notarization에 같은 helper 사용
+
+### 예방책
+
+- notary submit은 command success와 `status=Accepted`를 모두 확인한다.
+- `Invalid` 또는 `Rejected`면 stapling 전에 실패시킨다.
+- release report에는 command, 대상 artifact, status, log 요약을 기록하되 credential 원문은 기록하지 않는다.
+
+## 6. Sparkle nested component signing/timestamp 누락
+
+### 증상
+
+app notarization이 Sparkle nested XPC/Updater/Autoupdate 서명 문제로 실패한다.
+
+대표 판단:
+
+- 실패 run: `25633064531`
+- 실패 지점: app notarization
+- 관련 framework: `Sparkle.framework`
+- 관련 function: `sign_sparkle_components_for_notarization`
+
+### 재현 조건
+
+App bundle 안에 포함된 Sparkle framework의 nested component가 ad-hoc signature 상태이거나 Developer ID timestamp가 없는 상태로 notarization에 제출된다.
+
+주요 대상:
+
+- `Sparkle.framework/Versions/B/XPCServices/Downloader.xpc`
+- `Sparkle.framework/Versions/B/XPCServices/Installer.xpc`
+- `Sparkle.framework/Versions/B/Updater.app`
+- `Sparkle.framework/Versions/B/Autoupdate`
+
+### 원인
+
+Host app 자체만 Developer ID로 서명해도 nested component가 notarization 요구조건을 만족한다는 보장은 없다. Sparkle framework 내부 실행 구성요소는 별도로 서명 상태를 확인해야 한다.
+
+### 수정
+
+`scripts/release.sh`가 Sparkle nested component를 Developer ID/timestamp로 재서명한 뒤 Sparkle framework와 app bundle을 다시 seal하도록 보정했다.
+
+### 예방책
+
+- Sparkle 버전 업데이트 후 framework 내부 version directory와 nested component 경로를 재확인한다.
+- notary preflight가 도입되면 nested component 서명, timestamp, hardened runtime 상태를 제출 전에 fail-fast로 확인한다.
+- Sparkle framework 내부 경로가 `Versions/B`에 고정되어 있는 점은 [#219](https://github.com/postmelee/alhangeul-macos/issues/219)에서 discovery 기반 처리로 개선할 후보다.
+
+## 7. Quick Look/Thumbnail extension entitlement/timestamp 문제
+
+### 증상
+
+app notarization이 Quick Look 또는 Thumbnail extension의 entitlement/timestamp 문제로 실패한다.
+
+대표 판단:
+
+- 실패 run: `25633267598`
+- 실패 지점: app notarization
+- 관련 bundles: `AlhangeulPreview.appex`, `AlhangeulThumbnail.appex`
+- 대표 문제: `get-task-allow`, timestamp 없음
+- 관련 function: `sign_app_extension_for_notarization`
+
+### 재현 조건
+
+Release app bundle에 포함된 app extension이 debug entitlement를 유지하거나, Developer ID timestamp가 없는 signature 상태로 notarization에 제출된다.
+
+### 원인
+
+App extension은 host app과 별도 bundle이므로 release용 entitlements로 별도 서명해야 한다. Debug build 또는 개발용 signing metadata가 보존되면 notarization 요구조건과 충돌할 수 있다.
+
+### 수정
+
+`scripts/release.sh`에서 Quick Look/Thumbnail extension을 배포용 entitlements로 재서명하도록 보정했다.
+
+현재 기준:
+
+- `Sources/QLExtension/QLExtension.entitlements`
+- `Sources/ThumbnailExtension/ThumbnailExtension.entitlements`
+- bundle id placeholder는 release signing 시 실제 bundle id로 확장
+- extension 재서명 후 host app bundle 재서명
+
+### 예방책
+
+- release artifact에는 `get-task-allow`가 남아 있으면 안 된다.
+- `codesign --verify --strict`로 extension bundle 단독 검증을 수행한다.
+- notarization submit 전 preflight validator가 도입되면 host app, extension, Sparkle nested executable을 모두 확인한다. 이 개선은 [#219](https://github.com/postmelee/alhangeul-macos/issues/219) 범위다.
+
+## 다음 release 전 checklist
+
+- [ ] `gh` CLI를 사용하는 workflow step에 `GH_TOKEN`이 전달되는지 확인
+- [ ] certificate import helper stdout에 GitHub Actions output으로 사용할 값만 남는지 확인
+- [ ] release/rehearsal/PR CI runner에서 `cbindgen` 설치 또는 presence 확인
+- [ ] `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1` 사용 여부와 사용 이유를 release report에 기록
+- [ ] staticlib hash skip을 써도 source lock, Cargo lock, generated header, FFI symbol 검증은 유지되는지 확인
+- [ ] notary submit result JSON의 `status`가 `Accepted`인지 확인
+- [ ] notarization 실패 시 submission id로 `notarytool log`를 출력하는지 확인
+- [ ] Sparkle nested XPC/Updater/Autoupdate가 Developer ID/timestamp로 서명되는지 확인
+- [ ] Quick Look/Thumbnail extension에 `get-task-allow`가 남지 않는지 확인
+- [ ] app extension 단독 `codesign --verify --strict` 검증을 수행
+
+## 후속 이슈
+
+| 이슈 | 연결 이유 |
+|------|-----------|
+| [#219](https://github.com/postmelee/alhangeul-macos/issues/219) | signing/notarization preflight validator로 Sparkle nested component, app extension entitlement, timestamp 문제를 제출 전에 fail-fast 처리 |
+| [#220](https://github.com/postmelee/alhangeul-macos/issues/220) | Rust staticlib hash 재현성 검증 정책과 skip 허용 조건 정리 |
+| [#227](https://github.com/postmelee/alhangeul-macos/issues/227) | Rust bridge staticlib artifact 검증 정책과 PR CI/release workflow 보장 범위 재정의 |
+
+## 적용하지 않은 범위
+
+- release script 기능 변경
+- release workflow YAML 변경
+- notarization submit 또는 signing 실행
+- GitHub Release 게시
+- Pages deployment
+- Homebrew tap 배포
+- staticlib hash 장기 정책 확정
+
+이 문서는 `#188`에서 실제 발생한 release workflow 실패를 진단하기 위한 기록이다. 장기 정책 또는 자동 preflight 구현은 후속 이슈에서 다룬다.

--- a/mydocs/working/task_m019_218_stage1.md
+++ b/mydocs/working/task_m019_218_stage1.md
@@ -1,0 +1,160 @@
+# Task M019 #218 Stage 1 완료 보고서
+
+## 단계 목적
+
+`#188` `v0.1.1` public release 실행 중 발생한 workflow/signing/notarization/staticlib 실패 사례를 inventory로 정리하고, Stage 2 troubleshooting 문서의 구조와 제외 범위를 확정한다.
+
+확인 시각: `2026-05-11 KST`
+
+## 확인한 자료
+
+| 자료 | 확인 내용 |
+|------|-----------|
+| `mydocs/working/task_m018_188_stage4.md` | `v0.1.1` public release workflow 실패 run, 실패 지점, 원인, 보정 내역 |
+| `mydocs/report/task_m018_188_report.md` | 최종 public release build `4`, release workflow success, 잔여 위험 |
+| `mydocs/manual/release_distribution_guide.md` | release 작업 진입점, troubleshooting 분리 기준, 전체 release flow |
+| `mydocs/manual/release_signing_notarization_guide.md` | secret 기록 금지 원칙, signing/notarization 실패 시 분리 기준 |
+| `.github/workflows/release-publish.yml` | `GH_TOKEN`, `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY`, `cbindgen`, certificate import, Sparkle appcast 관련 현재 workflow 경로 |
+| `.github/workflows/release-rehearsal.yml`, `.github/workflows/pr-ci.yml` | `cbindgen` 설치와 staticlib hash skip 예외가 release/rehearsal/PR CI에 반영된 상태 |
+| `scripts/ci/import-developer-id-certificate.sh` | Developer ID `.p12` import helper가 `security` 출력을 stderr로 보내고 keychain path만 stdout에 남기는 현재 구조 |
+| `scripts/build-rust-macos.sh` | `cbindgen` 요구, `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY` 처리, FFI symbol/header 검증 유지 |
+| `scripts/release.sh` | Sparkle nested component signing, app extension entitlement signing, notary status/log 출력 경로 |
+
+## 문서화 대상 실패 사례
+
+Stage 2 troubleshooting 문서는 아래 7개 사례를 같은 구조로 정리한다.
+
+| 순서 | run | 실패 지점 | 문서화할 핵심 |
+|------|-----|-----------|---------------|
+| 1 | `25632437884` | upstream latest rhwp release 확인 | workflow에서 `GH_TOKEN`이 빠지면 `gh` 인증 기반 조회가 실패한다. release workflow에는 `GH_TOKEN: ${{ github.token }}`이 필요하다. |
+| 2 | `25632495693` | Developer ID certificate import | helper stdout에 `security` 출력이 섞이면 `$GITHUB_OUTPUT` format 오류가 난다. GitHub Actions output으로 사용할 값만 stdout에 남기고 나머지는 stderr로 보내야 한다. |
+| 3 | `25632545387` | rhwp lock verify | GitHub macOS runner에 `cbindgen`이 없으면 Rust bridge header generation/lock verify가 실패한다. release/rehearsal/PR CI에서 필요 시 `brew install cbindgen`을 수행한다. |
+| 4 | `25632598126` | rhwp staticlib hash verify | CI runner/toolchain 차이로 `Frameworks/universal/librhwp.a` byte-for-byte hash/size가 lock과 달라질 수 있다. 당시에는 staticlib byte hash만 제한적으로 skip하고 source lock, Cargo lock, generated header, FFI symbol 검증은 유지했다. |
+| 5 | `25632780594` | app notarization | notary status `Invalid` 뒤 상세 log 없이 stapling으로 진행하면 원인 진단이 어렵다. notary JSON status를 파싱하고 submission log를 출력해야 한다. |
+| 6 | `25633064531` | app notarization | Sparkle nested XPC/Updater/Autoupdate가 ad-hoc signature 또는 timestamp 없는 상태이면 notarization에서 거부될 수 있다. nested component를 Developer ID/timestamp로 재서명해야 한다. |
+| 7 | `25633267598` | app notarization | Quick Look/Thumbnail extension에 debug entitlement인 `get-task-allow`가 남거나 timestamp가 없으면 notarization에서 거부될 수 있다. 배포용 entitlements로 app extension을 재서명해야 한다. |
+
+## Stage 2 문서 구조
+
+신규 문서 파일명은 `mydocs/troubleshootings/release_v0_1_1_workflow_failures.md`로 둔다.
+
+문서 구조:
+
+1. 대상 release와 참조 자료
+   - 이슈: `#188`, `#218`
+   - 참조: `mydocs/working/task_m018_188_stage4.md`, `mydocs/report/task_m018_188_report.md`
+   - 최종 public release 결과: `v0.1.1` build `4`, workflow `25645869039`
+2. 전체 실패 흐름 요약 표
+   - run, 실패 지점, 대표 증상, 적용된 보정
+3. 사례별 진단 항목
+   - 증상
+   - 재현 조건
+   - 원인
+   - 수정
+   - 예방책
+4. 다음 release 전 checklist
+   - workflow env/auth
+   - certificate import output
+   - `cbindgen` availability
+   - staticlib hash skip 예외 사용 여부
+   - notary log 출력
+   - Sparkle nested signing
+   - app extension release entitlement
+5. 후속 이슈 연결
+   - `#219`: signing/notarization preflight validator
+   - `#220`: Rust staticlib hash 재현성 검증 정책
+   - `#227`: Rust bridge staticlib artifact 검증 정책 재정의
+
+## 민감 정보 제외 기준
+
+문서에 기록하지 않는 값:
+
+- Apple ID password
+- app-specific password
+- App Store Connect API private key
+- exported signing identity `.p12` payload와 password
+- Keychain credential payload
+- Sparkle EdDSA private key
+- GitHub token 값
+- notarization credential 원문
+
+문서화 가능한 값:
+
+- workflow variable/secret 이름
+- secret 값이 아닌 환경 변수 이름
+- run 번호와 실패 step 이름
+- public GitHub Actions run URL
+- script/function 이름
+- 비밀이 아닌 signing/notary 운영 식별자 위치(`release_environment.md` 참조)
+
+## 제외 범위
+
+다음 항목은 Stage 2 troubleshooting 문서에 주 사례로 넣지 않는다.
+
+- `v0.1.1` build `2` 배포 후 확인된 Quick Look/Thumbnail extension render crash
+  - 이유: release workflow 실패가 아니라 설치본 smoke 이후 발견된 제품 동작 문제다.
+  - 관련 최종 조치는 `#188` Stage 6-9와 최종 보고서에 남아 있다.
+- `v0.1.0` 또는 original `v0.1.1`에서 Sparkle 업데이트한 사용자의 Finder thumbnail cache 잔존
+  - 이유: release workflow 실패가 아니라 업데이트 후 Finder cache/extension refresh UX 문제다.
+  - 후속 이슈는 `#225`다.
+- Homebrew tap 공개, `brew style`, `brew audit`, tap install smoke
+  - 이유: `#209` 범위다.
+- staticlib hash 장기 정책 확정
+  - 이유: `#220`과 `#227` 범위다. 본 문서는 `#188` 당시의 제한적 예외와 검증 유지 범위만 설명한다.
+- preflight validator 구현
+  - 이유: `#219` 범위다.
+
+## release manual 연결 위치
+
+Stage 3에서 다음 위치에 짧은 링크를 추가하는 방향으로 정리한다.
+
+- `release_distribution_guide.md`
+  - 하위 매뉴얼 표 또는 `현재 release 자산` 근처에 release troubleshooting 문서 진입점을 추가한다.
+  - Rollback의 “원인, 영향 범위, 재발 방지책을 `mydocs/troubleshootings/`에 기록한다” 기준과 연결한다.
+- `release_signing_notarization_guide.md`
+  - `실패 시 분리 기준`에 signing/notarization 실패 사례 문서 링크를 추가한다.
+  - 사례 본문은 복제하지 않는다.
+
+## 현재 코드 기준 대조
+
+| 항목 | 현재 코드 위치 | Stage 2 문서 반영 방식 |
+|------|----------------|------------------------|
+| `GH_TOKEN` | `.github/workflows/release-publish.yml` env | release workflow에서 `gh` 사용 시 인증 env가 필요하다고 기록 |
+| Developer ID import helper | `scripts/ci/import-developer-id-certificate.sh` | stdout은 keychain path만, `security` 출력은 stderr로 보내야 한다고 기록 |
+| `cbindgen` | `scripts/build-rust-macos.sh`, workflow install step | runner에 없을 수 있으므로 workflow가 설치해야 한다고 기록 |
+| staticlib skip | `scripts/build-rust-macos.sh`, workflow env | `librhwp.a` byte hash만 skip하고 header/symbol/source lock 검증은 유지한다고 기록 |
+| notary log | `scripts/release.sh` `submit_for_notarization`, `print_notary_log` | invalid/not accepted 상태에서는 JSON과 notary log를 남겨야 한다고 기록 |
+| Sparkle nested signing | `scripts/release.sh` `sign_sparkle_components_for_notarization` | nested XPC/Updater/Autoupdate를 Developer ID로 재서명한다고 기록 |
+| app extension entitlements | `scripts/release.sh` `sign_app_extension_for_notarization` | Quick Look/Thumbnail appex를 배포용 entitlements로 재서명한다고 기록 |
+
+## 검증 결과
+
+```bash
+rg -n "25632437884|25632495693|25632545387|25632598126|25632780594|25633064531|25633267598|GH_TOKEN|cbindgen|staticlib|Sparkle nested|get-task-allow" \
+  mydocs/working/task_m018_188_stage4.md mydocs/report/task_m018_188_report.md
+```
+
+결과: Stage 4 보고서에서 7개 실패 run과 핵심 원인을 확인했다.
+
+```bash
+rg -n "troubleshooting|문제|notarization|Developer ID|Sparkle|staticlib" \
+  mydocs/manual/release_distribution_guide.md mydocs/manual/release_signing_notarization_guide.md
+```
+
+결과: release distribution guide에는 troubleshooting 분리 기준과 rollback 기록 기준이 있고, signing/notarization guide에는 실패 시 분리 기준이 있다. Stage 3에서 짧은 링크를 추가할 위치가 확인됐다.
+
+```bash
+git diff --check -- mydocs/working/task_m019_218_stage1.md
+```
+
+결과: 통과.
+
+## 변경 파일
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/working/task_m019_218_stage1.md` | 실패 사례 inventory, Stage 2 문서 구조, 제외 범위, manual 연결 위치 확정 |
+
+## 다음 단계
+
+Stage 2에서는 `mydocs/troubleshootings/release_v0_1_1_workflow_failures.md`를 작성한다. release manual 연결은 Stage 3에서 수행한다.

--- a/mydocs/working/task_m019_218_stage2.md
+++ b/mydocs/working/task_m019_218_stage2.md
@@ -1,0 +1,71 @@
+# Task M019 #218 Stage 2 완료 보고서
+
+## 단계 목적
+
+`mydocs/troubleshootings/release_v0_1_1_workflow_failures.md`를 추가해 `v0.1.1` release workflow 실패 사례를 운영 문서로 정리한다.
+
+확인 시각: `2026-05-11 KST`
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/troubleshootings/release_v0_1_1_workflow_failures.md` | `#188` release workflow 실패 7건의 증상, 재현 조건, 원인, 수정, 예방책 정리 |
+| `mydocs/working/task_m019_218_stage2.md` | Stage 2 완료 보고서 |
+| `mydocs/orders/20260511.md` | `#218` 상태 비고를 Stage 2 완료 보고서 승인 대기로 갱신 |
+
+## 문서화한 실패 사례
+
+| 항목 | 내용 |
+|------|------|
+| `GH_TOKEN` 누락 | `gh` CLI를 사용하는 release workflow에서 `GH_TOKEN: ${{ github.token }}` 전달 필요 |
+| Developer ID certificate import | `$GITHUB_OUTPUT`에 쓸 helper stdout은 keychain path 하나만 남기고 `security` 출력은 stderr로 분리 |
+| `cbindgen` 누락 | GitHub macOS runner에 `cbindgen`이 없을 수 있으므로 workflow에서 필요 시 설치 |
+| `librhwp.a` staticlib hash mismatch | `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`은 staticlib byte hash만 제한적으로 skip하고 source/header/symbol 검증은 유지 |
+| notarization log 부족 | notary JSON status와 submission log를 출력해 `Invalid` 상태 원인을 진단 |
+| Sparkle nested signing | XPC/Updater/Autoupdate nested component를 Developer ID/timestamp로 재서명 |
+| app extension entitlement | Quick Look/Thumbnail extension의 `get-task-allow` 제거와 배포용 entitlements 재서명 |
+
+## 후속 이슈 연결
+
+| 이슈 | 연결 |
+|------|------|
+| `#219` | signing/notarization preflight validator |
+| `#220` | Rust staticlib hash 재현성 검증 정책 |
+| `#227` | Rust bridge staticlib artifact 검증 정책 재정의 |
+
+## 제외한 작업
+
+- release script 기능 변경
+- release workflow YAML 변경
+- notarization submit, signing, GitHub Release 게시, Pages deployment
+- Homebrew tap 배포
+- staticlib hash 장기 정책 확정
+- release manual 링크 추가
+
+release manual 링크 추가는 구현계획서대로 Stage 3에서 수행한다.
+
+## 검증 결과
+
+```bash
+test -f mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+```
+
+결과: 통과.
+
+```bash
+rg -n "GH_TOKEN|Developer ID|GITHUB_OUTPUT|cbindgen|librhwp.a|ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY|notarization|Sparkle|get-task-allow|entitlement|#219|#220|#227" \
+  mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+```
+
+결과: 주요 실패 사례, 제한적 staticlib skip 예외, 후속 이슈 연결을 모두 확인했다.
+
+```bash
+git diff --check -- mydocs/troubleshootings/release_v0_1_1_workflow_failures.md mydocs/working/task_m019_218_stage2.md mydocs/orders/20260511.md
+```
+
+결과: 통과.
+
+## 다음 단계
+
+Stage 3에서는 `release_distribution_guide.md`와 필요 시 `release_signing_notarization_guide.md`에서 이번 troubleshooting 문서로 연결한다. 사례 본문은 manual에 복제하지 않는다.

--- a/mydocs/working/task_m019_218_stage3.md
+++ b/mydocs/working/task_m019_218_stage3.md
@@ -1,0 +1,58 @@
+# Task M019 #218 Stage 3 완료 보고서
+
+## 단계 목적
+
+release manual에서 `v0.1.1` release workflow 실패 사례 troubleshooting 문서로 진입할 수 있게 연결한다.
+
+확인 시각: `2026-05-11 KST`
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/manual/release_distribution_guide.md` | 문제 해결 기록 섹션을 추가하고 `release_v0_1_1_workflow_failures.md` 링크 제공 |
+| `mydocs/manual/release_signing_notarization_guide.md` | signing/notarization 실패 시 `v0.1.1` release workflow 실패 사례 문서 참조 추가 |
+| `mydocs/working/task_m019_218_stage3.md` | Stage 3 완료 보고서 |
+| `mydocs/orders/20260511.md` | `#218` 상태 비고를 Stage 3 완료 보고서 승인 대기로 갱신 |
+
+## 변경 내용
+
+`release_distribution_guide.md`에는 troubleshooting 문서의 위치와 읽는 시점을 짧게 추가했다. 기존 release 매뉴얼 본문에는 실패 사례 세부 내용을 복제하지 않았다.
+
+`release_signing_notarization_guide.md`에는 Sparkle nested component signing, app extension entitlement, notary log 부족이 의심될 때 `release_v0_1_1_workflow_failures.md`를 함께 확인하도록 링크만 추가했다.
+
+## 정책 충돌 점검
+
+| 항목 | 결과 |
+|------|------|
+| release 실행 권한 원칙 | 변경 없음 |
+| signing/notarization credential 기록 금지 | 변경 없음 |
+| troubleshooting 문서 분리 기준 | 유지, 특정 사례 문서 링크만 추가 |
+| staticlib hash 장기 정책 | `#220`, `#227`로 남김 |
+| preflight validator 구현 | `#219`로 남김 |
+
+## 검증 결과
+
+```bash
+rg -n "release_v0_1_1_workflow_failures|v0.1.1 release workflow|troubleshooting|실패 사례|문제 해결" \
+  mydocs/manual/release_distribution_guide.md mydocs/manual/release_signing_notarization_guide.md mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+```
+
+결과: release distribution guide, signing/notarization guide, troubleshooting 문서에서 연결 키워드를 확인했다.
+
+```bash
+rg -n "#220|#227|staticlib|ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY" \
+  mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+```
+
+결과: staticlib hash 예외는 `#220`, `#227` 후속 정책 의존성으로 남아 있음을 확인했다.
+
+```bash
+git diff --check -- mydocs/manual/release_distribution_guide.md mydocs/manual/release_signing_notarization_guide.md mydocs/working/task_m019_218_stage3.md mydocs/orders/20260511.md
+```
+
+결과: 통과.
+
+## 다음 단계
+
+Stage 4에서는 전체 문서 변경을 최종 검증하고, 오늘할일 완료 처리와 최종 보고서를 작성한다.

--- a/mydocs/working/task_m019_218_stage4.md
+++ b/mydocs/working/task_m019_218_stage4.md
@@ -1,0 +1,66 @@
+# Task M019 #218 Stage 4 완료 보고서
+
+## 단계 목적
+
+`#218` 전체 문서 변경을 최종 검증하고, 오늘할일과 최종 결과 보고서를 정리한다.
+
+확인 시각: `2026-05-11 13:30 KST`
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/troubleshootings/release_v0_1_1_workflow_failures.md` | `v0.1.1` release workflow 실패 사례 troubleshooting 문서 |
+| `mydocs/manual/release_distribution_guide.md` | release troubleshooting 문서 진입점 추가 |
+| `mydocs/manual/release_signing_notarization_guide.md` | signing/notarization 실패 시 troubleshooting 문서 참조 추가 |
+| `mydocs/report/task_m019_218_report.md` | 최종 결과 보고서 |
+| `mydocs/working/task_m019_218_stage4.md` | Stage 4 완료 보고서 |
+| `mydocs/orders/20260511.md` | `#218` 완료 처리 |
+
+## 최종 검증 내용
+
+| 검증 | 결과 |
+|------|------|
+| troubleshooting 문서 존재 | OK |
+| 핵심 실패 키워드 확인 | OK, `GH_TOKEN`, `GITHUB_OUTPUT`, `cbindgen`, `librhwp.a`, `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY`, `notarization`, `Sparkle`, `get-task-allow` 확인 |
+| release manual 링크 확인 | OK, release distribution/signing guide에서 troubleshooting 문서 링크 확인 |
+| 후속 이슈 연결 확인 | OK, `#219`, `#220`, `#227` 연결 확인 |
+| staticlib hash 장기 정책 경계 | OK, 본 문서는 `#188` 당시 제한적 예외만 설명하고 최종 정책은 `#220`/`#227`로 남김 |
+| release 실행 여부 | OK, release workflow, signing, notarization, GitHub Release, Pages deployment, Homebrew tap 작업 모두 미실행 |
+
+## 실행한 검증 명령
+
+```bash
+test -f mydocs/troubleshootings/release_v0_1_1_workflow_failures.md
+```
+
+```bash
+test -f mydocs/report/task_m019_218_report.md
+```
+
+```bash
+rg -n "GH_TOKEN|Developer ID|GITHUB_OUTPUT|cbindgen|librhwp.a|ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY|notarization|Sparkle|get-task-allow|#219|#220|#227" \
+  mydocs/troubleshootings/release_v0_1_1_workflow_failures.md mydocs/report/task_m019_218_report.md
+```
+
+```bash
+rg -n "release_v0_1_1_workflow_failures|v0.1.1 release workflow|실패 사례" \
+  mydocs/manual/release_distribution_guide.md mydocs/manual/release_signing_notarization_guide.md
+```
+
+```bash
+git diff --check
+git status --short
+```
+
+## 변경하지 않은 항목
+
+- release script 기능 변경 없음
+- release workflow YAML 변경 없음
+- notarization submit, signing, GitHub Release 게시, Pages deployment 없음
+- Homebrew tap 배포 없음
+- staticlib hash 장기 정책 확정 없음
+
+## 다음 단계
+
+이 Stage 4 보고서와 최종 결과 보고서 승인 후 `#218` PR 게시 절차로 넘어갈 수 있다.


### PR DESCRIPTION
## 요약

- 대상 타스크: #218 `v0.1.1` release workflow 실패 사례 troubleshooting 문서화
- 왜: `#188` Stage 4 보고서에 흩어진 release workflow 실패 기록을 장기 운영자가 재사용할 수 있는 진단 문서로 분리했습니다.
- 무엇: `GH_TOKEN`, `$GITHUB_OUTPUT`, `cbindgen`, `librhwp.a` hash mismatch, notarization log, Sparkle nested signing, extension entitlement 실패 사례를 증상/원인/수정/예방책으로 정리했습니다.
- 리뷰 포인트: release manual에는 사례를 복제하지 않고 troubleshooting 문서 링크만 둔 점, staticlib 장기 정책을 #220/#227로 남긴 점을 봐주세요.

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/9611b467fb217ef6cdfed65f8aaef86102c81f0a/mydocs/working/task_m019_218_stage1.md)** ([a12264a](https://github.com/postmelee/alhangeul-macos/commit/a12264a0f8f7564672cd70f06f4900fece6d02f6)): `#188` release 실패 7건 inventory와 문서 구조 확정
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/9611b467fb217ef6cdfed65f8aaef86102c81f0a/mydocs/working/task_m019_218_stage2.md)** ([416268b](https://github.com/postmelee/alhangeul-macos/commit/416268b0d3372b8e53ba120929d42a59438fe86a)): `v0.1.1` release workflow 실패 사례 troubleshooting 문서 추가
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/9611b467fb217ef6cdfed65f8aaef86102c81f0a/mydocs/working/task_m019_218_stage3.md)** ([4b43861](https://github.com/postmelee/alhangeul-macos/commit/4b43861d19898cec94e2860eb57ddcaf703d2248)): release distribution/signing manual에서 troubleshooting 문서로 연결
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/9611b467fb217ef6cdfed65f8aaef86102c81f0a/mydocs/working/task_m019_218_stage4.md)** ([9611b46](https://github.com/postmelee/alhangeul-macos/commit/9611b467fb217ef6cdfed65f8aaef86102c81f0a)): 최종 검증, 오늘할일 완료 처리, 최종 보고서 작성

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| Troubleshooting | `release_v0_1_1_workflow_failures.md` 신규 추가 | 실패 사례가 운영 진단 문서로 충분히 찾기 쉬운지 |
| Release manuals | release distribution/signing guide에 링크 추가 | manual 본문에 사례를 과도하게 복제하지 않았는지 |
| Task docs | 수행/구현계획서, 단계 보고서, 최종 보고서 작성 | 하이퍼-워터폴 산출물 누락 여부 |

- 수행 계획서: [task_m019_218.md](https://github.com/postmelee/alhangeul-macos/blob/9611b467fb217ef6cdfed65f8aaef86102c81f0a/mydocs/plans/task_m019_218.md)
- 구현 계획서: [task_m019_218_impl.md](https://github.com/postmelee/alhangeul-macos/blob/9611b467fb217ef6cdfed65f8aaef86102c81f0a/mydocs/plans/task_m019_218_impl.md)
- 최종 보고서: [task_m019_218_report.md](https://github.com/postmelee/alhangeul-macos/blob/9611b467fb217ef6cdfed65f8aaef86102c81f0a/mydocs/report/task_m019_218_report.md)

## 핵심 리뷰 포인트

- `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`은 `#188` 당시의 제한적 예외로만 설명하고, 장기 검증 정책은 #220/#227로 남겼습니다.
- signing/notarization preflight 구현은 #219로 남기고, 이번 PR은 문서화와 manual 연결만 수행했습니다.
- secret 값이나 credential payload는 기록하지 않고, workflow env/secret 이름과 public run 번호만 문서화했습니다.

## 검증

- `test -f mydocs/troubleshootings/release_v0_1_1_workflow_failures.md`
- `test -f mydocs/report/task_m019_218_report.md`
- `rg -n "GH_TOKEN|Developer ID|GITHUB_OUTPUT|cbindgen|librhwp.a|ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY|notarization|Sparkle|get-task-allow|#219|#220|#227" mydocs/troubleshootings/release_v0_1_1_workflow_failures.md mydocs/report/task_m019_218_report.md`
- `rg -n "release_v0_1_1_workflow_failures|v0.1.1 release workflow|실패 사례" mydocs/manual/release_distribution_guide.md mydocs/manual/release_signing_notarization_guide.md`
- `git diff --check`

## 관련 이슈

- #188: `v0.1.1` public release 실행과 실패 사례 원본
- #219: signing/notarization preflight validator 후속
- #220: Rust staticlib hash 재현성 검증 정책 후속
- #227: Rust bridge staticlib artifact 검증 정책 후속

## 후속 이슈 제안

- 없음. 관련 후속은 #219, #220, #227로 이미 등록되어 있습니다.

## 남은 리스크

- 본 PR은 troubleshooting 문서화만 수행했으며, 새 release run의 실제 성공을 보장하지 않습니다.
- staticlib hash skip 허용 조건과 장기 검증 기준은 #220/#227 결과를 따라 후속 보정될 수 있습니다.
