### PR TITLE
Task #257: Quick Look preview Skia backend 적용과 PDF fallback 검증

### DIFF
--- a/Sources/QLExtension/HwpPreviewProvider.swift
+++ b/Sources/QLExtension/HwpPreviewProvider.swift
@@ -65,7 +65,9 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
         filename: String
     ) {
         let diagnostics = page.diagnostics
-        logger.debug("Preview \(replyType, privacy: .public) render diagnostics file=\(filename, privacy: .public) policy=\(String(describing: diagnostics.policy), privacy: .public) backend=\(String(describing: diagnostics.backendUsed), privacy: .public) fallback=\(fallbackReasonDescription(diagnostics.fallbackReason), privacy: .public) pixel=\(Int(diagnostics.pixelSize.width), privacy: .public)x\(Int(diagnostics.pixelSize.height), privacy: .public) pngBytes=\(optionalIntDescription(diagnostics.pngBytes), privacy: .public) totalMs=\(millisecondsDescription(diagnostics.durationMs.totalMs), privacy: .public) skiaMs=\(optionalMillisecondsDescription(diagnostics.durationMs.skiaRenderMs), privacy: .public) decodeMs=\(optionalMillisecondsDescription(diagnostics.durationMs.pngDecodeMs), privacy: .public) coreMs=\(optionalMillisecondsDescription(diagnostics.durationMs.coreGraphicsRenderMs), privacy: .public)")
+        logger.debug("Preview \(replyType, privacy: .public) render backend file=\(filename, privacy: .public) policy=\(String(describing: diagnostics.policy), privacy: .public) backend=\(String(describing: diagnostics.backendUsed), privacy: .public) fallback=\(fallbackReasonDescription(diagnostics.fallbackReason), privacy: .public)")
+        logger.debug("Preview \(replyType, privacy: .public) render output pixel=\(Int(diagnostics.pixelSize.width), privacy: .public)x\(Int(diagnostics.pixelSize.height), privacy: .public) pngBytes=\(optionalIntDescription(diagnostics.pngBytes), privacy: .public)")
+        logger.debug("Preview \(replyType, privacy: .public) render timing totalMs=\(millisecondsDescription(diagnostics.durationMs.totalMs), privacy: .public) skiaMs=\(optionalMillisecondsDescription(diagnostics.durationMs.skiaRenderMs), privacy: .public) decodeMs=\(optionalMillisecondsDescription(diagnostics.durationMs.pngDecodeMs), privacy: .public) coreMs=\(optionalMillisecondsDescription(diagnostics.durationMs.coreGraphicsRenderMs), privacy: .public)")
     }
 
     private static func pdfReply(_ documentContext: HwpPreviewDocumentContext) throws -> QLPreviewReply {
@@ -114,7 +116,9 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
             totalRenderMs += page.diagnostics.durationMs.totalMs
         }
 
-        logger.debug("Preview PDF render diagnostics file=\(filename, privacy: .public) pages=\(result.pageCount, privacy: .public) skiaPages=\(skiaPages, privacy: .public) coreGraphicsPages=\(coreGraphicsPages, privacy: .public) embeddedThumbnailPages=\(embeddedThumbnailPages, privacy: .public) fallbackPages=\(fallbackPages, privacy: .public) pngBytes=\(pngBytes, privacy: .public) totalRenderMs=\(millisecondsDescription(totalRenderMs), privacy: .public)")
+        logger.debug("Preview PDF render backend file=\(filename, privacy: .public) pages=\(result.pageCount, privacy: .public) skiaPages=\(skiaPages, privacy: .public) coreGraphicsPages=\(coreGraphicsPages, privacy: .public)")
+        logger.debug("Preview PDF render fallback embeddedThumbnailPages=\(embeddedThumbnailPages, privacy: .public) fallbackPages=\(fallbackPages, privacy: .public)")
+        logger.debug("Preview PDF render output pngBytes=\(pngBytes, privacy: .public) totalRenderMs=\(millisecondsDescription(totalRenderMs), privacy: .public)")
     }
 
     private static func textReply(_ text: String, title: String) -> QLPreviewReply {

--- a/Sources/QLExtension/HwpPreviewProvider.swift
+++ b/Sources/QLExtension/HwpPreviewProvider.swift
@@ -76,7 +76,8 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
         let contentSize = documentContext.contentSize
         let result = try HwpPreviewPDFRenderer.render(
             context: documentContext,
-            policy: .skiaOptIn
+            policy: .skiaOptIn,
+            collectDiagnostics: true
         )
         let data = result.data
         logPDFDiagnostics(result, filename: filename)

--- a/Sources/QLExtension/HwpPreviewProvider.swift
+++ b/Sources/QLExtension/HwpPreviewProvider.swift
@@ -43,8 +43,10 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
         let contentSize = documentContext.contentSize
         let page = try HwpPageImageRenderer.renderPage(
             document: documentContext.document,
-            pageIndex: 0
+            pageIndex: 0,
+            policy: .skiaOptIn
         )
+        logRenderedPageDiagnostics(page, replyType: "PNG", filename: filename)
         let data = try HwpPageImageRenderer.encodePNG(page.image)
         logger.debug("Preview PNG ready file=\(filename, privacy: .public) bytes=\(data.count, privacy: .public)")
 
@@ -55,6 +57,15 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
             reply.title = filename
             return data
         }
+    }
+
+    private static func logRenderedPageDiagnostics(
+        _ page: HwpRenderedPage,
+        replyType: String,
+        filename: String
+    ) {
+        let diagnostics = page.diagnostics
+        logger.debug("Preview \(replyType, privacy: .public) render diagnostics file=\(filename, privacy: .public) policy=\(String(describing: diagnostics.policy), privacy: .public) backend=\(String(describing: diagnostics.backendUsed), privacy: .public) fallback=\(fallbackReasonDescription(diagnostics.fallbackReason), privacy: .public) pixel=\(Int(diagnostics.pixelSize.width), privacy: .public)x\(Int(diagnostics.pixelSize.height), privacy: .public) pngBytes=\(optionalIntDescription(diagnostics.pngBytes), privacy: .public) totalMs=\(millisecondsDescription(diagnostics.durationMs.totalMs), privacy: .public) skiaMs=\(optionalMillisecondsDescription(diagnostics.durationMs.skiaRenderMs), privacy: .public) decodeMs=\(optionalMillisecondsDescription(diagnostics.durationMs.pngDecodeMs), privacy: .public) coreMs=\(optionalMillisecondsDescription(diagnostics.durationMs.coreGraphicsRenderMs), privacy: .public)")
     }
 
     private static func pdfReply(_ documentContext: HwpPreviewDocumentContext) throws -> QLPreviewReply {
@@ -87,5 +98,30 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
     private static func errorDescription(_ error: Error) -> String {
         let nsError = error as NSError
         return "\(type(of: error))(domain=\(nsError.domain), code=\(nsError.code))"
+    }
+
+    private static func fallbackReasonDescription(_ reason: HwpPageRenderFallbackReason?) -> String {
+        guard let reason else {
+            return "none"
+        }
+        return String(describing: reason)
+    }
+
+    private static func optionalIntDescription(_ value: Int?) -> String {
+        guard let value else {
+            return "none"
+        }
+        return String(value)
+    }
+
+    private static func optionalMillisecondsDescription(_ value: Double?) -> String {
+        guard let value else {
+            return "none"
+        }
+        return millisecondsDescription(value)
+    }
+
+    private static func millisecondsDescription(_ value: Double) -> String {
+        String(format: "%.3f", value)
     }
 }

--- a/Sources/QLExtension/HwpPreviewProvider.swift
+++ b/Sources/QLExtension/HwpPreviewProvider.swift
@@ -72,8 +72,12 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
         logger.debug("Preview rendering PDF file=\(documentContext.filename, privacy: .public) pages=\(documentContext.pageCount, privacy: .public)")
         let filename = documentContext.filename
         let contentSize = documentContext.contentSize
-        let result = try HwpPreviewPDFRenderer.render(context: documentContext)
+        let result = try HwpPreviewPDFRenderer.render(
+            context: documentContext,
+            policy: .skiaOptIn
+        )
         let data = result.data
+        logPDFDiagnostics(result, filename: filename)
         logger.debug("Preview PDF ready file=\(filename, privacy: .public) pages=\(result.pageCount, privacy: .public) bytes=\(data.count, privacy: .public)")
 
         return QLPreviewReply(
@@ -83,6 +87,34 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
             reply.title = filename
             return data
         }
