### PR TITLE
Record v0.1.2 public release results

### DIFF
--- a/mydocs/orders/20260513.md
+++ b/mydocs/orders/20260513.md
@@ -4,5 +4,5 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #225 | rhwp 최신버전 반영 및 v0.1.2 배포 | 진행 중 | devel-webview merge 완료, main release PR preflight 진행: 11:04 |
+| #225 | rhwp 최신버전 반영 및 v0.1.2 배포 | 완료 | public GitHub Release, signed/notarized DMG, stable appcast, Pages 배포 완료: 11:30 |
 | #235 | Web viewer runtime 오류를 fatal 화면 대신 non-blocking banner로 표시 | 완료 | M019, Stage 5 최종 보고 완료: 09:47 |

--- a/mydocs/release/v0.1.2.md
+++ b/mydocs/release/v0.1.2.md
@@ -4,18 +4,18 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | #235 통합 후 build 8 release candidate local/rehearsal 검증 완료, `devel-webview` merge 후 main release PR 준비 중. public GitHub Release, stable Sparkle appcast, Pages 배포, public DMG SHA256은 아직 미확정 |
+| 상태 | `v0.1.2` build `8` public GitHub Release, signed/notarized DMG, stable Sparkle appcast, Pages 배포 완료 |
 | 목표 Git tag | `v0.1.2` |
 | 목표 app version | `0.1.2` |
 | 목표 build | `8` |
 | 직전 public release | `v0.1.1` build `4` |
 | GitHub Release | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.2 |
 | Pages 릴리즈 노트 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.2.html |
