### PR TITLE
Task #254: Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리

### DIFF
--- a/mydocs/orders/20260518.md
+++ b/mydocs/orders/20260518.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, Stage 1 완료보고서 작성 후 Stage 2 승인 대기 |
+| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, Stage 2 완료보고서 작성 후 Stage 3 승인 대기 |

--- a/mydocs/orders/20260518.md
+++ b/mydocs/orders/20260518.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |
+| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, Stage 1 완료보고서 작성 후 Stage 2 승인 대기 |

--- a/mydocs/orders/20260518.md
+++ b/mydocs/orders/20260518.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 5월 18일
+
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260518.md
+++ b/mydocs/orders/20260518.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, Stage 3 완료보고서 작성 후 Stage 4 승인 대기 |
+| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, Stage 4 완료보고서 작성 후 Stage 5 승인 대기 |

--- a/mydocs/orders/20260518.md
+++ b/mydocs/orders/20260518.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, Stage 4 완료보고서 작성 후 Stage 5 승인 대기 |
+| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 완료 | M020, 완료: 09:23 |

--- a/mydocs/orders/20260518.md
+++ b/mydocs/orders/20260518.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, Stage 2 완료보고서 작성 후 Stage 3 승인 대기 |
+| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, Stage 3 완료보고서 작성 후 Stage 4 승인 대기 |