+    }
+
+    private static func logPDFDiagnostics(_ result: HwpRenderedPreviewPDF, filename: String) {
+        var skiaPages = 0
+        var coreGraphicsPages = 0
+        var embeddedThumbnailPages = 0
+        var fallbackPages = 0
+        var pngBytes = 0
+        var totalRenderMs = 0.0
+
+        for page in result.pageDiagnostics {
+            switch page.diagnostics.backendUsed {
+            case .coreGraphics:
+                coreGraphicsPages += 1
+            case .skia:
+                skiaPages += 1
+            case .embeddedThumbnail:
+                embeddedThumbnailPages += 1
+            }
+
+            if page.diagnostics.fallbackReason != nil {
+                fallbackPages += 1
+            }
+            pngBytes += page.diagnostics.pngBytes ?? 0
+            totalRenderMs += page.diagnostics.durationMs.totalMs
+        }
+
+        logger.debug("Preview PDF render diagnostics file=\(filename, privacy: .public) pages=\(result.pageCount, privacy: .public) skiaPages=\(skiaPages, privacy: .public) coreGraphicsPages=\(coreGraphicsPages, privacy: .public) embeddedThumbnailPages=\(embeddedThumbnailPages, privacy: .public) fallbackPages=\(fallbackPages, privacy: .public) pngBytes=\(pngBytes, privacy: .public) totalRenderMs=\(millisecondsDescription(totalRenderMs), privacy: .public)")
     }
 
     private static func textReply(_ text: String, title: String) -> QLPreviewReply {

--- a/Sources/Shared/HwpPreviewPDFRenderer.swift
+++ b/Sources/Shared/HwpPreviewPDFRenderer.swift
@@ -51,26 +51,34 @@ enum HwpPreviewPDFRenderer {
 
     static func render(
         fileURL: URL,
-        policy: HwpPageRenderPolicy = .coreGraphicsOnly
+        policy: HwpPageRenderPolicy = .coreGraphicsOnly,
+        collectDiagnostics: Bool = false
     ) throws -> HwpRenderedPreviewPDF {
-        try render(context: load(fileURL: fileURL), policy: policy)
+        try render(
+            context: load(fileURL: fileURL),
+            policy: policy,
+            collectDiagnostics: collectDiagnostics
+        )
     }
 
     static func render(
         context: HwpPreviewDocumentContext,
-        policy: HwpPageRenderPolicy = .coreGraphicsOnly
+        policy: HwpPageRenderPolicy = .coreGraphicsOnly,
+        collectDiagnostics: Bool = false
     ) throws -> HwpRenderedPreviewPDF {
         try render(
             document: context.document,
             pageCount: context.pageCount,
             contentSize: context.contentSize,
-            policy: policy
+            policy: policy,
+            collectDiagnostics: collectDiagnostics
         )
     }
 
     static func render(
         previewInfo: HwpPreviewDocumentInfo,
-        policy: HwpPageRenderPolicy = .coreGraphicsOnly
+        policy: HwpPageRenderPolicy = .coreGraphicsOnly,
+        collectDiagnostics: Bool = false
     ) throws -> HwpRenderedPreviewPDF {
         let document = try RhwpDocument(
             data: previewInfo.data,
@@ -80,7 +88,8 @@ enum HwpPreviewPDFRenderer {
             document: document,
             pageCount: previewInfo.pageCount,
             contentSize: previewInfo.contentSize,
-            policy: policy
+            policy: policy,
+            collectDiagnostics: collectDiagnostics
         )
     }
 
@@ -88,7 +97,8 @@ enum HwpPreviewPDFRenderer {
         document: RhwpDocument,
         pageCount: Int,
         contentSize: CGSize,
-        policy: HwpPageRenderPolicy = .coreGraphicsOnly
+        policy: HwpPageRenderPolicy = .coreGraphicsOnly,
+        collectDiagnostics: Bool = false
     ) throws -> HwpRenderedPreviewPDF {
         let pdfData = NSMutableData()
         guard let consumer = CGDataConsumer(data: pdfData as CFMutableData) else {
@@ -104,19 +114,23 @@ enum HwpPreviewPDFRenderer {
         }
 
         var pageDiagnostics: [HwpPreviewPDFPageDiagnostics] = []
-        pageDiagnostics.reserveCapacity(pageCount)
+        if collectDiagnostics {
+            pageDiagnostics.reserveCapacity(pageCount)
+        }
         for pageIndex in 0..<pageCount {
             let renderedPage = try HwpPageImageRenderer.renderPage(
                 document: document,
                 pageIndex: pageIndex,
                 policy: policy
             )
-            pageDiagnostics.append(
-                HwpPreviewPDFPageDiagnostics(
-                    pageIndex: pageIndex,
-                    diagnostics: renderedPage.diagnostics
+            if collectDiagnostics {
+                pageDiagnostics.append(
+                    HwpPreviewPDFPageDiagnostics(
+                        pageIndex: pageIndex,
+                        diagnostics: renderedPage.diagnostics
+                    )
                 )
-            )
+            }
             drawPDFPage(renderedPage, in: context)
         }
 

--- a/Sources/Shared/HwpPreviewPDFRenderer.swift
+++ b/Sources/Shared/HwpPreviewPDFRenderer.swift
@@ -5,6 +5,12 @@ struct HwpRenderedPreviewPDF {
     let data: Data
     let contentSize: CGSize
     let pageCount: Int
+    let pageDiagnostics: [HwpPreviewPDFPageDiagnostics]
+}
+
+struct HwpPreviewPDFPageDiagnostics {
+    let pageIndex: Int
+    let diagnostics: HwpPageRenderDiagnostics
 }
 
 struct HwpPreviewDocumentInfo {
@@ -43,19 +49,29 @@ enum HwpPreviewPDFRenderer {
         )
     }
 
-    static func render(fileURL: URL) throws -> HwpRenderedPreviewPDF {
-        try render(context: load(fileURL: fileURL))
+    static func render(
+        fileURL: URL,
+        policy: HwpPageRenderPolicy = .coreGraphicsOnly
+    ) throws -> HwpRenderedPreviewPDF {
+        try render(context: load(fileURL: fileURL), policy: policy)
     }
 
-    static func render(context: HwpPreviewDocumentContext) throws -> HwpRenderedPreviewPDF {
+    static func render(
+        context: HwpPreviewDocumentContext,
+        policy: HwpPageRenderPolicy = .coreGraphicsOnly
+    ) throws -> HwpRenderedPreviewPDF {
         try render(
             document: context.document,
             pageCount: context.pageCount,
-            contentSize: context.contentSize
+            contentSize: context.contentSize,
+            policy: policy
         )
     }
 
-    static func render(previewInfo: HwpPreviewDocumentInfo) throws -> HwpRenderedPreviewPDF {
+    static func render(
+        previewInfo: HwpPreviewDocumentInfo,
+        policy: HwpPageRenderPolicy = .coreGraphicsOnly
+    ) throws -> HwpRenderedPreviewPDF {
         let document = try RhwpDocument(
             data: previewInfo.data,
             filename: previewInfo.filename
@@ -63,14 +79,16 @@ enum HwpPreviewPDFRenderer {
         return try render(
             document: document,
             pageCount: previewInfo.pageCount,
-            contentSize: previewInfo.contentSize
+            contentSize: previewInfo.contentSize,
+            policy: policy
         )
     }
 
     static func render(
         document: RhwpDocument,
         pageCount: Int,
-        contentSize: CGSize
+        contentSize: CGSize,
+        policy: HwpPageRenderPolicy = .coreGraphicsOnly
     ) throws -> HwpRenderedPreviewPDF {
         let pdfData = NSMutableData()
         guard let consumer = CGDataConsumer(data: pdfData as CFMutableData) else {
@@ -85,10 +103,18 @@ enum HwpPreviewPDFRenderer {
             throw HwpRenderError.pdfEncodingFailed
         }
 
+        var pageDiagnostics: [HwpPreviewPDFPageDiagnostics] = []
         for pageIndex in 0..<pageCount {
             let renderedPage = try HwpPageImageRenderer.renderPage(
                 document: document,
-                pageIndex: pageIndex
+                pageIndex: pageIndex,
+                policy: policy
+            )
+            pageDiagnostics.append(
+                HwpPreviewPDFPageDiagnostics(
+                    pageIndex: pageIndex,
+                    diagnostics: renderedPage.diagnostics
+                )
             )
             drawPDFPage(renderedPage, in: context)
         }
@@ -101,7 +127,8 @@ enum HwpPreviewPDFRenderer {
         return HwpRenderedPreviewPDF(
             data: pdfData as Data,
             contentSize: contentSize,
-            pageCount: pageCount
+            pageCount: pageCount,
+            pageDiagnostics: pageDiagnostics
         )
     }
 

--- a/Sources/Shared/HwpPreviewPDFRenderer.swift
+++ b/Sources/Shared/HwpPreviewPDFRenderer.swift
@@ -104,6 +104,7 @@ enum HwpPreviewPDFRenderer {
         }
 
         var pageDiagnostics: [HwpPreviewPDFPageDiagnostics] = []
+        pageDiagnostics.reserveCapacity(pageCount)
         for pageIndex in 0..<pageCount {
             let renderedPage = try HwpPageImageRenderer.renderPage(
                 document: document,

--- a/mydocs/orders/20260521.md
+++ b/mydocs/orders/20260521.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 5월 21일
+
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #257 | Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260521.md
+++ b/mydocs/orders/20260521.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #257 | Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증 | 진행중 | M020, Stage 2 완료, Stage 3 승인 대기 |
+| #257 | Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증 | 진행중 | M020, Stage 3 완료, Stage 4 승인 대기 |

--- a/mydocs/orders/20260521.md
+++ b/mydocs/orders/20260521.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #257 | Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증 | 진행중 | M020, Stage 1 완료, Stage 2 승인 대기 |
+| #257 | Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증 | 진행중 | M020, Stage 2 완료, Stage 3 승인 대기 |

--- a/mydocs/orders/20260521.md
+++ b/mydocs/orders/20260521.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #257 | Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증 | 진행중 | M020, Stage 3 완료, Stage 4 승인 대기 |
+| #257 | Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증 | 진행중 | M020, Stage 4 완료, Stage 5 승인 대기 |

--- a/mydocs/orders/20260521.md
+++ b/mydocs/orders/20260521.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #257 | Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #257 | Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증 | 진행중 | M020, Stage 1 완료, Stage 2 승인 대기 |

--- a/mydocs/orders/20260522.md
+++ b/mydocs/orders/20260522.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 5월 22일
+
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #257 | Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증 | 완료 | M020, 최종 보고서 작성, 완료: 23:41 |

--- a/mydocs/plans/task_m020_257.md
+++ b/mydocs/plans/task_m020_257.md
@@ -1,0 +1,134 @@
+# Task M020 #257 수행계획서
+
+## 목적
+
+Quick Look preview가 Shared renderer의 `skiaOptIn` 정책을 사용할 수 있게 연결하고, 단일 페이지 PNG reply와 다중 페이지 PDF preview에서 Skia PNG backend가 성공하거나 기존 CoreGraphics fallback으로 안전하게 돌아가는지 검증한다.
+
+이 작업은 Skia를 제품 기본 renderer로 승격하는 것이 아니라, Quick Look surface에서 opt-in 적용과 진단 로그, smoke 결과를 확보하는 단계다.
+
+## 배경
+
+#255에서 RustBridge의 `native-skia` PNG FFI와 provenance gate가 추가되었고, #256에서 `HwpPageImageRenderer`에 `coreGraphicsOnly`와 `skiaOptIn` 정책, backend diagnostics, CoreGraphics fallback contract가 추가되었다.
+
+현재 Quick Look provider는 단일 페이지 문서를 PNG reply로 반환하고, 다중 페이지 문서는 page bitmap을 PDF page에 삽입한다. 두 경로 모두 기본 인자로 `HwpPageImageRenderer.renderPage`를 호출하므로 현재 사용자-facing Quick Look preview는 여전히 CoreGraphics render tree 경로를 사용한다.
+
+M020의 순서상 #257은 #256 contract를 Quick Look에 연결하고, Finder thumbnail 적용(#258)과 release readiness gate(#259)에 넘길 Quick Look 결과를 남겨야 한다.
+
+## 범위
+
+포함:
+
+- `Sources/QLExtension/HwpPreviewProvider.swift` 단일 페이지 PNG reply의 `skiaOptIn` 적용
+- `Sources/Shared/HwpPreviewPDFRenderer.swift` 다중 페이지 PDF preview의 Skia opt-in 경로 추가 또는 명시적 검증 hook 정리
+- Quick Look 로그에 `backendUsed`, `fallbackReason`, `pngBytes`, `durationMs` 기록
+- 단일 페이지, 다중 페이지, fallback 대상 문서의 기존 정책 보존 확인
+- Skia 실패 또는 PNG decode 실패 시 CoreGraphics fallback 유지 확인
+- Quick Look smoke 절차와 대표 샘플 결과 기록
+
+제외:
+
+- Finder thumbnail 적용은 #258에서 처리한다.
+- Skia default 전환 판단은 #259에서 처리한다.
+- 새 rhwp release tag 반영과 upstream #947/#976/#982/#1018 회귀 확인은 #278에서 처리한다.
+- Swift PageLayerTree replay renderer 구현은 포함하지 않는다.
+- Swift CoreGraphics renderer에 upstream PUA/image/watermark 보정 로직을 포팅하지 않는다.
+- 사용자용 PDF export의 vector 품질 개선은 포함하지 않는다.
+
+## 설계 방향
+
+Quick Look 단일 페이지 PNG reply는 #256에서 추가된 `HwpPageImageRenderer.renderPage(document:pageIndex:policy:)`에 `policy: .skiaOptIn`을 명시 전달한다. 반환된 `HwpRenderedPage`는 기존처럼 PNG로 다시 encode하되, diagnostics를 로그에 남겨 실제 backend와 fallback 여부를 확인할 수 있게 한다.
+
+다중 페이지 Quick Look PDF는 기본 제품 판단을 과도하게 넓히지 않도록 page render policy를 명시적으로 전달할 수 있는 API를 추가한다. 초기 적용은 Quick Look preview 내부에서 Skia opt-in 경로를 검증하되, #257 보고서에 다중 페이지 PDF의 default 유지 또는 opt-in 적용 판단을 근거와 함께 남긴다.
+
+fallback은 Shared renderer가 담당한다. Quick Look provider는 Skia 실패를 별도 사용자 오류로 노출하지 않고, 최종적으로 CoreGraphics fallback까지 실패한 경우에만 기존 fallback classifier와 text reply 정책을 따른다.
+
+## 예상 변경 파일
+
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- `Sources/Shared/HwpPreviewPDFRenderer.swift`
+- 필요 시 `scripts/`의 기존 Quick Look smoke helper 보정
+- `mydocs/orders/20260521.md`
+- `mydocs/plans/task_m020_257.md`
+- `mydocs/plans/task_m020_257_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m020_257_stage{N}.md`
+- `mydocs/report/task_m020_257_report.md`
+
+읽기 대상 후보:
+
+- `mydocs/report/task_m020_256_report.md`
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- `mydocs/manual/swift_macos_code_rules_guide.md`
+- `mydocs/manual/build_run_guide.md`
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- `Sources/Shared/HwpPreviewPDFRenderer.swift`
+
+## 잠정 단계
+
+1. Stage 1: Quick Look render 호출부 inventory
+   - 단일 PNG reply, 다중 PDF reply, fallback classifier 흐름을 확인한다.
+   - #256 diagnostics contract와 Quick Look 로그에 필요한 필드를 정리한다.
+   - 구현계획서(`task_m020_257_impl.md`)에 정책 적용 범위와 다중 PDF 판단 기준을 고정한다.
+2. Stage 2: Quick Look 단일 페이지 PNG Skia opt-in 적용
+   - 단일 페이지 PNG reply가 `policy: .skiaOptIn`을 명시하도록 수정한다.
+   - backend/fallback diagnostics 로그를 추가한다.
+   - 기존 대용량, empty document, invalid page size fallback 흐름을 보존한다.
+3. Stage 3: 다중 페이지 PDF Skia opt-in 경로 검증
+   - `HwpPreviewPDFRenderer`가 page render policy를 받을 수 있게 정리한다.
+   - 다중 페이지 preview에서 Skia page image 삽입이 가능한지 opt-in smoke로 검증한다.
+   - default 전환 여부는 #259 입력으로 넘길 수 있게 보고서에 남긴다.
+4. Stage 4: Quick Look smoke와 fallback 검증
+   - 대표 HWP/HWPX 샘플로 단일/다중 page preview를 확인한다.
+   - Skia 성공, CoreGraphics fallback, text fallback 경로의 로그와 산출물을 기록한다.
+   - build, source rule, whitespace 검증을 수행한다.
+5. Stage 5: 최종 보고서와 PR 준비
+   - stage 산출물과 검증 결과, known limitation, #258/#259/#278 handoff를 정리한다.
+   - 오늘할일 완료 처리와 최종 보고서를 준비한다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260521.md mydocs/plans/task_m020_257.md
+rg -n "#257|Quick Look|Skia|skiaOptIn|CoreGraphics|fallback|diagnostics" \
+  mydocs/orders/20260521.md mydocs/plans/task_m020_257.md
+```
+
+구현 단계 후보:
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "skiaOptIn|backendUsed|fallbackReason|pngBytes|durationMs|HwpPreviewPDFRenderer|renderPage" \
+  Sources/QLExtension Sources/Shared mydocs
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+./scripts/validate-stage3-render.sh output/task257-stage4 samples/basic/request.hwp samples/basic/KTX.hwp
+git diff --check
+git status --short --branch
+```
+
+필요 시 추가 검증:
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+./scripts/smoke-clean-quicklook-install.sh
+```
+
+## 리스크
+
+- Quick Look extension process에서 Skia PNG encode와 Swift PNG re-encode가 latency를 늘릴 수 있다.
+- 다중 페이지 PDF에 모든 page image를 Skia로 넣으면 문서 크기와 생성 시간이 증가할 수 있다.
+- Skia와 CoreGraphics 간 font fallback, antialiasing, image scaling 차이가 smoke에서 크게 보일 수 있다.
+- Skia fallback이 Shared renderer 안에서 처리되므로 Quick Look 로그가 부족하면 실제 실패 원인 추적이 어려울 수 있다.
+- 설치본 Quick Look smoke는 LaunchServices/PlugInKit 캐시 영향을 받으므로 Debug build 검증과 분리해 해석해야 한다.
+- 새 upstream rhwp release에 포함될 PUA/image/watermark 개선은 #278에서 확인해야 하며, 이 작업 범위에서는 현재 pin의 동작만 기록한다.
+
+## 승인 요청 사항
+
+1. #257을 Quick Look preview의 `skiaOptIn` 적용과 다중 페이지 PDF opt-in 검증 작업으로 진행하는 범위 승인
+2. 단일 페이지 PNG reply는 Skia opt-in을 연결하되, fallback은 #256 Shared renderer contract에 맡기는 방향 승인
+3. 다중 페이지 PDF는 page render policy를 명시할 수 있게 정리하고, default 전환 판단은 #259로 넘기는 방향 승인
+4. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m020_257_impl.md`) 작성과 Stage 1 inventory 진행
+
+승인 전에는 Swift source, Quick Look provider 정책, build 설정 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m020_257_impl.md
+++ b/mydocs/plans/task_m020_257_impl.md
@@ -1,0 +1,262 @@
+# Task M020 #257 구현 계획서
+
+수행계획서: `mydocs/plans/task_m020_257.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #257 Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 브랜치: `local/task257`
+- 작업 위치: `/Users/melee/Documents/projects/rhwp-mac`
+- 기준 브랜치: `devel`
+- 선행 상태: #255에서 `rhwp_render_page_png` ABI가 추가되었고, #256에서 `HwpPageImageRenderer`의 `coreGraphicsOnly`/`skiaOptIn` 정책과 diagnostics/fallback contract가 구현되었다.
+- 목표: Quick Look 단일 페이지 PNG reply와 다중 페이지 bitmap PDF preview가 #256 Shared renderer contract를 통해 Skia opt-in 경로를 검증하고, 실패 시 CoreGraphics fallback을 유지한다.
+
+## 구현 원칙
+
+- Quick Look surface만 변경한다. Finder thumbnail 적용과 cache key 변경은 #258로 남긴다.
+- `Sources/RhwpCoreBridge`에는 AppKit/UIKit 의존을 추가하지 않는다.
+- Skia 실패는 Quick Look text fallback으로 바로 가지 않고 #256 Shared renderer의 CoreGraphics fallback을 먼저 사용한다.
+- 단일 페이지 PNG reply는 `policy: .skiaOptIn`을 명시해 Skia success/fallback diagnostics를 확보한다.
+- 다중 페이지 PDF는 page render policy를 받을 수 있는 API를 추가하고, Quick Look preview 경로에서 `skiaOptIn`을 명시한다.
+- 다중 페이지 PDF는 여전히 bitmap PDF container이며, vector PDF export 개선은 포함하지 않는다.
+- `Skia default` 또는 `Skia first`의 release 판단은 #259에서 수행한다. 이 이슈는 Quick Look surface의 opt-in 적용과 검증 결과를 남긴다.
+- 새 upstream rhwp release 반영과 #947/#976/#982/#1018 회귀 확인은 #278에서 수행한다.
+
+## Quick Look Backend Contract
+
+Quick Look에서 사용할 policy와 diagnostics는 #256 contract를 그대로 따른다.
+
+| 항목 | 값/필드 | 정책 |
+|---|---|---|
+| 단일 페이지 PNG policy | `.skiaOptIn` | Skia PNG render를 먼저 시도하고 실패 시 CoreGraphics fallback |
+| 다중 페이지 PDF policy | `.skiaOptIn` 명시 전달 | page별 Skia image 또는 fallback image를 PDF page에 삽입 |
+| 최종 reply type | `.png`, `.pdf`, `.plainText` | 기존 page count/fallback classifier 정책 유지 |
+| diagnostics | `backendUsed`, `fallbackReason`, `pngBytes`, `durationMs`, `pixelSize` | Quick Look 로그와 stage 보고서 입력 |
+| file size guard | `hwpQuickLookMaxFileSize` | Skia 호출 전 기존 위치에서 유지 |
+| empty/invalid page fallback | 기존 `HwpDocumentFallbackClassifier` | Shared renderer까지 도달하지 못한 입력 오류는 기존 text reply 정책 유지 |
+
+로그는 filename basename만 public으로 남기고, backend/fallback/duration/byte count는 diagnostics에서 읽어 기록한다. enum은 `String(describing:)`을 사용하되, 후속 필요가 있으면 Stage 2에서 작은 formatter helper로 고정한다.
+
+## Stage 1. Quick Look render 호출부 inventory
+
+### 목표
+
+Quick Look 단일 PNG reply, 다중 PDF reply, fallback classifier 흐름을 확인하고 Stage 2-3에서 변경할 API를 고정한다.
+
+### 작업
+
+- `HwpPreviewProvider`의 `pngReply`, `pdfReply`, text fallback 경로를 확인한다.
+- `HwpPreviewPDFRenderer`의 `render(context:)`, `render(previewInfo:)`, `render(document:pageCount:contentSize:)` 호출 관계를 확인한다.
+- `HwpPageImageRenderer`의 `skiaOptIn` diagnostics contract를 확인한다.
+- Quick Look 관련 smoke helper와 비교 script가 compile할 수 있도록 non-breaking API 방향을 정한다.
+- Stage 1 보고서에 확정된 변경 파일, API, 검증 명령을 기록한다.
+
+### 산출물
+
+- `mydocs/plans/task_m020_257_impl.md`
+- `mydocs/working/task_m020_257_stage1.md`
+- `mydocs/orders/20260521.md`
+
+### 검증
+
+```bash
+rg -n "HwpPreviewProvider|HwpPreviewPDFRenderer|HwpPageImageRenderer|renderPage\\(|skiaOptIn|backendUsed|fallbackReason|pngBytes|durationMs" \
+  Sources/QLExtension Sources/Shared scripts --glob '!**/Resources/**'
+rg -n "#257|Stage 1|skiaOptIn|Quick Look|backendUsed|fallbackReason|durationMs" \
+  mydocs/plans/task_m020_257_impl.md mydocs/working/task_m020_257_stage1.md mydocs/orders/20260521.md
+git diff --check
+```
+
+### 완료 기준
+
+- Stage 2-3에서 구현할 Swift API와 logging 범위가 단계 보고서에 고정된다.
+- 아직 Swift source를 변경하지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #257 Stage 1: Quick Look Skia 적용 범위 확정
+```
+
+## Stage 2. Quick Look 단일 페이지 PNG Skia opt-in 적용
+
+### 목표
+
+단일 페이지 Quick Look PNG reply가 `HwpPageImageRenderer.renderPage(..., policy: .skiaOptIn)`을 사용하고, 최종 backend와 fallback 이유를 로그에 남기도록 한다.
+
+### 작업
+
+- `HwpPreviewProvider.pngReply`에서 render policy를 `.skiaOptIn`으로 명시한다.
+- PNG encode 전후 로그에 `backendUsed`, `fallbackReason`, `pngBytes`, `durationMs.totalMs`, `pixelSize`를 기록한다.
+- Skia fallback은 Shared renderer가 처리하므로 provider는 기존 fallback classifier 흐름을 유지한다.
+- 단일 페이지 샘플에서 Skia path가 compile/runtime smoke 후보로 준비되었는지 확인한다.
+- Stage 2 보고서에 변경 API와 로그 필드를 기록한다.
+
+### 산출물
+
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- `mydocs/working/task_m020_257_stage2.md`
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "skiaOptIn|backendUsed|fallbackReason|pngBytes|durationMs|Preview PNG" Sources/QLExtension Sources/Shared
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+### 완료 기준
+
+- 단일 페이지 PNG reply가 Skia opt-in path를 시도한다.
+- Skia 실패 시 Shared renderer의 CoreGraphics fallback 결과가 PNG reply로 계속 반환될 수 있다.
+- Quick Look 로그에서 실제 backend와 fallback 여부를 확인할 수 있다.
+
+### 커밋 메시지
+
+```text
+Task #257 Stage 2: Quick Look PNG Skia opt-in 적용
+```
+
+## Stage 3. 다중 페이지 PDF Skia opt-in 경로 연결
+
+### 목표
+
+다중 페이지 Quick Look PDF renderer가 page render policy를 받을 수 있게 하고, Quick Look preview에서 Skia opt-in page image를 PDF page에 삽입할 수 있게 한다.
+
+### 작업
+
+- `HwpPreviewPDFRenderer.render(context:)`, `render(previewInfo:)`, `render(document:pageCount:contentSize:)`에 `policy` 기본 인자를 추가한다.
+- 기존 call site와 scripts는 기본값 때문에 CoreGraphics 호환을 유지한다.
+- `HwpPreviewProvider.pdfReply`는 `policy: .skiaOptIn`을 명시한다.
+- PDF render result에 page별 diagnostics summary를 담을 수 있는 구조를 추가한다.
+- `pdfReply` 로그에 page count, backend summary, fallback count, total duration 후보를 기록한다.
+- Stage 3 보고서에 다중 페이지 PDF default/opt-in 판단과 #259 handoff를 기록한다.
+
+### 산출물
+
+- `Sources/Shared/HwpPreviewPDFRenderer.swift`
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- 필요 시 `scripts/quicklook_pdf_renderer_compare.swift`
+- `mydocs/working/task_m020_257_stage3.md`
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "policy: HwpPageRenderPolicy|skiaOptIn|backendUsed|fallbackReason|pageDiagnostics|HwpRenderedPreviewPDF" \
+  Sources/Shared Sources/QLExtension scripts
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+### 완료 기준
+
+- 다중 페이지 PDF renderer가 page별 `skiaOptIn` render 결과를 받을 수 있다.
+- 기존 PDF renderer helper와 비교 script는 기본 인자로 계속 동작한다.
+- page별 backend/fallback 요약을 Quick Look 로그와 보고서에 남길 수 있다.
+
+### 커밋 메시지
+
+```text
+Task #257 Stage 3: Quick Look PDF Skia opt-in 경로 연결
+```
+
+## Stage 4. Quick Look smoke와 fallback 검증
+
+### 목표
+
+대표 샘플에서 Quick Look 단일 PNG와 다중 PDF 경로의 Skia opt-in 결과, fallback 결과, latency/byte 정보를 기록한다.
+
+### 작업
+
+- QLExtension과 HostApp Debug build를 실행한다.
+- 기존 CoreGraphics baseline smoke가 깨지지 않았는지 `validate-stage3-render.sh`로 확인한다.
+- 단일 페이지 샘플은 `samples/basic/request.hwp`, `samples/basic/KTX.hwp`, 필요 시 `samples/복학원서.hwp`를 사용한다.
+- 다중 페이지 샘플은 `samples/hwp-multi-001.hwp`, `samples/basic/exam_math.hwp`, `samples/hwpx/hwpx-01.hwpx` 중 최소 1개 이상을 사용한다.
+- `compare-quicklook-pdf-renderers.sh` 또는 task 전용 임시 command로 PDF path 결과를 측정한다.
+- 설치본/시스템 Quick Look smoke가 필요한 경우 `smoke-clean-quicklook-install.sh`는 Debug build 검증과 분리해 기록한다.
+- Stage 4 보고서에 명령, 결과, 알려진 제한, #258/#259/#278 handoff를 정리한다.
+
+### 산출물
+
+- 필요 시 task 전용 smoke 산출물 기록
+- `mydocs/working/task_m020_257_stage4.md`
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+./scripts/validate-stage3-render.sh output/task257-stage4 samples/basic/request.hwp samples/basic/KTX.hwp
+./scripts/compare-quicklook-pdf-renderers.sh output/task257-quicklook-pdf samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+git diff --check
+git status --short --branch
+```
+
+필요 시 설치본 smoke:
+
+```bash
+./scripts/smoke-clean-quicklook-install.sh
+```
+
+### 완료 기준
+
+- QLExtension Debug build가 통과한다.
+- 단일 PNG와 다중 PDF path에서 Skia opt-in success 또는 CoreGraphics fallback 결과가 기록된다.
+- 기존 text fallback classifier 흐름이 보존된다.
+- #258 Thumbnail 적용과 #259 readiness gate에 넘길 Quick Look 결과가 정리된다.
+
+### 커밋 메시지
+
+```text
+Task #257 Stage 4: Quick Look Skia smoke 검증
+```
+
+## Stage 5. 최종 보고서와 PR 준비
+
+### 목표
+
+전체 수용 기준을 다시 확인하고, 최종 결과보고서와 오늘할일 완료 처리를 수행한 뒤 PR 게시 준비 상태로 만든다.
+
+### 작업
+
+- Stage 1-4 산출물과 검증 결과를 최종 보고서에 정리한다.
+- 다중 페이지 PDF Skia 적용의 default 보류 여부와 #259 판단 입력을 명시한다.
+- #258, #259, #278 handoff를 정리한다.
+- 오늘할일을 완료로 갱신한다.
+- PR 게시 전 최종 build/source 검증과 `git status` 확인을 수행한다.
+
+### 산출물
+
+- `mydocs/report/task_m020_257_report.md`
+- `mydocs/orders/20260521.md`
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+rg -n "#257|skiaOptIn|backendUsed|fallbackReason|Quick Look|#258|#259|#278" \
+  mydocs/report/task_m020_257_report.md mydocs/orders/20260521.md Sources/QLExtension Sources/Shared
+git diff --check
+git status --short --branch
+```
+
+### 완료 기준
+
+- #257 완료 기준이 최종 보고서에 대응되어 있다.
+- 작업 브랜치에 미커밋 변경이 없다.
+- PR 생성 전 publish 준비 상태다.
+
+### 커밋 메시지
+
+```text
+Task #257 Stage 5 + 최종 보고서: Quick Look Skia 적용 결과 정리
+```

--- a/mydocs/report/task_m020_257_report.md
+++ b/mydocs/report/task_m020_257_report.md
@@ -13,7 +13,7 @@
 - PNG reply에 render diagnostics 로그를 추가했다.
 - 다중 페이지 Quick Look PDF renderer가 `HwpPageRenderPolicy`를 받을 수 있게 했다.
 - Quick Look PDF path에서 `policy: .skiaOptIn`을 명시하도록 변경했다.
-- PDF page별 `HwpPageRenderDiagnostics`를 `HwpRenderedPreviewPDF.pageDiagnostics`로 수집한다.
+- PDF page별 `HwpPageRenderDiagnostics`는 Quick Look/smoke path에서만 `collectDiagnostics: true`로 수집한다.
 - PDF reply에 backend별 page count, fallback count, Skia PNG bytes, render duration summary 로그를 추가했다.
 - Quick Look policy smoke helper를 추가해 `.coreGraphicsOnly`와 `.skiaOptIn` 결과를 같은 입력 문서에서 비교할 수 있게 했다.
 - 대표 단일/다중 샘플에서 Skia opt-in 성공과 fallback count를 기록했다.
@@ -23,7 +23,7 @@
 | 파일 | 내용 |
 |---|---|
 | `Sources/QLExtension/HwpPreviewProvider.swift` | 단일 PNG와 다중 PDF Quick Look reply에서 `skiaOptIn` policy 명시, PNG/PDF diagnostics logging 추가 |
-| `Sources/Shared/HwpPreviewPDFRenderer.swift` | PDF render API에 `policy` 기본 인자 추가, page별 diagnostics 수집 |
+| `Sources/Shared/HwpPreviewPDFRenderer.swift` | PDF render API에 `policy`와 `collectDiagnostics` 기본 인자 추가, page별 diagnostics opt-in 수집 |
 | `scripts/smoke-quicklook-skia-policy.sh` | Quick Look policy smoke wrapper 추가 |
 | `scripts/quicklook_skia_policy_smoke.swift` | CoreGraphics/Skia opt-in reply shape, backend, fallback, latency, byte count 측정 helper 추가 |
 | `mydocs/plans/task_m020_257_impl.md` | 구현계획서 |
@@ -59,8 +59,8 @@ Quick Look 단일 페이지 문서는 PNG reply를 유지한다. 내부 page ima
 
 Quick Look 다중 페이지 문서는 기존처럼 bitmap PDF container를 유지한다. 각 page image 생성만 `skiaOptIn` policy를 사용한다.
 
-- 모든 page는 `HwpPreviewPDFRenderer.render(..., policy: .skiaOptIn)` 내부에서 `HwpPageImageRenderer.renderPage`를 통해 생성된다.
-- page별 backend/fallback 결과는 `HwpRenderedPreviewPDF.pageDiagnostics`에 남는다.
+- 모든 page는 `HwpPreviewPDFRenderer.render(..., policy: .skiaOptIn, collectDiagnostics: true)` 내부에서 `HwpPageImageRenderer.renderPage`를 통해 생성된다.
+- Quick Look PDF path의 page별 backend/fallback 결과는 `HwpRenderedPreviewPDF.pageDiagnostics`에 남는다.
 - Quick Look provider는 PDF 전체 summary 로그를 남긴다.
 
 ## Smoke 결과

--- a/mydocs/report/task_m020_257_report.md
+++ b/mydocs/report/task_m020_257_report.md
@@ -18,9 +18,9 @@
 - Quick Look policy smoke helper를 추가해 `.coreGraphicsOnly`와 `.skiaOptIn` 결과를 같은 입력 문서에서 비교할 수 있게 했다.
 - 대표 단일/다중 샘플에서 Skia opt-in 성공과 fallback count를 기록했다.
 
-## 변경 파일
+## 변경 파일 목록과 영향 범위
 
-| 파일 | 요약 |
+| 파일 | 내용 |
 |---|---|
 | `Sources/QLExtension/HwpPreviewProvider.swift` | 단일 PNG와 다중 PDF Quick Look reply에서 `skiaOptIn` policy 명시, PNG/PDF diagnostics logging 추가 |
 | `Sources/Shared/HwpPreviewPDFRenderer.swift` | PDF render API에 `policy` 기본 인자 추가, page별 diagnostics 수집 |

--- a/mydocs/report/task_m020_257_report.md
+++ b/mydocs/report/task_m020_257_report.md
@@ -1,0 +1,152 @@
+# Task M020 #257 최종 보고서
+
+## 작업 개요
+
+- 이슈: #257 Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증
+- 마일스톤: M020 `v0.2.x Skia Quick Look/Thumbnail Backend`
+- 브랜치: `local/task257`
+- 목표: Quick Look preview의 단일 페이지 PNG reply와 다중 페이지 bitmap PDF preview에서 #256 Shared renderer의 `skiaOptIn` backend를 적용하고, 실패 시 CoreGraphics fallback과 기존 text fallback 정책이 유지되는지 검증한다.
+
+## 완료 범위
+
+- 단일 페이지 Quick Look PNG reply가 `HwpPageImageRenderer.renderPage(..., policy: .skiaOptIn)`을 사용하도록 변경했다.
+- PNG reply에 render diagnostics 로그를 추가했다.
+- 다중 페이지 Quick Look PDF renderer가 `HwpPageRenderPolicy`를 받을 수 있게 했다.
+- Quick Look PDF path에서 `policy: .skiaOptIn`을 명시하도록 변경했다.
+- PDF page별 `HwpPageRenderDiagnostics`를 `HwpRenderedPreviewPDF.pageDiagnostics`로 수집한다.
+- PDF reply에 backend별 page count, fallback count, Skia PNG bytes, render duration summary 로그를 추가했다.
+- Quick Look policy smoke helper를 추가해 `.coreGraphicsOnly`와 `.skiaOptIn` 결과를 같은 입력 문서에서 비교할 수 있게 했다.
+- 대표 단일/다중 샘플에서 Skia opt-in 성공과 fallback count를 기록했다.
+
+## 변경 파일
+
+| 파일 | 요약 |
+|---|---|
+| `Sources/QLExtension/HwpPreviewProvider.swift` | 단일 PNG와 다중 PDF Quick Look reply에서 `skiaOptIn` policy 명시, PNG/PDF diagnostics logging 추가 |
+| `Sources/Shared/HwpPreviewPDFRenderer.swift` | PDF render API에 `policy` 기본 인자 추가, page별 diagnostics 수집 |
+| `scripts/smoke-quicklook-skia-policy.sh` | Quick Look policy smoke wrapper 추가 |
+| `scripts/quicklook_skia_policy_smoke.swift` | CoreGraphics/Skia opt-in reply shape, backend, fallback, latency, byte count 측정 helper 추가 |
+| `mydocs/plans/task_m020_257_impl.md` | 구현계획서 |
+| `mydocs/working/task_m020_257_stage1.md` | Quick Look 호출부 inventory |
+| `mydocs/working/task_m020_257_stage2.md` | 단일 PNG Skia opt-in 적용 보고 |
+| `mydocs/working/task_m020_257_stage3.md` | 다중 PDF Skia opt-in 연결 보고 |
+| `mydocs/working/task_m020_257_stage4.md` | smoke 결과와 known limitation 정리 |
+| `mydocs/orders/20260521.md`, `mydocs/orders/20260522.md` | 작업 상태 기록과 완료 처리 |
+
+## 단계별 결과
+
+| 단계 | 커밋 | 요약 |
+|---|---|---|
+| 시작 | `0d18560` | 수행계획서와 2026-05-21 오늘할일 작성 |
+| Stage 1 | `e104c74` | Quick Look 단일 PNG, 다중 PDF, fallback 흐름 inventory와 구현계획서 작성 |
+| Stage 2 | `5df3e1f` | 단일 페이지 PNG reply에 `skiaOptIn` 적용, diagnostics logging 추가 |
+| Stage 3 | `b044ed6` | 다중 페이지 PDF renderer에 policy 인자와 page diagnostics 추가, Quick Look PDF path에 `skiaOptIn` 적용 |
+| Stage 4 | `49a0ad3` | Quick Look policy smoke helper 추가, 단일/다중 대표 샘플 smoke 기록 |
+| Stage 5 | 최종 보고서 커밋 | 최종 보고서와 오늘할일 완료 처리 |
+
+## 최종 동작
+
+### 단일 페이지 PNG
+
+Quick Look 단일 페이지 문서는 PNG reply를 유지한다. 내부 page image 생성은 `skiaOptIn` policy를 사용한다.
+
+1. Skia PNG render 시도
+2. PNG decode 성공 시 `.skia` backend image 반환
+3. Skia 실패, 빈 PNG, PNG decode 실패 시 CoreGraphics fallback
+4. CoreGraphics fallback까지 실패한 경우에만 기존 `HwpDocumentFallbackClassifier` text reply 흐름 사용
+
+### 다중 페이지 PDF
+
+Quick Look 다중 페이지 문서는 기존처럼 bitmap PDF container를 유지한다. 각 page image 생성만 `skiaOptIn` policy를 사용한다.
+
+- 모든 page는 `HwpPreviewPDFRenderer.render(..., policy: .skiaOptIn)` 내부에서 `HwpPageImageRenderer.renderPage`를 통해 생성된다.
+- page별 backend/fallback 결과는 `HwpRenderedPreviewPDF.pageDiagnostics`에 남는다.
+- Quick Look provider는 PDF 전체 summary 로그를 남긴다.
+
+## Smoke 결과
+
+Stage 4 helper smoke 결과:
+
+| 샘플 | Reply | Pages | CG backend | Skia backend | Skia fallback | CG bytes | Skia bytes | Skia PNG bytes | CG seconds | Skia seconds |
+|---|---|---:|---|---|---:|---:|---:|---:|---:|---:|
+| `request.hwp` | png | 1 | cg:1 | skia:1 | 0 | 82129 | 85981 | 88793 | 1.081279 | 0.095356 |
+| `KTX.hwp` | png | 1 | cg:1 | skia:1 | 0 | 555392 | 181146 | 165799 | 0.067094 | 0.073160 |
+| `복학원서.hwp` | png | 1 | cg:1 | skia:1 | 0 | 233831 | 225105 | 240643 | 0.412763 | 0.062871 |
+| `hwp-multi-001.hwp` | pdf | 10 | cg:10 | skia:10 | 0 | 1522638 | 1119989 | 1309516 | 0.404578 | 0.677783 |
+| `hwpx-01.hwpx` | pdf | 9 | cg:9 | skia:9 | 0 | 1489442 | 1094246 | 1316036 | 0.353663 | 0.623360 |
+
+결론:
+
+- 단일 페이지 PNG 샘플 3개 모두 Skia backend로 성공했고 fallback은 없었다.
+- 다중 페이지 PDF 샘플 2개 모두 모든 page가 Skia backend로 성공했고 fallback은 없었다.
+- 다중 페이지 PDF Skia path는 대표 샘플에서 CoreGraphics baseline보다 느렸다. default 전환 판단은 #259에서 별도로 해야 한다.
+
+산출물:
+
+- `output/task257-stage4/`
+- `output/task257-skia-policy/`
+- `output/task257-quicklook-pdf/`
+
+`output/`은 commit 대상이 아니다.
+
+## 최종 검증
+
+Stage 4 및 Stage 5에서 다음 검증을 수행했다.
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "#257|skiaOptIn|backendUsed|fallbackReason|Quick Look|#258|#259|#278" \
+  mydocs/report/task_m020_257_report.md mydocs/orders/20260522.md Sources/QLExtension Sources/Shared
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+git status --short --branch
+```
+
+결과:
+
+| 명령 | 결과 |
+|---|---|
+| `./scripts/check-no-appkit.sh` | 통과 |
+| `rg -n "#257\|skiaOptIn\|backendUsed\|fallbackReason\|Quick Look\|#258\|#259\|#278" ...` | 통과 |
+| `xcodebuild ... QLExtension ... build` | 통과 |
+| `xcodebuild ... HostApp ... build` | 통과 |
+| `git diff --check` | 통과 |
+| `git status --short --branch` | 최종 커밋 후 작업 트리 clean 확인 |
+
+Stage 2/3의 sandbox 내부 xcodebuild는 사용자 Swift/clang cache 쓰기 제한으로 실패한 뒤 sandbox 밖 재실행에서 통과했다. Stage 4/5 build는 같은 cache 제한을 피하기 위해 sandbox 밖에서 실행했다.
+
+## Known limitations
+
+- 이번 작업은 Debug/helper smoke 기준이다. 설치본 Quick Look UI smoke와 LaunchServices/PlugInKit 등록 검증은 release/package smoke에서 별도로 해석해야 한다.
+- Skia fallback을 강제로 유발하는 fixture는 이번 작업에서 만들지 않았다. fallback 동작은 #256 Shared renderer contract, code path, smoke의 fallback count 0 결과로 확인했다.
+- 단일 페이지 PNG reply는 Skia PNG를 `CGImage`로 decode한 뒤 다시 PNG로 encode한다. direct PNG reply 최적화는 별도 후속 후보다.
+- 다중 페이지 PDF Skia path는 모든 page에서 성공했지만 CoreGraphics보다 느린 대표 샘플이 있어, default 전환은 #259 readiness gate에서 판단해야 한다.
+- 현재 core pin은 새 upstream rhwp release를 반영하지 않는다. #947/#976/#982/#1018 포함 release tag 반영과 회귀 확인은 #278에서 처리한다.
+
+## Handoff
+
+### #258 Finder thumbnail
+
+- #257의 `HwpPageImageRenderer` diagnostics logging 방식과 policy smoke helper 결과를 참고할 수 있다.
+- Thumbnail에서는 cache key에 backend/render signature를 포함해야 하므로 #257의 PDF diagnostics와 별개로 cache 정책을 고정해야 한다.
+- Thumbnail은 요청 크기 기반 `max_dimension` 또는 scale mapping이 핵심이다.
+
+### #259 Readiness gate
+
+- Quick Look 단일 PNG는 대표 샘플에서 Skia fallback 없이 성공했다.
+- Quick Look 다중 PDF도 대표 샘플에서 모든 page가 Skia backend로 성공했다.
+- 다중 PDF Skia path latency가 CoreGraphics보다 느린 샘플이 있으므로 default 전환 판단에는 성능 gate가 필요하다.
+- 설치본 smoke와 package/memory 측정은 #259 입력으로 남긴다.
+
+### #278 새 rhwp release 반영
+
+- 이번 작업은 현재 pin 기준으로 Quick Look Skia path를 연결했다.
+- upstream #947/#976/#982/#1018 반영 확인은 새 rhwp release tag가 나온 뒤 #278에서 수행한다.
+- Swift CoreGraphics renderer에 PUA/image/watermark 보정 로직은 포팅하지 않았다.
+
+## 결론
+
+#257은 Quick Look preview surface에서 Skia PNG backend를 opt-in 경로로 연결했다. 단일 페이지 PNG와 다중 페이지 PDF 모두 `skiaOptIn` policy를 사용하며, 실패 시 #256 Shared renderer의 CoreGraphics fallback contract를 따른다. 대표 샘플 smoke에서는 단일/다중 모두 Skia backend가 fallback 없이 성공했다.
+
+다만 다중 페이지 PDF의 Skia path는 일부 샘플에서 CoreGraphics baseline보다 느리므로, release default 전환은 #259 readiness gate의 visual/performance/package 결과를 보고 별도로 판단해야 한다.

--- a/mydocs/working/task_m020_257_stage1.md
+++ b/mydocs/working/task_m020_257_stage1.md
@@ -1,0 +1,125 @@
+# Task M020 #257 Stage 1 보고서 - Quick Look Skia 적용 범위 확정
+
+## 단계 개요
+
+- 이슈: #257 Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증
+- 단계: Stage 1. Quick Look render 호출부 inventory
+- 목표: Quick Look 단일 PNG reply, 다중 PDF reply, fallback classifier 흐름을 확인하고 Stage 2-3에서 변경할 API와 logging 범위를 고정한다.
+
+## 확인한 현재 구조
+
+### 단일 페이지 PNG reply
+
+`Sources/QLExtension/HwpPreviewProvider.swift`의 `pngReply(_:)`는 `HwpPreviewPDFRenderer.load(fileURL:)`가 만든 `HwpPreviewDocumentContext`를 받아 첫 페이지를 렌더링한다.
+
+현재 호출은 다음 형태다.
+
+```swift
+let page = try HwpPageImageRenderer.renderPage(
+    document: documentContext.document,
+    pageIndex: 0
+)
+```
+
+`policy` 기본값 때문에 현재는 `coreGraphicsOnly`로 동작한다. Stage 2에서는 이 호출에 `policy: .skiaOptIn`을 명시한다.
+
+### 다중 페이지 PDF reply
+
+`HwpPreviewProvider.pdfReply(_:)`는 `HwpPreviewPDFRenderer.render(context:)`를 호출한다. `HwpPreviewPDFRenderer.render(document:pageCount:contentSize:)`는 모든 page에 대해 `HwpPageImageRenderer.renderPage(document:pageIndex:)`를 호출한 뒤 `CGContext` PDF page에 bitmap을 삽입한다.
+
+현재 다중 PDF renderer도 `policy` 기본값 때문에 `coreGraphicsOnly`다. Stage 3에서는 render API에 `policy: HwpPageRenderPolicy = .coreGraphicsOnly` 기본 인자를 추가해 기존 helper/script 호환성을 유지하고, Quick Look provider에서 `policy: .skiaOptIn`을 명시한다.
+
+### Shared renderer contract
+
+#256 결과로 `HwpPageImageRenderer.renderPage`는 이미 다음 contract를 제공한다.
+
+| 항목 | 현재 타입/필드 | #257 사용 |
+|---|---|---|
+| policy | `HwpPageRenderPolicy.coreGraphicsOnly`, `.skiaOptIn` | Quick Look provider가 명시 전달 |
+| backend | `HwpPageRenderBackend.coreGraphics`, `.skia`, `.embeddedThumbnail` | Quick Look 로그와 보고서에서 사용 |
+| fallback | `HwpPageRenderFallbackReason` | Skia 실패 후 CoreGraphics fallback 원인 기록 |
+| diagnostics | `HwpRenderedPage.diagnostics` | `backendUsed`, `fallbackReason`, `pngBytes`, `durationMs`, `pixelSize` 기록 |
+
+`skiaOptIn`에서 Skia PNG render가 실패하거나 PNG decode가 실패하면 Shared renderer가 CoreGraphics fallback을 수행한다. 따라서 Quick Look provider는 별도 Skia error UI를 만들지 않고 기존 fallback classifier를 유지하면 된다.
+
+## 확정한 구현 방향
+
+1. `HwpPreviewProvider.pngReply(_:)`
+   - `HwpPageImageRenderer.renderPage(..., policy: .skiaOptIn)`을 명시한다.
+   - `page.diagnostics`를 읽어 `backendUsed`, `fallbackReason`, `pngBytes`, `durationMs.totalMs`, `pixelSize`를 로그에 남긴다.
+   - 반환 형식은 기존과 동일하게 `.png` reply를 유지한다.
+
+2. `HwpPreviewPDFRenderer`
+   - `HwpRenderedPreviewPDF`에 page별 diagnostics summary를 추가한다.
+   - `render(context:)`, `render(previewInfo:)`, `render(document:pageCount:contentSize:)`에 `policy` 기본 인자를 추가한다.
+   - 내부 page loop에서 `HwpPageImageRenderer.renderPage(..., policy: policy)`를 호출한다.
+   - 기존 scripts와 helper는 기본값으로 계속 `coreGraphicsOnly`를 사용하므로 compile/runtime 호환을 유지한다.
+
+3. `HwpPreviewProvider.pdfReply(_:)`
+   - `HwpPreviewPDFRenderer.render(context:policy: .skiaOptIn)`을 호출한다.
+   - PDF result의 page diagnostics를 요약해 backend별 page 수, fallback page 수, PDF bytes를 로그에 남긴다.
+
+4. fallback 정책
+   - file size guard, empty document, invalid first page size는 기존 `HwpPreviewPDFRenderer.load`에서 유지한다.
+   - Shared renderer까지 도달한 Skia 실패는 CoreGraphics fallback을 우선한다.
+   - CoreGraphics fallback까지 실패하면 기존 `HwpDocumentFallbackClassifier`와 text reply 흐름을 유지한다.
+
+## 검증 후보
+
+Stage 2:
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "skiaOptIn|backendUsed|fallbackReason|pngBytes|durationMs|Preview PNG" Sources/QLExtension Sources/Shared
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+Stage 3:
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "policy: HwpPageRenderPolicy|skiaOptIn|backendUsed|fallbackReason|pageDiagnostics|HwpRenderedPreviewPDF" \
+  Sources/Shared Sources/QLExtension scripts
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+Stage 4:
+
+```bash
+./scripts/validate-stage3-render.sh output/task257-stage4 samples/basic/request.hwp samples/basic/KTX.hwp
+./scripts/compare-quicklook-pdf-renderers.sh output/task257-quicklook-pdf samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+설치본 smoke는 LaunchServices/PlugInKit 캐시 영향을 받으므로 Debug build 검증과 분리해 `smoke-clean-quicklook-install.sh` 결과로 기록한다.
+
+## 리스크와 보류 판단
+
+- 다중 페이지 PDF는 page별 Skia PNG decode를 반복하므로 성능 이득을 단정하지 않는다. #257에서는 Skia opt-in 경로를 연결하고 결과를 기록하되, default 전환 판단은 #259로 넘긴다.
+- 단일 페이지 PNG reply도 현재 Shared renderer가 Skia PNG를 `CGImage`로 decode한 뒤 다시 PNG로 encode한다. direct PNG reply 최적화는 #256 contract 밖의 별도 개선 후보로 남긴다.
+- 현재 upstream rhwp pin의 PUA/image/watermark 개선 범위는 #278에서 새 release tag 반영 후 재검증한다.
+
+## Stage 1 검증
+
+실행:
+
+```bash
+rg -n "HwpPreviewProvider|HwpPreviewPDFRenderer|HwpPageImageRenderer|renderPage\\(|skiaOptIn|backendUsed|fallbackReason|pngBytes|durationMs" \
+  Sources/QLExtension Sources/Shared scripts --glob '!**/Resources/**'
+rg -n "#257|Stage 1|skiaOptIn|Quick Look|backendUsed|fallbackReason|durationMs" \
+  mydocs/plans/task_m020_257_impl.md mydocs/working/task_m020_257_stage1.md mydocs/orders/20260521.md
+git diff --check
+```
+
+결과:
+
+- Quick Look 단일 PNG와 다중 PDF 호출부가 모두 현재 기본 `coreGraphicsOnly` 경로임을 확인했다.
+- #256 diagnostics contract가 Quick Look logging에 필요한 필드를 이미 제공함을 확인했다.
+- `HwpPreviewPDFRenderer`에 기본 인자 방식으로 policy를 추가하면 기존 script/helper 호환성을 유지할 수 있음을 확인했다.
+- Stage 1에서는 Swift source를 변경하지 않았다.
+
+## 다음 단계 승인 요청
+
+Stage 2에서 `Sources/QLExtension/HwpPreviewProvider.swift`를 변경해 단일 페이지 PNG reply에 `policy: .skiaOptIn`을 명시하고 diagnostics logging을 추가한다.

--- a/mydocs/working/task_m020_257_stage2.md
+++ b/mydocs/working/task_m020_257_stage2.md
@@ -1,0 +1,77 @@
+# Task M020 #257 Stage 2 보고서 - Quick Look PNG Skia opt-in 적용
+
+## 단계 개요
+
+- 이슈: #257 Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증
+- 단계: Stage 2. Quick Look 단일 페이지 PNG Skia opt-in 적용
+- 목표: 단일 페이지 Quick Look PNG reply가 `skiaOptIn` policy를 사용하고, 실제 backend/fallback diagnostics를 로그에 남기도록 한다.
+
+## 변경 내용
+
+### 단일 페이지 PNG reply policy
+
+`Sources/QLExtension/HwpPreviewProvider.swift`의 `pngReply(_:)`에서 첫 페이지 render 호출에 `policy: .skiaOptIn`을 명시했다.
+
+변경 후 단일 페이지 Quick Look PNG reply는 다음 순서로 동작한다.
+
+1. `HwpPreviewPDFRenderer.load(fileURL:)`가 기존처럼 file size, page count, first page size를 검증한다.
+2. `HwpPageImageRenderer.renderPage(document:pageIndex:policy: .skiaOptIn)`을 호출한다.
+3. #256 Shared renderer가 Skia PNG render를 먼저 시도한다.
+4. Skia 실패, 빈 PNG, PNG decode 실패 시 Shared renderer가 CoreGraphics fallback을 수행한다.
+5. 최종 `HwpRenderedPage`를 기존처럼 PNG로 encode해 `QLPreviewReply`에 반환한다.
+
+### Diagnostics logging
+
+단일 페이지 PNG render 직후 `HwpRenderedPage.diagnostics`를 로그에 남기는 helper를 추가했다.
+
+로그 필드:
+
+| 필드 | 출처 |
+|---|---|
+| `policy` | `diagnostics.policy` |
+| `backend` | `diagnostics.backendUsed` |
+| `fallback` | `diagnostics.fallbackReason`, 없으면 `none` |
+| `pixel` | `diagnostics.pixelSize` |
+| `pngBytes` | Skia PNG bytes count, 없으면 `none` |
+| `totalMs` | 전체 render/decode/fallback 시간 |
+| `skiaMs` | Skia render 시간, 없으면 `none` |
+| `decodeMs` | PNG decode 시간, 없으면 `none` |
+| `coreMs` | CoreGraphics render 시간, 없으면 `none` |
+
+filename은 기존 로그와 동일하게 basename만 public으로 남긴다.
+
+## 보존한 범위
+
+- 다중 페이지 PDF path는 Stage 2에서 변경하지 않았다.
+- Quick Look text fallback classifier 흐름은 변경하지 않았다.
+- file size guard, empty document, invalid page size 정책은 `HwpPreviewPDFRenderer.load`의 기존 흐름을 유지한다.
+- `Sources/RhwpCoreBridge`는 변경하지 않았다.
+- Finder thumbnail path는 변경하지 않았다.
+
+## 검증
+
+실행:
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "skiaOptIn|backendUsed|fallbackReason|pngBytes|durationMs|Preview PNG" Sources/QLExtension Sources/Shared
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+결과:
+
+- `check-no-appkit.sh`: 통과.
+- `rg`: `HwpPreviewProvider.pngReply`의 `policy: .skiaOptIn`과 diagnostics 로그, #256 Shared renderer diagnostics 필드를 확인했다.
+- `xcodebuild QLExtension Debug`: 최초 sandbox 실행은 Sparkle package fetch가 `Could not resolve host: github.com`으로 실패했다. 동일 명령을 네트워크 허용 재실행해 통과했다.
+- `git diff --check`: 통과.
+
+## 리스크와 후속
+
+- 단일 페이지 PNG reply는 아직 Shared renderer의 Skia PNG를 `CGImage`로 decode한 뒤 다시 PNG encode한다. direct PNG reply 최적화는 별도 후속 후보로 남긴다.
+- Skia failure를 강제로 만드는 runtime smoke는 Stage 2에서 수행하지 않았다. fallback taxonomy는 #256 Shared renderer contract에 의존한다.
+- 다중 페이지 PDF의 page별 Skia opt-in 연결과 page diagnostics summary는 Stage 3에서 처리한다.
+
+## 다음 단계 승인 요청
+
+Stage 3에서 `HwpPreviewPDFRenderer`가 page render policy를 받을 수 있게 하고, Quick Look 다중 페이지 PDF path에 `policy: .skiaOptIn`을 연결한다.

--- a/mydocs/working/task_m020_257_stage3.md
+++ b/mydocs/working/task_m020_257_stage3.md
@@ -1,0 +1,105 @@
+# Task M020 #257 Stage 3 보고서 - Quick Look PDF Skia opt-in 경로 연결
+
+## 단계 개요
+
+- 이슈: #257 Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증
+- 단계: Stage 3. 다중 페이지 PDF Skia opt-in 경로 연결
+- 목표: `HwpPreviewPDFRenderer`가 page render policy를 받을 수 있게 하고, Quick Look 다중 페이지 PDF path가 Skia opt-in page image를 사용할 수 있게 한다.
+
+## 변경 내용
+
+### PDF renderer policy 인자 추가
+
+`Sources/Shared/HwpPreviewPDFRenderer.swift`의 render API에 `policy: HwpPageRenderPolicy = .coreGraphicsOnly` 기본 인자를 추가했다.
+
+대상 API:
+
+- `render(fileURL:policy:)`
+- `render(context:policy:)`
+- `render(previewInfo:policy:)`
+- `render(document:pageCount:contentSize:policy:)`
+
+기본값은 모두 `.coreGraphicsOnly`라 기존 script, HostApp PDF export, legacy helper 호출은 기존 동작을 유지한다.
+
+### Page diagnostics 수집
+
+`HwpRenderedPreviewPDF`에 `pageDiagnostics`를 추가하고, page별 `HwpRenderedPage.diagnostics`를 `HwpPreviewPDFPageDiagnostics`로 수집하도록 했다.
+
+수집 필드:
+
+| 필드 | 의미 |
+|---|---|
+| `pageIndex` | PDF에 삽입한 page index |
+| `diagnostics.policy` | page render policy |
+| `diagnostics.backendUsed` | 실제 page image backend |
+| `diagnostics.fallbackReason` | Skia 실패 후 CoreGraphics fallback 이유 |
+| `diagnostics.pngBytes` | Skia PNG byte count |
+| `diagnostics.durationMs` | page별 render/decode/fallback 시간 |
+
+### Quick Look PDF path Skia opt-in
+
+`Sources/QLExtension/HwpPreviewProvider.swift`의 `pdfReply(_:)`에서 다음처럼 policy를 명시한다.
+
+```swift
+let result = try HwpPreviewPDFRenderer.render(
+    context: documentContext,
+    policy: .skiaOptIn
+)
+```
+
+다중 페이지 PDF도 page별로 Skia PNG render를 먼저 시도하고, 실패 시 Shared renderer의 CoreGraphics fallback image를 PDF page에 삽입한다.
+
+### PDF diagnostics summary logging
+
+Quick Look provider에 `logPDFDiagnostics` helper를 추가해 PDF result의 page diagnostics를 요약한다.
+
+로그 필드:
+
+| 필드 | 의미 |
+|---|---|
+| `pages` | PDF page count |
+| `skiaPages` | Skia backend로 성공한 page 수 |
+| `coreGraphicsPages` | CoreGraphics backend로 반환된 page 수 |
+| `embeddedThumbnailPages` | embedded thumbnail backend page 수 |
+| `fallbackPages` | fallback reason이 있는 page 수 |
+| `pngBytes` | page별 Skia PNG byte count 합계 |
+| `totalRenderMs` | page별 render duration 합계 |
+
+## 보존한 범위
+
+- HostApp의 `HwpPreviewPDFRenderer.render(document:pageCount:contentSize:)` 호출은 기본값 때문에 계속 CoreGraphics path를 사용한다.
+- `scripts/quicklook_pdf_renderer_compare.swift`의 `render(previewInfo:)` 호출도 기본값 때문에 기존 CoreGraphics PDF 비교 path를 유지한다.
+- Quick Look text fallback classifier 흐름은 변경하지 않았다.
+- Finder thumbnail path는 변경하지 않았다.
+- vector PDF export 개선은 포함하지 않았다.
+
+## 검증
+
+실행:
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "policy: HwpPageRenderPolicy|skiaOptIn|backendUsed|fallbackReason|pageDiagnostics|HwpRenderedPreviewPDF" \
+  Sources/Shared Sources/QLExtension scripts
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+결과:
+
+- `check-no-appkit.sh`: 통과.
+- `rg`: PDF renderer policy 기본 인자, Quick Look `skiaOptIn` 명시, page diagnostics 수집, PDF summary logging을 확인했다.
+- `xcodebuild QLExtension Debug`: 최초 sandbox 실행은 사용자 Swift/clang cache 쓰기 제한으로 실패했다. 동일 명령을 sandbox 밖에서 재실행해 통과했다.
+- `xcodebuild HostApp Debug`: 최초 sandbox 실행은 사용자 Swift/clang cache 쓰기 제한으로 실패했다. 동일 명령을 sandbox 밖에서 재실행해 통과했다.
+- `git diff --check`: 통과.
+
+## 리스크와 후속
+
+- 다중 페이지 PDF는 page별 Skia PNG render와 decode를 반복하므로 latency와 PDF 생성 시간이 늘 수 있다. 실제 샘플 측정은 Stage 4에서 기록한다.
+- `scripts/quicklook_pdf_renderer_compare.swift`는 기본값으로 CoreGraphics PDF path를 유지한다. Skia PDF path 비교가 필요하면 Stage 4에서 task 전용 helper 또는 명시 policy 옵션을 추가할지 판단한다.
+- Skia default 전환 여부는 #259 readiness gate에서 판단한다.
+
+## 다음 단계 승인 요청
+
+Stage 4에서 대표 샘플로 Quick Look 단일 PNG와 다중 PDF path의 Skia opt-in 결과, fallback 결과, latency/byte 정보를 기록한다.

--- a/mydocs/working/task_m020_257_stage4.md
+++ b/mydocs/working/task_m020_257_stage4.md
@@ -1,0 +1,141 @@
+# Task M020 #257 Stage 4 보고서 - Quick Look Skia smoke 검증
+
+## 단계 개요
+
+- 이슈: #257 Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증
+- 단계: Stage 4. Quick Look smoke와 fallback 검증
+- 목표: 대표 샘플에서 Quick Look 단일 PNG와 다중 PDF 경로의 Skia opt-in 결과, fallback 결과, latency/byte 정보를 기록한다.
+
+## 변경 내용
+
+### Quick Look Skia policy smoke helper 추가
+
+다음 task 전용 smoke helper를 추가했다.
+
+- `scripts/smoke-quicklook-skia-policy.sh`
+- `scripts/quicklook_skia_policy_smoke.swift`
+
+이 helper는 같은 입력 문서에 대해 Quick Look reply 형태를 기준으로 `.coreGraphicsOnly`와 `.skiaOptIn` policy를 모두 측정한다.
+
+측정 항목:
+
+| 항목 | 의미 |
+|---|---|
+| `Reply` | 단일 page는 PNG, 다중 page는 PDF |
+| `CGBackend` | CoreGraphics policy에서 backend별 page count |
+| `SkiaBackend` | Skia opt-in policy에서 backend별 page count |
+| `SkiaFallback` | Skia opt-in에서 fallback page count와 첫 fallback reason |
+| `CGBytes` / `SkiaBytes` | 최종 reply bytes |
+| `SkiaPNGBytes` | upstream Skia PNG bytes 합계 |
+| `CGSeconds` / `SkiaSeconds` | helper 기준 전체 생성 시간 |
+
+`output/task257-skia-policy/summary.txt`와 per-file detail을 생성한다. `output/`은 commit 대상이 아니다.
+
+## Smoke 결과
+
+### CoreGraphics baseline
+
+실행:
+
+```bash
+./scripts/validate-stage3-render.sh output/task257-stage4 samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+결과:
+
+| 샘플 | 결과 | page | bitmap | Hangul runs | non-white pixels |
+|---|---|---:|---:|---:|---:|
+| `samples/basic/request.hwp` | OK | 1 | 567x794 | 37 | 69132 |
+| `samples/basic/KTX.hwp` | OK | 1 | 1123x794 | 77 | 453754 |
+
+`KTX.hwp`에서 기존 layout overflow diagnostic이 출력됐지만 smoke는 통과했다.
+
+### Quick Look policy smoke
+
+실행:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh \
+  output/task257-skia-policy \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+결과 요약:
+
+| 샘플 | Reply | Pages | CG backend | Skia backend | Skia fallback | CG bytes | Skia bytes | Skia PNG bytes | CG seconds | Skia seconds |
+|---|---|---:|---|---|---:|---:|---:|---:|---:|---:|
+| `request.hwp` | png | 1 | cg:1 | skia:1 | 0 | 82129 | 85981 | 88793 | 1.081279 | 0.095356 |
+| `KTX.hwp` | png | 1 | cg:1 | skia:1 | 0 | 555392 | 181146 | 165799 | 0.067094 | 0.073160 |
+| `복학원서.hwp` | png | 1 | cg:1 | skia:1 | 0 | 233831 | 225105 | 240643 | 0.412763 | 0.062871 |
+| `hwp-multi-001.hwp` | pdf | 10 | cg:10 | skia:10 | 0 | 1522638 | 1119989 | 1309516 | 0.404578 | 0.677783 |
+| `hwpx-01.hwpx` | pdf | 9 | cg:9 | skia:9 | 0 | 1489442 | 1094246 | 1316036 | 0.353663 | 0.623360 |
+
+관찰:
+
+- 단일 page PNG 3개 모두 Skia opt-in에서 `backendUsed: .skia`, fallback 0으로 성공했다.
+- 다중 page PDF 2개 모두 모든 page가 Skia backend로 성공했고 fallback 0이었다.
+- 다중 page PDF는 Skia path가 CoreGraphics baseline보다 느렸다. page별 Skia PNG render/decode를 반복하기 때문에 #259에서 readiness gate 입력으로 다뤄야 한다.
+- 단일 page `request.hwp`의 CoreGraphics 시간이 다른 단일 샘플보다 높게 나왔는데, helper 첫 실행/캐시 비용 가능성이 있어 절대 수치보다는 backend 성공/fallback 여부와 bytes를 우선 입력으로 본다.
+
+산출:
+
+- `output/task257-skia-policy/summary.txt`
+- `output/task257-skia-policy/*-quicklook-skia-policy.txt`
+
+### 기존 Quick Look PDF/SVG 비교
+
+실행:
+
+```bash
+./scripts/compare-quicklook-pdf-renderers.sh \
+  output/task257-quicklook-pdf \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+결과:
+
+| 샘플 | Status | Pages | CurrentReply | NativePDFSeconds | NativePDFBytes | CoreSVGSeconds | CoreSVGBytes |
+|---|---|---:|---|---:|---:|---:|---:|
+| `hwp-multi-001.hwp` | OK | 10 | pdf | 1.459130 | 1522638 | 0.016468 | 3917212 |
+| `hwpx-01.hwpx` | OK | 9 | pdf | 0.354921 | 1489442 | 0.014376 | 3664984 |
+
+이 스크립트는 기본 인자 때문에 CoreGraphics PDF path를 측정한다. Skia opt-in 측정은 이번 Stage 4에서 추가한 policy smoke helper를 기준으로 기록했다.
+
+## Build/source 검증
+
+실행:
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "smoke-quicklook-skia-policy|quicklook_skia_policy|skiaOptIn|pageDiagnostics|backendUsed|fallbackReason|SkiaOptIn" \
+  scripts Sources mydocs/orders/20260521.md
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+결과:
+
+- `check-no-appkit.sh`: 통과.
+- `rg`: Skia opt-in provider path, PDF page diagnostics, smoke helper 추가를 확인했다.
+- `xcodebuild QLExtension Debug`: 통과.
+- `xcodebuild HostApp Debug`: 통과.
+- `git diff --check`: 통과.
+
+앞선 Stage 2/3에서 sandbox 내부 xcodebuild가 사용자 Swift/clang cache 쓰기 제한으로 실패한 이력이 있어, Stage 4 build는 sandbox 밖에서 실행했다.
+
+## Known limitations
+
+- Stage 4는 Debug/helper smoke 기준이다. 설치본 Quick Look UI smoke와 LaunchServices/PlugInKit 등록 검증은 별도 release/package smoke로 해석해야 한다.
+- Skia fallback을 강제로 유발하는 fixture는 이번 단계에서 만들지 않았다. fallback 동작은 #256 Shared renderer contract와 code path, 그리고 이번 smoke의 fallback count 0 결과로 확인했다.
+- 다중 page PDF의 Skia path는 모든 page에서 성공했지만 CoreGraphics baseline보다 느린 샘플이 있어, default 전환 판단은 #259로 넘긴다.
+- upstream rhwp 새 release의 PUA/image/watermark 회귀 확인은 #278에서 처리한다.
+
+## 다음 단계 승인 요청
+
+Stage 5에서 최종 보고서와 오늘할일 완료 처리를 수행하고, #258/#259/#278 handoff를 정리한다.

--- a/scripts/quicklook_skia_policy_smoke.swift
+++ b/scripts/quicklook_skia_policy_smoke.swift
@@ -135,7 +135,8 @@ struct QuickLookSkiaPolicySmoke {
 
                 let pdf = try HwpPreviewPDFRenderer.render(
                     context: context,
-                    policy: policy
+                    policy: policy,
+                    collectDiagnostics: true
                 )
                 return policyResult(
                     outputBytes: pdf.data.count,

--- a/scripts/quicklook_skia_policy_smoke.swift
+++ b/scripts/quicklook_skia_policy_smoke.swift
@@ -1,0 +1,408 @@
+import CoreGraphics
+import Foundation
+
+struct SmokeError: Error, CustomStringConvertible {
+    let description: String
+}
+
+struct Timed<Value> {
+    let value: Value
+    let seconds: Double
+}
+
+struct PolicyMeasurement {
+    let policyName: String
+    let status: String
+    let error: String?
+    let outputBytes: Int?
+    let outputPages: Int?
+    let elapsedSeconds: Double?
+    let skiaPages: Int
+    let coreGraphicsPages: Int
+    let embeddedThumbnailPages: Int
+    let fallbackPages: Int
+    let pngBytes: Int
+    let renderMs: Double
+    let firstFallback: String?
+}
+
+struct FileMeasurement {
+    let fileName: String
+    let filePath: String
+    let fileBytes: Int
+    let loadStatus: String
+    let loadError: String?
+    let pageCount: Int?
+    let replyType: String?
+    let firstPageSize: CGSize?
+    let coreGraphics: PolicyMeasurement?
+    let skiaOptIn: PolicyMeasurement?
+}
+
+@main
+struct QuickLookSkiaPolicySmoke {
+    static func main() throws {
+        let args = Array(CommandLine.arguments.dropFirst())
+        guard args.count >= 2 else {
+            throw SmokeError(description: "usage: quicklook_skia_policy_smoke <output-dir> <hwp-or-hwpx> [...]")
+        }
+
+        let outputDir = absoluteURL(args[0], isDirectory: true)
+        let inputs = args.dropFirst().map { absoluteURL($0) }
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+
+        var measurements: [FileMeasurement] = []
+        for inputURL in inputs {
+            let measurement = measure(inputURL: inputURL)
+            measurements.append(measurement)
+            try writeDetail(measurement, outputDir: outputDir)
+            print("\(measurement.loadStatus) \(measurement.fileName): \(rowSummary(measurement))")
+        }
+
+        try writeSummary(measurements, outputDir: outputDir)
+    }
+
+    private static func measure(inputURL: URL) -> FileMeasurement {
+        let fileName = inputURL.lastPathComponent
+        let fileBytes = (try? inputURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+
+        do {
+            let context = try HwpPreviewPDFRenderer.load(fileURL: inputURL)
+            let replyType = context.pageCount == 1 ? "png" : "pdf"
+            let coreGraphics = measurePolicy(
+                context: context,
+                policyName: "coreGraphicsOnly",
+                policy: .coreGraphicsOnly
+            )
+            let skiaOptIn = measurePolicy(
+                context: context,
+                policyName: "skiaOptIn",
+                policy: .skiaOptIn
+            )
+            return FileMeasurement(
+                fileName: fileName,
+                filePath: inputURL.path,
+                fileBytes: fileBytes,
+                loadStatus: "OK",
+                loadError: nil,
+                pageCount: context.pageCount,
+                replyType: replyType,
+                firstPageSize: context.contentSize,
+                coreGraphics: coreGraphics,
+                skiaOptIn: skiaOptIn
+            )
+        } catch {
+            return FileMeasurement(
+                fileName: fileName,
+                filePath: inputURL.path,
+                fileBytes: fileBytes,
+                loadStatus: "FAIL",
+                loadError: String(describing: error),
+                pageCount: nil,
+                replyType: nil,
+                firstPageSize: nil,
+                coreGraphics: nil,
+                skiaOptIn: nil
+            )
+        }
+    }
+
+    private static func measurePolicy(
+        context: HwpPreviewDocumentContext,
+        policyName: String,
+        policy: HwpPageRenderPolicy
+    ) -> PolicyMeasurement {
+        do {
+            let timedResult = try timed {
+                if context.pageCount == 1 {
+                    let page = try HwpPageImageRenderer.renderPage(
+                        document: context.document,
+                        pageIndex: 0,
+                        policy: policy
+                    )
+                    let png = try HwpPageImageRenderer.encodePNG(page.image)
+                    return policyResult(
+                        outputBytes: png.count,
+                        outputPages: 1,
+                        diagnostics: [
+                            HwpPreviewPDFPageDiagnostics(
+                                pageIndex: 0,
+                                diagnostics: page.diagnostics
+                            )
+                        ]
+                    )
+                }
+
+                let pdf = try HwpPreviewPDFRenderer.render(
+                    context: context,
+                    policy: policy
+                )
+                return policyResult(
+                    outputBytes: pdf.data.count,
+                    outputPages: pdfPageCount(data: pdf.data) ?? pdf.pageCount,
+                    diagnostics: pdf.pageDiagnostics
+                )
+            }
+            let result = timedResult.value
+            return PolicyMeasurement(
+                policyName: policyName,
+                status: "OK",
+                error: nil,
+                outputBytes: result.outputBytes,
+                outputPages: result.outputPages,
+                elapsedSeconds: timedResult.seconds,
+                skiaPages: result.skiaPages,
+                coreGraphicsPages: result.coreGraphicsPages,
+                embeddedThumbnailPages: result.embeddedThumbnailPages,
+                fallbackPages: result.fallbackPages,
+                pngBytes: result.pngBytes,
+                renderMs: result.renderMs,
+                firstFallback: result.firstFallback
+            )
+        } catch {
+            return PolicyMeasurement(
+                policyName: policyName,
+                status: "FAIL",
+                error: String(describing: error),
+                outputBytes: nil,
+                outputPages: nil,
+                elapsedSeconds: nil,
+                skiaPages: 0,
+                coreGraphicsPages: 0,
+                embeddedThumbnailPages: 0,
+                fallbackPages: 0,
+                pngBytes: 0,
+                renderMs: 0,
+                firstFallback: nil
+            )
+        }
+    }
+
+    private struct PolicyResult {
+        let outputBytes: Int
+        let outputPages: Int
+        let skiaPages: Int
+        let coreGraphicsPages: Int
+        let embeddedThumbnailPages: Int
+        let fallbackPages: Int
+        let pngBytes: Int
+        let renderMs: Double
+        let firstFallback: String?
+    }
+
+    private static func policyResult(
+        outputBytes: Int,
+        outputPages: Int,
+        diagnostics: [HwpPreviewPDFPageDiagnostics]
+    ) -> PolicyResult {
+        var skiaPages = 0
+        var coreGraphicsPages = 0
+        var embeddedThumbnailPages = 0
+        var fallbackPages = 0
+        var pngBytes = 0
+        var renderMs = 0.0
+        var firstFallback: String?
+
+        for page in diagnostics {
+            switch page.diagnostics.backendUsed {
+            case .coreGraphics:
+                coreGraphicsPages += 1
+            case .skia:
+                skiaPages += 1
+            case .embeddedThumbnail:
+                embeddedThumbnailPages += 1
+            }
+
+            if let fallbackReason = page.diagnostics.fallbackReason {
+                fallbackPages += 1
+                if firstFallback == nil {
+                    firstFallback = String(describing: fallbackReason)
+                }
+            }
+            pngBytes += page.diagnostics.pngBytes ?? 0
+            renderMs += page.diagnostics.durationMs.totalMs
+        }
+
+        return PolicyResult(
+            outputBytes: outputBytes,
+            outputPages: outputPages,
+            skiaPages: skiaPages,
+            coreGraphicsPages: coreGraphicsPages,
+            embeddedThumbnailPages: embeddedThumbnailPages,
+            fallbackPages: fallbackPages,
+            pngBytes: pngBytes,
+            renderMs: renderMs,
+            firstFallback: firstFallback
+        )
+    }
+
+    private static func timed<Value>(_ work: () throws -> Value) rethrows -> Timed<Value> {
+        let start = DispatchTime.now().uptimeNanoseconds
+        let value = try work()
+        let end = DispatchTime.now().uptimeNanoseconds
+        return Timed(value: value, seconds: Double(end - start) / 1_000_000_000)
+    }
+
+    private static func pdfPageCount(data: Data) -> Int? {
+        guard
+            let provider = CGDataProvider(data: data as CFData),
+            let document = CGPDFDocument(provider)
+        else {
+            return nil
+        }
+        return document.numberOfPages
+    }
+
+    private static func writeSummary(_ measurements: [FileMeasurement], outputDir: URL) throws {
+        var lines: [String] = []
+        lines.append("# Quick Look Skia Policy Smoke")
+        lines.append("")
+        lines.append("GeneratedAt: \(ISO8601DateFormatter().string(from: Date()))")
+        lines.append("")
+        lines.append("| File | Load | Reply | Pages | Size | CGStatus | CGBackend | CGFallback | CGBytes | CGSeconds | SkiaStatus | SkiaBackend | SkiaFallback | SkiaBytes | SkiaPNGBytes | SkiaSeconds |")
+        lines.append("|------|------|-------|-------|------|----------|-----------|------------|---------|-----------|------------|-------------|--------------|-----------|--------------|-------------|")
+
+        for measurement in measurements {
+            lines.append([
+                markdownCell(measurement.fileName),
+                measurement.loadStatus,
+                measurement.replyType ?? "-",
+                optionalInt(measurement.pageCount),
+                sizeString(measurement.firstPageSize),
+                measurement.coreGraphics?.status ?? "-",
+                backendSummary(measurement.coreGraphics),
+                fallbackSummary(measurement.coreGraphics),
+                optionalInt(measurement.coreGraphics?.outputBytes),
+                secondsString(measurement.coreGraphics?.elapsedSeconds),
+                measurement.skiaOptIn?.status ?? "-",
+                backendSummary(measurement.skiaOptIn),
+                fallbackSummary(measurement.skiaOptIn),
+                optionalInt(measurement.skiaOptIn?.outputBytes),
+                optionalInt(measurement.skiaOptIn?.pngBytes),
+                secondsString(measurement.skiaOptIn?.elapsedSeconds)
+            ].joined(separator: " | ").wrappedTableRow)
+        }
+
+        let failed = measurements.filter { $0.loadStatus == "FAIL" || $0.coreGraphics?.status == "FAIL" || $0.skiaOptIn?.status == "FAIL" }
+        if !failed.isEmpty {
+            lines.append("")
+            lines.append("## Failures")
+            lines.append("")
+            for measurement in failed {
+                lines.append("- `\(measurement.fileName)`: load=\(measurement.loadError ?? "-") cg=\(measurement.coreGraphics?.error ?? "-") skia=\(measurement.skiaOptIn?.error ?? "-")")
+            }
+        }
+
+        try lines.joined(separator: "\n").write(
+            to: outputDir.appendingPathComponent("summary.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    private static func writeDetail(_ measurement: FileMeasurement, outputDir: URL) throws {
+        let baseName = URL(fileURLWithPath: measurement.fileName)
+            .deletingPathExtension()
+            .lastPathComponent
+        let detailURL = outputDir.appendingPathComponent("\(baseName)-quicklook-skia-policy.txt")
+        var lines: [String] = []
+        lines.append("File: \(measurement.filePath)")
+        lines.append("LoadStatus: \(measurement.loadStatus)")
+        if let loadError = measurement.loadError {
+            lines.append("LoadError: \(loadError)")
+        }
+        lines.append("FileBytes: \(measurement.fileBytes)")
+        lines.append("ReplyType: \(measurement.replyType ?? "-")")
+        lines.append("PageCount: \(optionalInt(measurement.pageCount))")
+        lines.append("FirstPageSize: \(sizeString(measurement.firstPageSize))")
+        appendPolicy(measurement.coreGraphics, name: "CoreGraphics", lines: &lines)
+        appendPolicy(measurement.skiaOptIn, name: "SkiaOptIn", lines: &lines)
+        try lines.joined(separator: "\n").write(to: detailURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func appendPolicy(_ policy: PolicyMeasurement?, name: String, lines: inout [String]) {
+        lines.append("")
+        lines.append("[\(name)]")
+        guard let policy else {
+            lines.append("Status: -")
+            return
+        }
+        lines.append("Status: \(policy.status)")
+        if let error = policy.error {
+            lines.append("Error: \(error)")
+        }
+        lines.append("OutputBytes: \(optionalInt(policy.outputBytes))")
+        lines.append("OutputPages: \(optionalInt(policy.outputPages))")
+        lines.append("ElapsedSeconds: \(secondsString(policy.elapsedSeconds))")
+        lines.append("SkiaPages: \(policy.skiaPages)")
+        lines.append("CoreGraphicsPages: \(policy.coreGraphicsPages)")
+        lines.append("EmbeddedThumbnailPages: \(policy.embeddedThumbnailPages)")
+        lines.append("FallbackPages: \(policy.fallbackPages)")
+        lines.append("FirstFallback: \(policy.firstFallback ?? "-")")
+        lines.append("PNGBytes: \(policy.pngBytes)")
+        lines.append("RenderMs: \(formatMilliseconds(policy.renderMs))")
+    }
+
+    private static func rowSummary(_ measurement: FileMeasurement) -> String {
+        guard measurement.loadStatus == "OK" else {
+            return measurement.loadError ?? "load failed"
+        }
+        return "reply=\(measurement.replyType ?? "-") pages=\(optionalInt(measurement.pageCount)) cg=\(backendSummary(measurement.coreGraphics)) skia=\(backendSummary(measurement.skiaOptIn)) fallback=\(fallbackSummary(measurement.skiaOptIn))"
+    }
+
+    private static func backendSummary(_ measurement: PolicyMeasurement?) -> String {
+        guard let measurement, measurement.status == "OK" else {
+            return "-"
+        }
+        return "skia:\(measurement.skiaPages),cg:\(measurement.coreGraphicsPages),embedded:\(measurement.embeddedThumbnailPages)"
+    }
+
+    private static func fallbackSummary(_ measurement: PolicyMeasurement?) -> String {
+        guard let measurement, measurement.status == "OK" else {
+            return "-"
+        }
+        if measurement.fallbackPages == 0 {
+            return "0"
+        }
+        return "\(measurement.fallbackPages)(\(measurement.firstFallback ?? "unknown"))"
+    }
+
+    private static func absoluteURL(_ path: String, isDirectory: Bool = false) -> URL {
+        let url = URL(fileURLWithPath: path, isDirectory: isDirectory)
+        if path.hasPrefix("/") {
+            return url.standardizedFileURL
+        }
+        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(path, isDirectory: isDirectory)
+            .standardizedFileURL
+    }
+
+    private static func optionalInt(_ value: Int?) -> String {
+        guard let value else { return "-" }
+        return "\(value)"
+    }
+
+    private static func secondsString(_ value: Double?) -> String {
+        guard let value else { return "-" }
+        return String(format: "%.6f", value)
+    }
+
+    private static func formatMilliseconds(_ value: Double) -> String {
+        String(format: "%.3f", value)
+    }
+
+    private static func sizeString(_ size: CGSize?) -> String {
+        guard let size else { return "-" }
+        return "\(Int(size.width))x\(Int(size.height))"
+    }
+
+    private static func markdownCell(_ value: String) -> String {
+        value.replacingOccurrences(of: "|", with: "\\|")
+    }
+}
+
+private extension String {
+    var wrappedTableRow: String {
+        "| \(self) |"
+    }
+}

--- a/scripts/smoke-quicklook-skia-policy.sh
+++ b/scripts/smoke-quicklook-skia-policy.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 <output-dir> <hwp-or-hwpx> [...]
+
+Builds and runs a Quick Look policy smoke helper for the supplied HWP/HWPX
+inputs. It measures the current Quick Look reply shape with CoreGraphics and
+Skia opt-in policies, then writes summary.txt and per-file detail files.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -lt 2 ]; then
+  usage
+  exit 1
+fi
+
+OUT_DIR="$1"
+shift
+INPUTS=("$@")
+
+LIB="$ROOT/Frameworks/universal/librhwp.a"
+MODULEMAP_DIR="$ROOT/Frameworks/modulemap"
+if [ ! -f "$LIB" ]; then
+  echo "ERROR: missing $LIB" >&2
+  echo "Run: $ROOT/scripts/build-rust-macos.sh" >&2
+  exit 1
+fi
+if [ ! -f "$MODULEMAP_DIR/module.modulemap" ]; then
+  echo "ERROR: missing $MODULEMAP_DIR/module.modulemap" >&2
+  echo "Run: $ROOT/scripts/build-rust-macos.sh" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+BIN="$OUT_DIR/quicklook_skia_policy_smoke"
+SWIFT_MODULE_CACHE="$OUT_DIR/swift-module-cache-quicklook-skia-policy"
+CLANG_MODULE_CACHE="$OUT_DIR/clang-module-cache-quicklook-skia-policy"
+rm -rf "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
+mkdir -p "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
+
+swiftc -parse-as-library \
+  -module-cache-path "$SWIFT_MODULE_CACHE" \
+  -Xcc -fmodules-cache-path="$CLANG_MODULE_CACHE" \
+  -I "$MODULEMAP_DIR" \
+  "$ROOT/Sources/RhwpCoreBridge/RhwpDocument.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/FontFallback.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/FontResourceRegistry.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/CGTreeRenderer.swift" \
+  "$ROOT/Sources/Shared/HwpPageImageRenderer.swift" \
+  "$ROOT/Sources/Shared/HwpPreviewPDFRenderer.swift" \
+  "$ROOT/scripts/quicklook_skia_policy_smoke.swift" \
+  "$LIB" \
+  -framework CoreGraphics \
+  -framework CoreText \
+  -framework ImageIO \
+  -framework UniformTypeIdentifiers \
+  -framework Security \
+  -framework CoreFoundation \
+  -lc++ \
+  -liconv \
+  -lz \
+  -o "$BIN"
+
+"$BIN" "$OUT_DIR" "${INPUTS[@]}"


### PR DESCRIPTION
## 요약

- 대상 타스크: #257 Quick Look preview에서 Skia PNG backend 적용과 다중 페이지 PDF fallback 검증
- 왜: #256에서 만든 Shared `HwpPageImageRenderer`의 `skiaOptIn` policy를 Finder Quick Look preview surface에도 연결해, upstream rhwp native-skia PNG backend를 실제 preview 경로에서 검증하기 위함입니다.
- 무엇: Quick Look 단일 PNG reply와 다중 페이지 bitmap PDF reply가 `skiaOptIn`을 사용하도록 바꾸고, page/backend/fallback diagnostics와 smoke 측정 helper를 추가했습니다.
- 리뷰 포인트: `HwpPreviewProvider`의 policy 선택, `HwpPreviewPDFRenderer`의 기본 API 호환성, smoke 결과 해석과 #258/#259/#278 handoff입니다.

## PR base

- base: `devel`

## 변경 내역

- **[작업 시작](https://github.com/postmelee/alhangeul-macos/blob/f21ea620e0c63d173e2e43177fd4c9a02f6011be/mydocs/plans/task_m020_257.md)** ([0d18560](https://github.com/postmelee/alhangeul-macos/commit/0d18560)): 수행계획서와 2026-05-21 오늘할일 작성
- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/f21ea620e0c63d173e2e43177fd4c9a02f6011be/mydocs/working/task_m020_257_stage1.md)** ([e104c74](https://github.com/postmelee/alhangeul-macos/commit/e104c74)): Quick Look 단일 PNG, 다중 PDF, fallback 흐름 inventory와 구현계획서 작성
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/f21ea620e0c63d173e2e43177fd4c9a02f6011be/mydocs/working/task_m020_257_stage2.md)** ([5df3e1f](https://github.com/postmelee/alhangeul-macos/commit/5df3e1f)): 단일 페이지 PNG reply에 `skiaOptIn` 적용, diagnostics logging 추가
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/f21ea620e0c63d173e2e43177fd4c9a02f6011be/mydocs/working/task_m020_257_stage3.md)** ([b044ed6](https://github.com/postmelee/alhangeul-macos/commit/b044ed6)): 다중 페이지 PDF renderer에 policy 인자와 page diagnostics 추가, Quick Look PDF path에 `skiaOptIn` 적용
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/f21ea620e0c63d173e2e43177fd4c9a02f6011be/mydocs/working/task_m020_257_stage4.md)** ([49a0ad3](https://github.com/postmelee/alhangeul-macos/commit/49a0ad3)): Quick Look policy smoke helper 추가, 단일/다중 대표 샘플 smoke 기록
- **최종 보고** ([3112154](https://github.com/postmelee/alhangeul-macos/commit/3112154)): 최종 보고서와 2026-05-22 오늘할일 완료 처리
- **Copilot review 반영** ([764c011](https://github.com/postmelee/alhangeul-macos/commit/764c011)): 최종 보고서 표준명 보정, diagnostics 로그 분리, PDF diagnostics capacity 예약
- **Copilot review 반영** ([f21ea62](https://github.com/postmelee/alhangeul-macos/commit/f21ea62)): PDF diagnostics 수집을 opt-in으로 전환하고 Quick Look/smoke에서만 활성화

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `Sources/QLExtension/HwpPreviewProvider.swift` | 단일 PNG와 다중 PDF Quick Look reply에서 `policy: .skiaOptIn` 명시, PNG/PDF diagnostics logging 추가 | 기존 Quick Look reply shape은 유지하면서 page image backend만 opt-in으로 바뀌는지 |
| `Sources/Shared/HwpPreviewPDFRenderer.swift` | PDF render API에 `HwpPageRenderPolicy`와 `collectDiagnostics` 기본 인자 추가, page별 diagnostics opt-in 수집 | 기본값으로 기존 호출부와 HostApp PDF export의 diagnostics 미수집 경로가 유지되는지 |
| `scripts/smoke-quicklook-skia-policy.sh` | Quick Look reply shape 기준 CoreGraphics/Skia 비교 wrapper 추가 | Finder 설치본 smoke가 아니라 helper 기반 policy smoke라는 범위 |
| `scripts/quicklook_skia_policy_smoke.swift` | PNG/PDF reply, backend count, fallback count, bytes, latency 측정 | 수치가 회귀 판단의 입력이지만 통계 benchmark는 아니라는 점 |

작업 문서:

- 수행 계획서: [task_m020_257.md](https://github.com/postmelee/alhangeul-macos/blob/f21ea620e0c63d173e2e43177fd4c9a02f6011be/mydocs/plans/task_m020_257.md)
- 구현 계획서: [task_m020_257_impl.md](https://github.com/postmelee/alhangeul-macos/blob/f21ea620e0c63d173e2e43177fd4c9a02f6011be/mydocs/plans/task_m020_257_impl.md)
- 최종 보고서: [task_m020_257_report.md](https://github.com/postmelee/alhangeul-macos/blob/f21ea620e0c63d173e2e43177fd4c9a02f6011be/mydocs/report/task_m020_257_report.md)

## 핵심 리뷰 포인트

- Quick Look preview surface만 변경했습니다. HostApp native viewer renderer, Thumbnail surface, vector PDF export, upstream rhwp pin 변경은 포함하지 않습니다.
- 다중 페이지 PDF renderer의 public/shared API는 `policy` 기본값을 `.coreGraphicsOnly`, `collectDiagnostics` 기본값을 `false`로 둬 기존 호출부와 HostApp export의 의미를 유지합니다. Quick Look provider와 smoke helper만 명시적으로 `.skiaOptIn`/diagnostics 수집을 켭니다.
- Skia 실패 시 CoreGraphics fallback은 #256 Shared renderer contract를 그대로 사용합니다. 이번 smoke에서는 fallback이 발생하지 않았고, 강제 실패 fixture는 추가하지 않았습니다.

## Smoke 측정 결과

Stage 4 helper smoke는 대표 샘플 5개, 총 22 page에서 CoreGraphics baseline과 Skia opt-in 결과를 같은 reply shape으로 비교했습니다.

| 샘플 | Reply | Pages | CG backend | Skia backend | Skia fallback | CG bytes | Skia bytes | Skia PNG bytes | CG seconds | Skia seconds |
|---|---|---:|---|---|---:|---:|---:|---:|---:|---:|
| `request.hwp` | png | 1 | cg:1 | skia:1 | 0 | 82,129 | 85,981 | 88,793 | 1.081279 | 0.095356 |
| `KTX.hwp` | png | 1 | cg:1 | skia:1 | 0 | 555,392 | 181,146 | 165,799 | 0.067094 | 0.073160 |
| `복학원서.hwp` | png | 1 | cg:1 | skia:1 | 0 | 233,831 | 225,105 | 240,643 | 0.412763 | 0.062871 |
| `hwp-multi-001.hwp` | pdf | 10 | cg:10 | skia:10 | 0 | 1,522,638 | 1,119,989 | 1,309,516 | 0.404578 | 0.677783 |
| `hwpx-01.hwpx` | pdf | 9 | cg:9 | skia:9 | 0 | 1,489,442 | 1,094,246 | 1,316,036 | 0.353663 | 0.623360 |

수치 비교:

- Skia backend 성공률: 22/22 page 성공, fallback 0 page.
- 단일 페이지 PNG: 3/3 sample에서 Skia backend 성공. `request.hwp`와 `복학원서.hwp`는 Skia path가 더 빨랐고, `KTX.hwp`는 약 9% 느렸습니다.
- 다중 페이지 PDF: 19/19 page에서 Skia backend 성공. 두 다중 샘플 모두 output PDF bytes는 CoreGraphics 대비 약 26% 작았지만, latency는 약 67-76% 느렸습니다.
- 전체 smoke 합계 기준 output bytes는 CoreGraphics 3,883,432 bytes, Skia 2,706,467 bytes로 Skia 쪽이 약 30% 작았습니다. 다만 latency 합계는 샘플 구성과 warm/cold 영향이 있어 release 판단 지표로 직접 사용하지 않습니다.

## 결론과 관찰

- Quick Look 단일 PNG reply와 다중 PDF reply 모두 기존 reply shape을 유지하면서 Skia page image backend를 연결할 수 있었습니다.
- 대표 샘플에서는 Skia fallback이 발생하지 않아, #256 Shared renderer의 Skia opt-in path가 Quick Look surface에서도 정상 동작함을 확인했습니다.
- 단일 PNG는 실사용 가능성이 높아 보이지만, 다중 PDF는 성공 여부와 별개로 CoreGraphics보다 느린 샘플이 확인되어 default 전환 판단을 #259 readiness gate로 넘겨야 합니다.
- 다중 PDF의 output byte size는 Skia가 작게 나왔지만, PDF 생성 시간은 page별 Skia PNG render/decode/embedding 비용이 누적되는 형태로 관찰됩니다.

## 얻은 교훈 및 알게 된 점

- Quick Look 쪽에서 renderer 전환을 surface별로 다시 구현할 필요 없이, Shared `HwpPageImageRenderer` policy를 명시하는 방식으로 backend 전환과 fallback contract를 재사용할 수 있습니다.
- 다중 페이지 PDF path는 “page render 성공”만으로 충분하지 않습니다. page 수가 늘면 backend latency와 PDF embedding 비용이 사용자 체감에 바로 반영되므로, #259에서 visual/performance/package gate를 분리해 봐야 합니다.
- diagnostics를 page별로 보존해 두면 Quick Look provider 로그에서 backend mix, fallback reason, byte size, duration을 한 번에 요약할 수 있어 #258 Thumbnail cache policy와 #259 default 판단의 입력으로 재사용할 수 있습니다.

## 검증

- `./scripts/validate-stage3-render.sh output/task257-stage4 samples/basic/request.hwp samples/basic/KTX.hwp`
- `./scripts/smoke-quicklook-skia-policy.sh output/task257-skia-policy samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx`
- `./scripts/compare-quicklook-pdf-renderers.sh output/task257-quicklook-pdf samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx`
- `./scripts/check-no-appkit.sh`
- `rg -n "#257|skiaOptIn|backendUsed|fallbackReason|Quick Look|#258|#259|#278" mydocs/report/task_m020_257_report.md mydocs/orders/20260522.md Sources/QLExtension Sources/Shared`
- `xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedDataTask257 CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
- `git status --short --branch`

참고:

- Stage 2/3의 sandbox 내부 `xcodebuild`는 사용자 Swift/clang cache 쓰기 제한으로 실패한 뒤 sandbox 밖 재실행에서 통과했습니다.
- Stage 4/5 build는 같은 cache 제한을 피하기 위해 sandbox 밖에서 실행했고 통과했습니다.
- Finder 설치본 Quick Look UI smoke, LaunchServices/PlugInKit active provider path 확인, extension registration hygiene check는 이번 PR 범위가 아니라 #259 또는 release/package smoke에서 다룹니다.

## 관련 이슈

- #255: RustBridge native-skia PNG FFI와 build/provenance gate
- #256: Shared `HwpPageImageRenderer` Skia optional backend와 CoreGraphics fallback contract
- #258: Finder thumbnail에서 Skia scale/cache/memory 정책 적용과 smoke 검증
- #259: Skia backend visual/performance/package regression gate 정리
- #278: 새 rhwp release tag 반영 후 #947/#976/#982/#1018 upstream 회귀 확인

## 후속 이슈 제안

- 없음. 이번 PR의 후속 범위는 이미 #258, #259, #278로 분리되어 있습니다.

## 남은 리스크와 Handoff

- #258 handoff: Thumbnail surface는 요청 크기 기반 scale/cache/memory 정책이 핵심입니다. #257의 diagnostics logging과 smoke helper 구조는 재사용할 수 있지만, Thumbnail cache key에는 backend/render signature를 별도로 반영해야 합니다.
- #259 handoff: Quick Look 단일 PNG와 다중 PDF 모두 fallback 없이 Skia backend가 성공했습니다. 다만 다중 PDF latency가 CoreGraphics보다 느린 샘플이 있으므로 default 전환은 visual, performance, memory, package smoke 결과를 함께 보고 결정해야 합니다.
- #278 handoff: 이번 PR은 현재 core pin 기준으로 Quick Look Skia path만 연결합니다. upstream #947/#976/#982/#1018 포함 release tag가 배포된 뒤 core pin/provenance를 갱신하고, PUA 표시 문자열, image/watermark, render path 회귀를 Quick Look/Thumbnail Skia path에서 재확인해야 합니다.
- 강제 Skia 실패 fixture는 이번 PR에 없습니다. fallback count 0은 “대표 샘플에서 fallback 없이 성공”을 의미하며, fallback branch 자체의 강제 실패 테스트는 별도 후보입니다.

Closes #257