-| Public DMG | `alhangeul-macos-0.1.2.dmg` 예정 |
-| Public DMG SHA256 | 미확정 |
+| Public DMG | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.2/alhangeul-macos-0.1.2.dmg |
+| Public DMG SHA256 | `37a27321f03a84b8b28749b5f839ea5c5833975d20f2479e3b79ebd665811ead` |
 | Release 실행 이슈 | [#225](https://github.com/postmelee/alhangeul-macos/issues/225) |
 
-`v0.1.2` public 배포는 `devel-webview`의 검증 commit을 `main`에 반영하고 `v0.1.2` tag를 만든 뒤, 작업지시자의 별도 승인으로 `Release Publish DMG` workflow를 실행할 때 확정한다. 이 문서는 Stage 5/6/7/8 기준 release candidate metadata와 local/rehearsal 검증 기록이며, 실제 public DMG URL, SHA256, Sparkle EdDSA signature, GitHub Release latest 상태는 public workflow 성공 후 보강한다.
+`v0.1.2` public 배포는 `devel-webview`의 검증 commit을 `main`에 반영한 PR #238 merge commit `2c199b24c784c2044dae8473538515c59bd91939`에 tag `v0.1.2`를 만들고, `Release Publish DMG` workflow run `25774125473`에서 확정했다. 이 문서는 Stage 5/6/7/8 기준 release candidate metadata, local/rehearsal 검증, public GitHub Release와 Pages/Sparkle 배포 결과를 함께 기록한다.
 
 ## 사용자용 요약
 
@@ -23,7 +23,7 @@
 
 ## 직전 공개 릴리즈 대비 변경점
 
-기준 범위는 `v0.1.1..v0.1.2`다. 최종 release tag의 peeled commit은 public 배포 직전에 기록한다.
+기준 범위는 `v0.1.1..v0.1.2`다. 최종 release tag의 peeled commit은 `2c199b24c784c2044dae8473538515c59bd91939`다.
 
 | 영역 | 변경 |
 |------|------|
@@ -39,12 +39,12 @@
 
 | Issue | PR | 상태 | 내용 |
 |-------|----|------|------|
-| [#225](https://github.com/postmelee/alhangeul-macos/issues/225) | TBD | 진행 중 | `rhwp v0.7.11` 반영, update 후 Finder thumbnail refresh UX, About provenance, `v0.1.2` 배포 |
+| [#225](https://github.com/postmelee/alhangeul-macos/issues/225) | [#237](https://github.com/postmelee/alhangeul-macos/pull/237), [#238](https://github.com/postmelee/alhangeul-macos/pull/238) | public 배포 완료 | `rhwp v0.7.11` 반영, update 후 Finder thumbnail refresh UX, About provenance, `v0.1.2` 배포 |
 | [#235](https://github.com/postmelee/alhangeul-macos/issues/235) | [#236](https://github.com/postmelee/alhangeul-macos/pull/236) | 완료 | Web viewer runtime 오류를 fatal 화면 대신 non-blocking banner로 표시 |
 
 ## 검증 결과
 
-Stage 5/6/7/8 기준 source 검증, unsigned rehearsal DMG, ad-hoc signed local smoke, current/Hancom UTI thumbnail routing, GUI About 확인을 성공으로 기록한다. Developer ID signed/notarized DMG, 실제 Sparkle update, public Pages/appcast 확인은 public 배포 단계에서 별도로 기록한다.
+Stage 5/6/7/8 기준 source 검증, unsigned rehearsal DMG, ad-hoc signed local smoke, current/Hancom UTI thumbnail routing, GUI About 확인을 성공으로 기록한다. public 배포 단계에서는 Developer ID signed/notarized DMG, GitHub Release asset, stable Sparkle appcast, Pages release note를 추가로 확인했다.
 
 | 영역 | 현재 기준 | 결과 |
 |------|-----------|------|
@@ -57,8 +57,9 @@ Stage 5/6/7/8 기준 source 검증, unsigned rehearsal DMG, ad-hoc signed local 
 | Rehearsal DMG | unsigned local artifact | build `8` 기준 `./scripts/release.sh --skip-notarize 0.1.2` 통과, `hdiutil verify` VALID, SHA256 `e0c25bd72f64bc4fabbde97c62e92e4f391aad133b0ee9f41dd9a542fa45771b` |
 | Universal slice | release app bundle | app, preview, thumbnail 실행 파일 모두 `x86_64 arm64` 확인 |
 | Finder thumbnail smoke | ad-hoc signed local install | build `8` 기준 current UTI smoke와 Hancom 4종 forced routing 통과. smoke 산출물 `/private/tmp/alhangeul-visual-smoke/20260513-102822` |
-| Public DMG | 미생성 | signed/notarized public package에서 확정 |
-| Stable appcast | 미갱신 | public DMG와 EdDSA signature 확정 후 갱신 |
+| Public DMG | GitHub Release `v0.1.2` | signed/notarized public DMG 게시 완료. SHA256 `37a27321f03a84b8b28749b5f839ea5c5833975d20f2479e3b79ebd665811ead`, asset size `92,667,312` bytes |
+| Stable appcast | Pages `appcast.xml` | HTTP 200, `sparkle:shortVersionString=0.1.2`, `sparkle:version=8`, enclosure URL public DMG, EdDSA signature 확인 |
+| Pages release note | Pages `updates/v0.1.2.html` | HTTP 200 |
 | Homebrew Cask | 미갱신 | public DMG SHA256 확정 후 #209 또는 별도 승인 범위에서 갱신 |
 
 ## Stage 5 local/rehearsal 검증 결과
@@ -158,6 +159,22 @@ Stage 8은 #235의 Web viewer runtime 오류 banner UX가 `devel-webview`에 mer
 | DMG layout #184 check | final rehearsal DMG를 `-noautoopen -nobrowse -readonly`로 mount해 확인. root에는 `Alhangeul.app`과 `Applications` symlink가 있고 `.background/alhangeul-dmg-background.png`는 `720x460` PNG |
 | Local cleanup | rehearsal build 후 PlugInKit Preview/Thumbnail no matches, LaunchServices의 `build.noindex` Alhangeul/Updater stale 경로 미검출 |
 
+## Public release publish
+
+PR #238을 `main`에 merge한 뒤 tag `v0.1.2`를 push하고 `Release Publish DMG` workflow를 실행했다.
+
+| 항목 | 결과 |
+|------|------|
+| Main release PR | PR #238 `Release v0.1.2 build 8`, CI 통과 후 merge commit `2c199b24c784c2044dae8473538515c59bd91939` |
+| Release tag | annotated tag `v0.1.2`, peeled commit `2c199b24c784c2044dae8473538515c59bd91939` |
+| Workflow | `Release Publish DMG` run `25774125473` 성공. signed/notarized DMG build, public artifact verify, release notes, GitHub Release publish, appcast write, Pages deploy 모두 통과 |
+| GitHub Release | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.2, `draft=false`, `prerelease=false`, published `2026-05-13T02:27:53Z` |
+| Public DMG | `alhangeul-macos-0.1.2.dmg`, size `92,667,312` bytes |
+| SHA256 | `37a27321f03a84b8b28749b5f839ea5c5833975d20f2479e3b79ebd665811ead` |
+| SHA256 sidecar | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.2/alhangeul-macos-0.1.2.dmg.sha256 내용과 GitHub asset digest 일치 |
+| Stable appcast | https://postmelee.github.io/alhangeul-macos/appcast.xml HTTP 200, first item `0.1.2 (8)`, enclosure URL public DMG, EdDSA signature `gT+WgNhGAniyWdHXYM2OALXeiXnJNaUlfCMNtuzhSr1t24bQ/EL/XrTpMUK3lWPmngIJ6OqrMXLw2z8Dcuh6Dw==` |
+| Pages release note | https://postmelee.github.io/alhangeul-macos/updates/v0.1.2.html HTTP 200 |
+
 ## Release metadata
 
 | 대상 | 기준 |
@@ -178,14 +195,14 @@ Stage 8은 #235의 Web viewer runtime 오류 banner UX가 `devel-webview`에 mer
 
 public 배포 전에 다음 조건을 모두 만족해야 한다.
 
-- [ ] `local/task225` 변경을 `publish/task225` PR로 게시하고 `devel-webview`에 merge
-- [ ] `devel-webview`의 release candidate commit을 `main`에 merge하는 release PR 승인과 merge
-- [ ] `main`의 최종 release commit에 `v0.1.2` tag 생성
-- [ ] signed/notarized Release package build와 설치본 smoke 통과
-- [ ] GitHub Release body가 `scripts/ci/write-release-notes.sh` template 기준으로 생성됐는지 확인
-- [ ] public DMG `alhangeul-macos-0.1.2.dmg` SHA256 기록
-- [ ] stable Sparkle appcast의 `sparkle:shortVersionString=0.1.2`, `sparkle:version=8`, EdDSA signature 확인
-- [ ] public Pages `updates/v0.1.2.html`와 `appcast.xml` URL 확인
+- [x] `local/task225` 변경을 `publish/task225` PR로 게시하고 `devel-webview`에 merge
+- [x] `devel-webview`의 release candidate commit을 `main`에 merge하는 release PR 승인과 merge
+- [x] `main`의 최종 release commit에 `v0.1.2` tag 생성
+- [x] signed/notarized Release package build와 설치본 smoke 통과
+- [x] GitHub Release body가 `scripts/ci/write-release-notes.sh` template 기준으로 생성됐는지 확인
+- [x] public DMG `alhangeul-macos-0.1.2.dmg` SHA256 기록
+- [x] stable Sparkle appcast의 `sparkle:shortVersionString=0.1.2`, `sparkle:version=8`, EdDSA signature 확인
+- [x] public Pages `updates/v0.1.2.html`와 `appcast.xml` URL 확인
 - [ ] Homebrew Cask 갱신 여부를 public DMG SHA256 확정 후 별도 승인 범위에서 결정
 
 ## 알려진 제한 사항과 후속 이슈
@@ -194,7 +211,7 @@ public 배포 전에 다음 조건을 모두 만족해야 한다.
 - build별 launch maintenance는 `NSWorkspace.noteFileSystemChanged`로 Finder/Quick Look 재평가를 유도하지만, 전역 Quick Look cache 삭제를 보장하지 않는다.
 - 최근 문서 후보 밖 파일의 오래된 thumbnail cache는 그대로 남을 수 있다.
 - HWPX 문서는 현재 직접 저장이 제한되어 HWP export 경로를 사용한다.
-- public DMG SHA256, Sparkle appcast signature, GitHub Release latest 상태는 public 배포 후 확정한다.
+- Homebrew Cask 갱신은 public DMG SHA256 확정 후 별도 승인 범위에서 진행한다.
 
 ## Release communication checklist
 
@@ -210,9 +227,9 @@ public 배포 전에 다음 조건을 모두 만족해야 한다.
 - [x] local/rehearsal app/preview/thumbnail universal slice 확인
 - [x] ad-hoc signed local install 기준 Finder thumbnail smoke 확인
 - [x] About 창의 `rhwp v0.7.11 (a9dcdee)` 표시 확인
-- [ ] public DMG 생성
-- [ ] public DMG 안의 앱 본체와 Quick Look/Thumbnail extension 실행 파일이 `arm64 + x86_64` universal인지 확인
-- [ ] public DMG 안의 app/extension version이 `0.1.2 (8)`인지 확인
-- [ ] public DMG SHA256 기록
-- [ ] public GitHub Release URL과 latest 상태 확인
-- [ ] public `https://postmelee.github.io/alhangeul-macos/appcast.xml` stable item과 Sparkle EdDSA signature 확인
+- [x] public DMG 생성
+- [x] public DMG 안의 앱 본체와 Quick Look/Thumbnail extension 실행 파일이 `arm64 + x86_64` universal인지 확인
+- [x] public DMG 안의 app/extension version이 `0.1.2 (8)`인지 확인
+- [x] public DMG SHA256 기록
+- [x] public GitHub Release URL과 latest 상태 확인
+- [x] public `https://postmelee.github.io/alhangeul-macos/appcast.xml` stable item과 Sparkle EdDSA signature 확인

--- a/mydocs/report/task_m019_225_report.md
+++ b/mydocs/report/task_m019_225_report.md
@@ -4,8 +4,8 @@
 
 - 이슈: #225 rhwp 최신버전 반영 및 v0.1.2 배포 준비
 - 마일스톤: M019 (`v0.1.2`)
-- 브랜치: `local/task225`
-- 기준 브랜치: `devel-webview`
+- 브랜치: `local/task225`, `publish/task225`, `publish/task225-main`
+- 기준 브랜치: `devel-webview`, `main`
 - 최종 release candidate: `0.1.2 (8)`
 - 목표 tag: `v0.1.2`
 - 목적: `rhwp v0.7.11` core/studio를 반영하고, Finder Quick Look/Thumbnail update maintenance, About provenance, current/Hancom UTI 정책, release 문서와 workflow helper를 v0.1.2 public release 후보 기준으로 정리한다.
@@ -14,7 +14,7 @@
 
 `v0.1.2` build `8` release candidate를 만들고 local/rehearsal 검증을 완료했다. #235의 Web viewer runtime 오류 banner UX가 `devel-webview`에 먼저 merge되었으므로, 해당 변경을 #225 후보에 통합한 뒤 build `8`로 respin했다.
 
-public Developer ID signing, notarization, GitHub Release 게시, stable Sparkle appcast/Pages 배포는 아직 실행하지 않았다. 이 외부 공개 작업은 `publish/task225 -> devel-webview` PR merge, `devel-webview -> main` release PR merge, `v0.1.2` tag 생성 후 `Release Publish DMG` workflow에서 수행한다.
+이후 PR #237로 `devel-webview`에 반영하고, PR #238로 `main`에 반영했다. `main` merge commit `2c199b24c784c2044dae8473538515c59bd91939`에 tag `v0.1.2`를 생성한 뒤 `Release Publish DMG` workflow run `25774125473`에서 Developer ID signing, notarization, GitHub Release 게시, stable Sparkle appcast, Pages 배포를 완료했다.
 
 ## 주요 변경 파일
 
@@ -144,21 +144,17 @@ qlmanage -t -x -s 768 -c com.haansoft.hancomofficeviewer.mac.hwpx ...
 | legacy UTI 제거와 current/Hancom UTI 지원 | OK | plist search, clean smoke, Hancom forced routing |
 | #235 runtime banner 포함 | OK | #236 merge commit 통합, build 8 respin |
 | release rehearsal DMG 생성 | OK | `--skip-notarize` DMG와 SHA256 기록 |
-| public release 게시 | Pending | main merge/tag와 Release Publish workflow 실행 전 |
+| public release 게시 | OK | PR #238 main merge, tag `v0.1.2`, Release Publish DMG run `25774125473` 성공 |
 
 ## 미수행 범위
 
-- Developer ID signing과 notarization
-- GitHub Release public 게시와 asset upload
-- stable Sparkle appcast/Pages public deployment
-- public DMG Gatekeeper 설치 테스트
 - actual Sparkle update from public v0.1.1
 - Intel Mac 실기기 smoke
 - Homebrew Cask public SHA256 반영
 
 ## release handoff
 
-다음 release 실행 순서를 따른다.
+다음 release 실행 순서를 완료했다.
 
 1. `publish/task225` PR을 `devel-webview`에 merge한다.
 2. `devel-webview`의 release candidate commit을 `main`으로 반영하는 release PR을 merge한다.
@@ -166,20 +162,23 @@ qlmanage -t -x -s 768 -c com.haansoft.hancomofficeviewer.mac.hwpx ...
 4. `Release Publish DMG` workflow를 tag `v0.1.2`에서 `draft=false`, `prerelease=false`로 실행한다.
 5. signed/notarized public DMG SHA256, GitHub Release latest 상태, stable appcast EdDSA signature, Pages deployment URL을 `mydocs/release/v0.1.2.md`에 보강한다.
 
-## PR close 전략
-
-`publish/task225 -> devel-webview` PR 본문에는 다음을 명시한다.
+public 결과:
 
 ```text
-Closes #225
+GitHub Release: https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.2
+Public DMG: alhangeul-macos-0.1.2.dmg
+SHA256: 37a27321f03a84b8b28749b5f839ea5c5833975d20f2479e3b79ebd665811ead
+Sparkle appcast: https://postmelee.github.io/alhangeul-macos/appcast.xml
+Pages release note: https://postmelee.github.io/alhangeul-macos/updates/v0.1.2.html
 ```
 
-단, 실제 이슈 close는 PR merge와 public release 실행 상태를 확인한 뒤 작업지시자 승인 기준에 맞춰 처리한다.
+## PR close 전략
+
+PR #237은 `devel-webview`에 merge했고, PR #238은 `main`에 merge했다. 실제 public release 실행 상태까지 확인했으므로 #225는 post-release 기록 commit 후 close한다.
 
 ## 잔여 위험
 
-- public signing/notarization과 Gatekeeper 검증은 아직 workflow에서 확인하지 않았다.
-- Sparkle stable feed는 public DMG EdDSA signature가 확정된 뒤에만 검증 가능하다.
 - Finder/Quick Look cache는 macOS 내부 정책이므로 targeted refresh가 모든 과거 파일 thumbnail을 강제로 갱신하지는 않는다.
 - Intel Mac 실기기 smoke는 아직 수행하지 못했다.
 - #235가 완화한 Web viewer 오류의 root cause는 upstream `edwardkim/rhwp` #850에 남아 있다.
+- Homebrew Cask public SHA256 반영은 #209 또는 별도 승인 범위에서 진행해야 한다.


### PR DESCRIPTION
## Summary
- Record the completed v0.1.2 public release result after tag `v0.1.2` and Release Publish DMG workflow run `25774125473`.
- Update the release record, final task report, and daily order status with the public DMG SHA256, GitHub Release URL, stable appcast, and Pages verification.
- Leave Homebrew Cask and Intel hardware smoke as separate follow-up scope.

## Validation
- Release Publish DMG workflow succeeded.
- GitHub Release `v0.1.2` is public, non-draft, non-prerelease.
- Public DMG SHA256: `37a27321f03a84b8b28749b5f839ea5c5833975d20f2479e3b79ebd665811ead`.
- Pages appcast HTTP 200 with first item `0.1.2 (8)`.
- Pages v0.1.2 release note HTTP 200.

Refs #225