### PR TITLE
Task #219: signing/notarization preflight validator 강화

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -249,6 +249,19 @@ jobs:
             echo "- Source provenance, Cargo lock, generated header, and FFI symbol checks still run."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Record signing preflight policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Signing preflight policy"
+            echo
+            echo "- release command: \`./scripts/release.sh \"$VERSION\"\`"
+            echo "- Expected Team ID: \`${APPLE_TEAM_ID:-XH6JHKYXV8}\`"
+            echo "- Before app notarization submit, \`release.sh\` verifies Developer ID authority, Team ID, secure timestamp, hardened runtime, \`get-task-allow\` absence, and required Sparkle nested components."
+            echo "- Failure in this preflight blocks notarization submit."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Verify rhwp source, header, and ABI lock
         shell: bash
         run: |

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -145,6 +145,19 @@ jobs:
             echo "- Source provenance, Cargo lock, generated header, and FFI symbol checks still run."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Record signing preflight policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "## Signing preflight policy"
+            echo
+            echo "- release command: \`./scripts/release.sh --skip-notarize \"$VERSION\"\`"
+            echo "- Default rehearsal artifacts are unsigned and skip Developer ID signing preflight."
+            echo "- If \`ALHANGEUL_DEVELOPER_ID_APPLICATION\` is provided, \`release.sh\` runs the same app/extension/Sparkle signing preflight before DMG creation."
+            echo "- Rehearsal artifacts are never public release or Homebrew Cask inputs."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Verify rhwp source, header, and ABI lock
         shell: bash
         run: |

--- a/mydocs/manual/release_distribution_guide.md
+++ b/mydocs/manual/release_distribution_guide.md
@@ -39,7 +39,7 @@
 ## 현재 release 자산
 
 - `scripts/package-release.sh`: Release configuration 개발/검증용 zip 생성
-- `scripts/release.sh`: public DMG 생성, Developer ID 서명, notarization, staple, Gatekeeper 검증, sha256 생성
+- `scripts/release.sh`: public DMG 생성, Developer ID 서명, app notarization 전 signing preflight, notarization, staple, Gatekeeper 검증, sha256 생성
 - `scripts/ci/write-release-notes.sh`: GitHub Release 본문 후보 생성
 - `scripts/ci/check-release-notes-template.sh`: release note 필수 heading 검증
 - `scripts/ci/verify-universal-macos-app.sh`: app bundle 내부 앱/extension 실행 파일의 `arm64 + x86_64` slice 검증
@@ -101,6 +101,7 @@
 - [ ] 개발용 zip 산출물 생성
 - [ ] public DMG 산출물 생성
 - [ ] public DMG 안의 app/extension 실행 파일 `arm64 + x86_64` universal 검증
+- [ ] app notarization submit 전 signing preflight 통과: Developer ID, Team ID, timestamp, hardened runtime, `get-task-allow` 부재, Sparkle nested component 존재 확인
 - [ ] public DMG 안의 app bundle `Contents/Info.plist`에 `NSHumanReadableCopyright`가 포함되어 있고 현재 release 저작권자 문구와 일치하는지 확인
 - [ ] public DMG 안의 app bundle `Contents/Resources/Legal/{LICENSE,THIRD_PARTY_LICENSES.md,FONTS.md}` 존재 확인
 - [ ] public DMG 안의 app bundle `Contents/Resources/Legal/*` 파일이 release candidate commit의 canonical `LICENSE`, `THIRD_PARTY_LICENSES.md`, `Sources/HostApp/Resources/rhwp-studio/fonts/FONTS.md`와 같은지 확인

--- a/mydocs/manual/release_packaging_dmg_guide.md
+++ b/mydocs/manual/release_packaging_dmg_guide.md
@@ -119,10 +119,12 @@ ALHANGEUL_NOTARY_PROFILE="<notarytool keychain profile>" \
 
 ```text
 ALHANGEUL_DEVELOPER_ID_DMG
+APPLE_TEAM_ID
 ALHANGEUL_BUILD_ROOT
 ```
 
 `ALHANGEUL_DEVELOPER_ID_DMG`를 지정하지 않으면 `ALHANGEUL_DEVELOPER_ID_APPLICATION`과 같은 identity로 DMG를 서명한다.
+`APPLE_TEAM_ID`는 release signing preflight의 expected Team ID다. 지정하지 않으면 `XH6JHKYXV8`을 사용한다.
 
 public mode 산출물:
 
@@ -140,7 +142,9 @@ build.noindex/release/alhangeul-macos-<version>.dmg.sha256
 - Release configuration으로 HostApp 빌드
 - `Alhangeul.app`, `AlhangeulPreview.appex`, `AlhangeulThumbnail.appex` 실행 파일의 `arm64 + x86_64` universal 검증
 - Developer ID Application signing identity 확인
+- Sparkle nested component, Quick Look extension, Thumbnail extension, app bundle을 Developer ID/timestamp/hardened runtime 기준으로 재서명
 - app code signature 검증
+- app notarization submit 전 release signing preflight 실행
 - app notarization submit/wait
 - app staple
 - DMG 생성
@@ -182,6 +186,7 @@ rehearsal mode가 수행하는 일:
 - shared Swift boundary check
 - Release build
 - app/extension 실행 파일의 `arm64 + x86_64` universal 검증
+- `ALHANGEUL_DEVELOPER_ID_APPLICATION`이 제공된 signed rehearsal이면 app notarization submit 전과 같은 release signing preflight 실행
 - DMG layout 생성
 - DMG layout smoke 입력 산출물 생성
 - `hdiutil verify`
@@ -200,6 +205,7 @@ rehearsal mode가 수행하지 않는 일:
 - `*-rehearsal.dmg.sha256`은 Homebrew Cask `sha256`에 사용하지 않는다.
 - unsigned rehearsal build는 Finder Quick Look/Thumbnail 등록 보증에 쓰지 않는다.
 - signed/notarized public DMG 검증은 rehearsal 결과로 대체하지 않는다.
+- unsigned rehearsal에서 signing preflight가 skip된 경우, 결과를 public signing/notarization prerequisite 통과로 기록하지 않는다.
 - rehearsal DMG에서 background와 icon 위치가 정상이어도 public DMG signing/notarization/staple 후 최종 layout smoke를 반복한다.
 
 GitHub Actions `Release Rehearsal DMG` workflow를 사용할 때도 같은 산출물 계층을 따른다.

--- a/mydocs/manual/release_signing_notarization_guide.md
+++ b/mydocs/manual/release_signing_notarization_guide.md
@@ -55,10 +55,50 @@ ALHANGEUL_NOTARY_PROFILE="<notarytool keychain profile>" \
 
 ```text
 ALHANGEUL_DEVELOPER_ID_DMG
+APPLE_TEAM_ID
 ALHANGEUL_BUILD_ROOT
 ```
 
 `ALHANGEUL_DEVELOPER_ID_DMG`를 지정하지 않으면 `ALHANGEUL_DEVELOPER_ID_APPLICATION`과 같은 identity로 DMG를 서명한다.
+`APPLE_TEAM_ID`를 지정하지 않으면 현재 운영 기준인 `XH6JHKYXV8`을 signing preflight의 expected Team ID로 사용한다.
+
+## Notarization 전 signing preflight
+
+`scripts/release.sh` public mode는 app notarization submit 전에 release signing preflight를 실행한다.
+
+검증 위치:
+
+```text
+Release build
+-> Sparkle nested component와 app/extension Developer ID 재서명
+-> universal slice 검증
+-> codesign verify
+-> release signing preflight
+-> app notarization submit
+```
+
+검증 대상:
+
+- Host app
+- Quick Look extension
+- Thumbnail extension
+- Sparkle framework
+- Sparkle `XPCServices/Downloader.xpc`
+- Sparkle `XPCServices/Installer.xpc`
+- Sparkle `Updater.app`
+- Sparkle `Autoupdate`
+
+검증 기준:
+
+- Developer ID Application authority가 `ALHANGEUL_DEVELOPER_ID_APPLICATION`과 일치
+- Team ID가 `APPLE_TEAM_ID`와 일치
+- secure timestamp 존재
+- hardened runtime 존재
+- `com.apple.security.get-task-allow`가 true가 아님
+- Host app과 app extension의 bundle identifier가 release 기준과 일치
+- Sparkle required nested component가 모두 존재
+
+`--skip-notarize` rehearsal에서 `ALHANGEUL_DEVELOPER_ID_APPLICATION`이 없으면 signing preflight는 명시 로그를 남기고 건너뛴다. Developer ID identity를 제공한 signed rehearsal에서는 notarization은 하지 않더라도 같은 signing preflight를 실행한다.
 
 ## 서명과 공증 검증 항목
 
@@ -67,6 +107,7 @@ public mode에서 확인할 항목:
 - HostApp, QLExtension, ThumbnailExtension이 모두 올바르게 서명되는가
 - extension bundle이 app bundle 안에 올바르게 embed되는가
 - sandbox entitlement가 preview/thumbnail 동작과 충돌하지 않는가
+- app notarization submit 전에 release signing preflight가 통과하는가
 - notarization 후 Gatekeeper에서 실행 가능한가
 - stapled app과 stapled DMG가 모두 검증되는가
 

--- a/mydocs/orders/20260511.md
+++ b/mydocs/orders/20260511.md
@@ -14,7 +14,7 @@
 | #205 | 앱 버전과 bundled rhwp provenance 표기 정책 정리 | 완료 | 완료: 11:59 |
 | #227 | Rust bridge staticlib artifact 검증 정책 재정의 | 완료 | 완료: 13:08, 최종 보고서 작성 |
 | #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 완료 | 완료: 13:30, 최종 보고서 승인 대기 |
-| #219 | 릴리즈 preflight validator로 signing/notarization 사전 검증 강화 | 진행중 | M019, Stage 3 완료 후 Stage 4 진행 준비 |
+| #219 | 릴리즈 preflight validator로 signing/notarization 사전 검증 강화 | 진행중 | M019, Stage 4 완료 후 Stage 5 승인 대기 |
 
 ## M020 — v0.2 Mac 통합 확장
 

--- a/mydocs/orders/20260511.md
+++ b/mydocs/orders/20260511.md
@@ -13,7 +13,7 @@
 | #223 | 그림 선택 후 Space 입력 시 WKWebView viewer runtime error 발생 | 완료 | 완료: 12:55 |
 | #205 | 앱 버전과 bundled rhwp provenance 표기 정책 정리 | 완료 | 완료: 11:59 |
 | #227 | Rust bridge staticlib artifact 검증 정책 재정의 | 완료 | 완료: 13:08, 최종 보고서 작성 |
-| #219 | 릴리즈 preflight validator로 signing/notarization 사전 검증 강화 | 진행중 | M019, 수행계획서 작성 후 승인 대기 |
+| #219 | 릴리즈 preflight validator로 signing/notarization 사전 검증 강화 | 진행중 | M019, 구현계획서 작성 후 승인 대기 |
 
 ## M020 — v0.2 Mac 통합 확장
 

--- a/mydocs/orders/20260511.md
+++ b/mydocs/orders/20260511.md
@@ -14,7 +14,7 @@
 | #205 | 앱 버전과 bundled rhwp provenance 표기 정책 정리 | 완료 | 완료: 11:59 |
 | #227 | Rust bridge staticlib artifact 검증 정책 재정의 | 완료 | 완료: 13:08, 최종 보고서 작성 |
 | #218 | v0.1.1 release workflow 실패 사례 troubleshooting 문서화 | 완료 | 완료: 13:30, 최종 보고서 승인 대기 |
-| #219 | 릴리즈 preflight validator로 signing/notarization 사전 검증 강화 | 진행중 | M019, Stage 4 완료 후 Stage 5 승인 대기 |
+| #219 | 릴리즈 preflight validator로 signing/notarization 사전 검증 강화 | 완료 | 완료: 14:16, 최종 보고서 작성 |
 
 ## M020 — v0.2 Mac 통합 확장
 

