### PR TITLE
Release v0.1.3 Stage 5 Copilot 보정

### DIFF
--- a/.github/workflows/pages-docs-deploy.yml
+++ b/.github/workflows/pages-docs-deploy.yml
@@ -23,6 +23,8 @@ jobs:
     name: Prepare docs-only Pages artifact
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      deploy: ${{ steps.release_asset_gate.outputs.deploy }}
 
     steps:
       - name: Validate deployment ref
@@ -44,8 +46,64 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Check release asset availability
+        id: release_asset_gate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          release_link_matches="$(
+            grep -RhoE 'releases/(latest/download|download/v[0-9]+\.[0-9]+\.[0-9]+)/alhangeul-macos-[0-9]+\.[0-9]+\.[0-9]+\.dmg' docs || true
+          )"
+
+          if [ -z "$release_link_matches" ]; then
+            echo "deploy=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Release asset gate"
+              echo
+              echo "- deploy: allowed"
+              echo "- reason: no release DMG links found in docs"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          mapfile -t release_versions < <(
+            printf "%s\n" "$release_link_matches" \
+              | sed -E 's#.*alhangeul-macos-([0-9]+\.[0-9]+\.[0-9]+)\.dmg#\1#' \
+              | sort -u
+          )
+
+          missing_versions=()
+          for version in "${release_versions[@]}"; do
+            asset_url="https://github.com/postmelee/alhangeul-macos/releases/download/v${version}/alhangeul-macos-${version}.dmg"
+            if ! curl -fsIL --retry 3 --retry-delay 5 "$asset_url" >/dev/null; then
+              missing_versions+=("$version")
+            fi
+          done
+
+          if [ "${#missing_versions[@]}" -gt 0 ]; then
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "## Release asset gate"
+              echo
+              echo "- deploy: skipped"
+              echo "- missing release versions: \`${missing_versions[*]}\`"
+              echo "- reason: docs-only Pages deploy waits until linked public DMG assets exist"
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "## Release asset gate"
+            echo
+            echo "- deploy: allowed"
+            echo "- checked release versions: \`${release_versions[*]}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Fetch current public appcast
         id: appcast
+        if: steps.release_asset_gate.outputs.deploy == 'true'
         shell: bash
         env:
           PUBLIC_APPCAST_URL: https://postmelee.github.io/alhangeul-macos/appcast.xml
@@ -74,6 +132,7 @@ jobs:
 
       - name: Prepare Pages artifact
         id: pages_artifact
+        if: steps.release_asset_gate.outputs.deploy == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -102,6 +161,7 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload Pages artifact
+        if: steps.release_asset_gate.outputs.deploy == 'true'
         uses: actions/upload-pages-artifact@v5
         with:
           path: ${{ steps.pages_artifact.outputs.pages_artifact_dir }}
@@ -112,6 +172,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: prepare-pages-artifact
+    if: needs.prepare-pages-artifact.outputs.deploy == 'true'
     permissions:
       pages: write
       id-token: write

--- a/.github/workflows/pages-docs-deploy.yml
+++ b/.github/workflows/pages-docs-deploy.yml
@@ -49,6 +49,8 @@ jobs:
       - name: Check release asset availability
         id: release_asset_gate
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -75,10 +77,41 @@ jobs:
 
           missing_versions=()
           for version in "${release_versions[@]}"; do
-            asset_url="https://github.com/postmelee/alhangeul-macos/releases/download/v${version}/alhangeul-macos-${version}.dmg"
-            if ! curl -fsIL --retry 3 --retry-delay 5 "$asset_url" >/dev/null; then
+            response_file="$(mktemp)"
+            release_api_url="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/tags/v${version}"
+            http_status="$(
+              curl -sS --retry 3 --retry-delay 5 --retry-all-errors \
+                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                -o "$response_file" \
+                -w "%{http_code}" \
+                "$release_api_url"
+            )" || {
+              curl_exit="$?"
+              echo "ERROR: failed to query release v${version} through GitHub API; curl exit ${curl_exit}" >&2
+              rm -f "$response_file"
+              exit 1
+            }
+
+            if [ "$http_status" = "404" ]; then
+              missing_versions+=("$version")
+              rm -f "$response_file"
+              continue
+            fi
+
+            if [ "$http_status" != "200" ]; then
+              echo "ERROR: GitHub API returned HTTP ${http_status} for release v${version}" >&2
+              cat "$response_file" >&2
+              rm -f "$response_file"
+              exit 1
+            fi
+
+            if ! jq -e --arg asset "alhangeul-macos-${version}.dmg" '.assets[]? | select(.name == $asset)' "$response_file" >/dev/null; then
               missing_versions+=("$version")
             fi