--- a/mydocs/orders/20260518.md
+++ b/mydocs/orders/20260518.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #254 | Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/plans/task_m020_254.md
+++ b/mydocs/plans/task_m020_254.md
@@ -1,0 +1,134 @@
+# Task M020 #254 수행계획서
+
+## 목적
+
+Quick Look preview와 Finder thumbnail에 upstream `rhwp` native Skia PNG backend를 옵션 backend로 도입할지 판단할 수 있도록 설계와 rollout gate를 정리한다.
+
+완료 후에는 작업자가 RustBridge PNG FFI, Shared renderer abstraction, Quick Look/Thumbnail 적용, 검증 gate 후속 이슈를 어떤 순서와 기준으로 진행해야 하는지 명확히 알 수 있어야 한다.
+
+## 배경
+
+현재 Quick Look preview와 Finder thumbnail은 `rhwp_render_page_tree`가 반환한 legacy `PageRenderTree` JSON을 Swift에서 디코딩하고, `CGTreeRenderer`가 CoreGraphics/CoreText로 직접 그린다.
+
+현재 고정 core인 `rhwp v0.7.11`에는 `PageLayerTree` 기반 native Skia PNG backend가 포함되어 있다. 이 backend를 사용하면 Quick Look/Thumbnail 렌더링 책임을 upstream Rust renderer 쪽으로 옮길 수 있지만, `native-skia` feature 도입은 staticlib/package 크기, extension 메모리, PNG encode/decode 비용, font fallback, 시각 정합성에 영향을 줄 수 있다.
+
+따라서 바로 기본 renderer로 전환하지 않고, 기존 CoreGraphics renderer를 fallback으로 유지하는 optional backend 구조와 default 전환 조건을 먼저 설계한다.
+
+## 범위
+
+포함:
+
+- 현재 Quick Look/Thumbnail renderer 경로와 책임 경계 정리
+- upstream `edwardkim/rhwp` #536 native Skia 진행 상황과 현재 lock `v0.7.11` 적용 가능 범위 정리
+- `Skia 우선 + CoreGraphics fallback`, opt-in, default 전환 후보 비교
+- #96 `PageLayerTree native bridge 탐색` 및 #222 `Swift native renderer parity gap`과의 경계 정리
+- 후속 이슈 #255, #256, #257, #258, #259의 의존 순서와 gate 정의
+- build size, performance, memory, visual diff, release note known limitation 판단 기준 정리
+- 수행계획서, 구현계획서, 단계 보고서, 최종 보고서, 오늘할일 갱신
+
+제외:
+
+- 이 이슈에서 RustBridge ABI 또는 Swift renderer 구현을 직접 변경하지 않는다.
+- HostApp WKWebView viewer renderer 전환은 포함하지 않는다.
+- Swift native viewer 전면 전환은 포함하지 않는다.
+- upstream `rhwp` 자체 수정은 포함하지 않는다.
+- vector PDF export 또는 사용자용 PDF export 품질 개선은 포함하지 않는다.
+- signed/notarized public release 실행은 포함하지 않는다.
+
+## 설계 방향
+
+설계 문서는 제품 코드 변경 없이 작성한다. 기준선은 현재 제품 경로인 `HwpPageImageRenderer`, `HwpPreviewPDFRenderer`, `HwpThumbnailProvider`, `HwpThumbnailRenderCache`, `RhwpDocument`, `RustBridge`의 C ABI로 둔다.
+
+Skia backend는 먼저 Quick Look/Thumbnail에 한정된 raster backend 후보로 본다. HostApp viewer는 현재 `rhwp-studio` WKWebView 경로를 사용하므로 이번 설계의 직접 대상에서 제외한다.
+
+backend rollout은 세 축으로 나눠 판단한다.
+
+1. 기능 축: Skia PNG FFI가 page index, scale, max-dimension, failure를 안전하게 표현하는지 확인한다.
+2. 제품 축: Quick Look preview와 Finder thumbnail이 기존 CoreGraphics fallback을 유지하면서 Skia를 선택할 수 있는지 확인한다.
+3. 검증 축: visual diff, extension memory, latency, package size가 release 후보 수준인지 확인한다.
+
+최종 권장안은 default 전환이 아니라도 좋다. opt-in 유지, debug-only backend, Quick Look만 우선 적용, thumbnail은 보류 같은 결론도 gate 근거와 함께 남긴다.
+
+## 예상 변경 파일
+
+- 신규 후보: `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- `mydocs/orders/20260518.md`
+- `mydocs/plans/task_m020_254.md`
+- `mydocs/plans/task_m020_254_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m020_254_stage{N}.md`
+- `mydocs/report/task_m020_254_report.md`
+
+읽기 대상 후보:
+
+- `rhwp-core.lock`
+- `RustBridge/Cargo.toml`
+- `RustBridge/src/lib.rs`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/Shared/HwpPreviewPDFRenderer.swift`
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- `mydocs/tech/project_architecture.md`
+- `mydocs/manual/core_dependency_operation_guide.md`
+- `mydocs/manual/build_run_guide.md`
+
+## 잠정 단계
+
+1. Stage 1: 현행 Quick Look/Thumbnail renderer와 upstream Skia 적용 가능 범위 inventory
+   - 현재 CoreGraphics renderer 경로와 FFI 표면을 코드 기준으로 정리한다.
+   - `rhwp v0.7.11` native Skia API와 #536 진행 상태를 현재 앱 lock 기준으로 정리한다.
+   - #96, #222와 중복되는 부분과 별도인 부분을 분리한다.
+2. Stage 2: backend 선택 정책과 fallback contract 설계
+   - `Skia 우선 + CoreGraphics fallback`, explicit opt-in, debug-only 후보를 비교한다.
+   - failure taxonomy, logging, environment/user default 정책 후보를 정리한다.
+   - 구현계획서(`task_m020_254_impl.md`)에 후속 단계별 변경/검증 범위를 고정한다.
+3. Stage 3: 후속 이슈 의존 순서와 ABI/Shared/extension 적용 gate 정리
+   - #255, #256, #257, #258, #259의 선후관계와 stage handoff 조건을 정리한다.
+   - RustBridge ABI gate, Shared renderer gate, Quick Look/Thumbnail gate를 나눠 문서화한다.
+4. Stage 4: visual/performance/package readiness gate와 release 판단 기준 정리
+   - 대표 샘플, diff 기준, memory/latency/package size 측정 항목을 정리한다.
+   - default 전환, opt-in 유지, 보류 판단 기준을 정리한다.
+5. Stage 5: 최종 설계 문서와 보고서 정리
+   - 설계 문서와 최종 보고서를 작성한다.
+   - 오늘할일 완료 갱신과 후속 task-start 후보를 정리한다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260518.md mydocs/plans/task_m020_254.md
+```
+
+조사/문서화 단계 후보:
+
+```bash
+rg -n "native-skia|render_page_png|PageLayerTree|HwpPageImageRenderer|HwpPreviewPDFRenderer|HwpThumbnailProvider|RustBridge|CoreGraphics fallback|Skia" \
+  rhwp-core.lock RustBridge Sources mydocs/tech mydocs/manual mydocs/plans/task_m020_254_impl.md
+git diff --check
+```
+
+필요 시 GitHub 조회:
+
+```bash
+gh issue view 254 --repo postmelee/alhangeul-macos --json number,title,milestone,state,body
+gh issue view 536 --repo edwardkim/rhwp --json number,title,state,body
+```
+
+## 리스크
+
+- `native-skia` feature 도입으로 staticlib와 app package 크기가 크게 증가할 수 있다.
+- Skia PNG bytes를 Swift에서 다시 `CGImage`로 decode하는 비용이 extension latency에 영향을 줄 수 있다.
+- macOS system font fallback과 upstream Skia font fallback이 달라 시각 결과가 개선되지 않거나 일부 문서에서 악화될 수 있다.
+- Quick Look과 Thumbnail은 요구사항이 다르므로 같은 rollout 정책으로 묶으면 thumbnail latency나 memory를 놓칠 수 있다.
+- P15 이후 CanvasKit diagnostics나 P16 browser renderer 작업을 Quick Look/Thumbnail native Skia 적용과 혼동할 수 있다.
+- 설계 문서가 후속 이슈의 실제 구현 가능성을 과도하게 단정하면 later stage에서 재작업이 커질 수 있다.
+
+## 승인 요청 사항
+
+1. #254를 제품 코드 변경 없는 설계/rollout gate 정리 task로 진행하는 범위 승인
+2. Skia는 Quick Look/Thumbnail용 optional raster backend 후보로 한정하고, HostApp viewer와 vector PDF export는 제외하는 방향 승인
+3. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m020_254_impl.md`) 작성과 Stage 1 inventory 진행
+
+승인 전에는 RustBridge, Swift source, manual, release 문서 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m020_254_impl.md
+++ b/mydocs/plans/task_m020_254_impl.md
@@ -1,0 +1,248 @@
+# Task M020 #254 구현 계획서
+
+수행계획서: `mydocs/plans/task_m020_254.md`
+
+## 작업 개요
+
+- 이슈: #254 Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리
+- 마일스톤: `v0.2.x Skia Quick Look/Thumbnail Backend`
+- 브랜치: `local/task254`
+- 목표: Quick Look preview와 Finder thumbnail에 upstream `rhwp` native Skia PNG backend를 optional raster backend로 도입하기 위한 설계, fallback contract, 후속 이슈 의존 순서, 검증 gate를 확정한다.
+
+## 구현 원칙
+
+- 본 작업은 설계와 rollout gate 정리이며, 제품 Swift/Rust source는 변경하지 않는다.
+- `RustBridge` ABI 추가, `native-skia` feature enable, Quick Look/Thumbnail 적용은 후속 이슈 #255-#258에서 수행한다.
+- 현재 제품 기준선은 `PageRenderTree` JSON + Swift `CGTreeRenderer` + Quick Look/Thumbnail bitmap 경로다.
+- Skia 후보는 `PageLayerTree` + upstream native Skia PNG output으로 정의한다.
+- HostApp WKWebView viewer, CanvasKit browser renderer, vector PDF export는 이번 task 범위 밖으로 둔다.
+- 후속 이슈가 바로 실행할 수 있도록 stage별 산출물은 장기 기술 문서와 단계 보고서에 중복 없이 정리한다.
+
+## Stage 1. 현행 경로와 upstream Skia 적용 가능 범위 inventory
+
+대상:
+
+- `rhwp-core.lock`
+- `RustBridge/Cargo.toml`
+- `RustBridge/src/lib.rs`
+- `rhwp-ffi-symbols.txt`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/Shared/HwpPreviewPDFRenderer.swift`
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- `mydocs/tech/project_architecture.md`
+- GitHub upstream `edwardkim/rhwp` #536, 필요 시 관련 PR #599/#769/#925
+
+작업:
+
+1. 현재 Quick Look preview와 Finder thumbnail의 render flow를 코드 기준으로 정리한다.
+2. 현재 RustBridge FFI 표면과 `rhwp v0.7.11` lock 상태를 확인한다.
+3. upstream native Skia PNG API가 현재 lock에서 어디까지 포함되어 있는지 정리한다.
+4. #96, #222와 #254의 책임 경계를 정리한다.
+5. Stage 1 완료보고서를 작성한다.
+
+산출물:
+
+- `mydocs/working/task_m020_254_stage1.md`
+
+검증:
+
+```bash
+rg -n "rhwp_render_page_tree|renderPageTree|HwpPageImageRenderer|HwpPreviewPDFRenderer|HwpThumbnailProvider|native-skia|render_page_png" \
+  rhwp-core.lock RustBridge Sources mydocs/tech/project_architecture.md mydocs/working/task_m020_254_stage1.md
+git diff --check -- mydocs/plans/task_m020_254_impl.md mydocs/working/task_m020_254_stage1.md
+```
+
+완료 조건:
+
+- 현재 제품 경로와 Skia 후보 경로가 명확히 분리되어 있다.
+- 현재 lock 기준으로 당장 활용 가능한 upstream API와 아직 release 밖인 항목이 구분되어 있다.
+- #96/#222와 중복하지 않는 #254의 설계 책임이 정리되어 있다.
+
+커밋:
+
+```text
+Task #254 Stage 1: Skia Quick Look renderer inventory 정리
+```
+
+## Stage 2. backend 선택 정책과 fallback contract 설계
+
+대상:
+
+- 신규: `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- `mydocs/working/task_m020_254_stage2.md`
+
+작업:
+
+1. `CoreGraphics only`, `Skia opt-in`, `Skia first + CoreGraphics fallback`, `Skia default` 후보를 비교한다.
+2. failure taxonomy를 정의한다.
+   - FFI unavailable
+   - Skia render failure
+   - PNG decode failure
+   - invalid page size
+   - file size fallback
+   - memory/timeout fallback
+3. Quick Look과 Thumbnail의 backend 선택 정책 차이를 정리한다.
+4. 로그/진단 필드 후보를 정리한다.
+5. Stage 2 완료보고서를 작성한다.
+
+산출물:
+
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- `mydocs/working/task_m020_254_stage2.md`
+
+검증:
+
+```bash
+rg -n "CoreGraphics|Skia|fallback|Quick Look|Thumbnail|failure|decode|memory|timeout" \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage2.md
+git diff --check -- mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage2.md
+```
+
+완료 조건:
+
+- 기본 후보와 보류 후보의 장단점이 문서화되어 있다.
+- Quick Look과 Thumbnail에 같은 정책을 강제하지 않는다.
+- 후속 구현에서 사용할 fallback contract 초안이 있다.
+
+커밋:
+
+```text
+Task #254 Stage 2: Skia backend fallback contract 설계
+```
+
+## Stage 3. 후속 이슈 의존 순서와 handoff gate 정리
+
+대상:
+
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- `mydocs/working/task_m020_254_stage3.md`
+- GitHub issue #255, #256, #257, #258, #259
+
+작업:
+
+1. #255 RustBridge FFI, #256 Shared renderer, #257 Quick Look, #258 Thumbnail, #259 verification gate의 선후관계를 확정한다.
+2. 각 후속 이슈가 시작되기 위한 입력 조건과 완료 조건을 정리한다.
+3. ABI gate, Shared renderer gate, extension integration gate, release readiness gate를 분리한다.
+4. 필요하면 후속 이슈 본문 업데이트 후보를 보고서에 적는다. 이 단계에서는 GitHub issue 본문을 직접 수정하지 않는다.
+5. Stage 3 완료보고서를 작성한다.
+
+산출물:
+
+- `mydocs/working/task_m020_254_stage3.md`
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md` 갱신
+
+검증:
+
+```bash
+rg -n "#255|#256|#257|#258|#259|ABI gate|Shared renderer|Quick Look|Thumbnail|release readiness" \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage3.md
+git diff --check -- mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage3.md
+```
+
+완료 조건:
+
+- 후속 이슈 진행 순서와 handoff 조건이 명확하다.
+- #255-#259가 서로 중복해서 같은 책임을 갖지 않는다.
+- GitHub issue 본문 수정이 필요하면 별도 승인 후보로 남긴다.
+
+커밋:
+
+```text
+Task #254 Stage 3: Skia 후속 이슈 handoff gate 정리
+```
+
+## Stage 4. visual/performance/package readiness gate 정리
+
+대상:
+
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- `mydocs/working/task_m020_254_stage4.md`
+- 관련 기존 smoke/debug script 문서
+
+작업:
+
+1. 대표 샘플군을 정한다.
+   - 단일 페이지
+   - 다중 페이지
+   - 이미지 포함
+   - 수식/raw SVG/form object 후보
+   - text/font fallback 민감 문서
+2. visual diff 기준을 정리한다.
+3. extension latency/memory 측정 항목을 정리한다.
+4. `native-skia` feature로 인한 staticlib/Rhwp.xcframework/package size 측정 기준을 정리한다.
+5. default 전환, opt-in 유지, 보류 판단 기준을 정리한다.
+6. Stage 4 완료보고서를 작성한다.
+
+산출물:
+
+- `mydocs/working/task_m020_254_stage4.md`
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md` 갱신
+
+검증:
+
+```bash
+rg -n "visual|diff|latency|memory|package|staticlib|Rhwp.xcframework|default|opt-in|보류" \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage4.md
+git diff --check -- mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage4.md
+```
+
+완료 조건:
+
+- 후속 #259가 사용할 readiness checklist가 문서화되어 있다.
+- default 전환 판단이 감각이 아니라 측정 항목에 연결되어 있다.
+- release note known limitation 후보가 있다.
+
+커밋:
+
+```text
+Task #254 Stage 4: Skia readiness gate 정리
+```
+
+## Stage 5. 최종 설계 문서와 보고서 정리
+
+대상:
+
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- `mydocs/report/task_m020_254_report.md`
+- `mydocs/orders/20260518.md`
+
+작업:
+
+1. Stage 1-4 결론을 장기 기술 문서에 정리한다.
+2. 최종 권장 rollout 순서를 확정한다.
+3. 후속 이슈별 시작 조건과 잔여 리스크를 최종 보고서에 정리한다.
+4. 오늘할일 상태를 완료로 갱신한다.
+5. 최종 보고서를 작성한다.
+
+산출물:
+
+- `mydocs/report/task_m020_254_report.md`
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md` 최종 갱신
+- `mydocs/orders/20260518.md` 갱신
+
+검증:
+
+```bash
+rg -n "#254|#255|#256|#257|#258|#259|Skia|Quick Look|Thumbnail|fallback|readiness" \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/report/task_m020_254_report.md mydocs/orders/20260518.md
+git diff --check
+```
+
+완료 조건:
+
+- 후속 #255-#259를 진행할 설계 기준이 장기 문서에 남아 있다.
+- 최종 보고서가 완료 범위, 검증 결과, 잔여 리스크를 포함한다.
+- 오늘할일이 완료 상태로 갱신되어 있다.
+
+커밋:
+
+```text
+Task #254 Stage 5 + 최종 보고서: Skia optional backend 설계 정리
+```
+
+## 승인 요청
+
+이 구현계획 승인 후 Stage 1 `현행 Quick Look/Thumbnail renderer와 upstream Skia 적용 가능 범위 inventory`를 진행한다.

--- a/mydocs/report/task_m020_254_report.md
+++ b/mydocs/report/task_m020_254_report.md
@@ -1,0 +1,92 @@
+# Task M020 #254 최종 보고서
+
+## 작업 개요
+
+- 이슈: #254 Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리
+- 마일스톤: M020 `v0.2.x Skia Quick Look/Thumbnail Backend`
+- 브랜치: `local/task254`
+- 목표: upstream `rhwp v0.7.11` native Skia PNG backend를 Quick Look/Thumbnail에 optional backend로 도입하기 위한 설계, fallback contract, 후속 이슈 handoff, readiness gate를 문서화한다.
+
+## 완료 범위
+
+- 현재 Quick Look/Thumbnail renderer가 `PageRenderTree` JSON + Swift `CGTreeRenderer` + CoreGraphics/CoreText 경로임을 정리했다.
+- upstream `rhwp v0.7.11`에 `native-skia`, `render_page_png_native*`, `PngExportOptions`가 존재하지만 현재 앱 ABI에는 노출되지 않았음을 정리했다.
+- backend 후보를 비교하고 현재 기본값은 `CoreGraphics only`, 첫 구현은 `Skia opt-in`으로 권장했다.
+- Skia 실패 시 Quick Look text fallback 또는 Thumbnail tile fallback으로 바로 가지 않고 CoreGraphics fallback을 먼저 사용하는 contract를 정리했다.
+- #255-#259의 의존 순서와 gate별 입력/출력 조건을 정리했다.
+- #259가 사용할 대표 샘플군, visual diff triage, latency/memory/package 측정 항목, rollout 판단 기준을 정리했다.
+
+## 단계별 결과
+
+| 단계 | 산출물 | 요약 |
+|---|---|---|
+| Stage 1 | `mydocs/working/task_m020_254_stage1.md` | 현행 renderer flow, FFI 표면, upstream Skia 적용 후보, #96/#222/#254 경계 정리 |
+| Stage 2 | `mydocs/working/task_m020_254_stage2.md` | backend 선택 정책, failure taxonomy, Quick Look/Thumbnail fallback contract 정리 |
+| Stage 3 | `mydocs/working/task_m020_254_stage3.md` | #255-#259 handoff gate와 issue 본문 업데이트 후보 정리 |
+| Stage 4 | `mydocs/working/task_m020_254_stage4.md` | visual/performance/package readiness gate와 known limitation 후보 정리 |
+| Stage 5 | `mydocs/report/task_m020_254_report.md` | 최종 결론과 후속 실행 기준 정리 |
+
+장기 기술 문서는 `mydocs/tech/skia_quicklook_thumbnail_backend.md`에 남겼다.
+
+## 최종 권장 rollout
+
+권장 순서는 다음과 같다.
+
+```text
+#255 RustBridge native-skia PNG ABI
+-> #256 Shared renderer optional backend
+-> #257 Quick Look skiaOptIn integration
+-> #258 Thumbnail skiaOptIn integration
+-> #259 visual/performance/package readiness
+-> 별도 승인 후 Skia first/default 전환 판단
+```
+
+현재 시점의 기본값은 `CoreGraphics only`로 유지한다. 후속 구현의 첫 제품 노출은 `Skia opt-in`이며, `Skia first` 또는 `Skia default`는 #259 측정 결과와 별도 승인 없이는 진행하지 않는다.
+
+## 후속 이슈 시작 조건
+
+| 이슈 | 시작 조건 | 완료 조건 핵심 |
+|---|---|---|
+| #255 | `rhwp v0.7.11` lock과 upstream Skia PNG API 확인 결과 | Swift에서 호출 가능한 PNG C ABI, header/symbol/lock 정합성, staticlib/package size 기록 |
+| #256 | #255 ABI와 binary provenance 완료 | `RhwpDocument` wrapper, `HwpPageImageRenderer` backend 선택, CoreGraphics fallback, 진단 필드 |
+| #257 | #256 Shared renderer opt-in backend 완료 | 단일 page Quick Look PNG Skia success, 다중 page PDF 검증, fallback/logging 유지 |
+| #258 | #256 Shared renderer opt-in backend 완료 | `maximumPixelSize` to `max_dimension`, cache key backend 반영, thumbnail smoke |
+| #259 | #255-#258 완료 | visual diff, latency/memory, package delta, default/opt-in/보류 판단 |
+
+## 검증 결과
+
+각 단계 검증은 해당 Stage 보고서에 기록했다. 최종 단계에서는 다음 명령으로 최종 산출물 연결을 확인한다.
+
+```bash
+rg -n "#254|#255|#256|#257|#258|#259|Skia|Quick Look|Thumbnail|fallback|readiness" \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/report/task_m020_254_report.md mydocs/orders/20260518.md
+git diff --check
+```
+
+결과: 통과. 최종 기술 문서, 최종 보고서, 오늘할일에서 #254-#259, Skia, Quick Look/Thumbnail, fallback, readiness 기준이 연결되어 있음을 확인했다.
+
+`git diff --check`도 통과했다.
+
+## 잔여 리스크
+
+- 실제 `native-skia` feature 활성화, RustBridge ABI 추가, Swift wrapper 구현은 #255/#256 범위로 남아 있다.
+- Skia PNG decode 비용, extension memory, first-call latency, package size 증가는 아직 실측하지 않았다.
+- Skia와 CoreGraphics의 font fallback/text antialiasing 차이는 #259의 sample별 visual triage가 필요하다.
+- GitHub issue #255-#259 본문 보강은 후보만 정리했고 직접 수정하지 않았다.
+- `mydocs/tech/project_architecture.md`의 일부 `v0.7.10` 설명은 현재 `rhwp-core.lock`의 `v0.7.11`과 불일치하므로 별도 문서 정합성 작업 후보로 남긴다.
+
+## GitHub issue 본문 업데이트 후보
+
+후속 이슈 시작 직전에 작업지시자 승인을 받은 뒤 다음 보강을 검토한다.
+
+- #255: failure taxonomy 명칭과 ABI 오류 결과 표 반영
+- #256: `backendUsed`, `fallbackReason`, `pngBytes`, `durationMs` 진단 필드 명시
+- #257: 다중 페이지 PDF Skia 적용은 초기 default가 아니라 별도 opt-in 검증임을 명시
+- #258: cache key에 backend/render signature 포함 조건 보강
+- #259: #255-#258 산출물을 입력으로 받는 release readiness gate임을 명시
+
+## 결론
+
+#254는 Skia를 바로 기본 renderer로 전환하지 않는다. 현재 앱 구조와 upstream 상태를 기준으로 보면 Skia 도입은 가능하지만, 먼저 ABI, Shared renderer, Quick Look/Thumbnail surface, readiness gate를 순서대로 닫아야 한다.
+
+따라서 최종 결론은 `CoreGraphics only` 기본값 유지, `Skia opt-in`부터 구현, #259 측정 이후 default 전환 별도 승인이다.

--- a/mydocs/tech/skia_quicklook_thumbnail_backend.md
+++ b/mydocs/tech/skia_quicklook_thumbnail_backend.md
@@ -280,3 +280,116 @@ Skia optional backend는 다음 순서로 진행한다.
 - #257: 다중 페이지 PDF의 Skia 적용은 초기 default가 아니라 별도 opt-in 검증으로 시작한다고 명시.
 - #258: cache key에 backend/render signature를 포함한다는 완료 조건을 명시.
 - #259: #255-#258 산출물을 입력으로 받는 release readiness gate임을 명시.
+
+## readiness 샘플군
+
+#259는 모든 저장소 샘플을 매번 full visual diff하지 않는다. default 전환 판단에 필요한 대표군을 먼저 고정하고, 실패가 나온 계열만 확장한다.
+
+| 그룹 | 기본 샘플 | 목적 |
+|---|---|---|
+| 단일 페이지 | `samples/basic/KTX.hwp`, `samples/basic/request.hwp` | 빠른 Quick Look PNG reply, 기본 한글 text, 표/간단 layout |
+| 다중 페이지 | `samples/hwp-multi-001.hwp`, `samples/basic/exam_math.hwp`, `samples/hwpx/hwpx-01.hwpx` | Quick Look bitmap PDF, page loop, HWPX path |
+| 이미지 포함 | `samples/hwp-img-001.hwp`, `samples/img-start-001.hwp` | Skia PNG image replay, decode cost, crop/scale 회귀 |
+| 수식/도형 | `samples/eq-01.hwp`, `samples/group-drawing-02.hwp`, `samples/draw-group.hwp` | upstream Skia equation/vector replay와 Swift CoreGraphics 차이 확인 |
+| form/raw object 후보 | `samples/form-01.hwp`, `samples/hwpx/form-002.hwpx`, `samples/group-box.hwp` | form control, placeholder, object fallback 양상 확인 |
+| text/font 민감 | `samples/footnote-01.hwp`, `samples/basic/shortcut.hwp`, `samples/exam_kor.hwp`, `samples/lseg-02-mixed.hwp` | font fallback, footnote, control mark, line segment/spacing 차이 확인 |
+| package/smoke 기본 | `samples/basic/KTX.hwp`, `samples/basic/request.hwp`, `samples/exam_kor.hwp` | `validate-stage3-render.sh` 기본 smoke와 비교 가능한 최소 회귀 세트 |
+
+외부 개인 경로 샘플은 #259 보고서에 참고로만 기록하고, release readiness 기준은 저장소 `samples/` 파일을 우선 사용한다.
+
+## visual readiness 기준
+
+visual gate는 pixel diff 숫자 하나로 통과/실패를 결정하지 않는다. Skia, CoreGraphics, core SVG/rhwp-studio 기준의 차이를 함께 보고 hard fail과 허용 가능한 raster 차이를 분리한다.
+
+Hard fail:
+
+- Skia render가 crash, hang, timeout, empty PNG, decode failure로 끝난다.
+- page size 또는 aspect ratio가 CoreGraphics 기준과 다르다.
+- 본문, 표, 이미지, 수식, form control 중 주요 구조가 통째로 누락된다.
+- 잘림, 좌우/상하 반전, page 전체 offset, 투명 배경 같은 전체 page 계열 오류가 보인다.
+- Skia 실패 뒤 CoreGraphics fallback이 동작하지 않는다.
+
+Pixel diff triage:
+
+| 구간 | 의미 | 조치 |
+|---|---|---|
+| `0-1%` changed pixels | 보통 antialias/rasterizer 차이 | summary에 기록하고 통과 후보 |
+| `1-5%` changed pixels | text edge, 1px rounding, 일부 object 차이 가능 | diff PNG와 원본 이미지를 눈검증 |
+| `5-10%` changed pixels | text-heavy 또는 수식/도형 문서에서 흔할 수 있으나 구조 확인 필요 | sample별 known difference 또는 후속 이슈로 분류 |
+| `10%+` changed pixels | 큰 구조 차이 가능성이 높음 | default 전환 차단. 원인 분리 후 재검증 |
+
+이 구간은 자동 release gate가 아니라 triage 기준이다. 예를 들어 text-heavy 문서는 antialias 차이만으로 diff가 커질 수 있으므로, 구조 누락이 없고 CoreGraphics보다 Skia가 reference에 가까운 경우에는 known difference로 분류할 수 있다. 반대로 diff 비율이 낮아도 핵심 이미지나 수식 하나가 누락되면 hard fail이다.
+
+사용 도구:
+
+- `./scripts/validate-stage3-render.sh`: 기본 native renderer smoke. Skia default 판단 전에도 CoreGraphics fallback baseline이 깨지지 않았는지 확인한다.
+- `./scripts/render-debug-compare.sh`: core SVG, render tree JSON, native PNG, optional diff PNG를 생성한다.
+- `./scripts/visual-compare-quicklook-renderers.sh`: Quick Look 관련 native bitmap과 SVG/PDF 후보를 비교하는 기존 visual summary 도구다. Skia용 입력이 준비되면 같은 summary 형식으로 확장하거나 결과 형식을 맞춘다.
+- clean Quick Look/Thumbnail smoke script: extension 등록, thumbnail 생성, 실제 Finder/Quick Look 수동 확인 항목을 기록한다.
+
+## performance/memory readiness 기준
+
+#259는 같은 machine/session에서 CoreGraphics와 Skia를 같은 샘플 순서로 측정한다. cold start와 warm cache 결과를 섞지 않고 구분한다.
+
+Quick Look 측정 항목:
+
+- `inspectMs`: file size check, data read, document open, first page size/page count 확인
+- `renderMs`: page render 또는 page별 render 합계
+- `pngEncodeOrDecodeMs`: CoreGraphics PNG encode 또는 Skia PNG decode
+- `replyDataMs`: `QLPreviewReply` data block 실행 시간
+- `pageCount`, `replyType`, `backendUsed`, `fallbackReason`
+- peak RSS 또는 `memoryHighWaterMB`
+
+Thumbnail 측정 항목:
+
+- `requestPixelSize`, `pixelBucket`, `backendUsed`
+- cache miss render duration
+- cache hit response duration
+- Skia PNG bytes 길이와 decode duration
+- fallback 발생 횟수와 fallback reason
+- peak RSS 또는 `memoryHighWaterMB`
+
+성능 판단 후보:
+
+| 판단 | 조건 |
+|---|---|
+| default 전환 후보 | hard fail이 없고, Quick Look 단일 page와 Thumbnail cache miss p50이 CoreGraphics 대비 명확히 나쁘지 않으며, p95 또는 최악값이 사용자 체감 hang으로 보이지 않는다 |
+| opt-in 유지 | visual은 개선되지만 PNG decode나 first-call latency가 문서군 일부에서 CoreGraphics보다 불안정하다 |
+| 보류 | timeout, memory pressure, decode failure, cache 충돌, extension restart가 재현된다 |
+
+정확한 수치 threshold는 #259 실행 결과로 확정한다. Stage 4 기준에서는 최소한 sample별 CoreGraphics baseline, Skia result, delta, fallback reason이 같은 표에 기록되어야 한다.
+
+## package readiness 기준
+
+`native-skia` feature는 `skia-safe`와 binary cache 의존성 때문에 staticlib와 app package 크기에 영향을 줄 수 있다. #255와 #259는 아래 항목을 같은 report에 기록한다.
+
+| 항목 | 측정 예 | 기준 |
+|---|---|---|
+| Rust staticlib size | `stat -f%z Frameworks/universal/librhwp.a` | `rhwp-core.lock` reference와 비교 |
+| `Rhwp.xcframework` size | `du -sk Frameworks/Rhwp.xcframework` | native-skia 전후 delta 기록 |
+| generated header size/hash | `rhwp-core.lock` | ABI 변경 정합성 확인 |
+| Debug app bundle size | `du -sk build.noindex/.../Alhangeul.app` | extension 포함 bundle delta 기록 |
+| release zip/DMG candidate size | release/rehearsal 산출물 | public release 판단 시에만 기록 |
+| universal slice 유지 | `scripts/ci/verify-universal-macos-app.sh` | app과 appex가 `arm64 + x86_64` 유지 |
+
+size 증가 자체가 실패는 아니다. 다만 app/extension load time, download size, notarization/release artifact 크기 설명이 필요할 정도의 증가라면 release note known limitation 또는 rollout 보류 판단에 반영한다.
+
+## rollout 판단 기준
+
+| 결정 | 조건 | 후속 조치 |
+|---|---|---|
+| `Skia first` 전환 후보 | #255-#258 완료, #259 sample hard fail 없음, fallback 정상, Quick Look/Thumbnail latency와 memory가 CoreGraphics 대비 허용 가능, package delta 설명 가능 | 별도 승인 후 default policy 변경 이슈 생성 또는 기존 후속 이슈 갱신 |
+| `Skia opt-in` 유지 | visual coverage는 유효하지만 특정 sample군의 diff, latency, package delta가 아직 release default로 설명하기 어렵다 | opt-in/debug flag 유지, known limitation 기록, targeted follow-up 생성 |
+| 보류 | crash/hang/timeout, decode failure, major visual regression, fallback failure, extension memory pressure가 남아 있다 | default 전환 금지, 원인별 #255-#258 또는 upstream issue로 되돌림 |
+
+Quick Look과 Thumbnail은 따로 판단한다. Thumbnail이 안정적이어도 Quick Look 다중 페이지 PDF가 불안정하면 Thumbnail만 opt-in 또는 first 후보로 남길 수 있고, 반대도 가능하다.
+
+## release note known limitation 후보
+
+Skia optional backend가 release에 포함될 경우 다음 항목을 known limitation 후보로 검토한다.
+
+- Skia backend는 초기에는 opt-in 또는 내부 진단 경로이며 기본 Quick Look/Thumbnail 결과는 CoreGraphics renderer일 수 있다.
+- Skia와 CoreGraphics는 text antialiasing, font fallback, 일부 수식/도형 rasterization에서 pixel-perfect하게 같지 않을 수 있다.
+- 다중 페이지 Quick Look preview는 여전히 bitmap PDF container이며 vector PDF export 개선은 별도 범위다.
+- Quick Look/Thumbnail smoke 통과는 extension 등록과 대표 샘플 렌더 성공을 의미하며, 모든 HWP/HWPX 문서의 visual parity를 보장하지 않는다.
+- `native-skia` feature로 app bundle 또는 download artifact 크기가 증가할 수 있다.

--- a/mydocs/tech/skia_quicklook_thumbnail_backend.md
+++ b/mydocs/tech/skia_quicklook_thumbnail_backend.md
@@ -141,3 +141,142 @@ extension-safe `OSLog.Logger` 필드 후보는 다음과 같다.
 - `invalidPageSize`와 `fileSizeFallback`은 renderer fallback이 아니라 입력/정책 fallback으로 취급한다.
 - Thumbnail cache key에는 backend/render signature를 포함해야 한다.
 - `Skia first`와 `Skia default`는 #259 readiness gate 통과 전에는 열지 않는다.
+
+## 후속 이슈 의존 순서
+
+Skia optional backend는 다음 순서로 진행한다.
+
+```text
+#255 ABI gate
+-> #256 Shared renderer gate
+-> #257 Quick Look integration gate
+-> #258 Thumbnail integration gate
+-> #259 release readiness gate
+```
+
+#257과 #258은 #256의 Shared renderer contract가 고정된 뒤에는 서로 독립적으로 진행할 수 있다. 다만 한 작업자가 순차 진행할 때는 Quick Look의 단일/다중 page path를 먼저 검증한 뒤 Thumbnail cache와 scale 정책을 붙이는 순서가 리뷰하기 쉽다.
+
+## #255 ABI gate
+
+#255는 RustBridge와 binary provenance가 소유한다.
+
+입력 조건:
+
+- `rhwp-core.lock`과 `RustBridge/Cargo.toml`이 `rhwp v0.7.11` release tag 기준으로 정합해야 한다.
+- Stage 2 failure taxonomy 중 `ffiUnavailable`, `skiaRenderFailure`, `invalidPageSize`를 ABI 설계 입력으로 사용한다.
+- upstream `DocumentCore::render_page_png_native_with_export_options`와 `PngExportOptions`의 `scale`, `max_dimension`, `font_paths` 대응 방식을 확인한다.
+
+완료 조건:
+
+- Swift에서 호출 가능한 Skia PNG C ABI가 존재한다.
+- null handle, page out of range, invalid page size, Skia render failure가 안전하게 실패한다.
+- Rust가 넘긴 PNG byte buffer는 기존 `rhwp_free_bytes` 규칙과 정합한다.
+- `Frameworks/generated_rhwp.h`, `Rhwp.xcframework`, `rhwp-ffi-symbols.txt`, `rhwp-core.lock`이 새 ABI와 일치한다.
+- `native-skia` feature 도입 전후 Rust staticlib 또는 `Rhwp.xcframework` 크기 변화가 기록된다.
+
+비책임:
+
+- `RhwpDocument` Swift wrapper와 `HwpPageImageRenderer` backend 선택은 #256에서 처리한다.
+- Quick Look/Thumbnail provider 정책은 #257/#258에서 처리한다.
+
+## #256 Shared renderer gate
+
+#256은 Swift bridge wrapper와 Shared renderer backend abstraction이 소유한다.
+
+입력 조건:
+
+- #255의 Skia PNG ABI, generated header, symbol lock, binary provenance가 완료되어 있어야 한다.
+- Stage 2의 backend 값 `coreGraphics`/`skiaPNG`와 policy 값 `coreGraphicsOnly`/`skiaOptIn`을 구현 입력으로 사용한다.
+- 현재 `HwpRenderedPage` 호출부가 유지되어야 한다.
+
+완료 조건:
+
+- `RhwpDocument`에 Skia PNG bytes Swift wrapper가 존재한다.
+- `HwpPageImageRenderer`가 backend를 명시적으로 선택할 수 있다.
+- `Skia opt-in`에서 Skia success는 기존 `HwpRenderedPage` 계약으로 반환된다.
+- `ffiUnavailable`, `skiaRenderFailure`, `pngDecodeFailure`, `memoryTimeoutFallback`에서 CoreGraphics fallback이 동작한다.
+- `backendUsed`, `fallbackReason`, `pageSize`, `pixelSize`, `pngBytes`, `durationMs`를 기록할 수 있다.
+- 대표 샘플 1개 이상에서 Skia와 CoreGraphics 산출 차이가 기록된다.
+
+비책임:
+
+- Quick Look reply 선택과 Thumbnail cache key 변경은 #257/#258에서 처리한다.
+- `Skia first` 또는 `Skia default` 전환 결정은 #259에서 처리한다.
+
+## #257 Quick Look integration gate
+
+#257은 Quick Look preview extension surface가 소유한다.
+
+입력 조건:
+
+- #256의 Shared renderer가 `coreGraphicsOnly`와 `skiaOptIn`을 모두 지원해야 한다.
+- `HwpPreviewPDFRenderer`가 Shared renderer contract를 통해 backend와 fallback result를 받을 수 있어야 한다.
+- file size guard, empty document, invalid page size fallback 정책은 기존과 동일하게 유지되어야 한다.
+
+완료 조건:
+
+- 단일 페이지 Quick Look PNG reply가 `Skia opt-in`에서 Skia backend로 성공할 수 있다.
+- Skia 실패 또는 PNG decode 실패 시 Quick Look text fallback으로 바로 가지 않고 CoreGraphics fallback을 먼저 사용한다.
+- 다중 페이지 Quick Look PDF는 초기에는 CoreGraphics 유지 또는 별도 opt-in flag로 검증한다.
+- 다중 페이지 PDF에 Skia page image를 넣는 경우 page별 fallback reason이 기록된다.
+- Quick Look smoke 결과와 known limitation 후보가 보고서에 남는다.
+
+비책임:
+
+- Finder Thumbnail cache, pixel bucket, scale/max-dimension 정책은 #258에서 처리한다.
+- release default 전환은 #259에서 처리한다.
+
+## #258 Thumbnail integration gate
+
+#258은 Finder Thumbnail extension surface가 소유한다.
+
+입력 조건:
+
+- #256의 Shared renderer가 `skiaPNG` backend를 `maximumPixelSize`와 함께 호출할 수 있어야 한다.
+- Stage 2의 Thumbnail policy에 따라 긴 변 `maximumPixelSize`를 `PngExportOptions.max_dimension`에 매핑할 수 있어야 한다.
+- embedded thumbnail policy와 기존 fallback tile 정책이 유지되어야 한다.
+
+완료 조건:
+
+- Finder thumbnail이 `Skia opt-in`에서 요청 크기에 맞는 Skia bitmap을 생성할 수 있다.
+- `HwpThumbnailRenderCache` key가 file identity, pixel bucket, backend 또는 render signature를 반영한다.
+- Skia 실패 또는 PNG decode 실패 시 fallback tile로 바로 가지 않고 CoreGraphics fallback을 먼저 사용한다.
+- cache hit/miss가 backend 선택과 충돌하지 않는다.
+- 대표 크기별 thumbnail smoke 결과가 보고서에 남는다.
+
+비책임:
+
+- Quick Look provider와 다중 페이지 PDF path는 #257에서 처리한다.
+- 전체 visual/performance/package readiness 판단은 #259에서 처리한다.
+
+## #259 release readiness gate
+
+#259는 default 전환 또는 release 포함 여부를 판단하는 검증 gate다.
+
+입력 조건:
+
+- #255 ABI gate, #256 Shared renderer gate, #257 Quick Look integration gate, #258 Thumbnail integration gate가 완료되어야 한다.
+- 각 이슈가 남긴 binary size, visual diff, smoke, latency, memory, known limitation 결과를 수집한다.
+
+완료 조건:
+
+- 대표 HWP/HWPX 샘플군의 Skia vs CoreGraphics vs reference 결과가 기록된다.
+- Quick Look과 Thumbnail 각각의 latency, memory, decode cost가 기록된다.
+- `native-skia` feature 전후 staticlib, `Rhwp.xcframework`, app/package size 변화가 기록된다.
+- `Skia first` 전환, `Skia opt-in` 유지, 또는 보류 판단이 근거와 함께 남는다.
+- release note known limitation 초안이 준비된다.
+
+비책임:
+
+- renderer implementation 자체를 추가하거나 수정하지 않는다.
+- signed/notarized public release 실행은 별도 명시 지시 없이는 포함하지 않는다.
+
+## GitHub issue 본문 업데이트 후보
+
+현재 #255-#259 본문은 큰 책임 경계를 이미 포함한다. 다만 후속 이슈 시작 직전에 다음 보강을 검토한다.
+
+- #255: Stage 2 failure taxonomy의 `ffiUnavailable`, `skiaRenderFailure`, `invalidPageSize` 명칭을 ABI 오류 결과 표에 반영.
+- #256: `backendUsed`, `fallbackReason`, `pngBytes`, `durationMs` 진단 필드와 Thumbnail cache key 영향이 #258로 넘어간다는 점을 명시.
+- #257: 다중 페이지 PDF의 Skia 적용은 초기 default가 아니라 별도 opt-in 검증으로 시작한다고 명시.
+- #258: cache key에 backend/render signature를 포함한다는 완료 조건을 명시.
+- #259: #255-#258 산출물을 입력으로 받는 release readiness gate임을 명시.

--- a/mydocs/tech/skia_quicklook_thumbnail_backend.md
+++ b/mydocs/tech/skia_quicklook_thumbnail_backend.md
@@ -393,3 +393,16 @@ Skia optional backend가 release에 포함될 경우 다음 항목을 known limi
 - 다중 페이지 Quick Look preview는 여전히 bitmap PDF container이며 vector PDF export 개선은 별도 범위다.
 - Quick Look/Thumbnail smoke 통과는 extension 등록과 대표 샘플 렌더 성공을 의미하며, 모든 HWP/HWPX 문서의 visual parity를 보장하지 않는다.
 - `native-skia` feature로 app bundle 또는 download artifact 크기가 증가할 수 있다.
+
+## 최종 권장 rollout
+
+#254의 최종 권장은 보수적 단계 도입이다.
+
+1. #255에서 RustBridge `native-skia` PNG ABI와 binary provenance를 먼저 닫는다.
+2. #256에서 Shared renderer가 `coreGraphics`와 `skiaPNG`를 선택할 수 있게 만들되, 제품 기본값은 `coreGraphicsOnly`로 둔다.
+3. #257과 #258에서 Quick Look/Thumbnail surface별로 `skiaOptIn`을 검증한다. 두 surface는 같은 Shared contract를 쓰지만 rollout 판단은 분리한다.
+4. #259에서 visual/performance/package readiness를 측정한 뒤 `Skia first`, `Skia opt-in 유지`, `보류` 중 하나를 결정한다.
+
+현재 단계에서 `Skia default`는 권장하지 않는다. Skia는 upstream `v0.7.11`에 존재하지만 앱 ABI와 Swift wrapper, extension integration, package impact 검증이 아직 없기 때문이다.
+
+후속 이슈를 시작할 때는 이 문서의 gate 순서를 기준으로 삼고, GitHub issue 본문 업데이트는 각 이슈 시작 직전에 작업지시자 승인 후 반영한다.

--- a/mydocs/tech/skia_quicklook_thumbnail_backend.md
+++ b/mydocs/tech/skia_quicklook_thumbnail_backend.md
@@ -1,0 +1,143 @@
+# Skia Quick Look/Thumbnail optional backend 설계
+
+## 목적
+
+이 문서는 Quick Look preview와 Finder thumbnail에 upstream `rhwp` native Skia PNG renderer를 optional backend로 도입하기 위한 backend 선택 정책과 fallback contract를 정의한다.
+
+현재 제품 기준선은 `PageRenderTree` JSON을 Swift `CGTreeRenderer`가 CoreGraphics/CoreText로 그리는 경로다. Skia 후보는 upstream `rhwp v0.7.11`의 `native-skia` feature가 제공하는 `PageLayerTree` 기반 PNG export 경로다.
+
+## 범위
+
+- Quick Look preview extension의 단일 페이지 PNG reply와 다중 페이지 bitmap PDF reply
+- Finder Thumbnail extension의 첫 페이지 bitmap thumbnail
+- Shared renderer 계층의 backend 선택, fallback, 진단 필드
+- 후속 이슈 #255-#259가 구현할 정책 기준
+
+## 비범위
+
+- HostApp WKWebView viewer renderer 전환
+- browser CanvasKit renderer 도입
+- vector PDF export 품질 개선
+- Swift `PageLayerTree` renderer 완성
+- upstream `rhwp` 자체 수정
+- 사용자 설정 UI 노출
+
+## 현재 기준선
+
+현재 Quick Look/Thumbnail 공통 raster path는 `HwpPageImageRenderer`다.
+
+- `RhwpDocument.renderPageTree(at:)`가 `rhwp_render_page_tree` FFI를 호출한다.
+- `HwpPageImageRenderer.renderPage`가 render tree와 page size를 읽어 `CGContext`에 그린다.
+- Quick Look 단일 페이지는 `CGImage`를 PNG로 인코딩한다.
+- Quick Look 다중 페이지는 각 page `CGImage`를 PDF page에 그린다.
+- Thumbnail은 `HwpThumbnailRenderCache`를 거쳐 첫 페이지 `CGImage`를 Finder context에 그린다.
+
+따라서 Skia 도입은 Shared renderer 계층의 backend 선택으로 모델링한다. Quick Look/Thumbnail extension이 각각 별도 Skia 호출 규칙을 복제하지 않도록 한다.
+
+## backend 후보
+
+| 후보 | 설명 | 장점 | 단점 | Stage 2 판단 |
+|---|---|---|---|---|
+| `CoreGraphics only` | 현재 Swift `CGTreeRenderer` 경로만 사용 | 현재 동작과 package size 유지, fallback 단순 | upstream Skia 개선을 사용하지 못함, Swift renderer parity gap 유지 | 현재 기본값으로 유지 |
+| `Skia opt-in` | debug flag 또는 internal policy에서만 Skia를 먼저 시도하고 실패 시 CoreGraphics로 fallback | 제품 위험이 낮고 visual/performance 비교 가능, 후속 이슈를 작게 나눌 수 있음 | 사용자 기본 경험은 당장 개선되지 않음, 두 backend 진단과 cache 분기가 필요 | 첫 구현 권장 |
+| `Skia first + CoreGraphics fallback` | 일반 경로에서 Skia를 먼저 사용하고 실패 시 CoreGraphics 사용 | native Skia coverage를 넓게 검증 가능, Swift render tree gap을 우회할 수 있음 | package/load time과 font 차이를 충분히 보기 전에는 회귀 위험이 큼 | #259 readiness gate 통과 후 후보 |
+| `Skia default` | CoreGraphics fallback을 예외적 backup 또는 제거 후보로 둠 | 장기적으로 renderer path 단순화 가능 | fallback 제거 시 extension 안정성이 떨어지고 upstream 변경 영향이 커짐 | 현재 보류 |
+
+Stage 2 결론은 `CoreGraphics only`를 기본값으로 유지하고, #256 이후 구현은 `Skia opt-in`으로 시작하는 것이다. `Skia first`와 `Skia default`는 visual/performance/package readiness가 통과된 뒤 별도 승인으로 전환한다.
+
+## backend contract 초안
+
+후속 구현의 개념 모델은 다음과 같이 둔다.
+
+| 개념 | 값 | 의미 |
+|---|---|---|
+| backend | `coreGraphics` | 현재 `PageRenderTree` + `CGTreeRenderer` |
+| backend | `skiaPNG` | upstream `PageLayerTree` + native Skia PNG export |
+| policy | `coreGraphicsOnly` | Skia를 호출하지 않는다 |
+| policy | `skiaOptIn` | opt-in 조건에서 Skia를 먼저 시도하고 실패 시 CoreGraphics |
+| policy | `skiaFirstCoreGraphicsFallback` | 일반 경로에서 Skia를 먼저 시도하고 실패 시 CoreGraphics |
+| policy | `skiaDefault` | Skia를 기본 성공 경로로 보고 CoreGraphics fallback은 제한적으로만 사용 |
+
+Shared renderer는 결과에 `backendUsed`, `fallbackReason`, `pageSize`, `pixelSize`를 진단 가능하게 남겨야 한다. Thumbnail cache key에는 backend 또는 render signature를 포함해야 하며, fallback으로 생성된 CoreGraphics bitmap을 Skia 결과처럼 재사용하지 않아야 한다.
+
+## failure taxonomy
+
+| reason | 정의 | Quick Look 처리 | Thumbnail 처리 | 로그 수준 |
+|---|---|---|---|---|
+| `ffiUnavailable` | `native-skia` feature 미포함, C ABI symbol 부재, Swift bridge API 부재 | CoreGraphics fallback. CoreGraphics도 없으면 기존 fallback text reply | CoreGraphics fallback. CoreGraphics도 실패하면 fallback tile | warning |
+| `skiaRenderFailure` | upstream Skia 호출이 error를 반환하거나 빈 PNG bytes를 반환 | CoreGraphics fallback | CoreGraphics fallback | warning |
+| `pngDecodeFailure` | Skia PNG bytes를 `CGImageSource`/`CGImage`로 decode하지 못함 | CoreGraphics fallback | CoreGraphics fallback | warning |
+| `invalidPageSize` | page size가 0 이하, NaN, infinite, 또는 pixel 계산 불가 | backend 전환 없이 기존 fallback classifier로 처리 | backend 전환 없이 fallback tile 후보로 처리 | warning |
+| `fileSizeFallback` | 기존 50 MB guard 또는 extension policy상 render를 시도하지 않음 | Skia도 시도하지 않고 기존 text fallback | small thumbnail 정책이 별도로 승인되기 전에는 기존 fallback tile | info 또는 warning |
+| `memoryTimeoutFallback` | Skia render/decode가 timeout, memory pressure, allocation 실패로 중단 | CoreGraphics fallback. 동일 실패가 반복되면 text fallback | CoreGraphics fallback. 동일 실패가 반복되면 fallback tile | warning |
+| `coreGraphicsFallbackFailure` | Skia 실패 후 CoreGraphics fallback도 실패 | 기존 `HwpDocumentFallbackClassifier` 기준 text reply 또는 throw | 기존 fallback tile 또는 handler error | error |
+
+`invalidPageSize`, `fileSizeFallback`은 Skia와 CoreGraphics 중 어느 renderer가 더 나은지의 문제가 아니라 입력/정책 문제다. 이 경우 Skia를 우회 수단으로 쓰지 않는다.
+
+## Quick Look 정책
+
+Quick Look은 사용자에게 문서 내용을 크게 보여주는 surface이므로 안정성과 실패 설명을 우선한다.
+
+- 기본 policy는 `coreGraphicsOnly`다.
+- `skiaOptIn`에서는 단일 페이지 PNG reply에 Skia PNG를 먼저 시도할 수 있다.
+- 다중 페이지 PDF reply는 현재 bitmap PDF이므로 Skia PNG를 page별로 decode해서 넣을 수는 있지만, 초기 opt-in에서는 별도 flag로 분리한다.
+- file size guard는 Skia보다 앞에서 실행한다.
+- Skia 실패는 text fallback으로 바로 가지 않고 CoreGraphics fallback을 먼저 시도한다.
+- CoreGraphics fallback까지 실패하면 기존 `HwpDocumentFallbackClassifier`의 text reply 정책을 유지한다.
+
+Quick Look에서 Skia가 직접 PNG bytes를 반환하는 장점은 단일 페이지 PNG reply에서 Swift `CGImage` 생성과 PNG 재인코딩을 줄일 수 있다는 점이다. 반면 다중 페이지 PDF는 `CGImage` decode가 필요하므로 초기 성능 이득을 단정하지 않는다.
+
+## Thumbnail 정책
+
+Thumbnail은 작은 bitmap을 빠르게 제공하는 surface이므로 latency, memory, cache 안정성을 우선한다.
+
+- 기본 policy는 `coreGraphicsOnly`다.
+- `skiaOptIn`에서는 `HwpThumbnailRenderRequest.maximumPixelSize`의 긴 변을 upstream `PngExportOptions.max_dimension`에 매핑한다.
+- Skia PNG bytes는 Finder context에 직접 그릴 수 없으므로 `CGImage` decode가 필요하다.
+- cache key에는 file identity, pixel bucket에 더해 backend 또는 render signature를 포함한다.
+- Skia 실패는 fallback tile로 바로 가지 않고 CoreGraphics fallback을 먼저 시도한다.
+- CoreGraphics fallback까지 실패하면 기존 fallback tile 정책을 유지한다.
+
+Thumbnail은 Quick Look보다 `max_dimension` 매핑이 명확하다. 다만 PNG decode 비용과 cache key 변화가 있으므로 `Skia first` 전환은 Quick Look과 독립적으로 판단한다.
+
+## option mapping
+
+| 입력 | CoreGraphics 현재 처리 | Skia 후보 매핑 |
+|---|---|---|
+| Quick Look 단일 페이지 | page size 기준 1x bitmap 후 PNG encode | `scale = 1.0`부터 시작. 이후 target size 정책이 생기면 scale 계산 |
+| Quick Look 다중 페이지 | page size 기준 page별 bitmap을 PDF에 draw | 초기 opt-in에서는 CoreGraphics 유지. 별도 flag에서 page별 `scale = 1.0` 검증 |
+| Thumbnail maximum size/scale | `maximumPixelSize` bucket 계산 후 renderScale 산출 | 긴 변을 `PngExportOptions.max_dimension`에 매핑 |
+| file size > 50 MB | render 전 거절 | Skia 호출 전 동일하게 거절 |
+| font paths | Swift renderer가 bundled WOFF2/system fallback 사용 | upstream `font_paths` 지원은 별도 검증 후 연결 |
+
+## 로그와 진단 필드
+
+extension-safe `OSLog.Logger` 필드 후보는 다음과 같다.
+
+| 필드 | 예시 | 비고 |
+|---|---|---|
+| `surface` | `quicklook`, `thumbnail` | 호출 surface |
+| `replyType` | `png`, `pdf`, `tile`, `text` | Quick Look/Thumbnail 결과 형식 |
+| `policy` | `coreGraphicsOnly`, `skiaOptIn` | 선택 정책 |
+| `backendRequested` | `skiaPNG` | 최초 시도 backend |
+| `backendUsed` | `coreGraphics` | 실제 성공 backend |
+| `fallbackReason` | `pngDecodeFailure` | fallback이 없으면 생략 |
+| `pageIndex` | `0` | page별 진단 |
+| `pageCount` | `1` | 문서 page count |
+| `pageSize` | `595x842` | 문서 좌표계 크기 |
+| `pixelSize` | `1024x1448` | 실제 bitmap 크기 |
+| `fileSize` | `123456` | byte 단위, path 전체는 기록하지 않음 |
+| `durationMs` | `38` | render 또는 decode 구간 |
+| `pngBytes` | `456789` | Skia PNG bytes 길이 |
+| `cacheHit` | `true` | Thumbnail cache 진단 |
+
+파일명은 현재 코드처럼 basename만 public으로 남기고 full path는 기록하지 않는다. fallback reason은 문자열 enum으로 고정해 후속 visual/performance report에서 집계 가능하게 한다.
+
+## Stage 2 결론
+
+- 지금 기본값은 `CoreGraphics only`로 유지한다.
+- 첫 구현은 `Skia opt-in`이며, 실패 시 CoreGraphics fallback을 반드시 유지한다.
+- Quick Look과 Thumbnail은 같은 Shared backend contract를 쓰되 rollout 판단은 분리한다.
+- `invalidPageSize`와 `fileSizeFallback`은 renderer fallback이 아니라 입력/정책 fallback으로 취급한다.
+- Thumbnail cache key에는 backend/render signature를 포함해야 한다.
+- `Skia first`와 `Skia default`는 #259 readiness gate 통과 전에는 열지 않는다.

--- a/mydocs/working/task_m020_254_stage1.md
+++ b/mydocs/working/task_m020_254_stage1.md
@@ -1,0 +1,142 @@
+# Task M020 #254 Stage 1 보고서
+
+## 단계 목적
+
+Stage 1의 목적은 Skia를 Quick Look/Thumbnail의 optional backend로 검토하기 전에 현재 앱의 실제 렌더링 경로와 upstream `rhwp`의 사용 가능 표면을 분리해 확정하는 것이다. 이 단계에서는 제품 코드와 bridge ABI를 변경하지 않고 inventory만 남긴다.
+
+## 산출물
+
+| 파일 | 요약 |
+|---|---|
+| `mydocs/working/task_m020_254_stage1.md` | 현재 Quick Look/Thumbnail 경로, FFI 표면, upstream Skia 적용 후보, 관련 이슈 책임 경계 정리. 142 lines |
+| `mydocs/orders/20260518.md` | #254 상태를 Stage 1 완료 및 Stage 2 승인 대기 상태로 갱신. 7 lines |
+
+## 현재 Quick Look/Thumbnail 렌더 흐름
+
+현재 앱의 Quick Look/Thumbnail 경로는 upstream Skia PNG가 아니라 `PageRenderTree` JSON을 Swift에서 해석하는 CoreGraphics/CoreText 경로다.
+
+1. `RustBridge/src/lib.rs`는 `rhwp_render_page_tree`를 C ABI로 노출하고, 내부에서 `h.doc.build_page_render_tree(page)` 결과의 `tree.root`를 JSON으로 직렬화한다.
+2. `Sources/RhwpCoreBridge/RhwpDocument.swift`는 `renderPageTree(at:)`, `renderPageTreeJSON(at:)`, `pageSize(at:)`, `imageData(binDataId:)`만 Swift API로 제공한다. PNG raster API는 없다.
+3. `Sources/Shared/HwpPageImageRenderer.swift`는 `RhwpDocument.renderPageTree(at:)`와 `pageSize(at:)`를 읽어 `CGContext`에 `CGTreeRenderer`로 그린 뒤 `CGImage`를 반환한다.
+4. `Sources/QLExtension/HwpPreviewProvider.swift`는 단일 페이지 문서에서는 해당 `CGImage`를 PNG로 인코딩해 Quick Look reply를 만들고, 다중 페이지 문서에서는 `HwpPreviewPDFRenderer`가 각 페이지 bitmap을 PDF page에 그린다.
+5. `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`는 `HwpThumbnailRenderCache`를 통해 첫 페이지 `CGImage`를 얻고, Finder thumbnail context에 aspect-fit으로 그린다.
+6. `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`는 요청 pixel 크기를 bucket화하고, cache miss에서 `HwpPageImageRenderer.renderFirstPage(..., embeddedThumbnailPolicy: .never)`를 호출한다.
+
+따라서 Quick Look preview와 Finder thumbnail의 공통 병목은 `HwpPageImageRenderer.renderPage`이며, Skia backend를 붙인다면 이 공통 지점 위 또는 바로 아래에 backend 선택 정책을 둬야 한다.
+
+## 현재 RustBridge/lock 상태
+
+현재 lock은 `rhwp-core.lock` 기준 stable release tag `v0.7.11`, resolved commit `a9dcdee32b17a7f9a20c609a5ed547e62fb8ebae`다. `RustBridge/Cargo.toml`도 `rhwp = { git = "https://github.com/edwardkim/rhwp.git", tag = "v0.7.11" }`를 사용한다.
+
+현재 앱이 노출하는 FFI symbol set은 `rhwp-ffi-symbols.txt` 기준 다음 10개로 제한된다.
+
+- `rhwp_extract_thumbnail`
+- `rhwp_open`
+- `rhwp_page_count`
+- `rhwp_page_size`
+- `rhwp_render_page_svg`
+- `rhwp_render_page_tree`
+- `rhwp_image_data`
+- `rhwp_free_string`
+- `rhwp_free_bytes`
+- `rhwp_close`
+
+즉 현재 앱 ABI에는 `rhwp_render_page_png` 또는 native Skia 관련 symbol이 없다. 또한 현재 `RustBridge/Cargo.toml`의 `rhwp` dependency에는 `features = ["native-skia"]`가 지정되어 있지 않아 upstream의 Skia code path가 앱 산출물에 들어오지 않는다.
+
+## upstream v0.7.11 Skia 적용 후보
+
+로컬 Cargo checkout의 upstream `v0.7.11` 소스에는 `native-skia` feature와 native PNG export API가 이미 존재한다.
+
+- `Cargo.toml`의 `native-skia = ["dep:resvg", "dep:skia-safe"]`
+- `skia-safe = { version = "0.93.1", optional = true, default-features = false, features = ["binary-cache", "embed-icudtl", "pdf", "textlayout"] }`
+- `DocumentCore::render_page_png_native(page_num)`
+- `DocumentCore::render_page_png_native_with_fonts(page_num, font_paths)`
+- `DocumentCore::render_page_png_native_with_export_options(page_num, options)`
+- `PngExportOptions`의 `scale`, `max_dimension`, `vlm_target`, `dpi`, `font_paths`
+
+이 API는 `PageLayerTree`를 만든 뒤 `SkiaLayerRenderer`가 PNG bytes를 생성하는 native-only 경로다. Quick Look/Thumbnail 관점에서 가장 직접적인 후보는 `render_page_png_native_with_export_options`이며, thumbnail pixel cap에는 `max_dimension`, Quick Look preview에는 `scale` 또는 page target size 정책을 매핑할 수 있다.
+
+단, 이 후보는 현재 앱에 바로 사용 가능한 ABI가 아니다. 앱 측에서 최소한 다음 작업이 별도 이슈로 필요하다.
+
+- `RustBridge/Cargo.toml`에서 `rhwp/native-skia` feature 활성화 검토
+- `RustBridge/src/lib.rs`에 C ABI wrapper 추가
+- `rhwp-ffi-symbols.txt` 갱신
+- `Sources/RhwpCoreBridge`에 PNG bytes Swift API 추가
+- `HwpPageImageRenderer` 또는 새 backend abstraction에서 CoreGraphics renderer와 Skia renderer 선택
+- Quick Look/Thumbnail extension sandbox, binary size, first-call latency, font fallback 검증
+
+## upstream #536 진행상태 반영 범위
+
+`edwardkim/rhwp` #536은 2026-05-17 기준 open tracking issue다. 현재 확인된 진행 상황 중 Quick Look/Thumbnail에 직접 연결되는 부분은 P4-P9다.
+
+- P4 #599: `native-skia` feature와 native PNG raster backend 추가
+- P5 #626: native Skia equation replay 추가
+- P6 #720: native Skia raw SVG fragment replay 추가
+- P7 #740: native Skia form control static replay 추가
+- P8 #761: Layer IR schema/resource key hardening
+- P9 #769: native Skia text replay parity와 module split
+
+반대로 P15/P16의 CanvasKit direct renderer 계열은 browser Studio backend 방향이며, Quick Look/Thumbnail의 macOS native extension path에 바로 들어갈 표면이 아니다. 특히 P16은 아직 #536의 다음 후보로 남아 있으며 public native PNG API를 바꾸지 않는 범위로 설명되어 있다. 따라서 #254는 CanvasKit 도입이 아니라 v0.7.11에 이미 들어온 native Skia PNG path의 optional backend 적용 가능성을 다루는 것으로 범위를 고정한다.
+
+## 관련 이슈 책임 경계
+
+| 이슈 | 상태 | 책임 경계 |
+|---|---:|---|
+| #96 `PageLayerTree native bridge 탐색과 FFI 공존 경로 추가` | Closed | PageLayerTree JSON 추출과 bridge 공존 실험 범위다. Quick Look/Thumbnail 기본 렌더 경로 전환과 Swift PageLayerTree renderer 완성은 제외했다. |
+| #222 `rhwp v0.7.11 기준 Swift native renderer parity gap 정리와 따라잡기` | Closed | Swift CoreGraphics renderer의 parity gap과 구현 우선순위 정리 범위다. native-skia를 앱에 내장하는 구조 변경과 Quick Look/Thumbnail 배포 재릴리즈는 제외했다. |
+| #254 `Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리` | Open | Quick Look/Thumbnail에 Skia PNG를 optional backend로 넣을 때의 설계, fallback, rollout gate, 후속 이슈 분할을 정리한다. 이 단계에서는 제품 코드 구현을 하지 않는다. |
+
+따라서 #254의 Stage 2 이후 산출물은 #96의 bridge 탐색이나 #222의 parity gap 분석을 반복하지 않고, Quick Look/Thumbnail product path에서 backend 선택과 fallback contract를 결정하는 문서가 되어야 한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 코드, RustBridge ABI, project 설정은 변경하지 않았다.
+- 문서 변경은 신규 Stage 1 보고서와 오늘할일 상태 갱신뿐이다.
+- 기존 문서 본문을 재작성하거나 삭제하지 않았으므로 기존 내용 손실은 없다.
+- `mydocs/tech/project_architecture.md`에는 아직 `v0.7.10` lock 설명이 남아 있다. 실제 lock은 이미 `v0.7.11`이므로 별도 문서 정합성 작업에서 정리할 필요가 있다.
+
+## 검증 결과
+
+검증 명령은 Stage 1 보고서 작성 후 실행했다.
+
+```bash
+rg -n "rhwp_render_page_tree|renderPageTree|HwpPageImageRenderer|HwpPreviewPDFRenderer|HwpThumbnailProvider|native-skia|render_page_png" \
+  rhwp-core.lock RustBridge Sources mydocs/tech/project_architecture.md mydocs/working/task_m020_254_stage1.md
+```
+
+결과: 통과. 현재 앱 경로가 `rhwp_render_page_tree`/`renderPageTree`/`HwpPageImageRenderer` 중심이고, `native-skia`/`render_page_png`는 Stage 1 보고서와 RustBridge dependency 설정 검토 대상으로만 나타남을 확인했다.
+
+```bash
+git diff --check -- mydocs/plans/task_m020_254_impl.md mydocs/working/task_m020_254_stage1.md
+```
+
+결과: 통과.
+
+추가 확인:
+
+- `gh issue view 536 --repo edwardkim/rhwp`: #536은 open이며 P4-P15까지 완료, P16은 다음 후보로 남아 있음을 확인했다.
+- `gh issue view 96 --repo postmelee/alhangeul-macos`: #96은 closed이며 PageLayerTree bridge 탐색 범위임을 확인했다.
+- `gh issue view 222 --repo postmelee/alhangeul-macos`: #222는 closed이며 native-skia 내장 구조 변경을 제외한 Swift renderer parity gap 정리 범위임을 확인했다.
+- 로컬 Cargo checkout `/Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/a9dcdee`에서 `native-skia`, `render_page_png_native*`, `PngExportOptions` 존재를 확인했다.
+
+## 잔여 위험
+
+- `native-skia` feature를 켰을 때 `Rhwp.xcframework` 크기와 빌드 시간, extension load time 영향은 아직 측정하지 않았다.
+- Skia가 반환하는 PNG bytes를 Quick Look/Thumbnail에서 다시 decode해 `CGImage`로 그릴 경우, Swift renderer 대비 CPU/메모리 이득이 실제로 줄어들 수 있다.
+- font fallback과 text shaping 결과가 현재 CoreText renderer 및 upstream Skia renderer 사이에서 달라질 수 있다.
+- multi-page Quick Look PDF는 현재 bitmap PDF이므로 Skia backend를 붙여도 vector PDF 품질 개선은 별도 범위다.
+- current architecture 문서의 `v0.7.10` 설명은 stale 상태이며, #254 후속 문서화 단계에서 정합성 보정이 필요하다.
+
+## 다음 단계 영향
+
+Stage 2에서는 이 inventory를 기준으로 Quick Look/Thumbnail backend contract를 정해야 한다.
+
+- backend enum: 현재 CoreGraphics render-tree backend와 Skia PNG backend의 이름과 기본값
+- fallback 기준: Skia 실패, PNG decode 실패, oversize, timeout, unsupported feature, memory pressure
+- option mapping: Quick Look target size, Thumbnail `maximumPixelSize`, upstream `PngExportOptions.scale/max_dimension`
+- observability: extension-safe logging, error classification, cache key에 backend 포함 여부
+- rollout gate: default off, debug flag, sample corpus, visual diff, performance smoke
+
+## 승인 요청
+
+Stage 1은 구현 변경 없이 inventory 정리로 마무리한다. Stage 2 `Backend 선택 계약과 fallback 정책 설계`로 진행하려면 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m020_254_stage2.md
+++ b/mydocs/working/task_m020_254_stage2.md
@@ -1,0 +1,126 @@
+# Task M020 #254 Stage 2 보고서
+
+## 단계 목적
+
+Stage 2의 목적은 Quick Look/Thumbnail에 Skia를 optional backend로 도입할 때 사용할 backend 선택 정책과 fallback contract를 설계하는 것이다. 이 단계에서도 제품 Swift/Rust source는 변경하지 않고 장기 기술 문서와 단계 보고서만 남긴다.
+
+## 산출물
+
+| 파일 | 요약 |
+|---|---|
+| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | Skia Quick Look/Thumbnail optional backend의 정책, failure taxonomy, surface별 fallback contract 초안. 143 lines |
+| `mydocs/working/task_m020_254_stage2.md` | Stage 2 완료 보고서. 126 lines |
+| `mydocs/orders/20260518.md` | #254 상태를 Stage 2 완료 및 Stage 3 승인 대기 상태로 갱신. 7 lines |
+
+## backend 후보 비교 결과
+
+Stage 2에서는 네 후보를 비교했다.
+
+| 후보 | 판단 |
+|---|---|
+| `CoreGraphics only` | 현재 기본값으로 유지한다. 제품 위험, package size, extension load time이 가장 낮다. |
+| `Skia opt-in` | 첫 구현 권장안이다. Skia를 먼저 시도하되 실패 시 CoreGraphics fallback을 유지해 visual/performance 비교를 안전하게 쌓을 수 있다. |
+| `Skia first + CoreGraphics fallback` | readiness gate 통과 뒤 전환 후보로 둔다. 기본 경로 변경이므로 #259 검증 전에는 열지 않는다. |
+| `Skia default` | 현재 보류한다. CoreGraphics fallback을 약화하려면 upstream Skia coverage, package size, font 결과, extension 안정성이 먼저 입증되어야 한다. |
+
+결론은 현재 기본값을 `CoreGraphics only`로 유지하고, #256 이후 구현은 `Skia opt-in`으로 시작하는 것이다.
+
+## fallback contract 초안
+
+backend는 `coreGraphics`와 `skiaPNG`로 나누고, policy는 `coreGraphicsOnly`, `skiaOptIn`, `skiaFirstCoreGraphicsFallback`, `skiaDefault`로 정의했다.
+
+failure taxonomy는 다음 항목을 포함한다.
+
+- `ffiUnavailable`: Skia feature나 ABI symbol이 없으면 CoreGraphics fallback.
+- `skiaRenderFailure`: upstream Skia render error 또는 빈 PNG bytes면 CoreGraphics fallback.
+- `pngDecodeFailure`: Skia PNG bytes decode 실패면 CoreGraphics fallback.
+- `invalidPageSize`: renderer fallback이 아니라 입력 오류로 보고 기존 fallback classifier로 처리.
+- `fileSizeFallback`: 기존 50 MB guard를 Skia보다 앞에 둔다.
+- `memoryTimeoutFallback`: Skia render/decode 중 timeout 또는 allocation 실패 시 CoreGraphics fallback.
+- `coreGraphicsFallbackFailure`: Skia 실패 후 CoreGraphics도 실패하면 현재 Quick Look text fallback 또는 Thumbnail tile fallback.
+
+중요한 경계는 `invalidPageSize`와 `fileSizeFallback`을 Skia 우회 대상으로 보지 않는 것이다. 두 항목은 renderer 품질 문제가 아니라 입력/정책 문제이므로 Skia를 호출하지 않는다.
+
+## Quick Look과 Thumbnail 차이
+
+Quick Look은 큰 preview surface이므로 실패 설명과 내용 표시 안정성을 우선한다.
+
+- 단일 페이지 PNG reply는 `Skia opt-in` 후보로 적합하다.
+- 다중 페이지 PDF reply는 현재 bitmap PDF이며 Skia PNG를 다시 decode해야 하므로 초기 opt-in에서는 별도 flag로 분리한다.
+- Skia 실패 시 바로 text reply로 가지 않고 CoreGraphics fallback을 먼저 시도한다.
+
+Thumbnail은 작은 bitmap surface이므로 latency, memory, cache 안정성을 우선한다.
+
+- `maximumPixelSize`의 긴 변을 upstream `PngExportOptions.max_dimension`에 매핑할 수 있다.
+- Skia PNG bytes는 Finder context에 직접 그릴 수 없어서 decode 비용이 있다.
+- cache key에는 backend 또는 render signature를 추가해야 한다.
+- Skia 실패 시 바로 fallback tile로 가지 않고 CoreGraphics fallback을 먼저 시도한다.
+
+따라서 Quick Look과 Thumbnail은 같은 Shared backend contract를 사용하되, rollout policy와 readiness 판단은 분리한다.
+
+## 로그/진단 필드
+
+후속 구현에서 수집할 필드 후보는 다음과 같다.
+
+- `surface`
+- `replyType`
+- `policy`
+- `backendRequested`
+- `backendUsed`
+- `fallbackReason`
+- `pageIndex`
+- `pageCount`
+- `pageSize`
+- `pixelSize`
+- `fileSize`
+- `durationMs`
+- `pngBytes`
+- `cacheHit`
+
+full path는 기록하지 않고 현재 코드처럼 basename만 public으로 기록한다. fallback reason은 문자열 enum으로 고정해 #259 visual/performance report에서 집계 가능하게 한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 코드, RustBridge ABI, project 설정은 변경하지 않았다.
+- 신규 장기 기술 문서와 신규 Stage 2 보고서만 추가했다.
+- 오늘할일은 Stage 2 완료와 Stage 3 승인 대기 상태로 갱신했다.
+- 기존 문서를 삭제하거나 본문 재작성하지 않았다.
+
+## 검증 결과
+
+검증 명령은 Stage 2 문서 작성 후 실행한다.
+
+```bash
+rg -n "CoreGraphics|Skia|fallback|Quick Look|Thumbnail|failure|decode|memory|timeout" \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage2.md
+```
+
+결과: 통과. 문서가 backend 후보, fallback, Quick Look/Thumbnail 차이, failure taxonomy, decode/memory/timeout 항목을 포함하는지 확인했다.
+
+```bash
+git diff --check -- mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage2.md
+```
+
+결과: 통과. 최종 커밋 전 전체 `git diff --check`와 함께 재확인한다.
+
+## 잔여 위험
+
+- 실제 `native-skia` feature 활성화 시 binary/package 크기와 extension load time은 아직 측정하지 않았다.
+- Skia PNG decode 비용이 CoreGraphics 직접 render보다 낮은지 아직 알 수 없다.
+- font fallback과 text shaping 차이는 policy 문서만으로 닫히지 않는다.
+- timeout과 memory fallback은 아직 구현된 장치가 아니므로 #256-#258에서 구체화해야 한다.
+- 다중 페이지 Quick Look PDF에 Skia를 적용할지 여부는 Stage 4 readiness gate 전까지 보류한다.
+
+## 다음 단계 영향
+
+Stage 3에서는 이 contract를 기준으로 #255-#259의 의존 순서와 handoff gate를 정리한다.
+
+- #255는 `skiaPNG` backend가 호출할 RustBridge ABI를 만든다.
+- #256은 Shared renderer가 `coreGraphics`와 `skiaPNG`를 선택하고 fallback reason을 보존한다.
+- #257은 Quick Look surface의 policy와 reply별 적용 범위를 결정한다.
+- #258은 Thumbnail surface의 cache key와 `max_dimension` 매핑을 결정한다.
+- #259는 `Skia first` 또는 `Skia default` 전환 가능성을 판단하는 readiness gate를 만든다.
+
+## 승인 요청
+
+Stage 2는 backend 선택 정책과 fallback contract 설계로 마무리한다. Stage 3 `후속 이슈 의존 순서와 handoff gate 정리`로 진행하려면 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m020_254_stage3.md
+++ b/mydocs/working/task_m020_254_stage3.md
@@ -1,0 +1,160 @@
+# Task M020 #254 Stage 3 보고서
+
+## 단계 목적
+
+Stage 3의 목적은 #255-#259 후속 이슈의 의존 순서와 handoff gate를 정리하는 것이다. 이 단계에서는 GitHub issue 본문을 직접 수정하지 않고, 후속 작업자가 시작 조건과 완료 조건을 확인할 수 있도록 장기 기술 문서에 기준을 추가한다.
+
+## 산출물
+
+| 파일 | 요약 |
+|---|---|
+| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | #255-#259 의존 순서, ABI gate, Shared renderer gate, Quick Look/Thumbnail integration gate, release readiness gate 추가. 282 lines |
+| `mydocs/working/task_m020_254_stage3.md` | Stage 3 완료 보고서. 160 lines |
+| `mydocs/orders/20260518.md` | #254 상태를 Stage 3 완료 및 Stage 4 승인 대기 상태로 갱신. 7 lines |
+
+## 이슈 확인 결과
+
+GitHub issue #255-#259는 모두 `v0.2.x Skia Quick Look/Thumbnail Backend` milestone의 open issue로 확인했다.
+
+| 이슈 | 역할 | 확인한 책임 |
+|---|---|---|
+| #255 | ABI gate | RustBridge `native-skia` feature, PNG C ABI, generated header, `Rhwp.xcframework`, symbol/provenance 갱신 |
+| #256 | Shared renderer gate | `RhwpDocument` Swift wrapper, `HwpPageImageRenderer` backend 선택, Skia PNG decode, CoreGraphics fallback |
+| #257 | Quick Look integration gate | 단일 페이지 PNG reply, 다중 페이지 bitmap PDF path, Quick Look fallback/logging |
+| #258 | Thumbnail integration gate | `maximumPixelSize` to Skia `max_dimension`, thumbnail cache key, fallback tile/CoreGraphics fallback |
+| #259 | release readiness gate | visual diff, latency/memory, package size, default 전환 판단, known limitation |
+
+## 확정한 의존 순서
+
+확정한 기본 순서는 다음과 같다.
+
+```text
+#255 ABI gate
+-> #256 Shared renderer gate
+-> #257 Quick Look integration gate
+-> #258 Thumbnail integration gate
+-> #259 release readiness gate
+```
+
+#257과 #258은 #256의 Shared renderer contract가 고정된 뒤에는 서로 독립적으로 진행 가능하다. 단, 순차 진행 시에는 Quick Look을 먼저 적용해 단일/다중 page path를 확인하고, 이후 Thumbnail cache와 scale policy를 적용하는 편이 리뷰 단위가 명확하다.
+
+## gate별 handoff 기준
+
+### #255 ABI gate
+
+입력:
+
+- `rhwp v0.7.11` lock과 upstream native Skia PNG API 확인 결과
+- Stage 2 failure taxonomy 중 FFI와 Skia render failure 관련 항목
+
+출력:
+
+- Swift에서 호출 가능한 Skia PNG C ABI
+- generated header, `Rhwp.xcframework`, `rhwp-ffi-symbols.txt`, `rhwp-core.lock` 정합성
+- PNG byte buffer 소유권/free 규칙
+- staticlib/package size 변화 기록
+
+### #256 Shared renderer gate
+
+입력:
+
+- #255의 ABI와 binary provenance
+- Stage 2 backend contract
+
+출력:
+
+- `RhwpDocument` Skia PNG wrapper
+- `HwpPageImageRenderer` backend 선택 구조
+- Skia success를 기존 `HwpRenderedPage` 계약으로 연결
+- Skia failure에서 CoreGraphics fallback
+- backend/fallback 진단 필드
+
+### #257 Quick Look integration gate
+
+입력:
+
+- #256의 Shared renderer opt-in backend
+- 기존 Quick Look file size, empty document, invalid page size fallback 정책
+
+출력:
+
+- 단일 페이지 PNG reply의 Skia opt-in 성공 경로
+- Skia 실패 또는 PNG decode 실패 후 CoreGraphics fallback
+- 다중 페이지 PDF path 검증. 초기 default 전환은 보류하고 별도 opt-in 검증으로 시작
+- Quick Look smoke 결과와 known limitation 후보
+
+### #258 Thumbnail integration gate
+
+입력:
+
+- #256의 Shared renderer opt-in backend
+- Thumbnail `maximumPixelSize`와 Stage 2 `max_dimension` 매핑 정책
+
+출력:
+
+- 요청 크기에 맞는 Skia thumbnail bitmap
+- backend/render signature를 포함한 cache key 정책
+- Skia 실패 또는 PNG decode 실패 후 CoreGraphics fallback
+- 대표 크기별 Finder thumbnail smoke 결과
+
+### #259 release readiness gate
+
+입력:
+
+- #255-#258의 산출물과 검증 결과
+
+출력:
+
+- 대표 샘플군의 visual diff 결과
+- Quick Look/Thumbnail latency, memory, PNG decode cost 결과
+- staticlib, `Rhwp.xcframework`, app/package size 변화
+- `Skia first` 전환, `Skia opt-in` 유지, 또는 보류 판단
+- release note known limitation 초안
+
+## GitHub issue 본문 업데이트 후보
+
+이번 단계에서는 GitHub issue 본문을 직접 수정하지 않았다. 후속 이슈 시작 직전에 다음 보강을 검토한다.
+
+- #255: Stage 2 failure taxonomy 명칭을 ABI 오류 결과 표에 반영.
+- #256: `backendUsed`, `fallbackReason`, `pngBytes`, `durationMs` 진단 필드를 완료 기준에 추가.
+- #257: 다중 페이지 PDF의 Skia 적용은 초기 default가 아니라 별도 opt-in 검증이라고 명시.
+- #258: cache key에 backend/render signature를 포함한다는 완료 조건을 보강.
+- #259: #255-#258 완료 결과를 입력으로 받는 release readiness gate임을 명시.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 코드, RustBridge ABI, project 설정은 변경하지 않았다.
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`에 후속 이슈 의존 순서와 gate 기준을 추가했다.
+- 신규 Stage 3 보고서를 추가하고 오늘할일 상태만 갱신했다.
+- 기존 문서 내용을 삭제하지 않았고, Stage 2 정책 결론도 유지했다.
+
+## 검증 결과
+
+검증 명령은 Stage 3 문서 작성 후 실행한다.
+
+```bash
+rg -n "#255|#256|#257|#258|#259|ABI gate|Shared renderer|Quick Look|Thumbnail|release readiness" \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage3.md
+```
+
+결과: 통과. 문서가 #255-#259, ABI gate, Shared renderer gate, Quick Look/Thumbnail gate, release readiness gate를 포함하는지 확인했다.
+
+```bash
+git diff --check -- mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage3.md
+```
+
+결과: 통과. 최종 커밋 전 전체 `git diff --check`와 함께 재확인한다.
+
+## 잔여 위험
+
+- GitHub issue 본문은 아직 직접 업데이트하지 않았다. #254 최종 단계에서 업데이트 승인 여부를 다시 판단해야 한다.
+- #257과 #258을 병렬 진행할 경우 Shared renderer API 변경이 다시 생기면 충돌할 수 있다.
+- #259 readiness gate는 Stage 4에서 샘플군과 측정 항목이 더 구체화되어야 실행 가능하다.
+
+## 다음 단계 영향
+
+Stage 4에서는 #259가 사용할 visual/performance/package readiness checklist를 구체화한다. 특히 대표 샘플군, visual diff 기준, extension latency/memory, staticlib/package size, default 전환 판단 기준을 문서화해야 한다.
+
+## 승인 요청
+
+Stage 3은 후속 이슈 의존 순서와 handoff gate 정리로 마무리한다. Stage 4 `visual/performance/package readiness gate 정리`로 진행하려면 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m020_254_stage4.md
+++ b/mydocs/working/task_m020_254_stage4.md
@@ -1,0 +1,159 @@
+# Task M020 #254 Stage 4 보고서
+
+## 단계 목적
+
+Stage 4의 목적은 #259가 사용할 visual, performance, memory, package readiness gate를 구체화하는 것이다. 이 단계에서는 제품 코드와 GitHub issue 본문을 변경하지 않고, Stage 2-3에서 정한 optional backend/fallback/handoff 기준을 측정 가능한 gate로 연결한다.
+
+## 산출물
+
+| 파일 | 요약 |
+|---|---|
+| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | readiness 샘플군, visual diff triage, latency/memory/package 측정 항목, rollout 판단 기준, release note known limitation 후보 추가. 395 lines |
+| `mydocs/working/task_m020_254_stage4.md` | Stage 4 완료 보고서. 159 lines |
+| `mydocs/orders/20260518.md` | #254 상태를 Stage 4 완료 및 Stage 5 승인 대기 상태로 갱신. 7 lines |
+
+## 확인한 기존 검증 자산
+
+기존 문서와 스크립트 기준으로 다음 자산을 #259 readiness gate에 연결했다.
+
+| 자산 | 역할 |
+|---|---|
+| `scripts/validate-stage3-render.sh` | 기본 샘플의 native renderer smoke. 문서 open, render tree, 한글 text/glyph, page size, non-blank PNG 확인 |
+| `scripts/render-debug-compare.sh` | 특정 파일의 core SVG, render tree JSON, native PNG, optional pixel diff 생성 |
+| `scripts/visual-compare-quicklook-renderers.sh` | Quick Look 관련 visual summary와 pixel diff 생성 형식 참고 |
+| `mydocs/manual/render_core_native_compare_guide.md` | smoke와 debug compare의 역할, 산출물, diff 해석 기준 |
+| clean Quick Look/Thumbnail smoke script 계열 | extension 등록, thumbnail 생성, 실제 Quick Look/Finder 수동 smoke 기록 |
+| `mydocs/manual/release_policy_guide.md` | `Rhwp.xcframework`, staticlib, release artifact provenance/known limitation 공개 기준 |
+
+Stage 4에서는 새 검증 스크립트를 만들지 않았다. #259에서 Skia 산출물이 생기면 기존 summary 형식에 맞춰 확장하거나 report 표로 수집하면 된다.
+
+## 대표 샘플군
+
+기술 문서에 다음 대표군을 고정했다.
+
+| 그룹 | 기본 샘플 |
+|---|---|
+| 단일 페이지 | `samples/basic/KTX.hwp`, `samples/basic/request.hwp` |
+| 다중 페이지 | `samples/hwp-multi-001.hwp`, `samples/basic/exam_math.hwp`, `samples/hwpx/hwpx-01.hwpx` |
+| 이미지 포함 | `samples/hwp-img-001.hwp`, `samples/img-start-001.hwp` |
+| 수식/도형 | `samples/eq-01.hwp`, `samples/group-drawing-02.hwp`, `samples/draw-group.hwp` |
+| form/raw object 후보 | `samples/form-01.hwp`, `samples/hwpx/form-002.hwpx`, `samples/group-box.hwp` |
+| text/font 민감 | `samples/footnote-01.hwp`, `samples/basic/shortcut.hwp`, `samples/exam_kor.hwp`, `samples/lseg-02-mixed.hwp` |
+| package/smoke 기본 | `samples/basic/KTX.hwp`, `samples/basic/request.hwp`, `samples/exam_kor.hwp` |
+
+외부 개인 경로 샘플은 release readiness 기준으로 삼지 않고 참고로만 기록한다.
+
+## visual diff 기준
+
+visual gate는 pixel diff 숫자 하나로 통과/실패를 결정하지 않도록 정리했다.
+
+Hard fail:
+
+- crash, hang, timeout, empty PNG, decode failure
+- page size 또는 aspect ratio 불일치
+- 본문, 표, 이미지, 수식, form control 주요 구조 누락
+- 전체 page offset, 반전, clipping, 투명 배경
+- Skia 실패 뒤 CoreGraphics fallback 실패
+
+Pixel diff triage:
+
+- `0-1%`: 보통 antialias/rasterizer 차이. 통과 후보
+- `1-5%`: 눈검증 필요
+- `5-10%`: known difference 또는 후속 이슈 분류
+- `10%+`: default 전환 차단 후보
+
+단, diff 비율이 낮아도 핵심 object가 누락되면 hard fail이고, text-heavy 문서의 antialias 차이는 수치가 높아도 known difference로 분류할 수 있다.
+
+## latency/memory 기준
+
+Quick Look 측정 항목:
+
+- `inspectMs`
+- `renderMs`
+- `pngEncodeOrDecodeMs`
+- `replyDataMs`
+- `pageCount`, `replyType`, `backendUsed`, `fallbackReason`
+- peak RSS 또는 `memoryHighWaterMB`
+
+Thumbnail 측정 항목:
+
+- `requestPixelSize`, `pixelBucket`, `backendUsed`
+- cache miss render duration
+- cache hit response duration
+- Skia PNG bytes 길이와 decode duration
+- fallback 발생 횟수와 fallback reason
+- peak RSS 또는 `memoryHighWaterMB`
+
+Stage 4에서는 numeric threshold를 임의 확정하지 않았다. #259가 같은 machine/session에서 CoreGraphics baseline과 Skia result를 같은 표에 기록한 뒤 default 전환, opt-in 유지, 보류 판단을 내려야 한다.
+
+## package 기준
+
+기술 문서에 다음 측정 항목을 추가했다.
+
+- Rust staticlib size: `Frameworks/universal/librhwp.a`
+- `Rhwp.xcframework` size
+- generated header size/hash
+- Debug app bundle size
+- release zip/DMG candidate size
+- universal slice 유지 여부
+
+크기 증가 자체는 실패가 아니지만, app/extension load time이나 release artifact 설명이 필요할 정도의 증가라면 rollout 판단과 release note 후보에 반영한다.
+
+## rollout 판단 기준
+
+| 결정 | 조건 |
+|---|---|
+| `Skia first` 전환 후보 | #255-#258 완료, hard fail 없음, fallback 정상, latency/memory 허용 가능, package delta 설명 가능 |
+| `Skia opt-in` 유지 | visual coverage는 유효하지만 특정 sample군의 diff, latency, package delta가 default로 설명하기 어려움 |
+| 보류 | crash/hang/timeout, decode failure, major visual regression, fallback failure, extension memory pressure가 남음 |
+
+Quick Look과 Thumbnail은 서로 다른 surface이므로 하나의 결과를 다른 surface에 강제하지 않는다.
+
+## release note known limitation 후보
+
+다음 후보를 기술 문서에 추가했다.
+
+- Skia backend는 초기에는 opt-in 또는 내부 진단 경로일 수 있다.
+- Skia와 CoreGraphics는 text antialiasing, font fallback, 수식/도형 rasterization에서 pixel-perfect하게 같지 않을 수 있다.
+- 다중 페이지 Quick Look preview는 여전히 bitmap PDF container다.
+- Quick Look/Thumbnail smoke 통과는 모든 문서의 visual parity 보장이 아니다.
+- `native-skia` feature로 app bundle 또는 download artifact 크기가 증가할 수 있다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 코드, RustBridge ABI, project 설정은 변경하지 않았다.
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`에 Stage 4 readiness gate 기준만 추가했다.
+- 신규 Stage 4 보고서를 추가하고 오늘할일 상태만 갱신했다.
+- 기존 Stage 2-3 정책과 handoff gate 내용은 삭제하지 않았다.
+
+## 검증 결과
+
+검증 명령은 Stage 4 문서 작성 후 실행한다.
+
+```bash
+rg -n "visual|diff|latency|memory|package|staticlib|Rhwp.xcframework|default|opt-in|보류" \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage4.md
+```
+
+결과: 통과. 문서가 visual/diff, latency/memory, package/staticlib/Rhwp.xcframework, default/opt-in/보류 기준을 포함하는지 확인했다.
+
+```bash
+git diff --check -- mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/working/task_m020_254_stage4.md
+```
+
+결과: 통과. 최종 커밋 전 전체 `git diff --check`와 함께 재확인한다.
+
+## 잔여 위험
+
+- 실제 측정값은 아직 없다. #259에서 Skia 구현 산출물을 기준으로 실행해야 한다.
+- numeric threshold는 Stage 4에서 고정하지 않았다. sample별 baseline/result/delta를 수집한 뒤 #259에서 확정해야 한다.
+- Skia용 visual compare summary 형식은 아직 구현되지 않았다. 기존 visual compare 도구 형식을 재사용할지 #259에서 결정해야 한다.
+- release note known limitation은 후보이며 최종 문구는 Stage 5와 release 작업에서 정리해야 한다.
+
+## 다음 단계 영향
+
+Stage 5에서는 Stage 1-4 결론을 최종 설계 문서와 최종 보고서로 정리한다. 특히 권장 rollout 순서, 후속 이슈별 시작 조건, 잔여 리스크, GitHub issue 본문 업데이트 승인 후보를 최종 상태로 모아야 한다.
+
+## 승인 요청
+
+Stage 4는 visual/performance/package readiness gate 정리로 마무리한다. Stage 5 `최종 설계 문서와 보고서 정리`로 진행하려면 작업지시자 승인이 필요하다.


### PR DESCRIPTION
## 요약

- 대상 타스크: #254 Skia Quick Look/Thumbnail optional backend 설계와 rollout gate 정리
- 왜: upstream `rhwp v0.7.11`의 native Skia PNG backend를 앱 Quick Look/Thumbnail에 바로 기본 적용하지 않고, ABI와 fallback, rollout gate를 먼저 고정하기 위해 정리했습니다.
- 무엇: 현행 CoreGraphics renderer inventory, Skia optional backend contract, #255-#259 handoff gate, visual/performance/package readiness 기준, 최종 보고서를 추가했습니다.
- 리뷰 포인트: 제품 코드는 변경하지 않았고, `CoreGraphics only` 기본값 유지와 `Skia opt-in`부터 시작하는 rollout 판단이 핵심입니다.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/f849235f2b5e59f40cf6b612d5cada157254cdb2/mydocs/working/task_m020_254_stage1.md)** ([b7d5b9b](https://github.com/postmelee/alhangeul-macos/commit/b7d5b9b)): 현행 Quick Look/Thumbnail renderer flow와 upstream Skia 적용 후보를 inventory로 정리
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/f849235f2b5e59f40cf6b612d5cada157254cdb2/mydocs/working/task_m020_254_stage2.md)** ([20bcefc](https://github.com/postmelee/alhangeul-macos/commit/20bcefc)): backend 선택 정책과 failure taxonomy/fallback contract 설계
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/f849235f2b5e59f40cf6b612d5cada157254cdb2/mydocs/working/task_m020_254_stage3.md)** ([f9bc4a9](https://github.com/postmelee/alhangeul-macos/commit/f9bc4a9)): #255-#259 의존 순서와 handoff gate 정리
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/f849235f2b5e59f40cf6b612d5cada157254cdb2/mydocs/working/task_m020_254_stage4.md)** ([fd50001](https://github.com/postmelee/alhangeul-macos/commit/fd50001)): visual/performance/package readiness gate 정리
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/f849235f2b5e59f40cf6b612d5cada157254cdb2/mydocs/report/task_m020_254_report.md)** ([f849235](https://github.com/postmelee/alhangeul-macos/commit/f849235)): 최종 보고서와 최종 rollout 결론 정리

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | Skia optional backend 설계, fallback, handoff, readiness, 최종 rollout 기준 추가 | `Skia opt-in`부터 시작하고 default 전환은 #259 이후로 막는 판단이 타당한지 |
| `mydocs/working/task_m020_254_stage*.md` | Stage 1-4 단계별 보고서 추가 | 각 단계가 후속 이슈 #255-#259에 필요한 입력을 충분히 남기는지 |
| `mydocs/report/task_m020_254_report.md` | 최종 보고서 추가 | 후속 이슈 시작 조건과 잔여 리스크가 명확한지 |
| `mydocs/orders/20260518.md` | #254 완료 처리 | 하이퍼-워터폴 진행 상태 정합성 |

- 수행 계획서: [task_m020_254.md](https://github.com/postmelee/alhangeul-macos/blob/f849235f2b5e59f40cf6b612d5cada157254cdb2/mydocs/plans/task_m020_254.md)
- 구현 계획서: [task_m020_254_impl.md](https://github.com/postmelee/alhangeul-macos/blob/f849235f2b5e59f40cf6b612d5cada157254cdb2/mydocs/plans/task_m020_254_impl.md)
- 최종 보고서: [task_m020_254_report.md](https://github.com/postmelee/alhangeul-macos/blob/f849235f2b5e59f40cf6b612d5cada157254cdb2/mydocs/report/task_m020_254_report.md)

## 핵심 리뷰 포인트

- Skia를 바로 default로 전환하지 않고 `CoreGraphics only` 기본값 유지, `Skia opt-in` 첫 구현으로 제한한 판단
- `ffiUnavailable`, `skiaRenderFailure`, `pngDecodeFailure`, `memoryTimeoutFallback`에서 CoreGraphics fallback을 먼저 쓰는 contract
- #255-#259의 gate 순서와 각 이슈의 책임 경계가 중복되지 않는지

## 검증

- `rg -n "#254|#255|#256|#257|#258|#259|Skia|Quick Look|Thumbnail|fallback|readiness" mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/report/task_m020_254_report.md mydocs/orders/20260518.md`
- `git diff --check`
- `git log --oneline origin/devel..HEAD`
- `git status --short`

## 관련 이슈

- #255 RustBridge native-skia PNG FFI와 build/provenance gate 추가
- #256 Shared HwpPageImageRenderer에 Skia optional backend와 CoreGraphics fallback 추가
- #257 Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증
- #258 Finder thumbnail에서 Skia scale/cache/memory 정책 적용과 smoke 검증
- #259 Skia backend visual/performance/package regression gate 정리
- postmelee/alhangeul-macos#96
- postmelee/alhangeul-macos#222
- edwardkim/rhwp#536

## 후속 이슈 제안

- 새 이슈 제안 없음. 후속 구현/검증은 이미 생성된 #255-#259로 분리되어 있습니다.

## 남은 리스크

- 실제 `native-skia` feature 활성화, RustBridge ABI 추가, Swift wrapper 구현은 #255/#256 범위입니다.
- Skia PNG decode 비용, extension memory, first-call latency, package size 증가는 아직 실측하지 않았습니다.
- GitHub issue #255-#259 본문 보강은 후보만 정리했고 직접 수정하지 않았습니다.