--- a/mydocs/orders/20260511.md
+++ b/mydocs/orders/20260511.md
@@ -13,6 +13,7 @@
 | #223 | 그림 선택 후 Space 입력 시 WKWebView viewer runtime error 발생 | 완료 | 완료: 12:55 |
 | #205 | 앱 버전과 bundled rhwp provenance 표기 정책 정리 | 완료 | 완료: 11:59 |
 | #227 | Rust bridge staticlib artifact 검증 정책 재정의 | 완료 | 완료: 13:08, 최종 보고서 작성 |
+| #219 | 릴리즈 preflight validator로 signing/notarization 사전 검증 강화 | 진행중 | M019, 수행계획서 작성 후 승인 대기 |
 
 ## M020 — v0.2 Mac 통합 확장
 

--- a/mydocs/plans/task_m019_219.md
+++ b/mydocs/plans/task_m019_219.md
@@ -1,0 +1,119 @@
+# Task M019 #219 수행계획서
+
+## 목적
+
+release workflow가 app notarization을 제출하기 전에 app bundle 전체의 signing/notarization prerequisites를 fail-fast로 검증하도록 보강한다.
+
+완료 후에는 Host app, Quick Look extension, Thumbnail extension, Sparkle nested executable/framework의 Developer ID 서명, timestamp, hardened runtime, entitlement 상태가 notary submit 전에 명시 검증되어야 한다. Sparkle framework 내부 version directory가 `Versions/B`에서 바뀌어도 검증과 서명 경로가 고정 경로만 보지 않아야 한다.
+
+## 배경
+
+#188 v0.1.1 public release 실행 중 app notarization 단계에서 Sparkle nested XPC/Autoupdate의 ad-hoc signature/timestamp 누락, Quick Look/Thumbnail extension의 `get-task-allow`와 timestamp 누락이 순차적으로 드러났다. #188 Stage 4에서 release script는 실제 배포가 통과하도록 보정되었지만, 현재 release pipeline은 이 조건을 app bundle 생성 직후 별도 validator로 명시 검증하지 않는다.
+
+2026-05-11 KST 기준 최신 `devel-webview`는 PR #231 merge commit `984cd9cd328b51e618aa3eabe738b7260f5ff2d2`를 포함한다. PR #231은 Rust bridge staticlib 검증 정책, PR CI, release workflow의 source/header/ABI gate 정렬이 중심이며, #219의 release signing/notarization preflight validator 범위는 해결하지 않는다.
+
+최신 `scripts/release.sh` 기준으로도 `run_preflight`는 tool, signing identity, notary profile, clean worktree, source version을 확인하는 단계다. app bundle 생성 후에는 `verify_app_signature`가 `codesign --verify`를 수행하지만 Developer ID identity, timestamp, hardened runtime, debug entitlement 부재, Sparkle nested executable 누락을 구조적으로 검사하지 않는다. Sparkle signing 경로도 `Sparkle.framework/Versions/B`에 고정되어 있다.
+
+#225는 v0.1.2 release artifact, Sparkle update, Quick Look/Thumbnail smoke, public 배포 검증을 포함한다. 따라서 #225 release 실행 전에 #219를 완료해 같은 계열의 signing/notarization 결함을 notary 제출 전에 잡는 편이 안전하다.
+
+## 범위(포함·제외)
+
+포함:
+
+- app bundle 생성과 재서명 이후, app notarization 제출 전에 실행되는 release preflight validator 추가
+- Host app, Quick Look extension, Thumbnail extension, Sparkle framework, Sparkle XPCServices, `Updater.app`, `Autoupdate`의 서명 상태 검증
+- Developer ID Application signer, Team ID, secure timestamp, hardened runtime, `get-task-allow` 부재 검증
+- Sparkle framework 내부 component path를 `Versions/B` 고정 대신 `Versions/Current` 또는 discovery 기반으로 해석
+- 누락 component, 잘못된 signer, timestamp/runtime/entitlement 문제를 명확한 로그와 exit code로 실패 처리
+- release-publish/release-rehearsal 경로에서 validator가 실행되는지 연결 확인
+- release/signing/notarization 관련 매뉴얼 갱신
+- 수행계획서, 구현계획서, 단계 보고서, 최종 보고서, 오늘할일 갱신
+
+제외:
+
+- Sparkle 버전 업그레이드
+- Sparkle EdDSA appcast signing key 변경
+- notarization 우회, 검증 완화, 또는 notary failure 무시
+- public release 실행, GitHub Release 게시, Pages/appcast 갱신
+- Homebrew Cask 반영
+- #225의 rhwp v0.7.11 반영, update maintenance, release 실행 자체
+
+## 설계 방향
+
+검증은 `scripts/release.sh` 내부 함수로 시작하되, 로직이 커지면 별도 script로 분리 가능한 형태를 유지한다. 핵심은 notarization 제출 직전의 실제 `Alhangeul.app` bundle을 대상으로 검사하는 것이다. source preflight와 artifact preflight를 구분해, `run_preflight`는 기존처럼 환경과 입력을 확인하고, `sign_release_app_for_notarization` 이후 `verify_release_signing_preflight` 같은 단계에서 app bundle 내용을 검증한다.
+
+Sparkle path resolution은 `Sparkle.framework/Versions/Current`가 있으면 먼저 canonical target을 해석하고, 없으면 `Versions/*`에서 필요한 component를 보유한 version directory를 탐색한다. `Versions/B`는 현재 구조의 한 후보일 뿐으로 둔다. component가 없으면 조용히 skip하지 않고 public signing/notarization 모드에서는 실패해야 한다.
+
+서명 검증은 `codesign --verify`만으로 끝내지 않는다. `codesign --display --verbose=4`와 entitlement 추출 결과를 파싱해 signer/Team ID/timestamp/runtime을 확인하고, `codesign --entitlements :-` 또는 plist 추출로 `com.apple.security.get-task-allow`가 true로 남아 있으면 실패시킨다. Host app과 appex는 expected bundle identifier와 entitlement policy를 분리해 확인한다. Sparkle nested executable은 sandbox entitlement를 강제하지 않고 notarization prerequisite 중심으로 검증한다.
+
+release rehearsal은 Developer ID identity가 없는 unsigned rehearsal과 Developer ID가 있는 signing rehearsal을 구분한다. #219 완료 기준의 notarization preflight는 public signing path에서 반드시 실행되어야 한다. unsigned `--skip-notarize` rehearsal에서는 validator가 왜 건너뛰었는지 명확히 로그를 남기거나, Developer ID identity가 제공된 rehearsal에서 동일 검증을 실행하는 방식을 검토한다.
+
+## 예상 변경 파일
+
+- `scripts/release.sh`
+- 필요 시 `scripts/ci/` 또는 `scripts/` 하위 signing preflight helper
+- `.github/workflows/release-publish.yml`
+- `.github/workflows/release-rehearsal.yml`
+- `mydocs/manual/release_signing_notarization_guide.md`
+- `mydocs/manual/release_packaging_dmg_guide.md`
+- `mydocs/manual/release_distribution_guide.md`
+- `mydocs/orders/20260511.md`
+- `mydocs/plans/task_m019_219.md`
+- `mydocs/plans/task_m019_219_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m019_219_stage{N}.md`
+- `mydocs/report/task_m019_219_report.md`
+
+## 잠정 단계(3~6단계)
+
+1. Stage 1: signing/notarization preflight inventory
+   - 최신 `devel-webview`의 release script, release workflow, #188/#227 보고서, signing/notarization 매뉴얼을 대조한다.
+   - 검증 대상 component 목록과 expected signer/runtime/entitlement policy를 확정한다.
+2. Stage 2: Sparkle component discovery와 signing path 보강
+   - Sparkle version directory resolution을 `Versions/Current`/discovery 기반으로 바꾼다.
+   - nested component 누락을 public notarization path에서 실패시키도록 정리한다.
+3. Stage 3: artifact signing preflight validator 구현
+   - app/appex/Sparkle component별 signer, Team ID, timestamp, hardened runtime, debug entitlement 검증을 추가한다.
+   - 실패 로그가 component path와 기대 조건을 보여주도록 한다.
+4. Stage 4: workflow/문서 연결과 rehearsal 기준 정리
+   - release-publish/release-rehearsal에서 validator 실행 위치와 summary를 확인한다.
+   - release signing/notarization 문서에 preflight gate와 skip 조건을 기록한다.
+5. Stage 5: 통합 검증과 보고
+   - shell syntax, diff check, release helper dry-run, 가능 범위의 signed artifact 검증을 수행한다.
+   - notarization/public release를 실행하지 않은 범위와 #225 전에 남은 조건을 최종 보고서에 분리 기록한다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260511.md mydocs/plans/task_m019_219.md
+```
+
+구현 단계 후보:
+
+```bash
+bash -n scripts/release.sh
+bash -n scripts/ci/*.sh
+./scripts/release.sh --skip-notarize 0.1.2
+rg -n "preflight|notarization|Developer ID|timestamp|get-task-allow|Sparkle.framework/Versions|hardened runtime" \
+  scripts .github/workflows mydocs/manual
+git diff --check
+```
+
+Developer ID identity와 notary profile이 필요한 검증은 로컬 환경에서 실행 가능할 때만 수행한다. public release, GitHub Release 게시, stable appcast 갱신은 이번 작업의 검증 범위가 아니다.
+
+## 리스크
+
+- `codesign` 출력은 macOS/Xcode 버전에 따라 표현이 달라질 수 있어 parser를 너무 취약하게 만들면 false failure가 생길 수 있다.
+- Sparkle framework 내부 구조를 탐색할 때 현재 필요한 component와 future version의 구조 차이를 혼동하면 누락을 skip할 수 있다.
+- `--deep` 검증과 개별 nested component 검증의 의미를 혼동하면 실제 실패 원인을 사용자에게 충분히 보여주지 못할 수 있다.
+- unsigned rehearsal에서 preflight를 무리하게 강제하면 로컬 release rehearsal 사용성이 떨어질 수 있다.
+- 반대로 public signing path에서 skip 조건을 넓게 두면 #219의 fail-fast 목적을 잃는다.
+- #225 전에 완료하지 못하면 v0.1.2 release 실행 중 같은 계열의 notary failure를 늦게 발견할 수 있다.
+
+## 승인 요청 사항
+
+1. #219를 #225 release 실행 전 선행 작업으로 진행하는 방향 승인
+2. app bundle 생성/재서명 후, app notarization 제출 전 artifact signing preflight를 추가하는 설계 방향 승인
+3. Sparkle component path를 `Versions/Current` 우선 + discovery fallback으로 바꾸고, public notarization path에서 required component 누락을 실패시키는 방향 승인
+4. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m019_219_impl.md`) 작성

--- a/mydocs/plans/task_m019_219_impl.md
+++ b/mydocs/plans/task_m019_219_impl.md
@@ -1,0 +1,216 @@
+# Task M019 #219 구현계획서
+
+## 목적
+
+수행계획서에서 승인된 방향에 따라 release artifact signing/notarization preflight를 구현한다.
+
+본 구현은 public release path에서 `Alhangeul.app`을 app notarization에 제출하기 전에 Host app, Quick Look extension, Thumbnail extension, Sparkle framework와 nested executable의 서명 전제 조건을 명시 검증한다. 목표는 #188 Stage 4에서 notary submit 이후에야 드러났던 Sparkle timestamp 누락과 extension debug entitlement 문제를 app bundle 생성 직후 fail-fast로 잡는 것이다.
+
+## 승인된 기준
+
+- #219는 #225의 v0.1.2 release 실행 전에 끝내는 선행 작업으로 둔다.
+- source/environment preflight와 artifact signing preflight를 분리한다.
+- artifact signing preflight는 `build_app`와 `sign_release_app_for_notarization` 이후, `notarize_and_staple_app` 전에 실행한다.
+- Sparkle component path는 `Sparkle.framework/Versions/B` 고정이 아니라 `Versions/Current` 우선, discovery fallback 방식으로 찾는다.
+- public notarization path에서 required Sparkle component가 없거나 잘못 서명되면 skip하지 않고 실패한다.
+- unsigned `--skip-notarize` rehearsal은 public notarization prerequisite 검증 대상이 아님을 명확히 로그로 남긴다. Developer ID identity가 제공된 rehearsal에서 validator를 실행할지는 Stage 1 inventory에서 최종 확정한다.
+- public release, GitHub Release 게시, Pages/appcast 갱신, Homebrew Cask 반영은 이번 작업에서 수행하지 않는다.
+
+## 전체 단계
+
+### Stage 1: signing/notarization preflight inventory
+
+목표:
+
+- 최신 `devel-webview` 기준 release script와 release workflows의 현재 signing/notarization hook을 inventory로 정리한다.
+- 검증 대상 component 목록과 expected policy를 확정한다.
+- `--skip-notarize` rehearsal, Developer ID가 있는 rehearsal, public release path의 validator 실행 조건을 결정한다.
+
+예상 변경 파일:
+
+- `mydocs/working/task_m019_219_stage1.md`
+
+검증:
+
+```bash
+rg -n "run_preflight|sign_sparkle_components_for_notarization|verify_app_signature|notarize_and_staple_app|Sparkle.framework/Versions|ALHANGEUL_DEVELOPER_ID|skip-notarize" \
+  scripts/release.sh .github/workflows/release-publish.yml .github/workflows/release-rehearsal.yml mydocs/manual
+git diff --check -- mydocs/working/task_m019_219_stage1.md
+```
+
+커밋:
+
+```text
+Task #219 Stage 1: signing preflight inventory 정리
+```
+
+승인 게이트:
+
+- Stage 1 완료보고서 승인 후 Stage 2 진행
+
+### Stage 2: Sparkle component discovery와 signing path 보강
+
+목표:
+
+- `scripts/release.sh`에서 Sparkle framework version directory를 `Versions/Current` 우선으로 해석하고, 없으면 `Versions/*` discovery로 찾는 helper를 추가한다.
+- Sparkle nested component 목록을 한 곳에서 정의해 signing path와 validation path가 같은 resolution을 쓰도록 한다.
+- public notarization path에서 Sparkle framework나 required nested component가 누락되면 명확한 오류로 실패하게 한다.
+
+예상 변경 파일:
+
+- `scripts/release.sh`
+- `mydocs/working/task_m019_219_stage2.md`
+
+검증:
+
+```bash
+bash -n scripts/release.sh
+rg -n "resolve_sparkle|Sparkle.framework/Versions|XPCServices|Updater.app|Autoupdate|Versions/Current" scripts/release.sh
+git diff --check -- scripts/release.sh mydocs/working/task_m019_219_stage2.md
+```
+
+커밋:
+
+```text
+Task #219 Stage 2: Sparkle component discovery 보강
+```
+
+승인 게이트:
+
+- Stage 2 완료보고서 승인 후 Stage 3 진행
+
+### Stage 3: artifact signing preflight validator 구현
+
+목표:
+
+- app notarization 제출 전 실행되는 `verify_release_signing_preflight` 계열 함수를 추가한다.
+- Host app, Quick Look extension, Thumbnail extension, Sparkle framework, Sparkle XPCServices, `Updater.app`, `Autoupdate`에 대해 개별 `codesign --verify --strict`를 수행한다.
+- `codesign --display --verbose=4` 출력 또는 안정적인 보조 명령을 사용해 Developer ID Application signer, Team ID, secure timestamp, hardened runtime을 확인한다.
+- entitlement 추출 결과에서 `com.apple.security.get-task-allow`가 true이면 실패시킨다.
+- 실패 로그는 component label, path, 기대 조건, 확인된 상태를 보여준다.
+
+예상 변경 파일:
+
+- `scripts/release.sh`
+- 필요 시 `scripts/ci/` 또는 `scripts/` 하위 helper
+- `mydocs/working/task_m019_219_stage3.md`
+
+검증:
+
+```bash
+bash -n scripts/release.sh
+./scripts/release.sh --help
+rg -n "verify_release_signing_preflight|codesign --display|entitlements|get-task-allow|hardened runtime|TeamIdentifier|Timestamp" scripts
+git diff --check -- scripts mydocs/working/task_m019_219_stage3.md
+```
+
+환경이 허용되면 추가 검증:
+
+```bash
+./scripts/release.sh --skip-notarize 0.1.2
+```
+
+Developer ID identity가 없는 환경에서 실패하는 검증은 stage 보고서에 별도 기록하고, 가능한 정적 검증과 unsigned rehearsal 결과를 분리한다.
+
+커밋:
+
+```text
+Task #219 Stage 3: release signing preflight validator 추가
+```
+
+승인 게이트:
+
+- Stage 3 완료보고서 승인 후 Stage 4 진행
+
+### Stage 4: workflow와 release 문서 연결
+
+목표:
+
+- `release-publish.yml`과 `release-rehearsal.yml` summary가 signing preflight 실행/skip 조건을 설명하도록 보강한다.
+- release signing/notarization, packaging, distribution 문서에 preflight gate의 위치와 실패 기준을 기록한다.
+- #225 작업자가 v0.1.2 release 실행 전 어떤 preflight가 통과해야 하는지 확인할 수 있게 문서화한다.
+
+예상 변경 파일:
+
+- `.github/workflows/release-publish.yml`
+- `.github/workflows/release-rehearsal.yml`
+- `mydocs/manual/release_signing_notarization_guide.md`
+- `mydocs/manual/release_packaging_dmg_guide.md`
+- `mydocs/manual/release_distribution_guide.md`
+- `mydocs/working/task_m019_219_stage4.md`
+
+검증:
+
+```bash
+rg -n "signing preflight|notarization preflight|Developer ID|timestamp|get-task-allow|Sparkle.framework|release.sh" \
+  .github/workflows mydocs/manual
+git diff --check -- .github/workflows mydocs/manual mydocs/working/task_m019_219_stage4.md
+```
+
+커밋:
+
+```text
+Task #219 Stage 4: release preflight 문서와 workflow 정리
+```
+
+승인 게이트:
+
+- Stage 4 완료보고서 승인 후 Stage 5 진행
+
+### Stage 5: 통합 검증과 최종 보고
+
+목표:
+
+- shell syntax, release helper, rehearsal path, 문서 검색, diff check를 실행한다.
+- 가능하면 unsigned rehearsal DMG를 생성해 preflight skip/실행 로그와 기존 release flow 손상 여부를 확인한다.
+- 최종 보고서에 #219 완료 기준 충족 여부, public release 미실행 범위, #225 전 선행 조건을 정리한다.
+- 오늘할일 상태를 완료로 갱신한다.
+
+예상 변경 파일:
+
+- `mydocs/report/task_m019_219_report.md`
+- `mydocs/orders/20260511.md`
+
+검증:
+
+```bash
+bash -n scripts/release.sh
+bash -n scripts/ci/*.sh
+./scripts/release.sh --help
+./scripts/release.sh --skip-notarize 0.1.2
+rg -n "preflight|notarization|Developer ID|timestamp|get-task-allow|Sparkle.framework/Versions|hardened runtime|Versions/Current" \
+  scripts .github/workflows mydocs/manual
+git diff --check
+```
+
+Developer ID identity와 notary profile이 있는 환경에서는 추가로 public publish 없이 local signing path에서 artifact signing preflight가 실제로 실행되는지 확인한다. public GitHub Release와 stable appcast는 실행하지 않는다.
+
+커밋:
+
+```text
+Task #219 Stage 5 + 최종 보고서: release preflight 검증 정리
+```
+
+승인 게이트:
+
+- 최종 보고서 승인 후 `task-final-report` 절차로 PR 게시 진행
+
+## PR close 전략
+
+PR 본문에는 `Closes #219`를 명시한다.
+
+#225는 이번 PR에서 close하지 않는다. 대신 PR 본문과 최종 보고서에 "#225 release 실행 전에 #219 preflight gate가 선행 완료됐다"는 handoff를 남긴다.
+
+이슈 close는 PR merge 전 별도로 수행하지 않는다. merge 전에는 PR closing keyword 또는 최종 보고서 승인 흐름으로만 연결한다.
+
+## 리스크와 보정 기준
+
+- `codesign --display` 출력 parsing이 취약하면 Stage 3에서 helper 함수를 줄이고 `codesign --verify`, `spctl`, `plutil` 등 더 안정적인 명령 조합으로 보정한다.
+- Sparkle future version에서 component 구조가 바뀌면 discovery 기준이 과도하게 엄격할 수 있다. 단, public notarization path에서 필요한 현재 component 누락을 skip하지 않는 기준은 유지한다.
+- `--skip-notarize` rehearsal에서 Developer ID identity가 없으면 artifact signing preflight를 완전히 재현할 수 없다. 이 경우 public release path에서 실행될 hook 위치와 정적 검증을 보고서에 명확히 기록한다.
+- `./scripts/release.sh --skip-notarize 0.1.2`가 source version mismatch로 실패할 수 있다. 그 경우 현재 source version에 맞는 명령으로 대체하거나, 실패가 validator 변경과 무관함을 stage 보고서에 분리한다.
+- workflow YAML 변경이 실제 GitHub Actions 실행 없이는 완전 검증되지 않는다. 로컬에서는 문법/검색/스크립트 경로 확인까지 수행하고, PR CI와 release workflow dry path는 PR에서 확인한다.
+
+## 승인 요청 사항
+
+이 구현계획서 승인 후 Stage 1 signing/notarization preflight inventory를 시작한다.

--- a/mydocs/report/task_m019_219_report.md
+++ b/mydocs/report/task_m019_219_report.md
@@ -1,0 +1,122 @@
+# Task M019 #219 최종 보고서
+
+## 결론
+
+#219는 최신 `devel-webview` 기준으로 #225 전에 완료하는 것이 맞고, 이번 작업 범위의 signing/notarization preflight는 구현 완료로 판단한다.
+
+최신 기준 확인 시점에는 PR #231 merge commit `984cd9cd328b51e618aa3eabe738b7260f5ff2d2`가 `devel-webview`에 포함되어 있었다. 이후 작업 중 PR #232(`#218`)가 `devel-webview`에 추가 merge되어 `local/task219`에 병합했다.
+
+이번 작업으로 `scripts/release.sh` public release path는 app notarization submit 전에 Host app, Quick Look extension, Thumbnail extension, Sparkle framework와 Sparkle nested executable을 개별 검증한다. `--skip-notarize` rehearsal은 unsigned 기본 모드에서 preflight skip을 명시 로그로 남기고, Developer ID identity가 주어진 signed rehearsal에서는 같은 preflight를 실행한다.
+
+## 변경 요약
+
+| 영역 | 내용 |
+|------|------|
+| Sparkle component discovery | `Sparkle.framework/Versions/Current`를 우선 해석하고, 없거나 불완전하면 `Versions/*` discovery로 required component가 있는 version directory를 찾도록 변경 |
+| Sparkle required component | `XPCServices/Downloader.xpc`, `XPCServices/Installer.xpc`, `Updater.app`, `Autoupdate`를 signing/validation 공통 required 목록으로 관리 |
+| release signing preflight | notarization submit 전 `verify_release_signing_preflight` 추가 |
+| 검증 기준 | Developer ID Application authority, Team ID, secure timestamp, hardened runtime, `get-task-allow` 부재, expected bundle identifier, required Sparkle component 존재 확인 |
+| workflow summary | `release-publish.yml`, `release-rehearsal.yml`에 signing preflight 실행/skip 정책 기록 |
+| 매뉴얼 | signing/notarization, packaging/DMG, distribution 가이드에 preflight gate와 #225 전 확인 기준 기록 |
+
+## 완료 기준 확인
+
+| 기준 | 결과 | 근거 |
+|------|------|------|
+| #225 release 실행 전에 #219 선행 필요 여부 판단 | OK | #225는 public release 실행 타스크이므로 notary submit 전 fail-fast gate가 먼저 필요함 |
+| 최신 `devel-webview` + PR #231 기준 파악 | OK | PR #231 merge commit 포함 기준에서 #219 미해결 확인 후 진행 |
+| Sparkle `Versions/B` 고정 제거 | OK | `Versions/Current` 우선 + discovery fallback 적용 |
+| Sparkle nested component 누락을 public path에서 실패 처리 | OK | required component resolver가 누락 시 `fail` 처리 |
+| app/extension/Sparkle notarization 전 signing preflight 추가 | OK | `sign_release_app_for_notarization` 후, `notarize_and_staple_app` 전 hook 추가 |
+| Developer ID, Team ID, timestamp, runtime, debug entitlement 검증 | OK | component별 `codesign --verify --strict`, metadata, entitlement 확인 |
+| unsigned rehearsal skip 조건 명시 | OK | identity 없는 `--skip-notarize`에서 `Skipping release signing preflight...` 경고 출력 |
+| 문서와 workflow 연결 | OK | release workflow summary와 release manual 갱신 |
+
+## 검증 결과
+
+| 명령 | 결과 | 비고 |
+|------|------|------|
+| `bash -n scripts/release.sh` | OK | shell syntax 확인 |
+| `bash -n scripts/ci/*.sh` | OK | CI helper shell syntax 확인 |
+| `./scripts/release.sh --help` | OK | `APPLE_TEAM_ID` help 노출 확인 |
+| `rg -n "preflight\|notarization\|Developer ID\|timestamp\|get-task-allow\|Sparkle.framework/Versions\|hardened runtime\|Versions/Current" scripts .github/workflows mydocs/manual` | OK | 코드, workflow, manual 연결 확인 |
+| `git diff --check` | OK | whitespace 오류 없음 |
+| `ALHANGEUL_BUILD_ROOT=build.noindex/task219-stage5 ./scripts/release.sh --skip-notarize 0.1.1` | 부분 통과 | 네트워크 제한 해제 재시도 후 build/universal/preflight skip 지점까지 통과, DMG Finder layout 단계에서 실패 |
+
+## Rehearsal 상세
+
+첫 실행은 sandbox 네트워크 제한으로 Sparkle package clone이 실패했다.
+
+```text
+fatal: unable to access 'https://github.com/sparkle-project/Sparkle/': Could not resolve host: github.com
+```
+
+제한 해제 후 같은 명령을 재실행했고 다음 지점까지 통과했다.
+
+- Rust bridge artifact 검증
+- Xcode project 생성
+- Release app build
+- Host app, Quick Look extension, Thumbnail extension universal architecture 확인
+- unsigned rehearsal 경고 출력
+
+확인된 경고:
+
+```text
+WARN: Skipping codesign verification because this rehearsal build is unsigned.
+WARN: Skipping release signing preflight because this rehearsal build is unsigned.
+```
+
+이후 DMG 생성 단계의 기존 Finder layout AppleScript에서 실패했다.
+
+```text
+Finder에 오류 발생: toolbar visible of container window of disk "Alhangeul 0.1.1"을(를) false(으)로 설정할 수 없습니다. (-10006)
+```
+
+이 실패는 #219에서 추가한 signing preflight validator가 아니라 `create_dmg -> apply_dmg_finder_layout` 단계에서 발생했다. 따라서 #219의 preflight 실행/skip hook 위치는 확인됐지만, local full rehearsal DMG 산출물 생성은 완료하지 못했다.
+
+## 실행하지 않은 항목
+
+- Developer ID signing
+- signed rehearsal preflight 실제 실행
+- app notarization submit/wait
+- DMG signing/notarization/staple
+- Gatekeeper public artifact assessment
+- GitHub Release asset 업로드
+- Pages/appcast/Homebrew Cask 갱신
+- #225 release 실행
+
+## #225 Handoff
+
+#225는 이 PR이 `devel-webview`에 merge된 뒤 진행하는 것이 안전하다.
+
+#225에서 반드시 확인할 항목:
+
+- `release-publish.yml` summary의 signing preflight policy가 표시되는지 확인
+- public release mode에서 app notarization submit 전에 `Running release signing preflight`가 실행되는지 확인
+- preflight 실패 시 notary submit으로 넘어가지 않는지 확인
+- `APPLE_TEAM_ID`가 운영 Team ID `XH6JHKYXV8`와 다르면 workflow variable 또는 명령 환경에서 명시
+- signed rehearsal 또는 public release 환경에서 Developer ID/timestamp/hardened runtime/get-task-allow 검증을 실제 artifact 기준으로 확인
+
+별도 주의:
+
+- Stage 5 local rehearsal에서 Finder DMG layout AppleScript 실패가 관측됐다.
+- 이 문제는 #219 signing preflight 범위 밖이지만, #225 public release에서 재현되면 release packaging blocker로 처리해야 한다.
+- #225 시작 전 또는 #225 초반에 `Release Rehearsal DMG` workflow로 DMG 생성 경로를 먼저 확인하는 것이 좋다.
+
+## 커밋 흐름
+
+| 커밋 | 내용 |
+|------|------|
+| `54ae4ff` | 수행계획서 작성과 오늘할일 갱신 |
+| `e2388e8` | 구현계획서 작성 |
+| `6def904` | Stage 1 signing preflight inventory 정리 |
+| `e816761` | Stage 2 Sparkle component discovery 보강 |
+| `37d6b55` | Stage 3 release signing preflight validator 추가 |
+| `a99d12e` | 최신 `devel-webview` 병합 |
+| `de3932b` | Stage 4 release preflight 문서와 workflow 정리 |
+
+## 최종 판단
+
+#219의 원래 문제였던 "notarization submit 이후에야 signing/timestamp/entitlement 문제를 발견하는 구조"는 해결했다. 이제 public release path는 app notarization submit 전에 필요한 signing prerequisite를 명시 검증한다.
+
+다만 이 최종 보고서는 public release 성공 보고서가 아니다. signed/notarized artifact 생성, GitHub Release 게시, stable appcast, Pages, Homebrew Cask는 #225에서 별도 승인과 release credential이 있는 환경에서 수행해야 한다.

--- a/mydocs/working/task_m019_219_stage1.md
+++ b/mydocs/working/task_m019_219_stage1.md
@@ -1,0 +1,208 @@
+# Task M019 #219 Stage 1 완료 보고서
+
+## 단계 목적
+
+최신 `devel-webview` 기준 release script, release workflows, signing/notarization 문서, #188/#227 기록을 대조해 #219의 artifact signing preflight 구현 기준을 확정한다.
+
+확인 기준 커밋: `984cd9cd328b51e618aa3eabe738b7260f5ff2d2` (`origin/devel-webview`, PR #231 merge commit)
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/working/task_m019_219_stage1.md` | signing/notarization preflight inventory와 Stage 2 구현 기준 기록 |
+
+이번 단계에서 release script, workflow, manual 본문은 수정하지 않았다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 신규 단계 보고서만 추가했다.
+- 기존 source, workflow, manual 문서 본문은 변경하지 않았다.
+- public release, notarization, signing, GitHub Release 게시, Pages/appcast 갱신은 실행하지 않았다.
+
+## 최신 기준 확인
+
+현재 `local/task219`는 `origin/devel-webview`에서 분기했고, 작업 시작 전 확인한 `origin/devel-webview`는 PR #231 merge commit `984cd9cd328b51e618aa3eabe738b7260f5ff2d2`였다.
+
+PR #231의 범위는 Rust bridge staticlib 검증 정책, PR CI, release workflow의 source/header/ABI gate 정렬이다. #219가 요구하는 app bundle signing/notarization preflight, Sparkle component discovery, timestamp/runtime/entitlement 검증은 PR #231에서 해결되지 않았다.
+
+## 현재 release script inventory
+
+| 위치 | 현재 동작 | #219 관점 판단 |
+|------|-----------|----------------|
+| `run_preflight` | tool, signing identity, notary profile, clean worktree, source version 검증 | source/environment preflight이며 app bundle 내부 서명 상태는 확인하지 않음 |
+| `build_app` | Developer ID identity가 있으면 Xcode Release build에 Manual signing과 hardened runtime build setting 적용 | build setting만으로 nested component 최종 서명 상태를 보장하지 않음 |
+| `codesign_developer_id` | `--options runtime`, `--timestamp`, entitlements 또는 기존 entitlement 보존으로 서명 | 서명 수행 helper이며 결과 검증 helper는 아님 |
+| `sign_sparkle_components_for_notarization` | `Sparkle.framework/Versions/B`를 직접 보고 XPC/Updater/Autoupdate가 있으면 서명 | `Versions/B` 고정, component 누락 시 조용히 skip 가능 |
+| `sign_app_extension_for_notarization` | appex가 있으면 release entitlements를 expand 후 재서명 | appex 누락 시 조용히 return |
+| `verify_universal_app` | app/extension executable의 `arm64 + x86_64` 검증 | architecture 검증이며 signing 검증 아님 |
+| `verify_app_signature` | app `codesign --verify --deep --strict`, appex 개별 `codesign --verify --strict` | signer, Team ID, timestamp, hardened runtime, `get-task-allow` 부재를 명시 검증하지 않음 |
+| `notarize_and_staple_app` | public mode에서 app notary zip 제출 후 staple | 현재 signing 문제를 notary submit 이후에 발견할 수 있음 |
+
+현재 main flow는 다음 순서다.
+
+```text
+run_preflight
+-> reset_output
+-> build_rust_bridge
+-> check_shared_code
+-> generate_project
+-> build_app
+-> sign_release_app_for_notarization
+-> verify_universal_app
+-> verify_app_signature
+-> notarize_and_staple_app
+```
+
+#219의 artifact signing preflight는 `sign_release_app_for_notarization` 이후, `notarize_and_staple_app` 이전에 들어가야 한다. 기존 `verify_app_signature`를 확장하거나 새 `verify_release_signing_preflight`를 추가하되, Stage 2/3에서는 이름과 책임을 명확히 분리한다.
+
+## workflow inventory
+
+| Workflow | 관련 step | 현재 동작 | #219 영향 |
+|----------|-----------|-----------|-----------|
+| `release-publish.yml` | `Build signed and notarized DMG` | `./scripts/release.sh "$VERSION"` 실행 | public path이므로 artifact signing preflight가 반드시 실행되어야 함 |
+| `release-publish.yml` | `Record Rust bridge lock policy` | #227 정책에 따라 staticlib hash skip 설명 | #219 summary는 아직 없음 |
+| `release-rehearsal.yml` | `Build rehearsal DMG` | `./scripts/release.sh --skip-notarize "$VERSION"` 실행 | 기본 rehearsal은 unsigned/notarization skip이므로 public signing preflight 대상이 아님 |
+| `release-rehearsal.yml` | `Record Rust bridge lock policy` | #227 정책에 따라 staticlib hash skip 설명 | signing preflight skip/실행 조건 설명 없음 |
+
+workflow 자체에는 별도 signing validator step이 없다. 따라서 Stage 2/3에서 `scripts/release.sh`에 preflight hook을 넣으면 release-publish는 자동으로 보호된다. Stage 4에서는 workflow summary가 public path와 rehearsal path의 signing preflight 실행/skip 조건을 설명하도록 보강한다.
+
+## #188 실패 기록에서 끌어온 요구사항
+
+#188 Stage 4에서 public release workflow는 다음 계열의 문제를 notary submit 이후에 확인했다.
+
+| 실패 지점 | 원인 | #219에서 선행 검출할 조건 |
+|-----------|------|---------------------------|
+| app notarization | Sparkle nested XPC/Autoupdate가 ad-hoc signature와 timestamp 없음 | Sparkle framework/nested executable의 Developer ID signer와 secure timestamp |
+| app notarization | Quick Look/Thumbnail extension에 `get-task-allow`와 timestamp 없음 | appex entitlement의 `get-task-allow` 부재와 secure timestamp |
+
+따라서 Stage 3 validator는 단순 `codesign --verify` 통과 여부가 아니라 다음 상태를 별도 항목으로 검증해야 한다.
+
+- Developer ID Application signer
+- Team ID `XH6JHKYXV8`
+- secure timestamp 존재
+- hardened runtime option 존재
+- `com.apple.security.get-task-allow`가 true가 아님
+- required nested component 존재
+
+## 검증 대상 component 정책
+
+### Host app
+
+| 항목 | 기준 |
+|------|------|
+| path | `build.noindex/release/Alhangeul.app` |
+| bundle id | `com.postmelee.alhangeul` |
+| signer | `ALHANGEUL_DEVELOPER_ID_APPLICATION` |
+| Team ID | `XH6JHKYXV8` |
+| runtime | hardened runtime 필요 |
+| timestamp | secure timestamp 필요 |
+| entitlement | sandbox, user-selected read-write, network client, print, Sparkle mach lookup 유지. `get-task-allow` true 금지 |
+
+### Quick Look extension
+
+| 항목 | 기준 |
+|------|------|
+| path | `Alhangeul.app/Contents/PlugIns/AlhangeulPreview.appex` |
+| bundle id | `com.postmelee.alhangeul.QLExtension` |
+| signer | `ALHANGEUL_DEVELOPER_ID_APPLICATION` |
+| Team ID | `XH6JHKYXV8` |
+| runtime | hardened runtime 필요 |
+| timestamp | secure timestamp 필요 |
+| entitlement | sandbox + user-selected read-only 유지. `get-task-allow` true 금지 |
+
+### Thumbnail extension
+
+| 항목 | 기준 |
+|------|------|
+| path | `Alhangeul.app/Contents/PlugIns/AlhangeulThumbnail.appex` |
+| bundle id | `com.postmelee.alhangeul.ThumbnailExtension` |
+| signer | `ALHANGEUL_DEVELOPER_ID_APPLICATION` |
+| Team ID | `XH6JHKYXV8` |
+| runtime | hardened runtime 필요 |
+| timestamp | secure timestamp 필요 |
+| entitlement | sandbox + user-selected read-only 유지. `get-task-allow` true 금지 |
+
+### Sparkle framework와 nested executable
+
+| 항목 | 기준 |
+|------|------|
+| framework | `Alhangeul.app/Contents/Frameworks/Sparkle.framework` |
+| version dir | `Versions/Current` 우선, 없으면 `Versions/*` discovery |
+| required nested components | `XPCServices/Downloader.xpc`, `XPCServices/Installer.xpc`, `Updater.app`, `Autoupdate` |
+| signer | `ALHANGEUL_DEVELOPER_ID_APPLICATION` |
+| Team ID | `XH6JHKYXV8` |
+| runtime | hardened runtime 필요 |
+| timestamp | secure timestamp 필요 |
+| entitlement | Sparkle-specific entitlement를 강제하지 않음. `get-task-allow` true 금지 |
+
+Stage 2에서는 signing path와 validation path가 같은 Sparkle component resolver를 쓰도록 한다. public notarization path에서 framework 또는 required nested component가 없으면 skip하지 않고 실패한다.
+
+## 실행 조건 결정
+
+| 모드 | 조건 | artifact signing preflight |
+|------|------|----------------------------|
+| public release | `SKIP_NOTARIZE=0`, `ALHANGEUL_DEVELOPER_ID_APPLICATION` 필수 | 반드시 실행 |
+| signed rehearsal | `SKIP_NOTARIZE=1`, `ALHANGEUL_DEVELOPER_ID_APPLICATION` 제공 | 실행. notarization은 하지 않지만 signing prerequisite 회귀를 조기 확인 |
+| unsigned rehearsal | `SKIP_NOTARIZE=1`, `ALHANGEUL_DEVELOPER_ID_APPLICATION` 없음 | 명시 로그 후 skip. public release signing 보증으로 기록하지 않음 |
+
+이 기준을 적용하면 release-publish는 notary submit 전 fail-fast를 얻고, release-rehearsal은 기본 unsigned smoke를 유지한다. 필요 시 작업지시자가 Developer ID identity를 제공한 rehearsal에서 같은 validator를 실행할 수 있다.
+
+## Stage 2 구현 기준
+
+Stage 2에서는 source 변경을 Sparkle resolver와 signing path에 한정한다.
+
+- `Sparkle.framework` 존재 확인 helper 추가
+- `Versions/Current` symlink/dir 해석 helper 추가
+- `Versions/Current`가 없거나 유효하지 않으면 `Versions/*`에서 required component를 갖춘 directory 탐색
+- required component 목록을 배열 또는 helper로 중앙화
+- `sign_sparkle_components_for_notarization`이 새 resolver를 사용
+- public/signed path에서 required component 누락 시 `fail`
+- unsigned path에서는 기존처럼 Sparkle signing helper 자체가 실행되지 않음
+
+Stage 2는 validator parsing을 도입하지 않는다. signer/timestamp/runtime/entitlement 검증은 Stage 3으로 분리한다.
+
+## 검증 결과
+
+| 명령 | 결과 | 비고 |
+|------|------|------|
+| `git status -sb` | OK | `local/task219`, `origin/devel-webview` 대비 ahead 2 |
+| `rg -n "run_preflight\|sign_sparkle_components_for_notarization\|verify_app_signature\|notarize_and_staple_app\|Sparkle.framework/Versions\|ALHANGEUL_DEVELOPER_ID\|skip-notarize" ...` | OK | release script/workflow/manual 현황 확인 |
+| `sed -n '1,220p' mydocs/manual/release_signing_notarization_guide.md` | OK | 현재 manual은 대표 수동 검증 위주 |
+| `sed -n '1,260p' mydocs/manual/release_packaging_dmg_guide.md` | OK | public/rehearsal 산출물 계층 확인 |
+| `sed -n '120,190p' .github/workflows/release-rehearsal.yml` | OK | rehearsal은 `--skip-notarize` 실행 |
+| `sed -n '232,270p' .github/workflows/release-publish.yml` | OK | publish는 `./scripts/release.sh "$VERSION"` 실행 |
+| `sed -n '72,96p' mydocs/working/task_m018_188_stage4.md` | OK | #188 signing/notary 실패 원인 확인 |
+| `rg -n "Team ID\|XH6JHKYXV8\|ALHANGEUL_DEVELOPER_ID\|APPLE_TEAM_ID\|Developer ID" ...` | OK | Team ID와 signing identity 위치 확인 |
+| `rg -n "PRODUCT_BUNDLE_IDENTIFIER\|com\\.postmelee\\.alhangeul\|ENABLE_HARDENED_RUNTIME\|entitlements" project.yml Sources` | OK | bundle id와 entitlements source 확인 |
+| `plutil -p Sources/*/*.entitlements` | OK | Host/extension entitlement 기준 확인 |
+
+## 실행하지 않은 항목
+
+- `scripts/release.sh` 수정
+- workflow 수정
+- manual 수정
+- `./scripts/release.sh --skip-notarize` 실행
+- Developer ID signing
+- notarization submit/wait
+- public release 관련 외부 작업
+
+## 잔여 위험
+
+- `codesign --display --verbose=4` 출력 parsing은 macOS/Xcode 버전에 따라 달라질 수 있으므로 Stage 3에서 가능한 한 단순하고 실패 로그가 명확한 방식으로 구현해야 한다.
+- Sparkle future version에서 nested component 구성이 바뀌면 required component 정책을 갱신해야 한다. 이번 작업은 현재 Sparkle bundle 구조에서 notarization prerequisite을 fail-fast로 검증하는 범위다.
+- signed rehearsal은 Developer ID identity가 있는 환경에서만 검증 가능하다. GitHub `release-rehearsal.yml` 기본 path는 unsigned rehearsal이므로 artifact signing preflight 실행을 보장하지 않는다.
+
+## 다음 단계
+
+Stage 2 승인 후 다음을 수행한다.
+
+1. `scripts/release.sh`에 Sparkle framework version directory resolver를 추가한다.
+2. `sign_sparkle_components_for_notarization`에서 `Versions/B` 고정 경로를 제거한다.
+3. required Sparkle nested component 누락을 public/signed path에서 `fail`로 처리한다.
+4. Stage 2 완료보고서와 함께 커밋한다.
+
+## 승인 요청
+
+1. Stage 1 결과 승인
+2. Stage 2 `Sparkle component discovery와 signing path 보강` 진입 승인

--- a/mydocs/working/task_m019_219_stage2.md
+++ b/mydocs/working/task_m019_219_stage2.md
@@ -1,0 +1,113 @@
+# Task M019 #219 Stage 2 완료 보고서
+
+## 단계 목적
+
+Sparkle framework 내부 component signing 경로를 `Versions/B` 고정에서 `Versions/Current` 우선 + discovery fallback 방식으로 바꾸고, required nested component 누락을 public/signed path에서 조용히 skip하지 않도록 보강한다.
+
+확인 시각: `2026-05-11 13:41 KST`
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `scripts/release.sh` | Sparkle required component 목록, version directory resolver, 누락 component report helper 추가. `sign_sparkle_components_for_notarization`이 resolver 기반 경로를 사용하도록 변경 |
+| `mydocs/working/task_m019_219_stage2.md` | Stage 2 구현 결과와 검증 기록 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- Stage 2 범위에 맞춰 `scripts/release.sh`의 Sparkle signing path만 수정했다.
+- signer, Team ID, timestamp, hardened runtime, entitlement parser는 아직 추가하지 않았다. 이 범위는 Stage 3으로 유지한다.
+- workflow와 manual 본문은 수정하지 않았다.
+- public release, Developer ID signing, notarization submit/wait, GitHub Release 게시, Pages/appcast 갱신은 실행하지 않았다.
+
+## 변경 내용
+
+### Required component 목록 중앙화
+
+`sparkle_required_component_paths` helper를 추가해 Sparkle notarization signing 대상 nested component를 한 곳에서 관리한다.
+
+현재 required component:
+
+- `XPCServices/Downloader.xpc`
+- `XPCServices/Installer.xpc`
+- `Updater.app`
+- `Autoupdate`
+
+이 목록은 Stage 2부터 signing path에서 사용하고, Stage 3 validator에서도 같은 기준으로 재사용할 예정이다.
+
+### Sparkle version directory resolution
+
+새 resolver는 다음 순서로 version directory를 결정한다.
+
+1. `Sparkle.framework`와 `Sparkle.framework/Versions` 존재 확인
+2. `Versions/Current`가 directory 또는 symlink로 유효하면 물리 경로(`pwd -P`)로 해석
+3. `Versions/Current`가 required component를 모두 포함하면 그 경로 사용
+4. `Versions/Current`가 없거나 incomplete이면 `Versions/*`에서 `Current`를 제외하고 required component를 모두 포함한 directory 탐색
+5. 끝까지 찾지 못하면 확인한 `Versions` 위치와 누락 component path를 stderr에 출력한 뒤 실패
+
+`basename` 같은 추가 외부 tool 의존을 만들지 않기 위해 `Current` 제외는 shell parameter expansion(`${candidate##*/}`)으로 처리했다.
+
+### Signing path 보강
+
+기존 `sign_sparkle_components_for_notarization`은 `Sparkle.framework/Versions/B`를 직접 보고, version directory가 없으면 return하고, component가 없으면 해당 component만 skip했다.
+
+변경 후에는 Developer ID signing path에서 다음처럼 동작한다.
+
+- `resolve_sparkle_version_dir`로 version directory를 먼저 확정한다.
+- Sparkle framework 또는 `Versions` directory가 없으면 실패한다.
+- required nested component를 모두 갖춘 version directory가 없으면 실패한다.
+- 확정된 version directory의 required component를 모두 `codesign_developer_id`로 서명한다.
+- 마지막에 `Sparkle.framework`를 재서명한다.
+
+이제 public/signed path에서 Sparkle required component가 누락된 상태로 notary submit까지 진행하지 않는다.
+
+## Stage 1 기준 대비 결과
+
+| Stage 1 기준 | 결과 |
+|--------------|------|
+| `Sparkle.framework` 존재 확인 helper 추가 | OK. resolver에서 framework와 `Versions` directory를 확인 |
+| `Versions/Current` symlink/dir 해석 helper 추가 | OK. `resolve_sparkle_current_version_dir` 추가 |
+| `Versions/Current`가 없거나 유효하지 않으면 `Versions/*` discovery | OK. `Current` 제외 후 required component 보유 directory 탐색 |
+| required component 목록 중앙화 | OK. `sparkle_required_component_paths` 추가 |
+| `sign_sparkle_components_for_notarization`이 새 resolver 사용 | OK. `Versions/B` 고정 제거 |
+| public/signed path에서 required component 누락 시 `fail` | OK. resolver가 누락 component report 후 실패 |
+| unsigned path에서는 signing helper가 실행되지 않음 | OK. 기존 `DEVELOPER_ID_APPLICATION` empty guard 유지 |
+
+## 검증 결과
+
+| 명령 | 결과 | 비고 |
+|------|------|------|
+| `git status -sb` | OK | `local/task219`, `origin/devel-webview` 대비 ahead 3에서 시작 |
+| `bash -n scripts/release.sh` | OK | shell syntax 통과 |
+| `./scripts/release.sh --help` | OK | release script interface 출력 정상 |
+| `rg -n "resolve_sparkle\|Sparkle.framework/Versions\|XPCServices\|Updater.app\|Autoupdate\|Versions/Current" scripts/release.sh` | OK | resolver와 required component 목록 확인 |
+| `git diff -- scripts/release.sh` | OK | 변경 범위가 Sparkle resolver/signing path에 한정됨 |
+
+## 실행하지 않은 항목
+
+- `./scripts/release.sh --skip-notarize` 실행
+- Developer ID signing
+- notarization submit/wait
+- signer, Team ID, timestamp, hardened runtime, entitlement validation 구현
+- workflow summary 수정
+- manual 수정
+
+## 잔여 위험
+
+- Stage 2는 path discovery와 required component fail-fast만 다룬다. 실제 signer, timestamp, hardened runtime, `get-task-allow` 검증은 아직 `codesign --verify` 수준을 넘어서지 않는다.
+- Sparkle future version에서 required component 이름이 바뀌면 current policy가 실패한다. 이는 의도된 fail-fast이며, public release 전 Sparkle 구조 변경을 명시 검토해야 한다.
+- 실제 signed app bundle에서 resolver가 어떤 directory를 선택하는지는 Stage 3/5에서 release rehearsal 또는 signed path 실행 결과로 확인해야 한다.
+
+## 다음 단계
+
+Stage 3 승인 후 다음을 수행한다.
+
+1. app notarization 제출 전 실행되는 `verify_release_signing_preflight` 계열 함수를 추가한다.
+2. Host app, Quick Look extension, Thumbnail extension, Sparkle framework/nested component에 대해 개별 `codesign --verify --strict`를 수행한다.
+3. Developer ID signer, Team ID, timestamp, hardened runtime, `get-task-allow` 부재 검증을 추가한다.
+4. 실패 로그가 component label/path/기대 조건을 보여주도록 정리한다.
+
+## 승인 요청
+
+1. Stage 2 결과 승인
+2. Stage 3 `artifact signing preflight validator 구현` 진입 승인

--- a/mydocs/working/task_m019_219_stage3.md
+++ b/mydocs/working/task_m019_219_stage3.md
@@ -1,0 +1,136 @@
+# Task M019 #219 Stage 3 완료 보고서
+
+## 단계 목적
+
+app notarization 제출 전에 실행되는 artifact signing preflight validator를 `scripts/release.sh`에 추가한다. Host app, Quick Look extension, Thumbnail extension, Sparkle framework, Sparkle nested component의 code signature metadata를 명시 확인해 notary submit 이후에야 발견되던 signing/notarization prerequisite 문제를 fail-fast로 잡는다.
+
+확인 시각: `2026-05-11 13:45 KST`
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `scripts/release.sh` | release signing preflight helper와 main hook 추가 |
+| `mydocs/working/task_m019_219_stage3.md` | Stage 3 구현 결과와 검증 기록 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- `scripts/release.sh`에 artifact signing preflight 함수와 main flow hook을 추가했다.
+- Stage 2에서 추가한 Sparkle component resolver를 validator에서도 재사용했다.
+- workflow와 manual 본문은 수정하지 않았다. 해당 정리는 Stage 4 범위다.
+- public release, Developer ID signing, notarization submit/wait, GitHub Release 게시, Pages/appcast 갱신은 실행하지 않았다.
+
+## 변경 내용
+
+### Team ID 입력
+
+`APPLE_TEAM_ID`를 release signing preflight의 expected Team ID로 사용한다.
+
+- 기본값: `XH6JHKYXV8`
+- override: workflow/local 환경에서 `APPLE_TEAM_ID`를 지정하면 해당 값을 사용
+- `./scripts/release.sh --help`의 public release environment 섹션에 `APPLE_TEAM_ID`를 추가했다.
+
+### Bundle identifier 검증
+
+`verify_bundle_identifier` helper를 추가했다.
+
+검증 대상:
+
+- Host app: `com.postmelee.alhangeul`
+- Quick Look extension: `com.postmelee.alhangeul.QLExtension`
+- Thumbnail extension: `com.postmelee.alhangeul.ThumbnailExtension`
+
+Sparkle framework와 nested executable은 bundle id policy를 강제하지 않는다.
+
+### `get-task-allow` 검증
+
+`verify_no_get_task_allow` helper를 추가했다.
+
+`codesign --display --entitlements :-` 결과에서 `com.apple.security.get-task-allow`가 true이면 release signing preflight가 실패한다. entitlement가 없거나 key가 없으면 이 조건은 통과한다.
+
+### Component signature 검증
+
+`verify_release_component_signature` helper를 추가했다. 각 component에 대해 다음을 확인한다.
+
+- component path 존재
+- `codesign --verify --strict --verbose=2` 통과
+- expected bundle id가 있는 경우 `CFBundleIdentifier` 일치
+- Developer ID Application authority
+- `TeamIdentifier=$APPLE_TEAM_ID`
+- secure timestamp 존재, `Timestamp=none` 아님
+- hardened runtime 존재 (`Runtime Version=` 또는 codesign flags의 `runtime`)
+- `get-task-allow` true 아님
+
+실패 메시지는 component label, path, 기대 조건을 포함한다.
+
+### Release signing preflight hook
+
+`verify_release_signing_preflight` helper를 추가하고 main flow에서 `verify_app_signature` 이후, `notarize_and_staple_app` 이전에 호출했다.
+
+검증 대상:
+
+- `Alhangeul.app`
+- `AlhangeulPreview.appex`
+- `AlhangeulThumbnail.appex`
+- `Sparkle.framework`
+- `Sparkle.framework` resolved version directory의 required nested components
+  - `XPCServices/Downloader.xpc`
+  - `XPCServices/Installer.xpc`
+  - `Updater.app`
+  - `Autoupdate`
+
+`ALHANGEUL_DEVELOPER_ID_APPLICATION`이 없는 unsigned rehearsal에서는 preflight를 실행하지 않고 명시 warning을 출력한다. public mode는 `run_preflight`에서 Developer ID identity가 필수이므로, app notarization submit 전 이 validator가 반드시 실행된다.
+
+## Stage 3 기준 대비 결과
+
+| 구현계획 기준 | 결과 |
+|---------------|------|
+| app notarization 제출 전 `verify_release_signing_preflight` 추가 | OK. main flow에서 `verify_app_signature`와 `notarize_and_staple_app` 사이에 호출 |
+| Host/Quick Look/Thumbnail/Sparkle component 개별 `codesign --verify --strict` | OK. `verify_release_component_signature`에서 실행 |
+| Developer ID Application signer 확인 | OK. authority 검사 추가 |
+| Team ID 확인 | OK. `TeamIdentifier=$APPLE_TEAM_ID` 검사 추가 |
+| secure timestamp 확인 | OK. `Timestamp=` 존재와 `Timestamp=none` 부재 확인 |
+| hardened runtime 확인 | OK. `Runtime Version=` 또는 `flags=.*runtime` 확인 |
+| `get-task-allow` true 실패 | OK. entitlement output 검사 추가 |
+| 실패 로그에 label/path/기대 조건 포함 | OK. `signing preflight failed for {label}: ... at {path}` 형식 |
+
+## 검증 결과
+
+| 명령 | 결과 | 비고 |
+|------|------|------|
+| `git status -sb` | OK | `local/task219`, `origin/devel-webview` 대비 ahead 4에서 시작 |
+| `bash -n scripts/release.sh` | OK | shell syntax 통과 |
+| `./scripts/release.sh --help` | OK | `APPLE_TEAM_ID` help와 기존 interface 확인 |
+| `rg -n "verify_release_signing_preflight\|codesign --display\|entitlements\|get-task-allow\|hardened runtime\|TeamIdentifier\|Timestamp\|APPLE_TEAM_ID" scripts/release.sh` | OK | Stage 3 validator hook과 검사 조건 확인 |
+| `git diff -- scripts/release.sh` | OK | 변경 범위 확인 |
+
+## 실행하지 않은 항목
+
+- `./scripts/release.sh --skip-notarize` 실행
+- Developer ID signing
+- signed rehearsal
+- notarization submit/wait
+- workflow summary 수정
+- manual 수정
+- public release 관련 외부 작업
+
+`--skip-notarize` release build는 Stage 5 통합 검증에서 수행 후보로 유지한다. 이번 Stage 3에서는 shell syntax와 script interface, hook/condition 검색으로 implementation-level 검증을 완료했다.
+
+## 잔여 위험
+
+- 실제 signed app bundle에서 `codesign --display --verbose=4` 출력이 예상과 다를 가능성은 남아 있다. Stage 5 또는 release 환경에서 signed path 실행 결과를 확인해야 한다.
+- `codesign --display --entitlements :-` output format이 바뀌면 `get-task-allow` grep이 false negative를 낼 수 있다. 현재 macOS plist XML output 기준으로 검사한다.
+- Sparkle future version에서 required nested component 구성이 바뀌면 Stage 2 resolver와 Stage 3 validator 모두 실패한다. 이는 public release 전 구조 변경을 드러내기 위한 fail-fast 동작이다.
+
+## 다음 단계
+
+Stage 4 승인 후 다음을 수행한다.
+
+1. `release-publish.yml`과 `release-rehearsal.yml` summary에 signing preflight 실행/skip 기준을 반영한다.
+2. release signing/notarization, packaging, distribution 문서에 preflight gate 위치와 실패 기준을 기록한다.
+3. #225 release 실행 전 확인해야 하는 preflight 기준을 문서에 남긴다.
+
+## 승인 요청
+
+1. Stage 3 결과 승인
+2. Stage 4 `workflow와 release 문서 연결` 진입 승인

--- a/mydocs/working/task_m019_219_stage4.md
+++ b/mydocs/working/task_m019_219_stage4.md
@@ -1,0 +1,124 @@
+# Task M019 #219 Stage 4 완료 보고서
+
+## 단계 목적
+
+Stage 3에서 추가한 release signing preflight를 release workflow summary와 release 운영 문서에 연결한다. 작업자가 #225 등 후속 release 실행 전에 preflight 실행/skip 조건, 검증 항목, 실패 기준을 확인할 수 있게 한다.
+
+확인 시각: `2026-05-11 14:09 KST`
+
+## 사전 base 정렬
+
+Stage 4 시작 전 `origin/devel-webview`에 PR #232(`#218`)가 merge되어 `local/task219`이 behind 상태가 됐다. `origin/devel-webview`를 병합했고, `mydocs/orders/20260511.md` 충돌은 #218 완료 행과 #219 진행 행을 모두 보존하는 방식으로 해결했다.
+
+병합 커밋:
+
+```text
+Task #219: 최신 devel-webview 병합
+```
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `.github/workflows/release-publish.yml` | public release workflow summary에 signing preflight policy 기록 추가 |
+| `.github/workflows/release-rehearsal.yml` | rehearsal workflow summary에 unsigned/signed rehearsal signing preflight 조건 기록 추가 |
+| `mydocs/manual/release_signing_notarization_guide.md` | notarization 전 signing preflight 검증 위치, 대상, 기준 문서화 |
+| `mydocs/manual/release_packaging_dmg_guide.md` | public/rehearsal DMG 수행 항목과 `APPLE_TEAM_ID` 기준 보강 |
+| `mydocs/manual/release_distribution_guide.md` | release asset 설명과 최종 체크리스트에 signing preflight 추가 |
+| `mydocs/working/task_m019_219_stage4.md` | Stage 4 완료 보고서 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- workflow summary와 release manual만 수정했다.
+- `scripts/release.sh`는 Stage 4에서 수정하지 않았다.
+- #218 troubleshooting 문서는 복제하지 않고 기존 연결을 유지했다.
+- public release, Developer ID signing, notarization submit/wait, GitHub Release 게시, Pages/appcast 갱신은 실행하지 않았다.
+
+## 변경 내용
+
+### Release Publish workflow summary
+
+`release-publish.yml`에 `Record signing preflight policy` step을 추가했다.
+
+summary에 남기는 내용:
+
+- release command: `./scripts/release.sh "$VERSION"`
+- expected Team ID
+- app notarization submit 전에 Developer ID authority, Team ID, secure timestamp, hardened runtime, `get-task-allow` 부재, Sparkle nested component 존재를 검증한다는 점
+- preflight 실패가 notarization submit을 차단한다는 점
+
+### Release Rehearsal workflow summary
+
+`release-rehearsal.yml`에 `Record signing preflight policy` step을 추가했다.
+
+summary에 남기는 내용:
+
+- release command: `./scripts/release.sh --skip-notarize "$VERSION"`
+- 기본 rehearsal artifact는 unsigned이며 Developer ID signing preflight를 skip한다는 점
+- `ALHANGEUL_DEVELOPER_ID_APPLICATION`을 제공한 signed rehearsal에서는 같은 app/extension/Sparkle signing preflight가 실행된다는 점
+- rehearsal artifact는 public release 또는 Homebrew Cask 입력이 아니라는 점
+
+### Signing/notarization guide
+
+`release_signing_notarization_guide.md`에 `Notarization 전 signing preflight` 섹션을 추가했다.
+
+문서화한 항목:
+
+- preflight 실행 위치: 재서명과 universal/codesign verify 이후, app notarization submit 이전
+- 검증 대상: Host app, Quick Look extension, Thumbnail extension, Sparkle framework, Sparkle Downloader/Installer XPC, Updater.app, Autoupdate
+- 검증 기준: Developer ID authority, Team ID, secure timestamp, hardened runtime, `get-task-allow` 부재, bundle identifier, required Sparkle component 존재
+- unsigned rehearsal과 signed rehearsal의 실행/skip 조건
+
+### Packaging/distribution guide
+
+`release_packaging_dmg_guide.md`에는 public mode 수행 항목에 Sparkle/app/extension 재서명과 release signing preflight를 추가했다. rehearsal section에는 Developer ID identity가 제공된 signed rehearsal에서 같은 preflight가 실행되며, unsigned rehearsal skip 결과를 public signing prerequisite 통과로 기록하지 말라는 기준을 추가했다.
+
+`release_distribution_guide.md`에는 `scripts/release.sh` asset 설명과 최종 체크리스트에 app notarization 전 signing preflight 통과 항목을 추가했다.
+
+## Stage 4 기준 대비 결과
+
+| 구현계획 기준 | 결과 |
+|---------------|------|
+| release-publish summary가 signing preflight 실행 기준 설명 | OK |
+| release-rehearsal summary가 signing preflight 실행/skip 조건 설명 | OK |
+| signing/notarization 문서에 preflight gate 위치와 실패 기준 기록 | OK |
+| packaging/distribution 문서에 #225 release 실행 전 확인 기준 기록 | OK |
+| public release 실행 없음 | OK |
+
+## 검증 결과
+
+| 명령 | 결과 | 비고 |
+|------|------|------|
+| `git status -sb` | OK | Stage 4 전 최신 `origin/devel-webview` 병합 후 진행 |
+| `rg -n "signing preflight\|notarization preflight\|Developer ID\|timestamp\|get-task-allow\|Sparkle.framework\|release.sh" .github/workflows mydocs/manual` | OK | workflow/manual 연결 확인 |
+| `git diff --check -- .github/workflows mydocs/manual` | OK | whitespace 오류 없음 |
+| `git diff --stat` | OK | workflow 2개, manual 3개 변경 확인 |
+
+## 실행하지 않은 항목
+
+- `scripts/release.sh` 추가 수정
+- `./scripts/release.sh --skip-notarize` 실행
+- Developer ID signing
+- signed rehearsal
+- notarization submit/wait
+- public release 관련 외부 작업
+
+## 잔여 위험
+
+- workflow summary는 GitHub Actions에서 실제 실행해야 최종 렌더링을 확인할 수 있다. 로컬에서는 YAML fragment와 shell echo 구문 수준으로 확인했다.
+- signed rehearsal은 Developer ID identity가 있는 환경에서만 preflight 실행을 확인할 수 있다.
+- Stage 5에서 가능한 범위의 release helper/rehearsal 검증을 통해 unsigned skip path와 script syntax를 다시 확인해야 한다.
+
+## 다음 단계
+
+Stage 5 승인 후 다음을 수행한다.
+
+1. `bash -n scripts/release.sh`, `bash -n scripts/ci/*.sh`, `./scripts/release.sh --help`를 재실행한다.
+2. 가능한 경우 `./scripts/release.sh --skip-notarize <현재 source version>`으로 unsigned rehearsal path를 확인한다.
+3. 전체 검색과 `git diff --check`를 실행한다.
+4. 최종 보고서와 오늘할일 완료 처리 후 커밋한다.
+
+## 승인 요청
+
+1. Stage 4 결과 승인
+2. Stage 5 `통합 검증과 최종 보고` 진입 승인

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -353,30 +353,116 @@ expand_entitlements() {
   sed "s|\$(PRODUCT_BUNDLE_IDENTIFIER)|$bundle_id|g" "$source" > "$output"
 }
 
+sparkle_required_component_paths() {
+  printf '%s\n' \
+    "XPCServices/Downloader.xpc" \
+    "XPCServices/Installer.xpc" \
+    "Updater.app" \
+    "Autoupdate"
+}
+
+sparkle_version_dir_has_required_components() {
+  local version_dir="$1"
+  local component_rel
+
+  while IFS= read -r component_rel; do
+    if [ ! -e "$version_dir/$component_rel" ]; then
+      return 1
+    fi
+  done < <(sparkle_required_component_paths)
+
+  return 0
+}
+
+report_missing_sparkle_components() {
+  local version_dir="$1"
+  local component_rel
+
+  while IFS= read -r component_rel; do
+    if [ ! -e "$version_dir/$component_rel" ]; then
+      warn "Missing Sparkle notarization component: $version_dir/$component_rel"
+    fi
+  done < <(sparkle_required_component_paths)
+}
+
+resolve_sparkle_current_version_dir() {
+  local versions_dir="$1"
+  local current_dir="$versions_dir/Current"
+
+  if [ -d "$current_dir" ]; then
+    (cd "$current_dir" && pwd -P)
+  fi
+}
+
+resolve_sparkle_version_dir() {
+  local sparkle_framework="$1"
+  local versions_dir="$sparkle_framework/Versions"
+  local candidate
+  local current_version_dir
+  local resolved_candidate
+
+  if [ ! -d "$sparkle_framework" ]; then
+    fail "missing Sparkle framework: $sparkle_framework"
+  fi
+  if [ ! -d "$versions_dir" ]; then
+    fail "missing Sparkle framework Versions directory: $versions_dir"
+  fi
+
+  current_version_dir="$(resolve_sparkle_current_version_dir "$versions_dir")"
+  if [ -n "$current_version_dir" ]; then
+    if sparkle_version_dir_has_required_components "$current_version_dir"; then
+      echo "$current_version_dir"
+      return
+    fi
+    warn "Sparkle Versions/Current is missing required notarization components: $current_version_dir"
+    report_missing_sparkle_components "$current_version_dir"
+  fi
+
+  for candidate in "$versions_dir"/*; do
+    if [ ! -d "$candidate" ]; then
+      continue
+    fi
+    if [ "${candidate##*/}" = "Current" ]; then
+      continue
+    fi
+
+    resolved_candidate="$(cd "$candidate" && pwd -P)"
+    if sparkle_version_dir_has_required_components "$resolved_candidate"; then
+      echo "$resolved_candidate"
+      return
+    fi
+  done
+
+  warn "Checked Sparkle framework version directories under: $versions_dir"
+  for candidate in "$versions_dir"/*; do
+    if [ ! -d "$candidate" ]; then
+      continue
+    fi
+    if [ "${candidate##*/}" = "Current" ]; then
+      continue
+    fi
+    report_missing_sparkle_components "$candidate"
+  done
+  fail "could not find a Sparkle framework version directory with all required notarization components"
+}
+
 sign_sparkle_components_for_notarization() {
   if [ -z "$DEVELOPER_ID_APPLICATION" ]; then
     return
   fi
 
   local sparkle_framework="$APP_OUTPUT/Contents/Frameworks/Sparkle.framework"
-  local sparkle_version_dir="$sparkle_framework/Versions/B"
+  local sparkle_version_dir
+  local component_rel
   local component
 
-  if [ ! -d "$sparkle_version_dir" ]; then
-    return
-  fi
+  sparkle_version_dir="$(resolve_sparkle_version_dir "$sparkle_framework")"
 
   info "Signing Sparkle nested components for notarization"
-  for component in \
-    "$sparkle_version_dir/XPCServices/Downloader.xpc" \
-    "$sparkle_version_dir/XPCServices/Installer.xpc" \
-    "$sparkle_version_dir/Updater.app" \
-    "$sparkle_version_dir/Autoupdate"
-  do
-    if [ -e "$component" ]; then
-      codesign_developer_id "$component"
-    fi
-  done
+  while IFS= read -r component_rel; do
+    component="$sparkle_version_dir/$component_rel"
+    codesign_developer_id "$component"
+  done < <(sparkle_required_component_paths)
 
   codesign_developer_id "$sparkle_framework"
 }

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,6 +16,7 @@ KEEP_STAGING=0
 DEVELOPER_ID_APPLICATION="${ALHANGEUL_DEVELOPER_ID_APPLICATION:-}"
 NOTARY_PROFILE="${ALHANGEUL_NOTARY_PROFILE:-}"
 DEVELOPER_ID_DMG="${ALHANGEUL_DEVELOPER_ID_DMG:-$DEVELOPER_ID_APPLICATION}"