+
+            rm -f "$response_file"
           done
 
           if [ "${#missing_versions[@]}" -gt 0 ]; then

--- a/Sources/HostApp/Services/RhwpStudioHostBridgeScript.swift
+++ b/Sources/HostApp/Services/RhwpStudioHostBridgeScript.swift
@@ -123,7 +123,7 @@ enum RhwpStudioHostBridgeScript {
       ]);
       const mutatingCommandPrefixes = ["file:", "edit:", "insert:", "format:", "page:", "table:"];
       const keyboardMutationKeys = new Set(["Backspace", "Delete", "Enter", "Tab"]);
-      let isSettlingEditorState = false;
+      let settlingEditorStateDepth = 0;
 
       function postNative(message) {
         window.webkit?.messageHandlers?.alhangeulHost?.postMessage(message);
@@ -433,14 +433,14 @@ enum RhwpStudioHostBridgeScript {
       async function settleEditorState() {
         const activeElement = document.activeElement;
         if (activeElement instanceof HTMLElement && activeElement !== document.body) {
-          isSettlingEditorState = true;
+          settlingEditorStateDepth += 1;
           try {
             activeElement.dispatchEvent(new Event("change", { bubbles: true }));
             activeElement.blur();
             await waitForAnimationFrame();
             await waitForAnimationFrame();
           } finally {
-            isSettlingEditorState = false;
+            settlingEditorStateDepth -= 1;
           }
           return;
         }
@@ -712,7 +712,7 @@ enum RhwpStudioHostBridgeScript {
       document.addEventListener("beforeinput", () => postDocumentEdited("beforeinput"), true);
       document.addEventListener("input", () => postDocumentEdited("input"), true);
       document.addEventListener("change", () => {
-        if (!isSettlingEditorState) {
+        if (settlingEditorStateDepth === 0) {
           postDocumentEdited("change");
         }
       }, true);

--- a/Sources/HostApp/Services/RhwpStudioHostBridgeScript.swift
+++ b/Sources/HostApp/Services/RhwpStudioHostBridgeScript.swift
@@ -114,6 +114,8 @@ enum RhwpStudioHostBridgeScript {
         "edit:find",
         "edit:find-again",
         "edit:goto",
+        "edit:compare-documents",
+        "edit:document-history",
         "page:headerfooter-prev",
         "page:headerfooter-next",
         "page:headerfooter-close",
@@ -121,6 +123,7 @@ enum RhwpStudioHostBridgeScript {
       ]);
       const mutatingCommandPrefixes = ["file:", "edit:", "insert:", "format:", "page:", "table:"];
       const keyboardMutationKeys = new Set(["Backspace", "Delete", "Enter", "Tab"]);
+      let isSettlingEditorState = false;
 
       function postNative(message) {
         window.webkit?.messageHandlers?.alhangeulHost?.postMessage(message);
@@ -430,8 +433,16 @@ enum RhwpStudioHostBridgeScript {
       async function settleEditorState() {
         const activeElement = document.activeElement;
         if (activeElement instanceof HTMLElement && activeElement !== document.body) {
-          activeElement.dispatchEvent(new Event("change", { bubbles: true }));
-          activeElement.blur();
+          isSettlingEditorState = true;
+          try {
+            activeElement.dispatchEvent(new Event("change", { bubbles: true }));
+            activeElement.blur();
+            await waitForAnimationFrame();
+            await waitForAnimationFrame();
+          } finally {
+            isSettlingEditorState = false;
+          }
+          return;
         }
 
         await waitForAnimationFrame();
@@ -700,7 +711,11 @@ enum RhwpStudioHostBridgeScript {
       document.addEventListener("click", handleNativeCommandElementEvent, true);
       document.addEventListener("beforeinput", () => postDocumentEdited("beforeinput"), true);
       document.addEventListener("input", () => postDocumentEdited("input"), true);
-      document.addEventListener("change", () => postDocumentEdited("change"), true);
+      document.addEventListener("change", () => {
+        if (!isSettlingEditorState) {
+          postDocumentEdited("change");
+        }
+      }, true);
       document.addEventListener("cut", () => postDocumentEdited("cut"), true);
       document.addEventListener("paste", () => postDocumentEdited("paste"), true);
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
           GitHub
         </a>
         <a class="header-download-button"
-          href="https://github.com/postmelee/alhangeul-macos/releases/latest/download/alhangeul-macos-0.1.3.dmg"
+          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.3/alhangeul-macos-0.1.3.dmg"
           aria-label="Mac용 알한글 DMG 다운로드">
           다운로드
         </a>

--- a/docs/updates/index.html
+++ b/docs/updates/index.html
@@ -34,7 +34,7 @@
           GitHub
         </a>
         <a class="header-download-button"
-          href="https://github.com/postmelee/alhangeul-macos/releases/latest/download/alhangeul-macos-0.1.3.dmg"
+          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.3/alhangeul-macos-0.1.3.dmg"
           aria-label="Mac용 알한글 DMG 다운로드">
           다운로드
         </a>
@@ -48,7 +48,7 @@
       <p>앱에서는 메뉴 막대에서 새 버전을 확인할 수 있고, 웹에서는 Intel Mac과 Apple Silicon Mac을 모두 지원하는 단일 GitHub Release DMG를 직접 받을 수 있습니다.</p>
       <div class="updates-actions" aria-label="업데이트 주요 링크">
         <a class="page-action-button"
-          href="https://github.com/postmelee/alhangeul-macos/releases/latest/download/alhangeul-macos-0.1.3.dmg">
+          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.3/alhangeul-macos-0.1.3.dmg">
           최신 DMG 다운로드
         </a>
         <a class="page-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"

--- a/docs/updates/v0.1.3.html
+++ b/docs/updates/v0.1.3.html
@@ -34,7 +34,7 @@
           GitHub
         </a>
         <a class="header-download-button"
-          href="https://github.com/postmelee/alhangeul-macos/releases/latest/download/alhangeul-macos-0.1.3.dmg"
+          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.3/alhangeul-macos-0.1.3.dmg"
           aria-label="Mac용 알한글 DMG 다운로드">
           다운로드
         </a>
@@ -48,7 +48,7 @@
       <p>업스트림 <code>rhwp v0.7.12</code>를 반영해 HWP/HWPX 문서 열기와 viewer asset 기준을 갱신한 패치 릴리즈입니다.</p>
       <div class="updates-actions" aria-label="릴리즈 주요 링크">
         <a class="page-action-button"
-          href="https://github.com/postmelee/alhangeul-macos/releases/latest/download/alhangeul-macos-0.1.3.dmg">
+          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.3/alhangeul-macos-0.1.3.dmg">
           DMG 다운로드
         </a>
         <a class="page-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.3"
@@ -75,7 +75,7 @@
         <ul>
           <li>업스트림 tag 메시지 기준으로 여러 PR의 parser/viewer 결함 수정과 WMF, HWP3, LTO 관련 개선이 포함됩니다.</li>
           <li>bundled <code>rhwp-studio</code> Web/WASM asset도 같은 <code>v0.7.12</code> commit에서 다시 빌드했습니다.</li>
-          <li>Rust FFI symbol set은 이전 앱 릴리즈와 동일하며, Swift bridge API 표면은 유지됩니다.</li>
+          <li>Rust FFI에는 native PNG 렌더링용 <code>rhwp_render_page_png</code> symbol이 추가됐고, 앱 viewer와 Finder extension 경로는 새 bridge artifact 기준으로 검증했습니다.</li>
         </ul>
       </section>
 

--- a/mydocs/orders/20260518.md
+++ b/mydocs/orders/20260518.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #264 | 릴리즈 안내 변경사항 구분 기준 도입 | 완료 | M010, 완료: 11:50 |
-| #267 | rhwp v0.7.12 반영과 v0.1.3 public release 준비/배포 | 진행중 | M010, Stage 4 완료 후 Stage 5 승인 대기 |
+| #267 | rhwp v0.7.12 반영과 v0.1.3 public release 준비/배포 | 진행중 | M010, Stage 5 Copilot review 보정 진행 |
 
 ## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
 

--- a/mydocs/release/v0.1.3.md
+++ b/mydocs/release/v0.1.3.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.3` build `9` local/rehearsal 검증 완료, Stage 5 승인 대기 |
+| 상태 | `v0.1.3` build `9` local/rehearsal 검증과 Copilot review 보정 완료, public tag/workflow 승인 대기 |
 | 목표 Git tag | `v0.1.3` |
 | 목표 app version | `0.1.3` |
 | 목표 build | `9` |
@@ -48,7 +48,7 @@
 - 포함된 `rhwp` core: [`v0.7.12`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.12) (`1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5`)
 - bundled `rhwp-studio`: [`v0.7.12`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.12) (`1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5`)
 - upstream release body는 비어 있다. tag message와 Stage 1 diff 기준으로 `@jangster77` 7-PR 시리즈, Issue #952 결함 수정, WMF #966, HWP3 #968, LTO #818 관련 변경을 사용자-facing 문장으로 정리한다.
-- Rust FFI symbol set과 generated header hash는 이전 앱 릴리즈와 동일하므로 Swift bridge public ABI 변경은 없다.
+- Rust FFI symbol set에는 `rhwp_render_page_png`가 추가됐고 generated header hash/size도 갱신됐다. 기존 앱 viewer와 Finder extension 경로는 새 bridge artifact 기준으로 검증했다.
 
 ### 알한글 앱 변화
 
@@ -103,6 +103,16 @@ Stage 5 이후 보강할 검증:
 - public installed app 기준 Finder Quick Look/Thumbnail smoke
 - About 창의 `rhwp v0.7.12 (1899ef9)` 표시 확인
 - public DMG SHA256, Sparkle EdDSA signature, Homebrew Cask digest 기록
+
+Stage 5 PR review 보정:
+
+| 영역 | 보정 |
+|------|------|
+| Host bridge dirty state | print/share/export 전 editor state settle이 발생시킨 programmatic `change` event는 dirty marker로 전송하지 않도록 분리 |
+| rhwp-studio command classification | `edit:compare-documents`, `edit:document-history`를 non-mutating command로 분류 |
+| Release links | `v0.1.3` DMG link를 tag-fixed `releases/download/v0.1.3/...` 형식으로 정정 |
+| Release communication | FFI symbol/header 변경 설명을 `rhwp_render_page_png` 추가 기준으로 정정 |
+| Pages deploy guard | docs-only Pages workflow가 public DMG asset 확인 전에는 deploy를 건너뛰도록 release asset gate 추가 |
 
 ## Release metadata
 

--- a/mydocs/working/task_m010_267_stage5.md
+++ b/mydocs/working/task_m010_267_stage5.md
@@ -1,0 +1,38 @@
+# Task #267 Stage 5 보정 보고서
+
+## 개요
+
+`rhwp v0.7.12` 반영과 `v0.1.3` public release handoff PR 이후 Copilot review에서 확인된 유효 지적을 보정했다. 이 보정은 public tag 생성과 release workflow 실행 전에 source와 release communication을 다시 정렬하는 단계다.
+
+## 반영 내용
+
+| 영역 | 내용 |
+|------|------|
+| Host bridge | print/share/export 전 `settleEditorState()`가 발생시키는 programmatic `change` event를 dirty state로 전송하지 않도록 guard 추가 |
+| Host bridge | `rhwp-studio v0.7.12`의 `edit:compare-documents`, `edit:document-history` 명령을 non-mutating command로 분류 |
+| Pages release note | `v0.1.3` DMG link를 `releases/download/v0.1.3/alhangeul-macos-0.1.3.dmg`로 고정 |
+| Release note | `rhwp_render_page_png` 추가와 generated header hash/size 변경 사실을 반영 |
+| Pages workflow | public DMG asset이 없을 때 docs-only Pages deploy를 실패/배포하지 않고 건너뛰는 release asset gate 추가 |
+
+## PR 상태
+
+| PR | 대상 | 상태 |
+|----|------|------|
+| [#268](https://github.com/postmelee/alhangeul-macos/pull/268) | `publish/task267` -> `devel` | merged |
+| [#269](https://github.com/postmelee/alhangeul-macos/pull/269) | `devel` -> `main` | merged |
+
+## 검증
+
+| 항목 | 결과 | 명령 |
+|------|------|------|
+| Workflow YAML parse | 통과 | `ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path) }'` |
+| Release link scan | 통과 | docs release DMG link version 추출 결과 `0.1.0`, `0.1.1`, `0.1.2`, `0.1.3` |
+| Stale v0.1.3 latest link/FFI 문구 검색 | 통과 | `rg -n "latest/download/alhangeul-macos-0\\.1\\.3|Rust FFI symbol set.*동일|generated header hash.*동일" docs mydocs/release/v0.1.3.md` 결과 없음 |
+| Whitespace | 통과 | `git diff --check` |
+| HostApp Debug build | 통과 | `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedDataTask267Correction CODE_SIGNING_ALLOWED=NO build` |
+
+## 다음 단계
+
+- 보정 commit을 다시 `publish/task267` PR로 게시해 `devel`에 반영한다.
+- `devel` 보정분을 `main`에 반영한다.
+- public tag 생성과 release workflow 실행은 작업지시자 승인 후 별도 진행한다.

--- a/mydocs/working/task_m010_267_stage5.md
+++ b/mydocs/working/task_m010_267_stage5.md
@@ -9,10 +9,11 @@
 | 영역 | 내용 |
 |------|------|
 | Host bridge | print/share/export 전 `settleEditorState()`가 발생시키는 programmatic `change` event를 dirty state로 전송하지 않도록 guard 추가 |
+| Host bridge | 중첩 native command 호출에도 guard가 풀리지 않도록 settle guard를 counter 방식으로 보정 |
 | Host bridge | `rhwp-studio v0.7.12`의 `edit:compare-documents`, `edit:document-history` 명령을 non-mutating command로 분류 |
 | Pages release note | `v0.1.3` DMG link를 `releases/download/v0.1.3/alhangeul-macos-0.1.3.dmg`로 고정 |
 | Release note | `rhwp_render_page_png` 추가와 generated header hash/size 변경 사실을 반영 |
-| Pages workflow | public DMG asset이 없을 때 docs-only Pages deploy를 실패/배포하지 않고 건너뛰는 release asset gate 추가 |
+| Pages workflow | GitHub Releases API로 release/asset 존재를 확인하고, 404 또는 asset 없음만 skip하며 API/네트워크 오류는 실패 처리하도록 release asset gate 추가 |
 
 ## PR 상태
 
@@ -20,12 +21,14 @@
 |----|------|------|
 | [#268](https://github.com/postmelee/alhangeul-macos/pull/268) | `publish/task267` -> `devel` | merged |
 | [#269](https://github.com/postmelee/alhangeul-macos/pull/269) | `devel` -> `main` | merged |
+| [#270](https://github.com/postmelee/alhangeul-macos/pull/270) | `publish/task267` -> `devel` | Copilot follow-up 보정 반영 |
 
 ## 검증
 
 | 항목 | 결과 | 명령 |
 |------|------|------|
 | Workflow YAML parse | 통과 | `ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path) }'` |
+| Workflow actionlint | 통과 | `actionlint .github/workflows/pages-docs-deploy.yml` |
 | Release link scan | 통과 | docs release DMG link version 추출 결과 `0.1.0`, `0.1.1`, `0.1.2`, `0.1.3` |
 | Stale v0.1.3 latest link/FFI 문구 검색 | 통과 | `rg -n "latest/download/alhangeul-macos-0\\.1\\.3|Rust FFI symbol set.*동일|generated header hash.*동일" docs mydocs/release/v0.1.3.md` 결과 없음 |
 | Whitespace | 통과 | `git diff --check` |


### PR DESCRIPTION
## Summary
- Carry PR #270 Copilot review corrections from devel to main.
- Prevent programmatic editor settle changes from marking documents dirty, including nested settle calls.
- Pin v0.1.3 release links and gate docs-only Pages deploy on GitHub Release asset availability.

## Validation
- PR #270 CI passed: classify changed files, script syntax checks, release helper checks, macOS validation.
- Local validation passed: workflow YAML parse, actionlint, git diff --check, HostApp Debug build.

## Release note
- This does not create v0.1.3 tag or run public release workflow.