+APPLE_TEAM_ID="${APPLE_TEAM_ID:-XH6JHKYXV8}"
 
 usage() {
   cat <<EOF
@@ -31,6 +32,7 @@ Public release environment:
   ALHANGEUL_DEVELOPER_ID_APPLICATION   Developer ID Application signing identity.
   ALHANGEUL_NOTARY_PROFILE             notarytool keychain profile name.
   ALHANGEUL_DEVELOPER_ID_DMG           Optional DMG signing identity. Defaults to app identity.
+  APPLE_TEAM_ID                        Optional expected Team ID for signing preflight. Defaults to XH6JHKYXV8.
   ALHANGEUL_BUILD_ROOT                 Optional build root. Defaults to build.noindex.
 
 Examples:
@@ -530,6 +532,113 @@ verify_app_signature() {
   fi
 }
 
+verify_bundle_identifier() {
+  local label="$1"
+  local path="$2"
+  local expected_bundle_id="$3"
+  local info_plist="$path/Contents/Info.plist"
+  local actual_bundle_id
+
+  if [ -z "$expected_bundle_id" ]; then
+    return
+  fi
+  if [ ! -f "$info_plist" ]; then
+    fail "signing preflight failed for $label: missing Info.plist at $info_plist"
+  fi
+
+  if ! actual_bundle_id="$(plutil -extract CFBundleIdentifier raw -o - "$info_plist")"; then
+    fail "signing preflight failed for $label: unable to read CFBundleIdentifier from $info_plist"
+  fi
+  if [ "$actual_bundle_id" != "$expected_bundle_id" ]; then
+    fail "signing preflight failed for $label: expected bundle id $expected_bundle_id, got $actual_bundle_id at $path"
+  fi
+}
+
+verify_no_get_task_allow() {
+  local label="$1"
+  local path="$2"
+  local entitlements
+
+  entitlements="$(codesign --display --entitlements :- "$path" 2>/dev/null || true)"
+  if printf '%s\n' "$entitlements" \
+    | grep -A1 '<key>com.apple.security.get-task-allow</key>' \
+    | grep -q '<true/>'; then
+    fail "signing preflight failed for $label: com.apple.security.get-task-allow is true at $path"
+  fi
+}
+
+verify_release_component_signature() {
+  local label="$1"
+  local path="$2"
+  local expected_bundle_id="${3:-}"
+  local display
+
+  if [ ! -e "$path" ]; then
+    fail "signing preflight failed for $label: missing component at $path"
+  fi
+
+  codesign --verify --strict --verbose=2 "$path"
+  verify_bundle_identifier "$label" "$path" "$expected_bundle_id"
+
+  if ! display="$(codesign --display --verbose=4 "$path" 2>&1)"; then
+    fail "signing preflight failed for $label: unable to read codesign metadata at $path"
+  fi
+
+  if [[ "$DEVELOPER_ID_APPLICATION" == Developer\ ID\ Application:* ]]; then
+    if ! printf '%s\n' "$display" | grep -Fxq "Authority=$DEVELOPER_ID_APPLICATION"; then
+      fail "signing preflight failed for $label: expected authority $DEVELOPER_ID_APPLICATION at $path"
+    fi
+  elif ! printf '%s\n' "$display" | grep -Fq "Authority=Developer ID Application:"; then
+    fail "signing preflight failed for $label: expected Developer ID Application authority at $path"
+  fi
+
+  if ! printf '%s\n' "$display" | grep -Fxq "TeamIdentifier=$APPLE_TEAM_ID"; then
+    fail "signing preflight failed for $label: expected TeamIdentifier=$APPLE_TEAM_ID at $path"
+  fi
+  if ! printf '%s\n' "$display" | grep -q '^Timestamp='; then
+    fail "signing preflight failed for $label: missing secure timestamp at $path"
+  fi
+  if printf '%s\n' "$display" | grep -q '^Timestamp=none'; then
+    fail "signing preflight failed for $label: timestamp is none at $path"
+  fi
+  if ! printf '%s\n' "$display" | grep -q '^Runtime Version=' \
+    && ! printf '%s\n' "$display" | grep -q 'flags=.*runtime'; then
+    fail "signing preflight failed for $label: missing hardened runtime at $path"
+  fi
+
+  verify_no_get_task_allow "$label" "$path"
+}
+
+verify_release_signing_preflight() {
+  if [ -z "$DEVELOPER_ID_APPLICATION" ]; then
+    warn "Skipping release signing preflight because this rehearsal build is unsigned."
+    return
+  fi
+
+  local sparkle_framework="$APP_OUTPUT/Contents/Frameworks/Sparkle.framework"
+  local sparkle_version_dir
+  local component_rel
+
+  info "Running release signing preflight"
+  verify_release_component_signature "Host app" "$APP_OUTPUT" "com.postmelee.alhangeul"
+  verify_release_component_signature \
+    "Quick Look extension" \
+    "$APP_OUTPUT/Contents/PlugIns/AlhangeulPreview.appex" \
+    "com.postmelee.alhangeul.QLExtension"
+  verify_release_component_signature \
+    "Thumbnail extension" \
+    "$APP_OUTPUT/Contents/PlugIns/AlhangeulThumbnail.appex" \
+    "com.postmelee.alhangeul.ThumbnailExtension"
+
+  sparkle_version_dir="$(resolve_sparkle_version_dir "$sparkle_framework")"
+  verify_release_component_signature "Sparkle framework" "$sparkle_framework"
+  while IFS= read -r component_rel; do
+    verify_release_component_signature \
+      "Sparkle $component_rel" \
+      "$sparkle_version_dir/$component_rel"
+  done < <(sparkle_required_component_paths)
+}
+
 notary_json_value() {
   local key="$1"
   local json="$2"
@@ -742,6 +851,7 @@ main() {
   sign_release_app_for_notarization
   verify_universal_app
   verify_app_signature
+  verify_release_signing_preflight
   notarize_and_staple_app
   create_dmg
   sign_dmg


### PR DESCRIPTION
## 요약

- 대상 타스크: release artifact signing/notarization prerequisite를 app notarization submit 전에 fail-fast로 검증하도록 보강합니다.
- 왜: #188 public release 중 Sparkle nested executable timestamp/signing, extension debug entitlement 문제가 notary submit 이후에야 드러났고, #225 v0.1.2 release 전에 같은 계열의 실패를 앞단에서 차단해야 합니다.
- 무엇: Sparkle component discovery를 `Versions/Current` 우선 + discovery fallback으로 바꾸고, Host app/QL/Thumbnail/Sparkle component별 Developer ID, Team ID, timestamp, hardened runtime, `get-task-allow` 검증을 추가했습니다.
- 리뷰 포인트: `scripts/release.sh`의 `verify_release_signing_preflight` hook 위치와 unsigned/signed rehearsal 분기 정책을 먼저 봐 주세요.

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/d475cb1b2521765c44ab878f9303b80177030f9b/mydocs/working/task_m019_219_stage1.md)** ([6def904](https://github.com/postmelee/alhangeul-macos/commit/6def904614b438eab35d6693049b7ffe61cbdfe9)): signing/notarization preflight 대상 component와 실행 조건 inventory 정리
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/d475cb1b2521765c44ab878f9303b80177030f9b/mydocs/working/task_m019_219_stage2.md)** ([e816761](https://github.com/postmelee/alhangeul-macos/commit/e8167617a392b30839a1be0542fa8b44f421011b)): Sparkle `Versions/Current` 우선 discovery와 required component 공통 목록 도입
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/d475cb1b2521765c44ab878f9303b80177030f9b/mydocs/working/task_m019_219_stage3.md)** ([37d6b55](https://github.com/postmelee/alhangeul-macos/commit/37d6b552ef509e8454c571d75f92745e885892b7)): release signing preflight validator 구현
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/d475cb1b2521765c44ab878f9303b80177030f9b/mydocs/working/task_m019_219_stage4.md)** ([de3932b](https://github.com/postmelee/alhangeul-macos/commit/de3932bb4502d4f40ce8b7785e29153406672029)): release workflow summary와 signing/packaging/distribution 문서 연결
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/d475cb1b2521765c44ab878f9303b80177030f9b/mydocs/report/task_m019_219_report.md)** ([d475cb1](https://github.com/postmelee/alhangeul-macos/commit/d475cb1b2521765c44ab878f9303b80177030f9b)): 통합 검증, rehearsal 결과, #225 handoff 정리

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `scripts/release.sh` | Sparkle required component resolver와 release signing preflight 추가 | `notarize_and_staple_app` 호출 전에 fail-fast로 실행되는지 확인 |
| `.github/workflows/release-*.yml` | publish/rehearsal summary에 preflight policy 기록 | unsigned rehearsal과 signed rehearsal 설명이 실제 script 조건과 맞는지 확인 |
| `mydocs/manual/*release*` | release signing/notarization, packaging, distribution 기준 갱신 | #225 release 작업자가 따라야 할 선행 확인 기준이 충분한지 확인 |

- 수행 계획서: [task_m019_219.md](https://github.com/postmelee/alhangeul-macos/blob/d475cb1b2521765c44ab878f9303b80177030f9b/mydocs/plans/task_m019_219.md)
- 구현 계획서: [task_m019_219_impl.md](https://github.com/postmelee/alhangeul-macos/blob/d475cb1b2521765c44ab878f9303b80177030f9b/mydocs/plans/task_m019_219_impl.md)
- 최종 보고서: [task_m019_219_report.md](https://github.com/postmelee/alhangeul-macos/blob/d475cb1b2521765c44ab878f9303b80177030f9b/mydocs/report/task_m019_219_report.md)

## 핵심 리뷰 포인트

- `verify_release_signing_preflight`는 `sign_release_app_for_notarization`과 `verify_app_signature` 이후, app notarization submit 이전에 실행됩니다.
- public/signed rehearsal path에서는 Sparkle framework와 nested component가 누락되거나 Developer ID/Team ID/timestamp/hardened runtime/debug entitlement 기준을 만족하지 못하면 실패합니다.
- unsigned `--skip-notarize` rehearsal은 signing preflight를 통과한 것으로 기록하지 않고 명시적으로 skip 로그를 남깁니다.

## 검증

- `bash -n scripts/release.sh`
- `bash -n scripts/ci/*.sh`
- `./scripts/release.sh --help`
- `rg -n "preflight|notarization|Developer ID|timestamp|get-task-allow|Sparkle.framework/Versions|hardened runtime|Versions/Current" scripts .github/workflows mydocs/manual`
- `git diff --check`
- `ALHANGEUL_BUILD_ROOT=build.noindex/task219-stage5 ./scripts/release.sh --skip-notarize 0.1.1`
  - 네트워크 제한 해제 재시도 후 Rust bridge 검증, Release app build, universal architecture 확인, unsigned signing preflight skip 로그까지 확인했습니다.
  - 이후 기존 DMG Finder layout AppleScript 단계에서 `-10006`으로 실패했습니다. 이 실패는 이번 signing preflight validator가 아니라 `create_dmg -> apply_dmg_finder_layout` 경로의 별도 packaging 리스크입니다.

## 대상 이슈

Closes #219

## 관련 이슈

- 후속 release 실행: #225
- 참고 release 실패/정리: #188, #218
- 참고 최근 merge: #231

## 후속 이슈 제안

- Stage 5 local rehearsal에서 관측된 Finder DMG layout AppleScript `-10006` 실패가 #225 rehearsal/publish에서도 재현되면 별도 release packaging blocker로 분리합니다.

## 남은 리스크

- Developer ID identity가 없는 로컬 환경에서는 signed rehearsal preflight와 public notarization submit을 실행하지 않았습니다.
- GitHub Actions `release-publish`에서 실제 Developer ID certificate와 notary profile이 주입된 상태의 preflight 실행은 #225 release 작업에서 최종 확인해야 합니다.
