### PR TITLE
Task #280: rhwp-studio 기준 preview visual diff harness 구축

### DIFF
--- a/mydocs/orders/20260525.md
+++ b/mydocs/orders/20260525.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 5월 25일
+
+## M014 — v0.1.4 Native Preview/Viewer Parity
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260525.md
+++ b/mydocs/orders/20260525.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 진행중 | M014, Stage 1 완료, Stage 2 승인 대기 |
+| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 진행중 | M014, Stage 2 완료, Stage 3 승인 대기 |

--- a/mydocs/orders/20260525.md
+++ b/mydocs/orders/20260525.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 진행중 | M014, Stage 4 완료, Stage 5 승인 대기 |
+| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 완료 | M014, Stage 5 완료, 최종 보고 작성 |

--- a/mydocs/orders/20260525.md
+++ b/mydocs/orders/20260525.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 완료 | M014, Stage 5 완료, 최종 보고 작성 |
+| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 완료 | 완료: 09:00, M014 Stage 5 완료, 최종 보고 작성 |

--- a/mydocs/orders/20260525.md
+++ b/mydocs/orders/20260525.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 진행중 | M014, Stage 3 완료, Stage 4 승인 대기 |
+| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 진행중 | M014, Stage 4 완료, Stage 5 승인 대기 |

--- a/mydocs/orders/20260525.md
+++ b/mydocs/orders/20260525.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 진행중 | M014, Stage 1 완료, Stage 2 승인 대기 |

--- a/mydocs/orders/20260525.md
+++ b/mydocs/orders/20260525.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 진행중 | M014, Stage 2 완료, Stage 3 승인 대기 |
+| #280 | rhwp-studio 기준 preview visual diff harness 구축 | 진행중 | M014, Stage 3 완료, Stage 4 승인 대기 |

--- a/mydocs/plans/task_m014_280.md
+++ b/mydocs/plans/task_m014_280.md
@@ -1,0 +1,124 @@
+# Task M014 #280 수행계획서
+
+## 목적
+
+v0.1.4 native preview/viewer parity 작업에서 `rhwp-studio` 기본 렌더 결과와 Swift/native preview 결과를 같은 샘플, 같은 페이지, 같은 픽셀 좌표계로 비교할 수 있는 visual diff harness를 구축한다.
+
+완료 후 작업자는 Quick Look preview, Finder thumbnail, Shared native renderer, `rhwp-studio` 기준 출력의 차이를 파일별/페이지별 수치와 diff 이미지로 확인하고, #116, #122, #121, #110, #282 같은 후속 렌더 개선 PR에 전후 비교 자료를 첨부할 수 있어야 한다.
+
+## 배경
+
+현재 저장소에는 Swift native renderer와 core SVG/PDF 계열을 비교하는 `scripts/render-debug-compare.sh`, `scripts/visual-compare-quicklook-renderers.sh`, Quick Look Skia policy를 측정하는 `scripts/smoke-quicklook-skia-policy.sh`가 있다. 그러나 v0.1.4 마일스톤의 reference로 정한 bundled `rhwp-studio` 기본 렌더 결과를 캡처하고 native preview 출력과 직접 비교하는 공통 harness는 아직 없다.
+
+`rhwp-studio` 기본 렌더는 단순 canvas 한 장이 아니라 flow canvas와 BehindText/InFrontOfText overlay를 조합한다. 따라서 non-empty smoke나 core SVG 비교만으로는 watermark, overlay ordering, image fill/tile, RawSvg/OLE/chart, Placeholder/FormObject 차이를 안정적으로 추적하기 어렵다.
+
+이번 작업은 renderer 자체를 고치지 않고, 이후 renderer 개선 작업의 판단 기준을 먼저 만든다.
+
+## 범위
+
+포함:
+
+- bundled `Sources/HostApp/Resources/rhwp-studio`를 기준으로 reference render를 생성하는 절차 또는 helper 추가
+- Shared native renderer 또는 Quick Look/Thumbnail이 사용하는 page image 출력 생성 절차 연결
+- pixel diff, changed pixel ratio, mean/max RGB delta, non-white pixel, page size, output path, render timing 등 비교 지표 수집
+- diff PNG와 Markdown/텍스트 summary 생성
+- v0.1.4 sample set 선정 및 반복 실행 가능한 기본 명령 제공
+- margin guide, toolbar, menu bar, selection/caret 같은 editor chrome은 Finder preview/thumbnail parity 기준에서 제외한다는 정책 명시
+
+제외:
+
+- Swift renderer, Skia renderer, PageLayerTree compositor 구현 변경
+- upstream `edwardkim/rhwp` 수정
+- unreleased rhwp commit pin 적용
+- public release gate, signing, notarization, Homebrew 배포 작업
+- visual diff 수치 하나만으로 통과/실패를 자동 판정하는 hard gate 도입
+
+## 설계 방향
+
+기존 render smoke 자산을 재사용하되, 비교 기준을 `core SVG/PDF`에서 `bundled rhwp-studio default render`로 확장한다. `rhwp-studio` reference는 앱 bundle에 들어가는 정적 asset과 같은 snapshot을 사용하고, `rhwp-core.lock` 및 `rhwp-studio/manifest.json`의 tag/commit provenance를 summary에 남긴다.
+
+reference capture는 구현계획서에서 최종 확정하되, 1차 후보는 WebKit 기반 helper 또는 로컬 static server + browser capture 방식이다. 핵심 요구사항은 문서 bytes를 `rhwp-studio`에 로드하고, 첫 페이지 document content 영역만 안정적으로 캡처하며, menu/toolbar/status/ruler/margin guide 등 editor chrome을 diff 기준에서 분리하는 것이다.
+
+native 출력은 기존 `HwpPageImageRenderer`/`HwpPreviewPDFRenderer` 또는 `render-debug-compare` 경로를 재사용한다. 새 harness는 산출물 폴더를 다음처럼 구분한다.
+
+- `studio/`: `rhwp-studio` reference PNG와 capture metadata
+- `native/`: Swift/CoreGraphics 또는 Skia opt-in native preview PNG
+- `diff/`: reference vs native diff PNG
+- `summary.md`: 파일별 상태와 수치 비교
+
+## 예상 변경 파일
+
+- `scripts/preview-visual-diff-harness.sh` 또는 동등한 orchestration script
+- `scripts/preview_visual_diff_harness.swift` 또는 browser capture helper
+- 필요 시 기존 `scripts/visual_compare_quicklook_renderers.swift`의 diff utility 재사용/분리
+- 필요 시 `mydocs/tech/v014_preview_visual_diff_harness.md`
+- `mydocs/orders/20260525.md`
+- `mydocs/plans/task_m014_280.md`
+- `mydocs/plans/task_m014_280_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m014_280_stage{N}.md`
+- `mydocs/report/task_m014_280_report.md`
+
+## 잠정 단계
+
+1. Stage 1: 기존 render/smoke 자산 inventory와 reference capture 방식 확정
+   - `render-debug-compare`, `visual-compare-quicklook-renderers`, `smoke-quicklook-skia-policy`, bundled `rhwp-studio` 로딩 경로를 확인한다.
+   - `rhwp-studio` reference capture 방식을 하나로 고르고 구현계획서에 고정한다.
+2. Stage 2: `rhwp-studio` reference capture helper 구현
+   - sample 문서를 `rhwp-studio`에 로드하고 page content 영역의 PNG를 생성한다.
+   - editor chrome 제외 정책과 capture metadata를 summary에 남긴다.
+3. Stage 3: native preview 출력과 diff 산출물 생성
+   - 같은 sample/page에 대해 native preview PNG를 만들고 reference와 pixel diff를 계산한다.
+   - changed pixels, changed percent, mean/max RGB delta, non-white pixel, page size를 Markdown summary로 출력한다.
+4. Stage 4: v0.1.4 sample set과 후속 이슈 handoff 정리
+   - #116, #122, #121, #110, #282에서 재사용할 대표 샘플과 실행 명령을 고정한다.
+   - 한계, editor chrome 제외, 측정 수치 해석 기준을 문서화한다.
+5. Stage 5: 검증, 최종 보고서, PR 준비
+   - shell/Swift syntax, build 가능 범위, 대표 샘플 smoke를 검증한다.
+   - 최종 보고서에 기준 출력, native 출력, diff 수치, 후속 작업 handoff를 남긴다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260525.md mydocs/plans/task_m014_280.md
+rg -n "#280|rhwp-studio|visual diff|preview|Quick Look|Thumbnail|M014|v0.1.4" \
+  mydocs/orders/20260525.md mydocs/plans/task_m014_280.md
+```
+
+구현 단계 후보:
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-preview-diff --page 1 \
+  samples/복학원서.hwp samples/pic-crop-01.hwp samples/form-01.hwp samples/hwpx/form-002.hwpx
+git diff --check
+git status --short --branch
+```
+
+필요 시 추가 검증:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task280-quicklook-policy \
+  samples/복학원서.hwp samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask280 CODE_SIGNING_ALLOWED=NO build
+```
+
+## 리스크
+
+- `rhwp-studio` reference capture가 WebKit/browser event timing, font loading, device scale factor에 민감하면 같은 문서라도 수치가 흔들릴 수 있다.
+- bundled `rhwp-studio` UI의 editor chrome을 잘라내는 기준이 부정확하면 document render 차이와 UI 차이가 섞일 수 있다.
+- macOS CI/로컬 환경에서 headless browser 또는 WebKit helper 실행 가능성이 다를 수 있다.
+- `rhwp-studio`와 native renderer의 font fallback, antialiasing, rasterization 차이는 완전히 0으로 수렴하지 않을 수 있으므로 hard pass/fail threshold를 성급히 두면 안 된다.
+- 대용량/다중 페이지 문서는 reference capture 시간이 길 수 있어 기본 sample set과 확장 sample set을 분리해야 한다.
+
+## 승인 요청 사항
+
+1. #280을 `rhwp-studio` reference capture + native preview diff harness 구축 작업으로 진행하는 범위 승인
+2. Finder preview/thumbnail parity 기준에서 margin guide, menu, toolbar, selection/caret 등 editor chrome을 제외하는 정책 승인
+3. visual diff 수치는 후속 렌더 개선의 판단 자료로 사용하되, 이번 작업에서 release hard gate로 만들지 않는 방향 승인
+4. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m014_280_impl.md`) 작성과 Stage 1 inventory 진행
+
+승인 전에는 Swift source, script, renderer 동작 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m014_280_impl.md
+++ b/mydocs/plans/task_m014_280_impl.md
@@ -1,0 +1,332 @@
+# Task M014 #280 구현 계획서
+
+수행계획서: `mydocs/plans/task_m014_280.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #280 rhwp-studio 기준 preview visual diff harness 구축
+- 마일스톤: M014 (`v0.1.4 Native Preview/Viewer Parity`)
+- 브랜치: `local/task280`
+- 작업 위치: `/Users/melee/Documents/projects/rhwp-mac`
+- 기준 브랜치: `devel`
+- 목표: bundled `rhwp-studio` 기본 렌더 결과와 Swift/native preview 출력을 같은 샘플/페이지 단위로 생성하고, diff 이미지와 수치 summary를 남기는 반복 실행 harness를 만든다.
+
+## 구현 원칙
+
+- renderer 자체는 변경하지 않는다. #280은 측정/비교 harness만 추가한다.
+- reference는 `Sources/HostApp/Resources/rhwp-studio`에 bundled 된 정적 asset snapshot을 사용한다.
+- `rhwp-core.lock`과 `rhwp-studio/manifest.json`의 release tag, resolved commit, asset hash를 summary에 기록한다.
+- Finder preview/thumbnail parity 기준에서 menu, toolbar, status bar, ruler, selection/caret 등 editor chrome은 제외한다.
+- `rhwp-studio` canvas 내부에 margin guide가 그려져 분리할 수 없는 경우, diff summary에서 editor chrome residual로 분류하거나 mask 후보로 남긴다. 이번 작업에서 renderer 동작을 바꿔 제거하지 않는다.
+- visual diff 수치는 후속 렌더 개선의 판단 자료다. 이번 이슈에서 release hard gate threshold를 만들지 않는다.
+- `Sources/RhwpCoreBridge`에 AppKit/UIKit/WebKit 의존을 추가하지 않는다. WebKit/AppKit 사용은 `scripts/` helper 안에만 둔다.
+- upstream `edwardkim/rhwp` 수정, unreleased commit pin, rhwp-studio asset 갱신은 하지 않는다.
+
+## Harness 구조
+
+새 harness는 shell orchestration과 Swift helper로 구성한다.
+
+| 파일 | 역할 |
+|---|---|
+| `scripts/preview-visual-diff-harness.sh` | staticlib/modulemap 존재 확인, Swift helper compile, 기본 sample/page 인자 전달 |
+| `scripts/preview_visual_diff_harness.swift` | WebKit reference capture, native preview render, pixel diff, summary 작성 |
+| `mydocs/tech/v014_preview_visual_diff_harness.md` | 사용법, sample set, editor chrome 제외 정책, 수치 해석 기준 문서화 |
+
+기본 산출물 구조:
+
+```text
+<output-dir>/
+  studio/
+    {file}-page{N}-studio.png
+    {file}-page{N}-studio.json
+  native/
+    {file}-page{N}-native.png
+    {file}-page{N}-native.json
+  diff/
+    {file}-page{N}-diff.png
+  summary.md
+```
+
+Swift helper의 기본 CLI:
+
+```bash
+./scripts/preview-visual-diff-harness.sh <output-dir> [--page N] [--policy coreGraphicsOnly|skiaOptIn] <hwp-or-hwpx> [...]
+```
+
+초기 default는 `--policy coreGraphicsOnly`로 둔다. Skia opt-in 비교는 같은 harness 옵션으로 가능하게 하되, Skia release 판단은 #259/M20 쪽 결정으로 남긴다.
+
+## Reference Capture 설계
+
+`rhwp-studio` reference capture는 standalone Swift/WebKit helper에서 수행한다.
+
+1. `WKWebViewConfiguration`에 script-local URL scheme handler를 등록한다.
+   - `alhangeul-studio://app/...`는 `Sources/HostApp/Resources/rhwp-studio` 파일을 제공한다.
+   - `alhangeul-document://current?revision=...`는 현재 입력 문서 bytes를 제공한다.
+2. `alhangeul-studio://app/index.html?url=alhangeul-document://current?revision=...&filename=...`로 로드한다.
+3. navigation 완료 후 JavaScript polling으로 문서 로드 완료와 page element를 확인한다.
+4. menu/toolbar/status/ruler chrome을 숨기는 CSS를 주입한다.
+5. page content bounding rect를 계산하고 `WKWebView.takeSnapshot`으로 해당 rect를 PNG로 저장한다.
+6. capture metadata에는 selector, rect, devicePixelRatio, viewport size, page number, load timing, reference provenance를 기록한다.
+
+page selector는 Stage 1에서 확정한다. 후보 순서는 다음과 같다.
+
+1. `#scroll-content` 아래 page wrapper
+2. page별 canvas의 부모 element
+3. 첫 번째 visible page canvas와 overlay를 포함하는 가장 가까운 block ancestor
+
+canvas만 직접 추출하면 DOM overlay image가 빠질 수 있으므로, Stage 2 구현은 canvas 단독 `toDataURL`이 아니라 page wrapper snapshot을 우선한다.
+
+## Native Preview Render 설계
+
+native 출력은 기존 Shared renderer 경로를 사용한다.
+
+- 입력: `RhwpDocument(data:filename:)`
+- 기본: `HwpPageImageRenderer.renderPage(document:pageIndex:policy:)`
+- 옵션: `coreGraphicsOnly`, `skiaOptIn`
+- 크기 정렬: reference PNG 크기와 native PNG 크기가 다르면 native output을 reference 크기에 맞춰 rasterize한 뒤 diff한다. 원본 크기는 metadata에 따로 기록한다.
+- diagnostics: `backendUsed`, `fallbackReason`, `pixelSize`, `pngBytes`, `durationMs`를 native metadata에 기록한다.
+
+기존 `scripts/render-debug-compare.sh`는 render tree/core SVG 분석 보조 도구로 유지하고, 이번 harness의 native baseline은 Quick Look/Thumbnail이 공유하는 `HwpPageImageRenderer` 계층을 기준으로 한다.
+
+## Diff Metrics
+
+기존 `visual_compare_quicklook_renderers.swift`의 pixel diff 방식을 재사용하되, #280 helper 안에서 다음 값을 summary에 남긴다.
+
+| 지표 | 의미 |
+|---|---|
+| `changedPixels` / `changedPercent` | threshold 초과 pixel 수와 비율 |
+| `meanRGBDelta` | 전체 RGB 평균 차이 |
+| `maxRGBDelta` | 가장 큰 채널 차이 |
+| `diffBounds` | 차이가 발생한 bounding box |
+| `studioNonWhitePixels` / `nativeNonWhitePixels` | blank/empty 회귀 감지용 |
+| `studioSize` / `nativeSize` / `compareSize` | 크기 정렬 결과 |
+| `studioCaptureMs` / `nativeRenderMs` / `diffMs` | 성능 관찰값 |
+
+초기 pixel delta threshold는 기존 비교 helper와 맞춰 12로 둔다. threshold는 hard gate가 아니라 관찰 기준이다.
+
+## Stage 1. Inventory와 capture selector 확정
+
+### 목표
+
+기존 script, bundled `rhwp-studio` DOM 구조, HostApp scheme handler, Shared renderer contract를 확인하고 Stage 2-4의 구현 경계를 고정한다.
+
+### 작업
+
+- `scripts/render-debug-compare.sh`, `visual-compare-quicklook-renderers.sh`, `smoke-quicklook-skia-policy.sh`의 입력/산출물을 정리한다.
+- bundled `rhwp-studio` `index.html`, CSS, minified JS에서 page container, scroll container, canvas/overlay 구조 후보를 확인한다.
+- HostApp의 `RhwpStudioResourceSchemeHandler`, `RhwpStudioDocumentSchemeHandler`, `RhwpStudioResourceLocator`를 참고해 script-local scheme handler 범위를 확정한다.
+- Stage 2에서 사용할 WebKit capture readiness 조건과 selector fallback 순서를 정한다.
+- Stage 1 보고서에 확정된 파일/명령/selector 후보/리스크를 남긴다.
+
+### 산출물
+
+- `mydocs/plans/task_m014_280_impl.md`
+- `mydocs/working/task_m014_280_stage1.md`
+
+### 검증
+
+```bash
+rg -n "scroll-container|scroll-content|canvas|overlay|ruler|status-bar|renderPageToCanvasFiltered|loadFromUrlParam" \
+  Sources/HostApp/Resources/rhwp-studio/index.html \
+  Sources/HostApp/Resources/rhwp-studio/assets/index-*.css \
+  Sources/HostApp/Resources/rhwp-studio/assets/index-*.js
+rg -n "HwpPageImageRenderer|HwpRenderedPage|backendUsed|fallbackReason|renderPage\\(" \
+  Sources/Shared Sources/QLExtension scripts
+git diff --check
+```
+
+### 완료 기준
+
+- Stage 2에서 구현할 capture URL, selector, wait condition, metadata 필드가 보고서에 고정된다.
+- 아직 script/source 구현은 시작하지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #280 Stage 1: preview diff harness 구조 확정
+```
+
+## Stage 2. rhwp-studio reference capture 구현
+
+### 목표
+
+bundled `rhwp-studio`가 실제로 문서를 열어 렌더한 첫 page content 영역을 PNG와 metadata로 저장한다.
+
+### 작업
+
+- `scripts/preview-visual-diff-harness.sh`를 추가해 Swift helper compile과 실행을 담당하게 한다.
+- `scripts/preview_visual_diff_harness.swift`에 WebKit runner, script-local resource/document scheme handler, PNG writer를 구현한다.
+- page load 완료 polling, page rect 계산, editor chrome CSS hide, `takeSnapshot` 저장을 구현한다.
+- reference provenance와 capture timing metadata를 JSON으로 저장한다.
+- sample 1-2개로 `studio/*.png`와 `studio/*.json`이 생성되는지 smoke한다.
+
+### 산출물
+
+- `scripts/preview-visual-diff-harness.sh`
+- `scripts/preview_visual_diff_harness.swift`
+- `mydocs/working/task_m014_280_stage2.md`
+
+### 검증
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-stage2 --page 1 \
+  samples/basic/request.hwp samples/복학원서.hwp
+find build.noindex/task280-stage2/studio -maxdepth 1 -type f | sort
+git diff --check
+```
+
+### 완료 기준
+
+- `rhwp-studio` reference PNG와 metadata JSON이 생성된다.
+- metadata에 selector, rect, page number, devicePixelRatio, viewport, provenance가 남는다.
+- editor chrome 제외 정책이 capture CSS/metadata에 반영된다.
+
+### 커밋 메시지
+
+```text
+Task #280 Stage 2: rhwp-studio reference capture 추가
+```
+
+## Stage 3. native preview 출력과 diff 계산 구현
+
+### 목표
+
+같은 입력 문서와 page에 대해 native preview PNG를 생성하고, `rhwp-studio` reference와 pixel diff를 계산한다.
+
+### 작업
+
+- Swift helper에 `RhwpDocument`와 `HwpPageImageRenderer` 기반 native render 경로를 추가한다.
+- `--policy coreGraphicsOnly|skiaOptIn` 옵션을 구현한다.
+- reference/native 크기 차이를 metadata에 기록하고, 비교용 image는 reference 크기로 정렬한다.
+- diff PNG와 `summary.md`를 생성한다.
+- failure row가 있는 경우에도 나머지 파일을 계속 처리하게 한다.
+
+### 산출물
+
+- `scripts/preview_visual_diff_harness.swift`
+- 필요 시 `scripts/preview-visual-diff-harness.sh`
+- `mydocs/working/task_m014_280_stage3.md`
+
+### 검증
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-stage3 --page 1 \
+  samples/basic/request.hwp samples/복학원서.hwp
+find build.noindex/task280-stage3 -maxdepth 2 -type f | sort
+sed -n '1,120p' build.noindex/task280-stage3/summary.md
+git diff --check
+```
+
+### 완료 기준
+
+- `studio`, `native`, `diff`, `summary.md` 산출물이 모두 생성된다.
+- summary에 changed pixel, RGB delta, non-white pixel, backend diagnostics가 기록된다.
+- 개별 파일 실패가 전체 harness 실패 원인으로 명확히 보고된다.
+
+### 커밋 메시지
+
+```text
+Task #280 Stage 3: native preview diff 계산 추가
+```
+
+## Stage 4. sample set과 사용 문서 정리
+
+### 목표
+
+v0.1.4 렌더 개선 이슈들이 공통으로 재사용할 sample set, 실행 명령, 수치 해석 기준, 한계를 문서화한다.
+
+### 작업
+
+- 기본 sample set과 확장 sample set을 정한다.
+- `mydocs/tech/v014_preview_visual_diff_harness.md`에 사용법과 산출물 설명을 작성한다.
+- editor chrome 제외와 margin guide residual 처리 기준을 명시한다.
+- #116, #122, #121, #110, #282에서 어떤 샘플과 수치를 봐야 하는지 handoff를 정리한다.
+
+### 기본 sample set 후보
+
+| 목적 | 샘플 |
+|---|---|
+| 일반 HWP smoke | `samples/basic/request.hwp` |
+| watermark/effect | `samples/복학원서.hwp` |
+| image crop/fill | `samples/pic-crop-01.hwp` |
+| form/placeholder | `samples/form-01.hwp`, `samples/hwpx/form-002.hwpx` |
+| HWPX smoke | `samples/hwpx/hwpx-01.hwpx` |
+
+확장 후보는 `samples/tac-img-02.hwp`, `samples/tac-img-02.hwpx`, `samples/eq-01.hwp`, `samples/draw-group.hwp`, `samples/table-vpos-01.hwp`를 둔다.
+
+### 산출물
+
+- `mydocs/tech/v014_preview_visual_diff_harness.md`
+- `mydocs/working/task_m014_280_stage4.md`
+
+### 검증
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-stage4 --page 1 \
+  samples/basic/request.hwp samples/복학원서.hwp samples/pic-crop-01.hwp \
+  samples/form-01.hwp samples/hwpx/form-002.hwpx samples/hwpx/hwpx-01.hwpx
+rg -n "#116|#122|#121|#110|#282|rhwp-studio|editor chrome|margin guide|changedPixels" \
+  mydocs/tech/v014_preview_visual_diff_harness.md build.noindex/task280-stage4/summary.md
+git diff --check
+```
+
+### 완료 기준
+
+- 후속 이슈에서 그대로 실행할 기본 명령과 sample set이 문서화된다.
+- visual diff 수치의 해석 범위와 제외 항목이 명확히 남는다.
+
+### 커밋 메시지
+
+```text
+Task #280 Stage 4: preview diff sample set 문서화
+```
+
+## Stage 5. 최종 검증과 PR 준비
+
+### 목표
+
+전체 harness가 대표 샘플에서 동작하는지 확인하고, 최종 보고서와 오늘할일 완료 처리를 수행해 PR 게시 준비 상태로 만든다.
+
+### 작업
+
+- 대표 sample set으로 최종 smoke를 실행한다.
+- shell/Swift syntax, source boundary, bundled asset verification을 수행한다.
+- 최종 보고서에 관찰된 수치, 한계, 후속 이슈 handoff를 정리한다.
+- 오늘할일을 완료로 갱신한다.
+
+### 산출물
+
+- `mydocs/report/task_m014_280_report.md`
+- `mydocs/orders/20260525.md`
+
+### 검증
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-final --page 1 \
+  samples/basic/request.hwp samples/복학원서.hwp samples/pic-crop-01.hwp \
+  samples/form-01.hwp samples/hwpx/form-002.hwpx samples/hwpx/hwpx-01.hwpx
+swiftc -parse-as-library scripts/preview_visual_diff_harness.swift \
+  -framework AppKit -framework WebKit -framework CoreGraphics -framework ImageIO -framework UniformTypeIdentifiers \
+  -o /tmp/task280-syntax-check
+rg -n "#280|changedPixels|meanRGBDelta|rhwp-studio|#116|#122|#121|#110|#282" \
+  mydocs/report/task_m014_280_report.md mydocs/orders/20260525.md
+git diff --check
+git status --short --branch
+```
+
+### 완료 기준
+
+- 대표 sample set에서 `summary.md`와 PNG/JSON 산출물이 생성된다.
+- 최종 보고서에 smoke 측정 결과, 관찰, 수치 비교자료, 한계, 후속 handoff가 기록된다.
+- 작업 브랜치에 미커밋 변경이 없다.
+
+### 커밋 메시지
+
+```text
+Task #280 Stage 5: preview diff harness 최종 보고
+```

--- a/mydocs/report/task_m014_280_report.md
+++ b/mydocs/report/task_m014_280_report.md
@@ -1,0 +1,193 @@
+# Task M014 #280 최종 보고서 - rhwp-studio 기준 preview visual diff harness 구축
+
+## 작업 개요
+
+- 이슈: #280 rhwp-studio 기준 preview visual diff harness 구축
+- 마일스톤: M014 `v0.1.4 Native Preview/Viewer Parity`
+- 브랜치: `local/task280`
+- 목표: bundled `rhwp-studio` 기본 렌더 결과와 Swift/native preview 출력을 같은 샘플/page 단위로 생성하고, diff 이미지와 수치 summary를 반복 실행 가능한 형태로 남긴다.
+
+## 최종 결론
+
+`scripts/preview-visual-diff-harness.sh`와 `scripts/preview_visual_diff_harness.swift`를 추가해 v0.1.4 native 렌더 개선 작업의 기준 harness를 구축했다.
+
+현재 harness는 다음을 생성한다.
+
+```text
+<output-dir>/
+  studio/
+    {file}-page{N}-studio.png
+    {file}-page{N}-studio.json
+  native/
+    {file}-page{N}-native.png
+    {file}-page{N}-native.json
+  diff/
+    {file}-page{N}-diff.png
+  summary.md
+```
+
+기본 비교 정책은 `coreGraphicsOnly`이며, `--policy skiaOptIn`으로 Skia optional backend도 관찰할 수 있다. 최종 sample set 6개는 모두 OK로 산출물이 생성됐다.
+
+## 주요 산출물
+
+| 파일 | 역할 |
+|---|---|
+| `scripts/preview-visual-diff-harness.sh` | asset 검증, Swift helper compile, 입력/옵션 전달 |
+| `scripts/preview_visual_diff_harness.swift` | Studio reference capture, native render, pixel diff, summary 생성 |
+| `mydocs/tech/v014_preview_visual_diff_harness.md` | 사용법, sample set, 수치 해석, 후속 handoff 문서 |
+| `mydocs/working/task_m014_280_stage1.md` | inventory와 capture selector 확정 |
+| `mydocs/working/task_m014_280_stage2.md` | Studio reference capture 구현 보고 |
+| `mydocs/working/task_m014_280_stage3.md` | native render와 diff 구현 보고 |
+| `mydocs/working/task_m014_280_stage4.md` | sample set 문서화 보고 |
+
+## 최종 실행 명령
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-final --page 1 \
+  samples/basic/request.hwp samples/복학원서.hwp samples/pic-crop-01.hwp \
+  samples/form-01.hwp samples/hwpx/form-002.hwpx samples/hwpx/hwpx-01.hwpx
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task280-syntax-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task280-syntax-clang-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task280-syntax-check
+```
+
+최종 smoke 산출물 위치:
+
+```text
+build.noindex/task280-final/
+```
+
+## 최종 smoke 측정 결과
+
+기준:
+
+- Page: `1`
+- NativePolicy: `coreGraphicsOnly`
+- StudioReleaseTag: `v0.7.12`
+- StudioResolvedCommit: `1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5`
+- Viewport: `1400x1800`
+- SettleMs: `120`
+- DiffPixelThreshold: `12`
+
+| 파일 | StudioSize | NativeSize | CompareSize | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | NativeBackend | NativeMs |
+|---|---:|---:|---:|---:|---:|---:|---:|---|---|---:|
+| `request.hwp` | `1133x1587` | `567x794` | `1133x1587` | `325488/1798071` | `18.1021%` | `11.5796` | `255` | `36,36 1061x1515` | `coreGraphics` | `1037.0ms` |
+| `복학원서.hwp` | `1587x2245` | `794x1123` | `1587x2245` | `1153323/3562815` | `32.3711%` | `42.9364` | `255` | `83,45 1436x2155` | `coreGraphics` | `389.4ms` |
+| `pic-crop-01.hwp` | `1587x2245` | `794x1123` | `1587x2245` | `72763/3562815` | `2.0423%` | `0.8092` | `186` | `121,234 1345x1814` | `coreGraphics` | `3.1ms` |
+| `form-01.hwp` | `1587x2245` | `794x1123` | `1587x2245` | `28738/3562815` | `0.8066%` | `0.4845` | `255` | `197,234 1194x1814` | `coreGraphics` | `2.1ms` |
+| `form-002.hwpx` | `1587x2244` | `794x1123` | `1587x2244` | `601515/3561228` | `16.8907%` | `17.6360` | `255` | `121,159 1345x1962` | `coreGraphics` | `25.3ms` |
+| `hwpx-01.hwpx` | `1587x2245` | `794x1123` | `1587x2245` | `540973/3562815` | `15.1839%` | `15.6722` | `255` | `121,159 1345x1981` | `coreGraphics` | `29.8ms` |
+
+모든 row는 `OK`다. `studio`, `native`, `diff`, `summary.md` 산출물이 모두 생성됐다.
+
+Studio reference metadata는 모두 `captureMode=canvasDataURL`, `overlayIncluded=false`였다. `overlayCount`는 `복학원서.hwp`가 `5`, 나머지 기본 샘플이 `1`이었다.
+
+## 추가 Skia 관찰
+
+Stage 3에서 `--policy skiaOptIn` smoke를 별도로 확인했다.
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-stage3-skia --page 1 \
+  --policy skiaOptIn samples/basic/request.hwp
+```
+
+결과:
+
+| 파일 | StudioSize | NativeSize | ChangedPercent | MeanRGBDelta | NativeBackend | NativeMs |
+|---|---:|---:|---:|---:|---|---:|
+| `request.hwp` | `1133x1587` | `567x794` | `12.4856%` | `9.5936` | `skia` | `53.9ms` |
+
+단일 샘플 기준으로 Skia는 CoreGraphics보다 changedPercent와 mean delta가 낮았다. 이 수치는 관찰 자료이며, Skia default 전환 판단은 M20/#259 범위로 남긴다.
+
+## 관찰과 얻은 점
+
+### Studio capture
+
+초기 설계는 `WKWebView.takeSnapshot`으로 page rect를 캡처하는 방식이었다. 실제 smoke에서는 `takeSnapshot`이 canvas 배경은 잡지만 canvas backing store의 문서 내용을 빈 화면처럼 캡처하는 현상이 있었다.
+
+JavaScript로 canvas backing store를 샘플링하면 non-white pixel이 확인되어, `rhwp-studio` 렌더 자체는 완료된 상태임을 확인했다. 따라서 reference PNG는 다음 방식으로 고정했다.
+
+- WebKit에서 bundled `rhwp-studio`를 실제로 로드한다.
+- `#scroll-content canvas`를 page selector로 사용한다.
+- canvas backing store를 `toDataURL('image/png')`로 export한다.
+- 투명 배경은 흰색 임시 canvas에 합성한다.
+- DOM overlay는 PNG에 포함하지 않고 metadata에 기록한다.
+
+### Native render
+
+native 출력은 `HwpPageImageRenderer.renderPage(document:pageIndex:policy:)`를 사용한다. JSON metadata에는 `policy`, `backendUsed`, `fallbackReason`, `pageSize`, `pixelSize`, `pngBytes`, `renderMs`가 기록된다.
+
+### Diff
+
+diff는 Studio reference 크기를 기준으로 한다. 현재 Studio canvas backing store는 device scale 2에 가깝고, native CoreGraphics output은 page point 기준 scale 1이다. 따라서 native output을 Studio 크기로 확대해 비교한다.
+
+## 한계
+
+- `captureMode=canvasDataURL`이므로 DOM overlay는 reference PNG에 포함되지 않는다.
+- `overlayIncluded=false`이며, overlay 후보 수는 `studio/*.json`의 `overlayCount`로만 추적한다.
+- canvas 내부 margin guide, crop mark, editor guide는 PNG에 남을 수 있다.
+- `ChangedPercent`는 release hard gate가 아니다. scale 차이, antialiasing, text shaping, editor residual 영향을 함께 본다.
+- Codex sandbox 안에서는 WKWebView가 WebKit/Cache/GPU/LaunchServices sandbox extension을 만들지 못해 smoke가 정상 완료되지 않았다. WKWebView smoke는 sandbox 밖 실행 승인을 받아 수행했다.
+- `request.hwp`와 `pic-crop-01.hwp`에서 기존 renderer의 `LAYOUT_OVERFLOW` stderr가 관찰됐다. harness 실패는 아니지만 후속 renderer 개선에서 참고할 수 있다.
+
+## 후속 이슈 handoff
+
+### #282 Quick Look/Thumbnail native compositor
+
+- 기본 샘플: `request.hwp`, `복학원서.hwp`
+- 확장 샘플: `tac-img-02.hwp`, `tac-img-02.hwpx`
+- `StudioCapture=canvasDataURL`, `overlayIncluded=false` 한계를 PR에 명시한다.
+- `studio/*.json`의 `overlayCount`를 보고 overlay 후보가 있는 샘플을 우선 확인한다.
+
+### #116 복학원서 JPEG watermark/effect
+
+- 기본 샘플: `복학원서.hwp`
+- 추가 후보: `20250130-hongbo.hwp`, `aift.hwp`
+- watermark/effect 주변 `DiffBounds`, `ChangedPercent`, `MeanRGBDelta` 전후 비교를 남긴다.
+
+### #122 image fill mode/tile/placement
+
+- 기본 샘플: `pic-crop-01.hwp`
+- 확장 샘플: `tac-img-02.hwp`, `tac-img-02.hwpx`
+- image crop/fill 영역 diff와 tile/placement 변경 전후 수치를 남긴다.
+
+### #121 RawSvg/OLE/chart resource
+
+- 기본 후보: `draw-group.hwp`, `eq-01.hwp`
+- 작업 중 확인한 RawSvg/OLE/chart 전용 샘플을 추가한다.
+- resource 미지원과 layout/scale 차이를 분리해 기록한다.
+
+### #110 Placeholder/FormObject static preview
+
+- 기본 샘플: `form-01.hwp`, `hwpx/form-002.hwpx`
+- placeholder/form object 영역의 diff bounds와 HWP/HWPX 양쪽 개선 여부를 확인한다.
+
+## 검증 결과
+
+| 검증 | 결과 |
+|---|---|
+| `./scripts/verify-rhwp-studio-assets.sh` | OK |
+| `./scripts/check-no-appkit.sh` | OK |
+| `./scripts/preview-visual-diff-harness.sh build.noindex/task280-final ...` | OK |
+| full dependency `swiftc -parse-as-library ... scripts/preview_visual_diff_harness.swift ...` | OK |
+| `git diff --check` | OK |
+
+## 남은 작업
+
+#280 자체의 harness 구축은 완료됐다. 이후 v0.1.4 렌더 품질 개선은 #283, #281, #282, #116, #122, #121, #110 순서로 이 harness의 sample set과 summary row를 재사용해 진행한다.

--- a/mydocs/tech/v014_preview_visual_diff_harness.md
+++ b/mydocs/tech/v014_preview_visual_diff_harness.md
@@ -1,0 +1,233 @@
+# v0.1.4 preview visual diff harness
+
+## 목적
+
+이 문서는 v0.1.4 Native Preview/Viewer Parity 작업에서 `rhwp-studio` 기본 렌더와 native preview renderer 출력을 같은 입력/page 단위로 비교하는 방법을 정리한다.
+
+이 harness의 1차 목적은 후속 렌더 개선 이슈가 전후 수치를 같은 형식으로 남기게 하는 것이다. `changedPixels`나 `changedPercent`는 release hard gate가 아니라 관찰 지표다.
+
+## 기본 실행
+
+기본 정책은 현재 native preview 기준선인 `coreGraphicsOnly`다.
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-stage4 --page 1 \
+  samples/basic/request.hwp \
+  samples/복학원서.hwp \
+  samples/pic-crop-01.hwp \
+  samples/form-01.hwp \
+  samples/hwpx/form-002.hwpx \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+Skia optional backend를 비교할 때만 `--policy skiaOptIn`을 명시한다.
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-skia-check --page 1 \
+  --policy skiaOptIn samples/basic/request.hwp
+```
+
+CLI 옵션:
+
+| 옵션 | 기본값 | 의미 |
+|---|---|---|
+| `--page N` | `1` | 1-based page 번호 |
+| `--policy coreGraphicsOnly|skiaOptIn` | `coreGraphicsOnly` | native renderer backend policy |
+| `--viewport WIDTHxHEIGHT` | `1400x1800` | `rhwp-studio` WKWebView viewport |
+| `--settle-ms N` | `120` | Studio load 후 추가 settle 시간 |
+| `--resource-dir DIR` | `Sources/HostApp/Resources/rhwp-studio` | bundled Studio resource directory |
+
+## 산출물
+
+```text
+<output-dir>/
+  studio/
+    {file}-page{N}-studio.png
+    {file}-page{N}-studio.json
+  native/
+    {file}-page{N}-native.png
+    {file}-page{N}-native.json
+  diff/
+    {file}-page{N}-diff.png
+  summary.md
+```
+
+주요 파일:
+
+| 파일 | 용도 |
+|---|---|
+| `summary.md` | 샘플별 Studio/native/diff 요약표 |
+| `studio/*.png` | `rhwp-studio` 기준 reference PNG |
+| `studio/*.json` | Studio provenance, capture mode, overlay metadata |
+| `native/*.png` | `HwpPageImageRenderer` native preview PNG |
+| `native/*.json` | native backend, fallback, size, timing metadata |
+| `diff/*.png` | threshold 12 기준 pixel diff visualization |
+
+## 수치 해석 기준
+
+summary 주요 필드:
+
+| 필드 | 의미 |
+|---|---|
+| `StudioSize` | Studio reference PNG 크기 |
+| `NativeSize` | native renderer 원본 PNG 크기 |
+| `CompareSize` | diff 계산 크기. 현재 Studio reference 크기와 같다 |
+| `ChangedPixels` | threshold 12를 넘은 pixel 수와 전체 pixel 수 |
+| `ChangedPercent` | `ChangedPixels / totalPixels * 100` |
+| `MeanRGBDelta` | 전체 RGB 채널 평균 차이 |
+| `MaxRGBDelta` | 가장 큰 채널 차이 |
+| `DiffBounds` | 차이가 발생한 bounding box |
+| `StudioCapture` | 현재 `canvasDataURL` |
+| `NativeBackend` | `coreGraphics`, `skia`, 또는 fallback reason 포함 |
+| `NativeMs` | native render duration |
+
+현재 Studio reference는 device scale 2에 가까운 canvas backing store 크기로 생성되고, native CoreGraphics output은 page point 기준 scale 1 PNG로 생성된다. 따라서 diff는 native output을 Studio reference 크기에 맞춰 확대해 계산한다.
+
+이 때문에 수치가 다음 요인의 영향을 받을 수 있다.
+
+- scale 차이로 인한 antialiasing 차이
+- Studio canvas와 CoreGraphics/CoreText text shaping 차이
+- canvas 내부 editor guide 또는 margin guide 잔류
+- DOM overlay가 reference PNG에 포함되지 않는 한계
+
+결론을 쓸 때는 `ChangedPercent` 하나만 보지 말고 `DiffBounds`, `MeanRGBDelta`, 원본 `studio/native/diff` PNG를 같이 확인한다.
+
+## editor chrome과 margin guide
+
+Finder Quick Look/Thumbnail parity 기준에서 menu, toolbar, status bar, ruler, selection/caret 같은 editor chrome은 비교 대상에서 제외한다.
+
+Stage 2-3 helper는 DOM chrome을 숨기고 Studio page canvas를 capture한다. 다만 현재 reference PNG는 `WKWebView.takeSnapshot`이 canvas 내용을 안정적으로 잡지 못해 `canvasDataURL` 기반으로 저장한다.
+
+현재 한계:
+
+- `captureMode=canvasDataURL`
+- `overlayIncluded=false`
+- DOM overlay는 PNG에 포함하지 않고 `studio/*.json`의 `overlayCount`와 `overlayIncluded`로 기록한다.
+- canvas 내부 margin guide, crop mark, editor guide는 PNG에 남을 수 있다.
+
+따라서 #282 이전에는 overlay가 빠진 차이를 native compositor 회귀로 단정하지 않는다. #282는 이 한계를 줄이기 위해 PageLayerTree overlay metadata와 native compositor 순서를 맞추는 작업이다.
+
+## 기본 sample set
+
+v0.1.4 렌더 개선 이슈의 공통 smoke는 다음 6개를 기본으로 둔다.
+
+| 목적 | 샘플 | 주요 확인 포인트 |
+|---|---|---|
+| 일반 HWP smoke | `samples/basic/request.hwp` | 표, 이미지 로고, 붉은 텍스트, 기본 flow |
+| watermark/effect | `samples/복학원서.hwp` | JPEG watermark/effect, 투명키, 큰 form layout |
+| image crop/fill | `samples/pic-crop-01.hwp` | 이미지 crop, clip, 배치 |
+| form/placeholder HWP | `samples/form-01.hwp` | form placeholder, 정적 form object |
+| form/placeholder HWPX | `samples/hwpx/form-002.hwpx` | HWPX form/static preview |
+| HWPX smoke | `samples/hwpx/hwpx-01.hwpx` | HWPX multi-page open/render smoke |
+
+Stage 4 기준 smoke 결과:
+
+| 파일 | ChangedPercent | MeanRGBDelta | NativeBackend | NativeMs |
+|---|---:|---:|---|---:|
+| `request.hwp` | `18.1021%` | `11.5796` | `coreGraphics` | `1049.1ms` |
+| `복학원서.hwp` | `32.3726%` | `42.9398` | `coreGraphics` | `415.3ms` |
+| `pic-crop-01.hwp` | `2.0423%` | `0.8092` | `coreGraphics` | `6.7ms` |
+| `form-01.hwp` | `0.8066%` | `0.4845` | `coreGraphics` | `2.2ms` |
+| `form-002.hwpx` | `16.8925%` | `17.6456` | `coreGraphics` | `35.5ms` |
+| `hwpx-01.hwpx` | `15.1839%` | `15.6722` | `coreGraphics` | `29.0ms` |
+
+Stage 4 smoke 산출물 위치:
+
+```text
+build.noindex/task280-stage4/
+```
+
+## 확장 sample set
+
+작업 범위가 맞을 때만 추가 실행한다.
+
+| 목적 | 샘플 |
+|---|---|
+| image/table anchored content | `samples/tac-img-02.hwp`, `samples/tac-img-02.hwpx` |
+| equation | `samples/eq-01.hwp` |
+| grouped drawing | `samples/draw-group.hwp` |
+| table vertical positioning | `samples/table-vpos-01.hwp` |
+
+## 후속 이슈 handoff
+
+### #282 Quick Look/Thumbnail native compositor
+
+추천 샘플:
+
+- `samples/basic/request.hwp`
+- `samples/복학원서.hwp`
+- `samples/tac-img-02.hwp`
+- `samples/tac-img-02.hwpx`
+
+확인할 항목:
+
+- `StudioCapture=canvasDataURL`, `overlayIncluded=false` 한계를 PR에 명시한다.
+- `studio/*.json`의 `overlayCount`를 확인해 DOM overlay 후보가 있는 샘플을 우선 본다.
+- native compositor 순서가 background, BehindText overlay, flow, InFrontOfText overlay에 가까워졌는지 diff bounds와 PNG로 확인한다.
+
+### #116 복학원서 JPEG watermark/effect
+
+추천 샘플:
+
+- `samples/복학원서.hwp`
+- 필요 시 `samples/20250130-hongbo.hwp`, `samples/aift.hwp`
+
+확인할 항목:
+
+- watermark/effect 보정 전후의 `ChangedPercent`, `MeanRGBDelta`, `DiffBounds`
+- 붉은 도장/워터마크 주변 diff가 줄었는지 PNG로 확인
+- canvas 내부 margin guide residual과 실제 image effect 차이를 구분
+
+### #122 image fill mode/tile/placement
+
+추천 샘플:
+
+- `samples/pic-crop-01.hwp`
+- `samples/tac-img-02.hwp`
+- `samples/tac-img-02.hwpx`
+
+확인할 항목:
+
+- image crop/fill 영역의 `DiffBounds`
+- tile/placement 변경 전후 `ChangedPercent`
+- native `*.json`의 backend/fallback이 바뀌지 않았는지 확인
+
+### #121 RawSvg/OLE/chart resource
+
+추천 샘플:
+
+- `samples/draw-group.hwp`
+- `samples/eq-01.hwp`
+- 이슈 작업 중 확인한 RawSvg/OLE/chart 전용 샘플
+
+확인할 항목:
+
+- 새 resource 렌더링 영역의 diff가 줄었는지 확인
+- resource 미지원 상태와 layout/scale 차이를 분리해 기록
+
+### #110 Placeholder/FormObject static preview
+
+추천 샘플:
+
+- `samples/form-01.hwp`
+- `samples/hwpx/form-002.hwpx`
+
+확인할 항목:
+
+- placeholder/form object 영역의 `DiffBounds`
+- 정적 preview 보강 전후 `ChangedPercent`
+- HWP와 HWPX 모두에서 같은 방향으로 개선되는지 확인
+
+## 보고서 기록 기준
+
+후속 PR/단계 보고서에는 최소 다음을 남긴다.
+
+- 실행 명령
+- input sample set
+- `summary.md` 전체 또는 관련 row
+- `StudioCapture`, `overlayIncluded`, `NativeBackend`, fallback reason
+- 변경 전후 `ChangedPercent`, `MeanRGBDelta`, `DiffBounds`
+- 시각 확인한 `studio/native/diff` PNG 위치
+- hard gate가 아닌 관찰 지표라는 해석
+
+현재 harness는 반복 측정 도구다. 렌더 개선의 성공 여부는 수치, diff bounds, 실제 PNG 확인, 해당 이슈의 책임 범위를 함께 보고 판단한다.

--- a/mydocs/working/task_m014_280_stage1.md
+++ b/mydocs/working/task_m014_280_stage1.md
@@ -1,0 +1,185 @@
+# Task M014 #280 Stage 1 보고서 - preview diff harness 구조 확정
+
+## 단계 개요
+
+- 이슈: #280 rhwp-studio 기준 preview visual diff harness 구축
+- 단계: Stage 1. Inventory와 capture selector 확정
+- 목표: 기존 비교 script, bundled `rhwp-studio` 렌더 표면, HostApp scheme handler, Shared renderer contract를 확인하고 Stage 2-4 구현 경계를 고정한다.
+
+이번 단계는 조사와 구조 확정만 수행했다. Swift source와 script 구현은 시작하지 않았다.
+
+## 확인한 현재 구조
+
+### 기존 비교와 smoke script
+
+`scripts/render-debug-compare.sh`는 Swift helper를 compile해 render tree JSON, core SVG, native PNG, 선택적 core PNG와 diff 산출물을 생성한다. 문서 내부 render tree와 core renderer를 진단하기에는 유용하지만, bundled `rhwp-studio`가 실제 WebView에서 보여주는 기본 화면을 reference로 캡처하지는 않는다.
+
+`scripts/visual-compare-quicklook-renderers.sh`는 native PNG와 SVG-PDF raster 결과를 비교한다. diff 계산에는 이미 다음 지표가 있다.
+
+| 지표 | 현재 의미 |
+|---|---|
+| `changedPixels` / `changedPercent` | threshold 초과 pixel 수와 비율 |
+| `meanRGBDelta` | RGB 평균 차이 |
+| `maxRGBDelta` | 최대 채널 차이 |
+| `bounds` | 차이가 발생한 bounding box |
+
+`scripts/smoke-quicklook-skia-policy.sh`는 `coreGraphicsOnly`와 `skiaOptIn` 정책별 backend count, PNG bytes, render time을 측정한다. #280 harness는 이 정책 옵션과 diagnostics 표현을 재사용하되, 기준 이미지는 `rhwp-studio` WebKit snapshot으로 둔다.
+
+### rhwp-studio DOM과 렌더 표면
+
+`Sources/HostApp/Resources/rhwp-studio/index.html`의 viewer/editor 영역은 다음 구조다.
+
+```html
+<div id="editor-area">
+  <div id="ruler-corner"></div>
+  <canvas id="h-ruler"></canvas>
+  <canvas id="v-ruler"></canvas>
+  <div id="scroll-container">
+    <div id="scroll-content"></div>
+  </div>
+</div>
+<div id="status-bar">...</div>
+```
+
+CSS 기준으로 문서 page canvas는 `#scroll-content canvas`에 absolute 배치되고, `left: 50%`와 `transform: translate(-50%)`로 가운데 정렬된다. `#scroll-container`는 scrollable viewport이고, `#scroll-content`는 여러 page를 포함하는 문서 content root다.
+
+minified JS 조사 결과 문서 로드는 `?url=...&filename=...` query를 읽어 입력 bytes를 fetch한 뒤 `loadDocument()`로 진행된다. `window.postMessage` 기반 `rhwp-request` API에는 `ready`, `loadFile`, `pageCount`, `getPageSvg` 등이 있지만, 기본 화면 기준 diff에는 `getPageSvg`보다 실제 page 영역 snapshot이 더 적합하다. Studio 기본 렌더는 canvas와 DOM overlay가 함께 보일 수 있기 때문이다.
+
+### HostApp의 Studio resource와 document scheme
+
+HostApp은 다음 custom scheme을 사용한다.
+
+| Scheme | 구현 | 역할 |
+|---|---|---|
+| `alhangeul-studio://app/...` | `RhwpStudioResourceSchemeHandler` | bundled `rhwp-studio` 정적 asset 제공 |
+| `alhangeul-document://current?...` | `RhwpStudioDocumentSchemeHandler` | 현재 문서 bytes 제공 |
+
+`RhwpStudioResourceLocator`는 다음 형태의 URL을 만든다.
+
+```text
+alhangeul-studio://app/index.html?url=alhangeul-document://current?revision=<N>&filename=<name>
+```
+
+다만 HostApp 구현은 `Bundle.main` resource lookup을 전제로 한다. Stage 2의 standalone Swift helper는 앱 bundle 안에서 실행되지 않으므로 HostApp handler를 직접 재사용하지 않고, 같은 scheme과 MIME/CORS/no-store 정책을 script-local handler로 재현한다.
+
+### Native preview renderer contract
+
+`Sources/Shared/HwpPageImageRenderer.swift`는 `HwpPageRenderPolicy.coreGraphicsOnly`와 `skiaOptIn`을 제공한다. 반환값 `HwpRenderedPage`에는 `image`, `size`, `diagnostics`가 있고 diagnostics에는 `backendUsed`, `fallbackReason`, `pageSize`, `pixelSize`, `pngBytes`, `durationMs`가 포함된다.
+
+#280 harness의 native baseline은 Quick Look/Thumbnail이 공유할 이 계층으로 둔다. 기본 정책은 현재 preview 기준과 맞춰 `coreGraphicsOnly`이며, `skiaOptIn`은 옵션으로만 제공한다.
+
+## 확정한 구현 방향
+
+### Reference capture 방식
+
+Stage 2에서는 standalone Swift/WebKit helper를 추가한다.
+
+1. `WKWebViewConfiguration`에 script-local `alhangeul-studio`와 `alhangeul-document` scheme handler를 등록한다.
+2. `Sources/HostApp/Resources/rhwp-studio`의 `index.html`을 `alhangeul-studio://app/index.html?url=...&filename=...`로 연다.
+3. navigation 완료 후 JavaScript polling으로 `#scroll-content canvas` 수와 대상 page canvas의 bounding rect를 확인한다.
+4. `requestAnimationFrame` 두 번과 짧은 settle delay를 둬 비동기 canvas redraw와 image decode 직후의 흔들림을 줄인다.
+5. editor chrome을 숨기는 CSS를 주입한 뒤 `WKWebView.takeSnapshot`으로 page rect를 PNG 저장한다.
+
+canvas 자체의 `toDataURL`은 사용하지 않는다. page rect snapshot을 사용해야 canvas 위/주변의 DOM overlay가 reference에 포함될 수 있다.
+
+### Selector와 rect 기준
+
+Stage 2 기본 selector 기준은 `#scroll-content canvas`의 page index다.
+
+| 우선순위 | 기준 | 판단 |
+|---|---|---|
+| 1 | 대상 page canvas의 bounding rect | page 단위 캡처의 안정적 기준 |
+| 2 | 같은 vertical span과 교차하는 `#scroll-content` 하위 overlay rect를 포함한 union rect | DOM overlay가 확인되는 문서에서 확장 |
+| 3 | `#scroll-content` 전체 | page rect 계산 실패 시 metadata에 fallback으로 기록 |
+
+여러 page 문서에서 `#scroll-content` 전체를 바로 캡처하면 page 간 공백과 다른 page가 섞일 수 있으므로 기본값으로 사용하지 않는다.
+
+### Chrome 제외 정책
+
+Finder Quick Look/Thumbnail parity 기준에서 menu, toolbar, status bar, ruler, selection/caret은 reference에서 제외한다. Stage 2 helper는 다음 DOM chrome을 `display: none !important`로 숨긴다.
+
+```css
+#menu-bar,
+#icon-toolbar,
+#style-bar,
+#status-bar,
+#ruler-corner,
+#h-ruler,
+#v-ruler {
+  display: none !important;
+}
+```
+
+canvas 내부에 이미 그려진 margin guide나 editor guide는 DOM CSS로 제거할 수 없다. 이번 이슈에서는 renderer 동작을 바꾸지 않고, metadata와 summary에서 `editorChromeResidual` 또는 mask 후보로 남긴다.
+
+### Native render와 diff
+
+Stage 3의 native 출력은 다음 경로로 생성한다.
+
+```swift
+HwpPageImageRenderer.renderPage(
+    document: document,
+    pageIndex: pageIndex,
+    policy: policy
+)
+```
+
+Studio reference PNG와 native PNG 크기가 다르면 원본 크기는 metadata에 보존하고, 비교용 raster는 Studio reference 크기에 맞춘다. diff threshold는 기존 `visual_compare_quicklook_renderers.swift`와 같은 pixel delta `12`를 초기 관찰 기준으로 사용한다. hard gate threshold는 #280 범위에서 만들지 않는다.
+
+## Stage 2 구현 범위
+
+Stage 2에서 추가할 파일:
+
+- `scripts/preview-visual-diff-harness.sh`
+- `scripts/preview_visual_diff_harness.swift`
+
+Stage 2에서 다룰 산출물:
+
+- `studio/{file}-page{N}-studio.png`
+- `studio/{file}-page{N}-studio.json`
+
+Stage 2 metadata 필드:
+
+| 필드 | 목적 |
+|---|---|
+| `sourcePath`, `filename`, `page` | 입력 식별 |
+| `loadURL`, `selector`, `rect` | capture 재현성 |
+| `devicePixelRatio`, `viewportSize` | WebKit raster 조건 |
+| `captureMs`, `settleMs` | 측정 시간 |
+| `studioReleaseTag`, `studioResolvedCommit`, `assetHash` | reference provenance |
+| `chromeHidden`, `editorChromeResidual` | 제외/잔류 chrome 판단 |
+
+Stage 2에서는 아직 native render와 diff 계산을 구현하지 않는다.
+
+## 리스크와 보류 판단
+
+- `rhwp-studio` page canvas는 minified asset 내부 구현에 의존한다. selector는 public DOM id인 `#scroll-content`와 canvas 배치에만 기대도록 좁힌다.
+- DOM overlay가 page canvas의 형제/자식 중 어떤 형태로 붙는지는 문서별로 다를 수 있다. Stage 2는 overlay union rect metadata를 남기고, 실제 overlay 캡처 품질은 Stage 3 sample diff에서 다시 확인한다.
+- Studio canvas 내부 guide는 CSS로 제거할 수 없으므로 이번 harness의 diff에는 잔류 chrome noise가 남을 수 있다. 이는 후속 mask나 Studio capture mode 조정 후보로 남긴다.
+- `getPageSvg` API는 reference 후보로 남길 수 있지만, 이번 harness의 기본 reference는 사용자가 보는 Studio WebView snapshot으로 둔다.
+
+## Stage 1 검증
+
+실행:
+
+```bash
+rg -n "scroll-container|scroll-content|canvas|overlay|ruler|status-bar|renderPageToCanvasFiltered|loadFromUrlParam" \
+  Sources/HostApp/Resources/rhwp-studio/index.html \
+  Sources/HostApp/Resources/rhwp-studio/assets/index-*.css \
+  Sources/HostApp/Resources/rhwp-studio/assets/index-*.js
+rg -n "HwpPageImageRenderer|HwpRenderedPage|backendUsed|fallbackReason|renderPage\\(" \
+  Sources/Shared Sources/QLExtension scripts
+```
+
+결과:
+
+- bundled `rhwp-studio`의 문서 표시 root가 `#scroll-container`와 `#scroll-content`임을 확인했다.
+- page별 렌더 표면은 `#scroll-content canvas`이며, page 단위 snapshot rect 계산의 기준으로 사용할 수 있음을 확인했다.
+- HostApp의 custom scheme URL 구조와 MIME/CORS/no-store 정책을 확인했다.
+- HostApp scheme handler는 `Bundle.main` 의존이 있으므로 standalone helper에서는 script-local handler로 재현해야 함을 확인했다.
+- `HwpPageImageRenderer` diagnostics가 native render backend와 fallback, size, timing 기록에 필요한 필드를 이미 제공함을 확인했다.
+- Stage 1에서는 source/script 구현을 시작하지 않았다.
+
+## 다음 단계 승인 요청
+
+Stage 2에서는 위 구조를 기준으로 `scripts/preview-visual-diff-harness.sh`와 `scripts/preview_visual_diff_harness.swift`를 추가해 `rhwp-studio` reference PNG와 metadata JSON 생성까지만 구현한다.

--- a/mydocs/working/task_m014_280_stage2.md
+++ b/mydocs/working/task_m014_280_stage2.md
@@ -1,0 +1,150 @@
+# Task M014 #280 Stage 2 보고서 - rhwp-studio reference capture 추가
+
+## 단계 개요
+
+- 이슈: #280 rhwp-studio 기준 preview visual diff harness 구축
+- 단계: Stage 2. rhwp-studio reference capture 구현
+- 목표: bundled `rhwp-studio`가 실제로 문서를 열어 렌더한 page content를 PNG와 metadata JSON으로 저장한다.
+
+이번 단계에서는 native preview render와 pixel diff는 구현하지 않았다. 해당 범위는 Stage 3로 남겼다.
+
+## 변경 파일
+
+### `scripts/preview-visual-diff-harness.sh`
+
+새 shell wrapper를 추가했다.
+
+- `scripts/verify-rhwp-studio-assets.sh`로 bundled Studio asset 구조를 먼저 검증한다.
+- Swift helper를 `build.noindex/<output>/preview_visual_diff_harness`로 compile한다.
+- 기본 CLI:
+
+```bash
+./scripts/preview-visual-diff-harness.sh <output-dir> \
+  [--page N] [--viewport WIDTHxHEIGHT] [--settle-ms N] [--resource-dir DIR] \
+  <hwp-or-hwpx> [...]
+```
+
+기본값:
+
+| 옵션 | 기본값 |
+|---|---|
+| `--page` | `1` |
+| `--viewport` | `1400x1800` |
+| `--settle-ms` | `120` |
+| `--resource-dir` | `Sources/HostApp/Resources/rhwp-studio` |
+
+### `scripts/preview_visual_diff_harness.swift`
+
+새 Swift/WebKit helper를 추가했다.
+
+- `alhangeul-studio://app/...` script-local resource scheme handler를 구현했다.
+- `alhangeul-document://current?revision=...` script-local document scheme handler를 구현했다.
+- `rhwp-studio` load URL은 HostApp과 같은 형태로 만든다.
+- `#scroll-content canvas`를 page selector로 사용한다.
+- `requestAnimationFrame` 두 번과 `--settle-ms`만큼의 추가 settle 시간을 둔다.
+- menu, toolbar, status bar, ruler chrome을 CSS로 숨긴다.
+- page canvas, overlay count, viewport, devicePixelRatio, Studio provenance, capture mode를 metadata JSON에 기록한다.
+
+산출물 구조:
+
+```text
+<output-dir>/
+  studio/
+    {file}-page{N}-studio.png
+    {file}-page{N}-studio.json
+  summary.md
+```
+
+## 구현 중 관찰과 결정
+
+초기 설계는 `WKWebView.takeSnapshot`으로 page rect를 직접 캡처하는 방식이었다. 실제 smoke에서 `takeSnapshot`은 page canvas 영역의 배경은 캡처하지만 canvas backing store의 문서 내용은 빈 화면처럼 잡는 현상이 있었다.
+
+동시에 JavaScript로 canvas backing store를 샘플링하면 non-white pixel이 확인되어, `rhwp-studio` 렌더 자체는 완료된 상태임을 확인했다. 따라서 Stage 2 helper는 다음 방식으로 고정했다.
+
+1. WebKit에서 Studio를 실제로 로드하고 문서를 렌더한다.
+2. page canvas readiness와 canvas backing store non-white sample을 확인한다.
+3. reference PNG는 canvas `toDataURL('image/png')` 결과를 흰 배경 임시 canvas에 합성해 저장한다.
+4. DOM overlay는 `overlayCount`로 기록하되, 현재 PNG에는 포함하지 않는다.
+
+metadata에는 이 결정을 다음 필드로 남긴다.
+
+| 필드 | 의미 |
+|---|---|
+| `captureMode` | 현재 `canvasDataURL` |
+| `overlayIncluded` | 현재 `false` |
+| `overlayCount` | page canvas와 교차하는 DOM overlay 후보 수 |
+| `canvasSampleNonWhitePixels` / `canvasSamplePixels` | canvas backing store가 실제 내용을 갖는지 확인하는 샘플 |
+| `snapshotSampleNonWhitePixels` / `snapshotSamplePixels` | `takeSnapshot` 결과 관찰값 |
+
+이 결정은 Stage 3 diff를 진행하기 위한 실용적인 기준이다. 단, DOM overlay까지 포함한 완전한 Studio visual snapshot은 아직 해결되지 않았다.
+
+## Smoke 결과
+
+실행:
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-stage2 --page 1 \
+  samples/basic/request.hwp samples/복학원서.hwp
+find build.noindex/task280-stage2 -maxdepth 2 -type f | sort
+sed -n '1,80p' build.noindex/task280-stage2/summary.md
+sips -g pixelWidth -g pixelHeight \
+  build.noindex/task280-stage2/studio/request-page1-studio.png \
+  build.noindex/task280-stage2/studio/복학원서-page1-studio.png
+```
+
+결과:
+
+- `verify-rhwp-studio-assets.sh`: OK
+- `request.hwp`: OK
+- `복학원서.hwp`: OK
+
+| 파일 | PNG 크기 | CanvasSampleNonWhite | CaptureMode | CaptureMs | PNG bytes |
+|---|---:|---:|---|---:|---:|
+| `request.hwp` | `1133x1587` | `4535/36774` | `canvasDataURL` | `7504.2ms` | `211754` |
+| `복학원서.hwp` | `1587x2245` | `1901/44250` | `canvasDataURL` | `2277.7ms` | `328133` |
+
+시각 확인:
+
+- `request.hwp` reference PNG는 문서 본문, 표, 색상, 이미지 로고가 보이는 상태로 생성됐다.
+- `복학원서.hwp` reference PNG는 한글/영문 텍스트, 표, 붉은 도장 요소가 보이는 상태로 생성됐다.
+
+## Sandbox 관찰
+
+Codex sandbox 안에서 WKWebView helper를 실행하면 WebKit이 다음 계열의 sandbox extension을 만들지 못해 page readiness까지 진행하지 못했다.
+
+- `com.apple.gputools.service`
+- `com.apple.coreservices.launchservicesd`
+- `com.apple.webinspector`
+- `~/Library/WebKit/...`
+- `~/Library/Caches/...`
+
+따라서 Stage 2 smoke는 sandbox 밖 실행 승인을 받아 검증했다. 일반 로컬 터미널 실행에서는 이 제약이 없을 것으로 판단한다.
+
+## 한계와 Stage 3 반영점
+
+- 현재 reference PNG는 `canvasDataURL` 기반이라 DOM overlay를 포함하지 않는다.
+- `overlayCount`와 `overlayIncluded=false`를 metadata에 기록하므로 Stage 3 summary에서 이 한계를 노출해야 한다.
+- `WKWebView.takeSnapshot` 결과는 관찰값으로만 보존한다. 이후 DOM overlay까지 포함해야 하면 별도 overlay rasterization 또는 WebKit snapshot 대체 경로가 필요하다.
+- Stage 3에서는 native render와 diff를 구현하되, 먼저 canvas reference와 native output의 크기 정렬 및 diff 산출을 완성하는 것이 우선이다.
+
+## 검증
+
+실행:
+
+```bash
+git diff --check -- scripts/preview-visual-diff-harness.sh scripts/preview_visual_diff_harness.swift
+rg -n "preview-visual-diff-harness|preview_visual_diff_harness|canvasDataURL|captureMode|overlayIncluded|canvasSample|snapshotSample|WKWebView|alhangeul-studio|alhangeul-document" \
+  scripts/preview-visual-diff-harness.sh scripts/preview_visual_diff_harness.swift
+git status --short --branch
+```
+
+결과:
+
+- whitespace 문제 없음.
+- 새 wrapper와 Swift helper의 핵심 경로를 확인했다.
+- Stage 2에서는 `Sources/` 코드를 변경하지 않았다.
+
+## 다음 단계 승인 요청
+
+Stage 3에서는 같은 입력 문서와 page에 대해 `HwpPageImageRenderer` 기반 native PNG를 생성하고, Stage 2 reference PNG와 pixel diff 및 `summary.md`를 생성한다.

--- a/mydocs/working/task_m014_280_stage3.md
+++ b/mydocs/working/task_m014_280_stage3.md
@@ -1,0 +1,152 @@
+# Task M014 #280 Stage 3 보고서 - native preview와 pixel diff 구현
+
+## 단계 개요
+
+- 이슈: #280 rhwp-studio 기준 preview visual diff harness 구축
+- 단계: Stage 3. native preview 출력과 diff 계산 구현
+- 목표: Stage 2의 `rhwp-studio` reference PNG와 같은 입력/page에 대해 native preview PNG를 생성하고, pixel diff PNG와 summary 수치를 남긴다.
+
+이번 단계에서는 sample set 문서화와 사용 문서 정리는 진행하지 않았다. 해당 범위는 Stage 4로 남겼다.
+
+## 변경 내용
+
+### Wrapper 확장
+
+`scripts/preview-visual-diff-harness.sh`를 확장했다.
+
+- `--policy coreGraphicsOnly|skiaOptIn` 옵션을 추가했다.
+- Rust static lib와 modulemap 존재를 확인한다.
+- Swift helper compile에 다음 source/link dependency를 추가했다.
+  - `Sources/RhwpCoreBridge/RhwpDocument.swift`
+  - `Sources/RhwpCoreBridge/RenderTree.swift`
+  - `Sources/RhwpCoreBridge/FontFallback.swift`
+  - `Sources/RhwpCoreBridge/FontResourceRegistry.swift`
+  - `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+  - `Sources/Shared/HwpPageImageRenderer.swift`
+  - `Frameworks/universal/librhwp.a`
+
+### Swift helper 확장
+
+`scripts/preview_visual_diff_harness.swift`에 native render와 diff engine을 추가했다.
+
+- `NativePreviewRenderer`
+  - `RhwpDocument(data:filename:)`로 문서를 연다.
+  - `HwpPageImageRenderer.renderPage(document:pageIndex:policy:)`를 호출한다.
+  - `native/{file}-page{N}-native.png`를 저장한다.
+  - `native/{file}-page{N}-native.json`에 policy, backend, fallback, page size, pixel size, PNG bytes, render timing을 기록한다.
+- `VisualDiffEngine`
+  - `studio` reference PNG를 RGBA로 읽는다.
+  - native `CGImage`를 Studio reference 크기에 맞춰 rasterize한다.
+  - 기존 visual compare helper와 같은 pixel delta threshold `12`를 사용한다.
+  - `diff/{file}-page{N}-diff.png`와 `summary.md` 수치를 생성한다.
+
+산출물 구조는 다음으로 확장됐다.
+
+```text
+<output-dir>/
+  studio/
+    {file}-page{N}-studio.png
+    {file}-page{N}-studio.json
+  native/
+    {file}-page{N}-native.png
+    {file}-page{N}-native.json
+  diff/
+    {file}-page{N}-diff.png
+  summary.md
+```
+
+## Smoke 결과
+
+### 기본 정책: coreGraphicsOnly
+
+실행:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-stage3 --page 1 \
+  samples/basic/request.hwp samples/복학원서.hwp
+```
+
+결과:
+
+| 파일 | StudioSize | NativeSize | CompareSize | ChangedPercent | MeanRGBDelta | MaxRGBDelta | NativeBackend | NativeMs |
+|---|---:|---:|---:|---:|---:|---:|---|---:|
+| `request.hwp` | `1133x1587` | `567x794` | `1133x1587` | `18.1021%` | `11.5796` | `255` | `coreGraphics` | `1018.1ms` |
+| `복학원서.hwp` | `1587x2245` | `794x1123` | `1587x2245` | `32.3726%` | `42.9398` | `255` | `coreGraphics` | `404.0ms` |
+
+관찰:
+
+- Studio reference는 device scale 2에 가까운 backing store 크기로 생성된다.
+- native CoreGraphics output은 page point size 기준 scale 1 PNG로 생성된다.
+- diff는 native output을 Studio reference 크기에 맞춰 확대한 뒤 계산한다.
+- `request.hwp` native render 중 기존 renderer diagnostics인 `LAYOUT_OVERFLOW` 2건이 stderr에 출력됐다.
+
+### 옵션 정책: skiaOptIn
+
+실행:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-stage3-skia --page 1 \
+  --policy skiaOptIn samples/basic/request.hwp
+```
+
+결과:
+
+| 파일 | StudioSize | NativeSize | CompareSize | ChangedPercent | MeanRGBDelta | MaxRGBDelta | NativeBackend | NativeMs |
+|---|---:|---:|---:|---:|---:|---:|---|---:|
+| `request.hwp` | `1133x1587` | `567x794` | `1133x1587` | `12.4856%` | `9.5936` | `255` | `skia` | `53.9ms` |
+
+관찰:
+
+- `--policy skiaOptIn` 경로는 Skia backend를 사용했다.
+- 같은 `request.hwp` 기준으로 Stage 3 smoke에서는 CoreGraphics보다 changedPercent와 mean delta가 낮았다.
+- 이 수치는 단일 샘플 관찰이며, Skia 전환 판단 기준으로 사용하지 않는다.
+
+## 산출물 확인
+
+확인:
+
+```bash
+find build.noindex/task280-stage3 -maxdepth 2 -type f | sort
+sed -n '1,120p' build.noindex/task280-stage3/summary.md
+sips -g pixelWidth -g pixelHeight \
+  build.noindex/task280-stage3/studio/request-page1-studio.png \
+  build.noindex/task280-stage3/native/request-page1-native.png \
+  build.noindex/task280-stage3/diff/request-page1-diff.png \
+  build.noindex/task280-stage3/studio/복학원서-page1-studio.png \
+  build.noindex/task280-stage3/native/복학원서-page1-native.png \
+  build.noindex/task280-stage3/diff/복학원서-page1-diff.png
+```
+
+결과:
+
+- `studio`, `native`, `diff` 폴더가 생성됐다.
+- 각 샘플마다 PNG와 JSON metadata가 생성됐다.
+- diff PNG 크기는 Studio reference 크기와 일치했다.
+
+## 한계와 Stage 4 반영점
+
+- Stage 2에서 확인한 대로 reference PNG는 `canvasDataURL` 기반이므로 DOM overlay를 포함하지 않는다. summary의 `StudioCapture=canvasDataURL`와 Studio JSON의 `overlayIncluded=false`를 통해 이 사실을 추적한다.
+- 현재 summary는 hard gate가 아니라 관찰 자료다. changedPercent가 높아도 Stage 3에서는 실패 처리하지 않는다.
+- native output과 Studio reference의 scale이 다르므로, diff는 native를 Studio 크기로 확대해 비교한다. Stage 4 문서에 이 해석 기준을 명시해야 한다.
+- `request.hwp`에서 `LAYOUT_OVERFLOW` stderr가 관찰됐다. 이는 diff harness 실패는 아니지만, 후속 렌더 개선 후보를 찾을 때 참고할 수 있다.
+
+## 검증
+
+실행:
+
+```bash
+./scripts/check-no-appkit.sh
+git diff --check
+rg -n -- "NativePolicy|DiffPixelThreshold|NativePreviewRenderer|VisualDiffEngine|captureMode|overlayIncluded|changedPercent|HwpPageImageRenderer|renderPage\\(" \
+  scripts/preview_visual_diff_harness.swift scripts/preview-visual-diff-harness.sh
+```
+
+결과:
+
+- shared Swift code의 AppKit/UIKit 의존 금지 검증 통과.
+- whitespace 검증 통과.
+- Stage 3에서 `Sources/` 코드는 변경하지 않았다.
+
+## 다음 단계 승인 요청
+
+Stage 4에서는 sample set과 사용 문서를 정리한다. 특히 `canvasDataURL` reference의 overlay 한계, scale 정렬 기준, summary 수치 해석 방법, 기본 실행 예시를 문서화한다.

--- a/mydocs/working/task_m014_280_stage4.md
+++ b/mydocs/working/task_m014_280_stage4.md
@@ -1,0 +1,108 @@
+# Task M014 #280 Stage 4 보고서 - preview diff sample set 문서화
+
+## 단계 개요
+
+- 이슈: #280 rhwp-studio 기준 preview visual diff harness 구축
+- 단계: Stage 4. sample set과 사용 문서 정리
+- 목표: v0.1.4 렌더 개선 이슈들이 공통으로 재사용할 sample set, 실행 명령, 수치 해석 기준, 한계, 후속 이슈 handoff를 문서화한다.
+
+이번 단계에서는 harness code를 변경하지 않았다.
+
+## 변경 파일
+
+### `mydocs/tech/v014_preview_visual_diff_harness.md`
+
+새 기술 문서를 추가했다.
+
+포함 내용:
+
+- 기본 실행 명령과 `--policy`, `--page`, `--viewport`, `--settle-ms`, `--resource-dir` 옵션
+- `studio`, `native`, `diff`, `summary.md` 산출물 구조
+- `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta`, `DiffBounds`, `NativeBackend`, `NativeMs` 해석 기준
+- editor chrome 제외와 canvas 내부 margin guide residual 기준
+- `canvasDataURL`, `overlayIncluded=false` 한계
+- v0.1.4 기본 sample set 6개와 확장 sample set
+- #282, #116, #122, #121, #110 handoff
+- 후속 PR/보고서 기록 기준
+
+## 기본 sample set
+
+문서화한 기본 sample set:
+
+| 목적 | 샘플 |
+|---|---|
+| 일반 HWP smoke | `samples/basic/request.hwp` |
+| watermark/effect | `samples/복학원서.hwp` |
+| image crop/fill | `samples/pic-crop-01.hwp` |
+| form/placeholder HWP | `samples/form-01.hwp` |
+| form/placeholder HWPX | `samples/hwpx/form-002.hwpx` |
+| HWPX smoke | `samples/hwpx/hwpx-01.hwpx` |
+
+확장 sample set:
+
+- `samples/tac-img-02.hwp`
+- `samples/tac-img-02.hwpx`
+- `samples/eq-01.hwp`
+- `samples/draw-group.hwp`
+- `samples/table-vpos-01.hwp`
+
+## Stage 4 smoke 결과
+
+실행:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task280-stage4 --page 1 \
+  samples/basic/request.hwp samples/복학원서.hwp samples/pic-crop-01.hwp \
+  samples/form-01.hwp samples/hwpx/form-002.hwpx samples/hwpx/hwpx-01.hwpx
+```
+
+결과:
+
+- 6개 기본 샘플 모두 OK
+- `studio`, `native`, `diff`, `summary.md` 생성 확인
+- `request.hwp`와 `pic-crop-01.hwp`에서 기존 renderer의 `LAYOUT_OVERFLOW` stderr 관찰
+- Stage 4 smoke는 WKWebView 실행이 필요하므로 sandbox 밖 실행 승인을 받아 수행했다.
+
+요약 수치:
+
+| 파일 | ChangedPercent | MeanRGBDelta | NativeBackend | NativeMs |
+|---|---:|---:|---|---:|
+| `request.hwp` | `18.1021%` | `11.5796` | `coreGraphics` | `1049.1ms` |
+| `복학원서.hwp` | `32.3726%` | `42.9398` | `coreGraphics` | `415.3ms` |
+| `pic-crop-01.hwp` | `2.0423%` | `0.8092` | `coreGraphics` | `6.7ms` |
+| `form-01.hwp` | `0.8066%` | `0.4845` | `coreGraphics` | `2.2ms` |
+| `form-002.hwpx` | `16.8925%` | `17.6456` | `coreGraphics` | `35.5ms` |
+| `hwpx-01.hwpx` | `15.1839%` | `15.6722` | `coreGraphics` | `29.0ms` |
+
+산출물 위치:
+
+```text
+build.noindex/task280-stage4/
+```
+
+## 해석 기준 확정
+
+- `ChangedPercent`는 hard gate가 아니라 관찰 지표다.
+- Stage 4 기준 reference는 `captureMode=canvasDataURL`이며 `overlayIncluded=false`다.
+- DOM overlay는 PNG에 포함하지 않고 `studio/*.json`의 `overlayCount`로 기록한다.
+- canvas 내부 margin guide와 crop mark는 남을 수 있으므로 diff 해석에서 editor chrome residual로 분리한다.
+- native output과 Studio reference scale이 다르므로 diff는 native output을 Studio reference 크기로 확대해 계산한다.
+
+## 검증
+
+실행:
+
+```bash
+rg -n "#116|#122|#121|#110|#282|rhwp-studio|editor chrome|margin guide|changedPixels" \
+  mydocs/tech/v014_preview_visual_diff_harness.md build.noindex/task280-stage4/summary.md
+git diff --check
+```
+
+결과:
+
+- 기술 문서에 후속 이슈 handoff와 수치 해석 기준이 포함됐다.
+- whitespace 검증 통과.
+
+## 다음 단계 승인 요청
+
+Stage 5에서는 전체 harness 최종 smoke를 실행하고, 최종 보고서에 smoke 측정 결과, 관찰, 수치 비교자료, 한계, 후속 handoff를 정리한다.

--- a/scripts/preview-visual-diff-harness.sh
+++ b/scripts/preview-visual-diff-harness.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESOURCE_DIR="$ROOT/Sources/HostApp/Resources/rhwp-studio"
+PAGE_NUMBER=1
+VIEWPORT_SIZE="1400x1800"
+SETTLE_MS=120
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 <output-dir> [--page N] [--viewport WIDTHxHEIGHT] [--settle-ms N] [--resource-dir DIR] <hwp-or-hwpx> [...]
+
+Captures bundled rhwp-studio reference PNGs and metadata JSON files for the
+selected page. Page numbers are 1-based. The default page is 1.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -lt 2 ]; then
+  usage
+  exit 1
+fi
+
+OUT_DIR="$1"
+shift
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --page)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --page requires a positive integer" >&2
+        exit 1
+      fi
+      PAGE_NUMBER="$2"
+      shift 2
+      ;;
+    --viewport)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --viewport requires WIDTHxHEIGHT" >&2
+        exit 1
+      fi
+      VIEWPORT_SIZE="$2"
+      shift 2
+      ;;
+    --settle-ms)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --settle-ms requires a non-negative integer" >&2
+        exit 1
+      fi
+      SETTLE_MS="$2"
+      shift 2
+      ;;
+    --resource-dir)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --resource-dir requires a directory" >&2
+        exit 1
+      fi
+      RESOURCE_DIR="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "ERROR: unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ "$#" -eq 0 ]; then
+  echo "ERROR: missing input document" >&2
+  usage
+  exit 1
+fi
+
+case "$PAGE_NUMBER" in
+  ''|*[!0-9]*)
+    echo "ERROR: --page must be a positive integer" >&2
+    exit 1
+    ;;
+  0)
+    echo "ERROR: --page must be greater than 0" >&2
+    exit 1
+    ;;
+esac
+
+case "$SETTLE_MS" in
+  ''|*[!0-9]*)
+    echo "ERROR: --settle-ms must be a non-negative integer" >&2
+    exit 1
+    ;;
+esac
+
+case "$VIEWPORT_SIZE" in
+  *x*)
+    ;;
+  *)
+    echo "ERROR: --viewport must use WIDTHxHEIGHT" >&2
+    exit 1
+    ;;
+esac
+
+"$ROOT/scripts/verify-rhwp-studio-assets.sh" --resource-dir "$RESOURCE_DIR"
+
+mkdir -p "$OUT_DIR"
+BIN="$OUT_DIR/preview_visual_diff_harness"
+SWIFT_MODULE_CACHE="$OUT_DIR/swift-module-cache-preview"
+CLANG_MODULE_CACHE="$OUT_DIR/clang-module-cache-preview"
+rm -rf "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
+mkdir -p "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
+
+swiftc -parse-as-library \
+  -module-cache-path "$SWIFT_MODULE_CACHE" \
+  -Xcc -fmodules-cache-path="$CLANG_MODULE_CACHE" \
+  "$ROOT/scripts/preview_visual_diff_harness.swift" \
+  -framework AppKit \
+  -framework CoreGraphics \
+  -framework Foundation \
+  -framework ImageIO \
+  -framework WebKit \
+  -o "$BIN"
+
+"$BIN" "$OUT_DIR" \
+  --resource-dir "$RESOURCE_DIR" \
+  --page "$PAGE_NUMBER" \
+  --viewport "$VIEWPORT_SIZE" \
+  --settle-ms "$SETTLE_MS" \
+  "$@"

--- a/scripts/preview-visual-diff-harness.sh
+++ b/scripts/preview-visual-diff-harness.sh
@@ -7,13 +7,14 @@ RESOURCE_DIR="$ROOT/Sources/HostApp/Resources/rhwp-studio"
 PAGE_NUMBER=1
 VIEWPORT_SIZE="1400x1800"
 SETTLE_MS=120
+POLICY="coreGraphicsOnly"
 
 usage() {
   cat >&2 <<EOF
-Usage: $0 <output-dir> [--page N] [--viewport WIDTHxHEIGHT] [--settle-ms N] [--resource-dir DIR] <hwp-or-hwpx> [...]
+Usage: $0 <output-dir> [--page N] [--policy coreGraphicsOnly|skiaOptIn] [--viewport WIDTHxHEIGHT] [--settle-ms N] [--resource-dir DIR] <hwp-or-hwpx> [...]
 
-Captures bundled rhwp-studio reference PNGs and metadata JSON files for the
-selected page. Page numbers are 1-based. The default page is 1.
+Captures bundled rhwp-studio reference PNGs, native renderer PNGs, diff PNGs,
+and metadata for the selected page. Page numbers are 1-based. The default page is 1.
 EOF
 }
 
@@ -46,6 +47,14 @@ while [ "$#" -gt 0 ]; do
         exit 1
       fi
       VIEWPORT_SIZE="$2"
+      shift 2
+      ;;
+    --policy)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --policy requires coreGraphicsOnly or skiaOptIn" >&2
+        exit 1
+      fi
+      POLICY="$2"
       shift 2
       ;;
     --settle-ms)
@@ -112,7 +121,29 @@ case "$VIEWPORT_SIZE" in
     ;;
 esac
 
+case "$POLICY" in
+  coreGraphicsOnly|skiaOptIn)
+    ;;
+  *)
+    echo "ERROR: --policy must be coreGraphicsOnly or skiaOptIn" >&2
+    exit 1
+    ;;
+esac
+
 "$ROOT/scripts/verify-rhwp-studio-assets.sh" --resource-dir "$RESOURCE_DIR"
+
+LIB="$ROOT/Frameworks/universal/librhwp.a"
+MODULEMAP_DIR="$ROOT/Frameworks/modulemap"
+if [ ! -f "$LIB" ]; then
+  echo "ERROR: missing $LIB" >&2
+  echo "Run: $ROOT/scripts/build-rust-macos.sh" >&2
+  exit 1
+fi
+if [ ! -f "$MODULEMAP_DIR/module.modulemap" ]; then
+  echo "ERROR: missing $MODULEMAP_DIR/module.modulemap" >&2
+  echo "Run: $ROOT/scripts/build-rust-macos.sh" >&2
+  exit 1
+fi
 
 mkdir -p "$OUT_DIR"
 BIN="$OUT_DIR/preview_visual_diff_harness"
@@ -124,17 +155,33 @@ mkdir -p "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
 swiftc -parse-as-library \
   -module-cache-path "$SWIFT_MODULE_CACHE" \
   -Xcc -fmodules-cache-path="$CLANG_MODULE_CACHE" \
+  -I "$MODULEMAP_DIR" \
+  "$ROOT/Sources/RhwpCoreBridge/RhwpDocument.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/FontFallback.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/FontResourceRegistry.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/CGTreeRenderer.swift" \
+  "$ROOT/Sources/Shared/HwpPageImageRenderer.swift" \
   "$ROOT/scripts/preview_visual_diff_harness.swift" \
+  "$LIB" \
   -framework AppKit \
   -framework CoreGraphics \
+  -framework CoreText \
   -framework Foundation \
   -framework ImageIO \
+  -framework UniformTypeIdentifiers \
+  -framework Security \
+  -framework CoreFoundation \
   -framework WebKit \
+  -lc++ \
+  -liconv \
+  -lz \
   -o "$BIN"
 
 "$BIN" "$OUT_DIR" \
   --resource-dir "$RESOURCE_DIR" \
   --page "$PAGE_NUMBER" \
+  --policy "$POLICY" \
   --viewport "$VIEWPORT_SIZE" \
   --settle-ms "$SETTLE_MS" \
   "$@"

--- a/scripts/preview_visual_diff_harness.swift
+++ b/scripts/preview_visual_diff_harness.swift
@@ -2,6 +2,8 @@ import AppKit
 import CoreGraphics
 import Darwin
 import Foundation
+import ImageIO
+import UniformTypeIdentifiers
 import WebKit
 
 struct PreviewHarnessError: Error, CustomStringConvertible {
@@ -12,6 +14,7 @@ struct HarnessOptions {
     let outputDir: URL
     let resourceDir: URL
     let pageNumber: Int
+    let policy: HwpPageRenderPolicy
     let viewportSize: CGSize
     let settleMilliseconds: Int
     let inputURLs: [URL]
@@ -107,6 +110,69 @@ struct PNGOutput {
     let height: Int
     let sampleNonWhitePixels: Int
     let samplePixels: Int
+}
+
+struct NativeRenderMetadata: Codable {
+    let sourcePath: String
+    let filename: String
+    let page: Int
+    let pageCount: Int
+    let policy: String
+    let backendUsed: String
+    let fallbackReason: String?
+    let pageSize: SizeMetadata
+    let pixelSize: SizeMetadata
+    let pngPath: String
+    let pngBytes: Int
+    let nonWhiteSamplePixels: Int
+    let sampledPixels: Int
+    let renderMs: Double
+    let skiaRenderMs: Double?
+    let pngDecodeMs: Double?
+    let coreGraphicsRenderMs: Double?
+}
+
+struct NativeRenderResult {
+    let pngURL: URL
+    let jsonURL: URL
+    let image: CGImage
+    let pngBytes: Int
+    let pageCount: Int
+    let policy: String
+    let backendUsed: String
+    let fallbackReason: String?
+    let renderMs: Double
+    let pixelWidth: Int
+    let pixelHeight: Int
+    let nonWhiteSamplePixels: Int
+    let sampledPixels: Int
+}
+
+struct RGBAImage {
+    let width: Int
+    let height: Int
+    var pixels: [UInt8]
+}
+
+struct DiffResult {
+    let changedPixels: Int
+    let totalPixels: Int
+    let changedPercent: Double
+    let meanRGBDelta: Double
+    let maxRGBDelta: Int
+    let bounds: CGRect?
+}
+
+struct VisualDiffResult {
+    let diffURL: URL
+    let changedPixels: Int
+    let totalPixels: Int
+    let changedPercent: Double
+    let meanRGBDelta: Double
+    let maxRGBDelta: Int
+    let bounds: CGRect?
+    let compareWidth: Int
+    let compareHeight: Int
 }
 
 struct PageState {
@@ -965,6 +1031,204 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
     }
 }
 
+enum NativePreviewRenderer {
+    static func render(
+        inputURL: URL,
+        outputDir: URL,
+        pageNumber: Int,
+        policy: HwpPageRenderPolicy
+    ) throws -> NativeRenderResult {
+        let data = try Data(contentsOf: inputURL)
+        let document = try RhwpDocument(data: data, filename: inputURL.lastPathComponent)
+        guard document.pageCount > 0 else {
+            throw PreviewHarnessError(description: "page count is zero")
+        }
+        let pageIndex = pageNumber - 1
+        guard pageIndex >= 0, pageIndex < document.pageCount else {
+            throw PreviewHarnessError(description: "page \(pageNumber) is out of range: pageCount=\(document.pageCount)")
+        }
+
+        let baseName = inputURL.deletingPathExtension().lastPathComponent
+        let outputBase = "\(baseName)-page\(pageNumber)"
+        let pngURL = outputDir.appendingPathComponent("\(outputBase)-native.png", isDirectory: false)
+        let jsonURL = outputDir.appendingPathComponent("\(outputBase)-native.json", isDirectory: false)
+
+        let page = try HwpPageImageRenderer.renderPage(
+            document: document,
+            pageIndex: pageIndex,
+            policy: policy
+        )
+        let pngData = try HwpPageImageRenderer.encodePNG(page.image)
+        try pngData.write(to: pngURL, options: .atomic)
+        let sample = sampleNonWhitePixels(cgImage: page.image)
+
+        let diagnostics = page.diagnostics
+        let metadata = NativeRenderMetadata(
+            sourcePath: inputURL.path,
+            filename: inputURL.lastPathComponent,
+            page: pageNumber,
+            pageCount: document.pageCount,
+            policy: renderPolicyName(diagnostics.policy),
+            backendUsed: backendName(diagnostics.backendUsed),
+            fallbackReason: diagnostics.fallbackReason.map(fallbackReasonName),
+            pageSize: SizeMetadata(width: diagnostics.pageSize.width, height: diagnostics.pageSize.height),
+            pixelSize: SizeMetadata(width: diagnostics.pixelSize.width, height: diagnostics.pixelSize.height),
+            pngPath: pngURL.path,
+            pngBytes: pngData.count,
+            nonWhiteSamplePixels: sample.nonWhite,
+            sampledPixels: sample.total,
+            renderMs: diagnostics.durationMs.totalMs,
+            skiaRenderMs: diagnostics.durationMs.skiaRenderMs,
+            pngDecodeMs: diagnostics.durationMs.pngDecodeMs,
+            coreGraphicsRenderMs: diagnostics.durationMs.coreGraphicsRenderMs
+        )
+        try writeJSON(metadata, to: jsonURL)
+
+        return NativeRenderResult(
+            pngURL: pngURL,
+            jsonURL: jsonURL,
+            image: page.image,
+            pngBytes: pngData.count,
+            pageCount: document.pageCount,
+            policy: metadata.policy,
+            backendUsed: metadata.backendUsed,
+            fallbackReason: metadata.fallbackReason,
+            renderMs: metadata.renderMs,
+            pixelWidth: page.image.width,
+            pixelHeight: page.image.height,
+            nonWhiteSamplePixels: sample.nonWhite,
+            sampledPixels: sample.total
+        )
+    }
+}
+
+enum VisualDiffEngine {
+    static func compare(
+        studioPNG: URL,
+        nativeImage: CGImage,
+        outputDir: URL,
+        baseName: String,
+        pageNumber: Int
+    ) throws -> VisualDiffResult {
+        let studio = try loadRGBAImage(studioPNG)
+        let native = try drawCGImageToRGBA(nativeImage, width: studio.width, height: studio.height)
+        let (diff, diffImage) = makeDiffImage(reference: studio, candidate: native)
+        let diffURL = outputDir.appendingPathComponent("\(baseName)-page\(pageNumber)-diff.png", isDirectory: false)
+        try writePNG(diffImage, to: diffURL)
+        return VisualDiffResult(
+            diffURL: diffURL,
+            changedPixels: diff.changedPixels,
+            totalPixels: diff.totalPixels,
+            changedPercent: diff.changedPercent,
+            meanRGBDelta: diff.meanRGBDelta,
+            maxRGBDelta: diff.maxRGBDelta,
+            bounds: diff.bounds,
+            compareWidth: studio.width,
+            compareHeight: studio.height
+        )
+    }
+
+    private static func loadRGBAImage(_ url: URL) throws -> RGBAImage {
+        guard
+            let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+            let image = CGImageSourceCreateImageAtIndex(source, 0, nil)
+        else {
+            throw PreviewHarnessError(description: "failed to load image: \(url.path)")
+        }
+        return try drawCGImageToRGBA(image, width: image.width, height: image.height)
+    }
+
+    private static func drawCGImageToRGBA(_ image: CGImage, width: Int, height: Int) throws -> RGBAImage {
+        var rgba = blankRGBA(width: width, height: height)
+        try rgba.withBitmapContext { context in
+            context.setFillColor(red: 1, green: 1, blue: 1, alpha: 1)
+            context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+            context.interpolationQuality = .high
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        }
+        return rgba
+    }
+
+    private static func blankRGBA(width: Int, height: Int) -> RGBAImage {
+        let bytesPerRow = width * 4
+        return RGBAImage(width: width, height: height, pixels: [UInt8](repeating: 255, count: height * bytesPerRow))
+    }
+
+    private static func makeDiffImage(reference: RGBAImage, candidate: RGBAImage) -> (DiffResult, RGBAImage) {
+        precondition(reference.width == candidate.width && reference.height == candidate.height)
+
+        var diffImage = blankRGBA(width: reference.width, height: reference.height)
+        var changedPixels = 0
+        var totalDelta = 0
+        var maxDelta = 0
+        var minX = reference.width
+        var minY = reference.height
+        var maxX = -1
+        var maxY = -1
+
+        for y in 0..<reference.height {
+            for x in 0..<reference.width {
+                let index = (y * reference.width + x) * 4
+                let redDelta = abs(Int(reference.pixels[index]) - Int(candidate.pixels[index]))
+                let greenDelta = abs(Int(reference.pixels[index + 1]) - Int(candidate.pixels[index + 1]))
+                let blueDelta = abs(Int(reference.pixels[index + 2]) - Int(candidate.pixels[index + 2]))
+                let pixelDelta = max(redDelta, greenDelta, blueDelta)
+                totalDelta += redDelta + greenDelta + blueDelta
+                maxDelta = max(maxDelta, pixelDelta)
+
+                if pixelDelta > 12 {
+                    changedPixels += 1
+                    minX = min(minX, x)
+                    minY = min(minY, y)
+                    maxX = max(maxX, x)
+                    maxY = max(maxY, y)
+                    diffImage.pixels[index] = 255
+                    diffImage.pixels[index + 1] = UInt8(max(0, 255 - pixelDelta))
+                    diffImage.pixels[index + 2] = UInt8(max(0, 255 - pixelDelta))
+                    diffImage.pixels[index + 3] = 255
+                } else {
+                    let gray = UInt8(240)
+                    diffImage.pixels[index] = gray
+                    diffImage.pixels[index + 1] = gray
+                    diffImage.pixels[index + 2] = gray
+                    diffImage.pixels[index + 3] = 255
+                }
+            }
+        }
+
+        let totalPixels = reference.width * reference.height
+        let bounds: CGRect?
+        if maxX >= 0 {
+            bounds = CGRect(x: minX, y: minY, width: maxX - minX + 1, height: maxY - minY + 1)
+        } else {
+            bounds = nil
+        }
+        return (
+            DiffResult(
+                changedPixels: changedPixels,
+                totalPixels: totalPixels,
+                changedPercent: totalPixels == 0 ? 0 : Double(changedPixels) * 100.0 / Double(totalPixels),
+                meanRGBDelta: totalPixels == 0 ? 0 : Double(totalDelta) / Double(totalPixels * 3),
+                maxRGBDelta: maxDelta,
+                bounds: bounds
+            ),
+            diffImage
+        )
+    }
+
+    private static func writePNG(_ image: RGBAImage, to url: URL) throws {
+        var image = image
+        let cgImage = try image.makeCGImage()
+        guard let destination = CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil) else {
+            throw PreviewHarnessError(description: "failed to create PNG destination: \(url.path)")
+        }
+        CGImageDestinationAddImage(destination, cgImage, nil)
+        guard CGImageDestinationFinalize(destination) else {
+            throw PreviewHarnessError(description: "failed to write PNG: \(url.path)")
+        }
+    }
+}
+
 @main
 struct PreviewVisualDiffHarness {
     static func main() throws {
@@ -972,7 +1236,11 @@ struct PreviewVisualDiffHarness {
 
         let options = try parseOptions(Array(CommandLine.arguments.dropFirst()))
         let studioDir = options.outputDir.appendingPathComponent("studio", isDirectory: true)
+        let nativeDir = options.outputDir.appendingPathComponent("native", isDirectory: true)
+        let diffDir = options.outputDir.appendingPathComponent("diff", isDirectory: true)
         try FileManager.default.createDirectory(at: studioDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: nativeDir, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: diffDir, withIntermediateDirectories: true)
 
         let manifest = try StudioManifest.load(from: options.resourceDir)
         let renderer = StudioReferenceRenderer(
@@ -983,17 +1251,19 @@ struct PreviewVisualDiffHarness {
 
         var failed = false
         var summaryLines: [String] = []
-        summaryLines.append("# Preview Visual Diff Harness - Studio Reference")
+        summaryLines.append("# Preview Visual Diff Harness")
         summaryLines.append("")
         summaryLines.append("Page: \(options.pageNumber)")
+        summaryLines.append("NativePolicy: \(renderPolicyName(options.policy))")
         summaryLines.append("ResourceDir: \(options.resourceDir.path)")
         summaryLines.append("StudioReleaseTag: \(manifest.source_release_tag)")
         summaryLines.append("StudioResolvedCommit: \(manifest.source_resolved_commit)")
         summaryLines.append("Viewport: \(Int(options.viewportSize.width))x\(Int(options.viewportSize.height))")
         summaryLines.append("SettleMs: \(options.settleMilliseconds)")
+        summaryLines.append("DiffPixelThreshold: 12")
         summaryLines.append("")
-        summaryLines.append("| File | Status | Size | CanvasCount | OverlayCount | CanvasSampleNonWhite | CaptureMode | CaptureMs | StudioPNG | StudioJSON |")
-        summaryLines.append("|------|--------|------|-------------|--------------|----------------------|-------------|-----------|-----------|------------|")
+        summaryLines.append("| File | Status | StudioSize | NativeSize | CompareSize | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | StudioCapture | NativeBackend | NativeMs | StudioPNG | NativePNG | DiffPNG |")
+        summaryLines.append("|------|--------|------------|------------|-------------|---------------|----------------|--------------|-------------|------------|---------------|---------------|----------|-----------|-----------|---------|")
 
         for inputURL in options.inputURLs {
             do {
@@ -1003,33 +1273,48 @@ struct PreviewVisualDiffHarness {
                     pageNumber: options.pageNumber,
                     manifest: manifest
                 )
+                let native = try NativePreviewRenderer.render(
+                    inputURL: inputURL,
+                    outputDir: nativeDir,
+                    pageNumber: options.pageNumber,
+                    policy: options.policy
+                )
+                let baseName = inputURL.deletingPathExtension().lastPathComponent
+                let diff = try VisualDiffEngine.compare(
+                    studioPNG: result.pngURL,
+                    nativeImage: native.image,
+                    outputDir: diffDir,
+                    baseName: baseName,
+                    pageNumber: options.pageNumber
+                )
                 summaryLines.append([
                     markdownCell(result.fileName),
                     "OK",
                     "\(result.pngWidth)x\(result.pngHeight)",
-                    "\(result.canvasCount)",
-                    "\(result.overlayCount)",
-                    "\(result.canvasSampleNonWhitePixels)/\(result.canvasSamplePixels)",
+                    "\(native.pixelWidth)x\(native.pixelHeight)",
+                    "\(diff.compareWidth)x\(diff.compareHeight)",
+                    "\(diff.changedPixels)/\(diff.totalPixels)",
+                    formatPercent(diff.changedPercent),
+                    formatDouble(diff.meanRGBDelta),
+                    "\(diff.maxRGBDelta)",
+                    boundsString(diff.bounds),
                     result.captureMode,
-                    formatMilliseconds(result.captureMs),
+                    native.backendUsed + fallbackSuffix(native.fallbackReason),
+                    formatMilliseconds(native.renderMs),
                     markdownCell(result.pngURL.path),
-                    markdownCell(result.jsonURL.path)
+                    markdownCell(native.pngURL.path),
+                    markdownCell(diff.diffURL.path)
                 ].joined(separator: " | ").wrappedTableRow)
-                print("OK \(result.fileName): studioPNG=\(result.pngURL.path) metadata=\(result.jsonURL.path)")
+                print(
+                    "OK \(result.fileName): studioPNG=\(result.pngURL.path) nativePNG=\(native.pngURL.path) diffPNG=\(diff.diffURL.path)"
+                )
             } catch {
                 failed = true
-                summaryLines.append([
+                let failureCells = [
                     markdownCell(inputURL.lastPathComponent),
-                    "FAIL: \(String(describing: error).replacingOccurrences(of: "|", with: "/"))",
-                    "-",
-                    "-",
-                    "-",
-                    "-",
-                    "-",
-                    "-",
-                    "-",
-                    "-"
-                ].joined(separator: " | ").wrappedTableRow)
+                    "FAIL: \(String(describing: error).replacingOccurrences(of: "|", with: "/"))"
+                ] + Array(repeating: "-", count: 14)
+                summaryLines.append(failureCells.joined(separator: " | ").wrappedTableRow)
                 print("FAIL \(inputURL.path): \(error)", to: &standardError)
             }
         }
@@ -1048,7 +1333,7 @@ struct PreviewVisualDiffHarness {
     private static func parseOptions(_ args: [String]) throws -> HarnessOptions {
         guard args.count >= 2 else {
             throw PreviewHarnessError(
-                description: "usage: preview_visual_diff_harness <output-dir> [--page N] [--viewport WIDTHxHEIGHT] [--settle-ms N] [--resource-dir DIR] <hwp-or-hwpx> [...]"
+                description: "usage: preview_visual_diff_harness <output-dir> [--page N] [--policy coreGraphicsOnly|skiaOptIn] [--viewport WIDTHxHEIGHT] [--settle-ms N] [--resource-dir DIR] <hwp-or-hwpx> [...]"
             )
         }
 
@@ -1056,6 +1341,7 @@ struct PreviewVisualDiffHarness {
         let outputDir = absoluteURL(remaining.removeFirst(), isDirectory: true)
         var resourceDir = absoluteURL("Sources/HostApp/Resources/rhwp-studio", isDirectory: true)
         var pageNumber = 1
+        var policy = HwpPageRenderPolicy.coreGraphicsOnly
         var viewportSize = CGSize(width: 1400, height: 1800)
         var settleMilliseconds = 120
 
@@ -1074,6 +1360,13 @@ struct PreviewVisualDiffHarness {
                     throw PreviewHarnessError(description: "--resource-dir requires a directory")
                 }
                 resourceDir = absoluteURL(value, isDirectory: true)
+                remaining.removeFirst()
+            case "--policy":
+                remaining.removeFirst()
+                guard let value = remaining.first else {
+                    throw PreviewHarnessError(description: "--policy requires coreGraphicsOnly or skiaOptIn")
+                }
+                policy = try parsePolicy(value)
                 remaining.removeFirst()
             case "--viewport":
                 remaining.removeFirst()
@@ -1102,10 +1395,22 @@ struct PreviewVisualDiffHarness {
             outputDir: outputDir,
             resourceDir: resourceDir,
             pageNumber: pageNumber,
+            policy: policy,
             viewportSize: viewportSize,
             settleMilliseconds: settleMilliseconds,
             inputURLs: remaining.map { absoluteURL($0) }
         )
+    }
+
+    private static func parsePolicy(_ value: String) throws -> HwpPageRenderPolicy {
+        switch value {
+        case "coreGraphicsOnly":
+            return .coreGraphicsOnly
+        case "skiaOptIn":
+            return .skiaOptIn
+        default:
+            throw PreviewHarnessError(description: "--policy must be coreGraphicsOnly or skiaOptIn")
+        }
     }
 
     private static func parseViewport(_ value: String) throws -> CGSize {
@@ -1258,9 +1563,110 @@ private func formatMilliseconds(_ value: Double) -> String {
     String(format: "%.1f", value)
 }
 
+private func formatPercent(_ value: Double) -> String {
+    String(format: "%.4f%%", value)
+}
+
+private func formatDouble(_ value: Double) -> String {
+    String(format: "%.4f", value)
+}
+
+private func boundsString(_ bounds: CGRect?) -> String {
+    guard let bounds else {
+        return "-"
+    }
+    return "\(Int(bounds.minX)),\(Int(bounds.minY)) \(Int(bounds.width))x\(Int(bounds.height))"
+}
+
+private func renderPolicyName(_ policy: HwpPageRenderPolicy) -> String {
+    switch policy {
+    case .coreGraphicsOnly:
+        return "coreGraphicsOnly"
+    case .skiaOptIn:
+        return "skiaOptIn"
+    }
+}
+
+private func backendName(_ backend: HwpPageRenderBackend) -> String {
+    switch backend {
+    case .coreGraphics:
+        return "coreGraphics"
+    case .skia:
+        return "skia"
+    case .embeddedThumbnail:
+        return "embeddedThumbnail"
+    }
+}
+
+private func fallbackReasonName(_ reason: HwpPageRenderFallbackReason) -> String {
+    switch reason {
+    case .ffiUnavailable:
+        return "ffiUnavailable"
+    case .invalidDocumentHandle:
+        return "invalidDocumentHandle"
+    case .invalidPageIndex:
+        return "invalidPageIndex"
+    case .invalidRenderOptions:
+        return "invalidRenderOptions"
+    case .invalidPageSize:
+        return "invalidPageSize"
+    case .skiaRenderFailure:
+        return "skiaRenderFailure"
+    case .pngDecodeFailure:
+        return "pngDecodeFailure"
+    case .memoryTimeoutFallback:
+        return "memoryTimeoutFallback"
+    }
+}
+
+private func fallbackSuffix(_ reason: String?) -> String {
+    guard let reason else {
+        return ""
+    }
+    return " fallback=\(reason)"
+}
+
 extension String {
     var wrappedTableRow: String {
         "| \(self) |"
+    }
+}
+
+private extension RGBAImage {
+    mutating func withBitmapContext(_ work: (CGContext) throws -> Void) throws {
+        let bytesPerRow = width * 4
+        try pixels.withUnsafeMutableBytes { buffer in
+            guard let context = CGContext(
+                data: buffer.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else {
+                throw PreviewHarnessError(description: "failed to create bitmap context")
+            }
+            try work(context)
+        }
+    }
+
+    mutating func makeCGImage() throws -> CGImage {
+        let bytesPerRow = width * 4
+        return try pixels.withUnsafeMutableBytes { buffer in
+            guard let context = CGContext(
+                data: buffer.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ), let image = context.makeImage() else {
+                throw PreviewHarnessError(description: "failed to create CGImage")
+            }
+            return image
+        }
     }
 }
 

--- a/scripts/preview_visual_diff_harness.swift
+++ b/scripts/preview_visual_diff_harness.swift
@@ -466,17 +466,23 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             throw PreviewHarnessError(description: "page \(pageNumber) rect is unavailable")
         }
 
-        let snapshotRect = try visibleSnapshotRect(snapshotRectMetadata.cgRect)
-        let image = try takeSnapshot(rect: snapshotRect)
-        var png = try pngData(from: image)
-        var captureMode = "webViewSnapshot"
-        var overlayIncluded = true
-        let snapshotSampleNonWhitePixels = png.sampleNonWhitePixels
-        let snapshotSamplePixels = png.samplePixels
+        var png: PNGOutput
+        var captureMode = "canvasDataURL"
+        var overlayIncluded = false
+        var snapshotSampleNonWhitePixels = 0
+        var snapshotSamplePixels = 0
         if pageState.canvasSampleNonWhitePixels > 0 {
             png = try exportCanvasPNG(pageNumber: pageNumber)
-            captureMode = "canvasDataURL"
-            overlayIncluded = false
+            if let snapshotPNG = try? captureSnapshotPNG(rect: snapshotRectMetadata.cgRect) {
+                snapshotSampleNonWhitePixels = snapshotPNG.sampleNonWhitePixels
+                snapshotSamplePixels = snapshotPNG.samplePixels
+            }
+        } else {
+            png = try captureSnapshotPNG(rect: snapshotRectMetadata.cgRect)
+            captureMode = "webViewSnapshot"
+            overlayIncluded = true
+            snapshotSampleNonWhitePixels = png.sampleNonWhitePixels
+            snapshotSamplePixels = png.samplePixels
         }
         try png.data.write(to: pngURL, options: .atomic)
 
@@ -587,23 +593,12 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         self.window = window
     }
 
-    private func waitForNavigation(timeout: TimeInterval) throws {
-        let deadline = Date().addingTimeInterval(timeout)
-        while navigationResult == nil && Date() < deadline {
-            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
-        }
-
-        guard let navigationResult else {
-            throw PreviewHarnessError(description: "rhwp-studio navigation timed out")
-        }
-        try navigationResult.get()
-    }
-
     private func waitForPageReady(pageNumber: Int, timeout: TimeInterval) throws {
         let deadline = Date().addingTimeInterval(timeout)
         var lastState: PageState?
         var lastError: Error?
         while Date() < deadline {
+            try throwIfNavigationFailed()
             do {
                 let state = try currentPageState(pageNumber: pageNumber)
                 if state.ready {
@@ -623,6 +618,12 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         throw PreviewHarnessError(description: "rhwp-studio page \(pageNumber) readiness timed out: \(reason)")
     }
 
+    private func throwIfNavigationFailed() throws {
+        if case .failure(let error) = navigationResult {
+            throw PreviewHarnessError(description: "rhwp-studio navigation failed: \(error)")
+        }
+    }
+
     private func alignPageAndHideChrome(pageNumber: Int) throws {
         _ = try evaluateJavaScript(alignAndHideChromeScript(pageNumber: pageNumber), timeout: 5)
         _ = try evaluateJavaScript(settleFlagScript(), timeout: 5)
@@ -635,6 +636,7 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             }
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
         }
+        throw PreviewHarnessError(description: "rhwp-studio capture settle timed out for page \(pageNumber)")
     }
 
     private func currentPageState(pageNumber: Int) throws -> PageState {
@@ -723,6 +725,12 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             throw PreviewHarnessError(description: "WKWebView snapshot timed out")
         }
         return try result.get()
+    }
+
+    private func captureSnapshotPNG(rect: CGRect) throws -> PNGOutput {
+        let snapshotRect = try visibleSnapshotRect(rect)
+        let image = try takeSnapshot(rect: snapshotRect)
+        return try pngData(from: image)
     }
 
     private func exportCanvasPNG(pageNumber: Int) throws -> PNGOutput {
@@ -1020,11 +1028,17 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         """
         (() => {
           window.__alhangeulPreviewCaptureSettled = false;
-          requestAnimationFrame(() => {
+          const markSettled = () => {
+            window.__alhangeulPreviewCaptureSettled = true;
+          };
+          if (typeof requestAnimationFrame === 'function') {
             requestAnimationFrame(() => {
-              window.__alhangeulPreviewCaptureSettled = true;
+              requestAnimationFrame(markSettled);
             });
-          });
+            setTimeout(markSettled, 250);
+          } else {
+            setTimeout(markSettled, 0);
+          }
           return true;
         })();
         """

--- a/scripts/preview_visual_diff_harness.swift
+++ b/scripts/preview_visual_diff_harness.swift
@@ -1,0 +1,1272 @@
+import AppKit
+import CoreGraphics
+import Darwin
+import Foundation
+import WebKit
+
+struct PreviewHarnessError: Error, CustomStringConvertible {
+    let description: String
+}
+
+struct HarnessOptions {
+    let outputDir: URL
+    let resourceDir: URL
+    let pageNumber: Int
+    let viewportSize: CGSize
+    let settleMilliseconds: Int
+    let inputURLs: [URL]
+}
+
+struct StudioManifest: Decodable {
+    let source_release_tag: String
+    let source_resolved_commit: String
+    let entrypoints: [String: Entrypoint]
+
+    struct Entrypoint: Codable {
+        let path: String
+        let sha256: String
+    }
+
+    static func load(from resourceDir: URL) throws -> StudioManifest {
+        let url = resourceDir.appendingPathComponent("manifest.json", isDirectory: false)
+        do {
+            let data = try Data(contentsOf: url)
+            return try JSONDecoder().decode(StudioManifest.self, from: data)
+        } catch {
+            throw PreviewHarnessError(description: "failed to read rhwp-studio manifest: \(url.path): \(error)")
+        }
+    }
+}
+
+struct RectMetadata: Codable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    var cgRect: CGRect {
+        CGRect(x: x, y: y, width: width, height: height)
+    }
+}
+
+struct SizeMetadata: Codable {
+    let width: Double
+    let height: Double
+}
+
+struct StudioCaptureMetadata: Codable {
+    let sourcePath: String
+    let filename: String
+    let page: Int
+    let loadURL: String
+    let selector: String
+    let rect: RectMetadata
+    let canvasRect: RectMetadata
+    let devicePixelRatio: Double
+    let viewportSize: SizeMetadata
+    let canvasCount: Int
+    let overlayCount: Int
+    let usedOverlayUnion: Bool
+    let canvasSampleNonWhitePixels: Int
+    let canvasSamplePixels: Int
+    let snapshotSampleNonWhitePixels: Int
+    let snapshotSamplePixels: Int
+    let captureMode: String
+    let overlayIncluded: Bool
+    let statusText: String
+    let captureMs: Double
+    let settleMs: Int
+    let studioReleaseTag: String
+    let studioResolvedCommit: String
+    let entrypoints: [String: StudioManifest.Entrypoint]
+    let chromeHidden: [String]
+    let editorChromeResidual: String?
+    let pngPath: String
+    let pngBytes: Int
+    let pngWidth: Int
+    let pngHeight: Int
+}
+
+struct StudioCaptureResult {
+    let fileName: String
+    let pngURL: URL
+    let jsonURL: URL
+    let pngWidth: Int
+    let pngHeight: Int
+    let canvasCount: Int
+    let overlayCount: Int
+    let canvasSampleNonWhitePixels: Int
+    let canvasSamplePixels: Int
+    let captureMode: String
+    let captureMs: Double
+}
+
+struct PNGOutput {
+    let data: Data
+    let width: Int
+    let height: Int
+    let sampleNonWhitePixels: Int
+    let samplePixels: Int
+}
+
+struct PageState {
+    let ready: Bool
+    let reason: String
+    let selector: String
+    let statusText: String
+    let canvasCount: Int
+    let overlayCount: Int
+    let usedOverlayUnion: Bool
+    let canvasSampleNonWhitePixels: Int
+    let canvasSamplePixels: Int
+    let devicePixelRatio: Double
+    let viewportSize: SizeMetadata
+    let canvasRect: RectMetadata?
+    let snapshotRect: RectMetadata?
+
+    init(dictionary: [String: Any]) {
+        ready = dictionary["ready"] as? Bool ?? false
+        reason = dictionary["reason"] as? String ?? ""
+        selector = dictionary["selector"] as? String ?? "#scroll-content canvas"
+        statusText = dictionary["statusText"] as? String ?? ""
+        canvasCount = intValue(dictionary["canvasCount"])
+        overlayCount = intValue(dictionary["overlayCount"])
+        usedOverlayUnion = dictionary["usedOverlayUnion"] as? Bool ?? false
+        canvasSampleNonWhitePixels = intValue(dictionary["canvasSampleNonWhitePixels"])
+        canvasSamplePixels = intValue(dictionary["canvasSamplePixels"])
+        devicePixelRatio = doubleValue(dictionary["devicePixelRatio"], default: 1)
+
+        if let viewport = dictionary["viewportSize"] as? [String: Any] {
+            viewportSize = SizeMetadata(
+                width: doubleValue(viewport["width"]),
+                height: doubleValue(viewport["height"])
+            )
+        } else {
+            viewportSize = SizeMetadata(width: 0, height: 0)
+        }
+
+        if let rect = dictionary["canvasRect"] as? [String: Any] {
+            canvasRect = RectMetadata(
+                x: doubleValue(rect["x"]),
+                y: doubleValue(rect["y"]),
+                width: doubleValue(rect["width"]),
+                height: doubleValue(rect["height"])
+            )
+        } else {
+            canvasRect = nil
+        }
+
+        if let rect = dictionary["snapshotRect"] as? [String: Any] {
+            snapshotRect = RectMetadata(
+                x: doubleValue(rect["x"]),
+                y: doubleValue(rect["y"]),
+                width: doubleValue(rect["width"]),
+                height: doubleValue(rect["height"])
+            )
+        } else {
+            snapshotRect = nil
+        }
+    }
+}
+
+final class StudioResourceSchemeHandler: NSObject, WKURLSchemeHandler {
+    static let scheme = "alhangeul-studio"
+    static let host = "app"
+
+    private let resourceDir: URL
+    private let fileManager: FileManager
+
+    init(resourceDir: URL, fileManager: FileManager = .default) {
+        self.resourceDir = resourceDir.standardizedFileURL
+        self.fileManager = fileManager
+    }
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+        guard let url = urlSchemeTask.request.url,
+              url.scheme?.lowercased() == Self.scheme,
+              url.host?.lowercased() == Self.host
+        else {
+            fail("invalid rhwp-studio resource URL", url: urlSchemeTask.request.url, task: urlSchemeTask)
+            return
+        }
+
+        let relativePath = normalizedRelativePath(from: url)
+        let fileURL = resourceDir.appendingPathComponent(relativePath, isDirectory: false).standardizedFileURL
+        guard isResourceFile(fileURL) else {
+            fail("missing rhwp-studio resource: \(relativePath)", url: url, task: urlSchemeTask)
+            return
+        }
+
+        do {
+            let data = try Data(contentsOf: fileURL)
+            guard let response = HTTPURLResponse(
+                url: url,
+                statusCode: 200,
+                httpVersion: "HTTP/1.1",
+                headerFields: [
+                    "Content-Type": contentType(for: fileURL),
+                    "Access-Control-Allow-Origin": "*",
+                    "Cache-Control": "no-store"
+                ]
+            ) else {
+                fail("failed to create rhwp-studio resource response", url: url, task: urlSchemeTask)
+                return
+            }
+            urlSchemeTask.didReceive(response)
+            urlSchemeTask.didReceive(data)
+            urlSchemeTask.didFinish()
+        } catch {
+            fail("failed to read rhwp-studio resource: \(relativePath): \(error)", url: url, task: urlSchemeTask)
+        }
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {}
+
+    private func normalizedRelativePath(from url: URL) -> String {
+        var path = url.path
+        if path.isEmpty || path == "/" {
+            return "index.html"
+        }
+        if path.hasPrefix("/") {
+            path.removeFirst()
+        }
+        return path
+    }
+
+    private func isResourceFile(_ fileURL: URL) -> Bool {
+        let rootPath = resourceDir.path
+        let targetPath = fileURL.path
+        guard targetPath == rootPath || targetPath.hasPrefix(rootPath + "/") else {
+            return false
+        }
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: targetPath, isDirectory: &isDirectory) && !isDirectory.boolValue
+    }
+
+    private func contentType(for fileURL: URL) -> String {
+        switch fileURL.pathExtension.lowercased() {
+        case "html":
+            return "text/html; charset=utf-8"
+        case "js":
+            return "text/javascript; charset=utf-8"
+        case "css":
+            return "text/css; charset=utf-8"
+        case "wasm":
+            return "application/wasm"
+        case "json", "webmanifest":
+            return "application/json; charset=utf-8"
+        case "svg":
+            return "image/svg+xml"
+        case "png":
+            return "image/png"
+        case "ico":
+            return "image/x-icon"
+        case "woff2":
+            return "font/woff2"
+        case "txt", "md", "ts":
+            return "text/plain; charset=utf-8"
+        default:
+            return "application/octet-stream"
+        }
+    }
+
+    private func fail(_ message: String, url: URL?, task: WKURLSchemeTask) {
+        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: message]
+        if let url {
+            userInfo[NSURLErrorFailingURLErrorKey] = url
+        }
+        task.didFailWithError(NSError(domain: "PreviewVisualDiffStudioResource", code: -1, userInfo: userInfo))
+    }
+}
+
+final class StudioDocumentSchemeHandler: NSObject, WKURLSchemeHandler {
+    static let scheme = "alhangeul-document"
+    static let host = "current"
+
+    private let data: Data
+    private let revision: Int
+
+    init(data: Data, revision: Int) {
+        self.data = data
+        self.revision = revision
+    }
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+        guard let url = urlSchemeTask.request.url,
+              url.scheme?.lowercased() == Self.scheme,
+              url.host?.lowercased() == Self.host
+        else {
+            fail("invalid rhwp-studio document URL", url: urlSchemeTask.request.url, task: urlSchemeTask)
+            return
+        }
+
+        guard requestedRevision(from: url) == revision else {
+            fail("requested document revision does not match", url: url, task: urlSchemeTask)
+            return
+        }
+
+        guard let response = HTTPURLResponse(
+            url: url,
+            statusCode: 200,
+            httpVersion: "HTTP/1.1",
+            headerFields: [
+                "Access-Control-Allow-Origin": "*",
+                "Cache-Control": "no-store",
+                "Content-Length": String(data.count),
+                "Content-Type": "application/octet-stream"
+            ]
+        ) else {
+            fail("failed to create rhwp-studio document response", url: url, task: urlSchemeTask)
+            return
+        }
+
+        urlSchemeTask.didReceive(response)
+        urlSchemeTask.didReceive(data)
+        urlSchemeTask.didFinish()
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {}
+
+    private func requestedRevision(from url: URL) -> Int? {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == "revision" })?
+            .value
+            .flatMap(Int.init)
+    }
+
+    private func fail(_ message: String, url: URL?, task: WKURLSchemeTask) {
+        var userInfo: [String: Any] = [NSLocalizedDescriptionKey: message]
+        if let url {
+            userInfo[NSURLErrorFailingURLErrorKey] = url
+        }
+        task.didFailWithError(NSError(domain: "PreviewVisualDiffStudioDocument", code: -1, userInfo: userInfo))
+    }
+}
+
+final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
+    private let resourceDir: URL
+    private let viewportSize: CGSize
+    private let settleMilliseconds: Int
+    private var webView: WKWebView?
+    private var window: NSWindow?
+    private var resourceSchemeHandler: StudioResourceSchemeHandler?
+    private var documentSchemeHandler: StudioDocumentSchemeHandler?
+    private var navigationResult: Result<Void, Error>?
+
+    init(resourceDir: URL, viewportSize: CGSize, settleMilliseconds: Int) {
+        self.resourceDir = resourceDir
+        self.viewportSize = viewportSize
+        self.settleMilliseconds = settleMilliseconds
+    }
+
+    func capture(
+        inputURL: URL,
+        outputDir: URL,
+        pageNumber: Int,
+        manifest: StudioManifest
+    ) throws -> StudioCaptureResult {
+        let data = try Data(contentsOf: inputURL)
+        let loadURL = try makeLoadURL(filename: inputURL.lastPathComponent, revision: 1)
+        let baseName = inputURL.deletingPathExtension().lastPathComponent
+        let outputBase = "\(baseName)-page\(pageNumber)"
+        let pngURL = outputDir.appendingPathComponent("\(outputBase)-studio.png", isDirectory: false)
+        let jsonURL = outputDir.appendingPathComponent("\(outputBase)-studio.json", isDirectory: false)
+
+        try createWebView(documentData: data, revision: 1)
+        defer {
+            webView?.navigationDelegate = nil
+            webView?.stopLoading()
+            window?.orderOut(nil)
+            webView = nil
+            window = nil
+            resourceSchemeHandler = nil
+            documentSchemeHandler = nil
+            navigationResult = nil
+        }
+
+        let startTime = Date()
+        webView?.load(URLRequest(url: loadURL))
+        try waitForPageReady(pageNumber: pageNumber, timeout: 30)
+        try alignPageAndHideChrome(pageNumber: pageNumber)
+        runMainLoop(milliseconds: settleMilliseconds)
+        let pageState = try currentPageState(pageNumber: pageNumber)
+        guard pageState.ready else {
+            throw PreviewHarnessError(description: "page \(pageNumber) not ready after settle: \(pageState.reason)")
+        }
+        guard let snapshotRectMetadata = pageState.snapshotRect,
+              let canvasRectMetadata = pageState.canvasRect
+        else {
+            throw PreviewHarnessError(description: "page \(pageNumber) rect is unavailable")
+        }
+
+        let snapshotRect = try visibleSnapshotRect(snapshotRectMetadata.cgRect)
+        let image = try takeSnapshot(rect: snapshotRect)
+        var png = try pngData(from: image)
+        var captureMode = "webViewSnapshot"
+        var overlayIncluded = true
+        let snapshotSampleNonWhitePixels = png.sampleNonWhitePixels
+        let snapshotSamplePixels = png.samplePixels
+        if pageState.canvasSampleNonWhitePixels > 0 {
+            png = try exportCanvasPNG(pageNumber: pageNumber)
+            captureMode = "canvasDataURL"
+            overlayIncluded = false
+        }
+        try png.data.write(to: pngURL, options: .atomic)
+
+        let elapsedMs = Date().timeIntervalSince(startTime) * 1000
+        let metadata = StudioCaptureMetadata(
+            sourcePath: inputURL.path,
+            filename: inputURL.lastPathComponent,
+            page: pageNumber,
+            loadURL: loadURL.absoluteString,
+            selector: pageState.selector,
+            rect: snapshotRectMetadata,
+            canvasRect: canvasRectMetadata,
+            devicePixelRatio: pageState.devicePixelRatio,
+            viewportSize: pageState.viewportSize,
+            canvasCount: pageState.canvasCount,
+            overlayCount: pageState.overlayCount,
+            usedOverlayUnion: pageState.usedOverlayUnion,
+            canvasSampleNonWhitePixels: pageState.canvasSampleNonWhitePixels,
+            canvasSamplePixels: pageState.canvasSamplePixels,
+            snapshotSampleNonWhitePixels: snapshotSampleNonWhitePixels,
+            snapshotSamplePixels: snapshotSamplePixels,
+            captureMode: captureMode,
+            overlayIncluded: overlayIncluded,
+            statusText: pageState.statusText,
+            captureMs: elapsedMs,
+            settleMs: settleMilliseconds,
+            studioReleaseTag: manifest.source_release_tag,
+            studioResolvedCommit: manifest.source_resolved_commit,
+            entrypoints: manifest.entrypoints,
+            chromeHidden: chromeSelectors,
+            editorChromeResidual: "canvas 내부 margin/editor guide는 CSS로 제거하지 않고 reference에 잔류할 수 있음",
+            pngPath: pngURL.path,
+            pngBytes: png.data.count,
+            pngWidth: png.width,
+            pngHeight: png.height
+        )
+        try writeJSON(metadata, to: jsonURL)
+
+        return StudioCaptureResult(
+            fileName: inputURL.lastPathComponent,
+            pngURL: pngURL,
+            jsonURL: jsonURL,
+            pngWidth: png.width,
+            pngHeight: png.height,
+            canvasCount: pageState.canvasCount,
+            overlayCount: pageState.overlayCount,
+            canvasSampleNonWhitePixels: pageState.canvasSampleNonWhitePixels,
+            canvasSamplePixels: pageState.canvasSamplePixels,
+            captureMode: captureMode,
+            captureMs: elapsedMs
+        )
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        navigationResult = .success(())
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        navigationResult = .failure(error)
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        navigationResult = .failure(error)
+    }
+
+    private var chromeSelectors: [String] {
+        [
+            "#menu-bar",
+            "#icon-toolbar",
+            "#style-bar",
+            "#status-bar",
+            "#ruler-corner",
+            "#h-ruler",
+            "#v-ruler"
+        ]
+    }
+
+    private func createWebView(documentData: Data, revision: Int) throws {
+        navigationResult = nil
+        let resourceHandler = StudioResourceSchemeHandler(resourceDir: resourceDir)
+        let documentHandler = StudioDocumentSchemeHandler(data: documentData, revision: revision)
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .nonPersistent()
+        configuration.setURLSchemeHandler(resourceHandler, forURLScheme: StudioResourceSchemeHandler.scheme)
+        configuration.setURLSchemeHandler(documentHandler, forURLScheme: StudioDocumentSchemeHandler.scheme)
+
+        let frame = CGRect(origin: .zero, size: viewportSize)
+        let webView = WKWebView(frame: frame, configuration: configuration)
+        webView.wantsLayer = true
+        webView.navigationDelegate = self
+        webView.setValue(false, forKey: "drawsBackground")
+
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = webView
+        window.alphaValue = 1
+        window.ignoresMouseEvents = true
+        window.setFrameOrigin(NSPoint(x: -20000, y: -20000))
+        window.orderBack(nil)
+
+        self.resourceSchemeHandler = resourceHandler
+        self.documentSchemeHandler = documentHandler
+        self.webView = webView
+        self.window = window
+    }
+
+    private func waitForNavigation(timeout: TimeInterval) throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while navigationResult == nil && Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+
+        guard let navigationResult else {
+            throw PreviewHarnessError(description: "rhwp-studio navigation timed out")
+        }
+        try navigationResult.get()
+    }
+
+    private func waitForPageReady(pageNumber: Int, timeout: TimeInterval) throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastState: PageState?
+        var lastError: Error?
+        while Date() < deadline {
+            do {
+                let state = try currentPageState(pageNumber: pageNumber)
+                if state.ready {
+                    return
+                }
+                lastState = state
+            } catch {
+                lastError = error
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+        let reason = lastState.map {
+            "\($0.reason), canvasCount=\($0.canvasCount), status=\($0.statusText)"
+        } ?? lastError.map {
+            String(describing: $0)
+        } ?? "no page state"
+        throw PreviewHarnessError(description: "rhwp-studio page \(pageNumber) readiness timed out: \(reason)")
+    }
+
+    private func alignPageAndHideChrome(pageNumber: Int) throws {
+        _ = try evaluateJavaScript(alignAndHideChromeScript(pageNumber: pageNumber), timeout: 5)
+        _ = try evaluateJavaScript(settleFlagScript(), timeout: 5)
+
+        let deadline = Date().addingTimeInterval(1)
+        while Date() < deadline {
+            let settled = try evaluateJavaScript("window.__alhangeulPreviewCaptureSettled === true", timeout: 2) as? Bool ?? false
+            if settled {
+                return
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+    }
+
+    private func currentPageState(pageNumber: Int) throws -> PageState {
+        let value = try evaluateJavaScript(pageStateScript(pageNumber: pageNumber), timeout: 5)
+        guard let json = value as? String,
+              let data = json.data(using: .utf8),
+              let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw PreviewHarnessError(description: "unexpected page state result: \(String(describing: value))")
+        }
+        return PageState(dictionary: dictionary)
+    }
+
+    private func evaluateJavaScript(_ script: String, timeout: TimeInterval) throws -> Any? {
+        guard let webView else {
+            throw PreviewHarnessError(description: "WKWebView is not available")
+        }
+
+        var result: Result<Any?, Error>?
+        webView.evaluateJavaScript(script) { value, error in
+            if let error {
+                result = .failure(error)
+            } else {
+                result = .success(value)
+            }
+        }
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while result == nil && Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+
+        guard let result else {
+            throw PreviewHarnessError(description: "JavaScript evaluation timed out")
+        }
+        return try result.get()
+    }
+
+    private func visibleSnapshotRect(_ rect: CGRect) throws -> CGRect {
+        guard let webView else {
+            throw PreviewHarnessError(description: "WKWebView is not available")
+        }
+        let integral = CGRect(
+            x: floor(rect.origin.x),
+            y: floor(rect.origin.y),
+            width: ceil(rect.width),
+            height: ceil(rect.height)
+        )
+        let visible = integral.intersection(webView.bounds)
+        guard visible.width > 0, visible.height > 0 else {
+            throw PreviewHarnessError(description: "snapshot rect is outside viewport: \(rect)")
+        }
+        guard abs(visible.width - integral.width) < 1, abs(visible.height - integral.height) < 1 else {
+            throw PreviewHarnessError(
+                description: "snapshot rect does not fit viewport: rect=\(integral), viewport=\(webView.bounds.size). Increase --viewport."
+            )
+        }
+        return integral
+    }
+
+    private func takeSnapshot(rect: CGRect) throws -> NSImage {
+        guard let webView else {
+            throw PreviewHarnessError(description: "WKWebView is not available")
+        }
+
+        var result: Result<NSImage, Error>?
+        let configuration = WKSnapshotConfiguration()
+        configuration.rect = rect
+        configuration.afterScreenUpdates = true
+        webView.takeSnapshot(with: configuration) { image, error in
+            if let error {
+                result = .failure(error)
+            } else if let image {
+                result = .success(image)
+            } else {
+                result = .failure(PreviewHarnessError(description: "WKWebView snapshot returned nil image"))
+            }
+        }
+
+        let deadline = Date().addingTimeInterval(10)
+        while result == nil && Date() < deadline {
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+
+        guard let result else {
+            throw PreviewHarnessError(description: "WKWebView snapshot timed out")
+        }
+        return try result.get()
+    }
+
+    private func exportCanvasPNG(pageNumber: Int) throws -> PNGOutput {
+        let value = try evaluateJavaScript(canvasDataURLScript(pageNumber: pageNumber), timeout: 10)
+        guard let json = value as? String,
+              let data = json.data(using: .utf8),
+              let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dataURL = dictionary["dataURL"] as? String
+        else {
+            throw PreviewHarnessError(description: "unexpected canvas export result: \(String(describing: value))")
+        }
+
+        let marker = "base64,"
+        guard let markerRange = dataURL.range(of: marker) else {
+            throw PreviewHarnessError(description: "canvas export did not return base64 PNG data")
+        }
+        let base64 = String(dataURL[markerRange.upperBound...])
+        guard let pngData = Data(base64Encoded: base64) else {
+            throw PreviewHarnessError(description: "failed to decode canvas PNG data")
+        }
+
+        let width = intValue(dictionary["width"])
+        let height = intValue(dictionary["height"])
+        return PNGOutput(
+            data: pngData,
+            width: width,
+            height: height,
+            sampleNonWhitePixels: intValue(dictionary["canvasSampleNonWhitePixels"]),
+            samplePixels: intValue(dictionary["canvasSamplePixels"])
+        )
+    }
+
+    private func makeLoadURL(filename: String, revision: Int) throws -> URL {
+        var documentComponents = URLComponents()
+        documentComponents.scheme = StudioDocumentSchemeHandler.scheme
+        documentComponents.host = StudioDocumentSchemeHandler.host
+        documentComponents.queryItems = [
+            URLQueryItem(name: "revision", value: String(revision))
+        ]
+        guard let documentURL = documentComponents.url else {
+            throw PreviewHarnessError(description: "failed to build document URL")
+        }
+
+        var components = URLComponents()
+        components.scheme = StudioResourceSchemeHandler.scheme
+        components.host = StudioResourceSchemeHandler.host
+        components.path = "/index.html"
+        components.queryItems = [
+            URLQueryItem(name: "url", value: documentURL.absoluteString),
+            URLQueryItem(name: "filename", value: filename)
+        ]
+        guard let url = components.url else {
+            throw PreviewHarnessError(description: "failed to build rhwp-studio load URL")
+        }
+        return url
+    }
+
+    private func pageStateScript(pageNumber: Int) -> String {
+        """
+        JSON.stringify((() => {
+          const pageNumber = \(pageNumber);
+          const content = document.querySelector('#scroll-content');
+          const canvases = content
+            ? Array.from(content.querySelectorAll('canvas')).filter((canvas) => {
+                const rect = canvas.getBoundingClientRect();
+                return rect.width > 0 && rect.height > 0 && canvas.width > 0 && canvas.height > 0;
+              })
+            : [];
+          const target = canvases[pageNumber - 1] || null;
+          const statusText = (document.querySelector('#sb-message')?.textContent || '').trim();
+          const rectObject = (rect) => ({
+            x: rect.left,
+            y: rect.top,
+            width: rect.width,
+            height: rect.height
+          });
+          const viewportSize = {
+            width: window.innerWidth,
+            height: window.innerHeight
+          };
+          if (!content) {
+            return {
+              ready: false,
+              reason: 'missing #scroll-content',
+              selector: '#scroll-content canvas',
+              statusText,
+              canvasCount: 0,
+              overlayCount: 0,
+              usedOverlayUnion: false,
+              canvasSampleNonWhitePixels: 0,
+              canvasSamplePixels: 0,
+              devicePixelRatio: window.devicePixelRatio || 1,
+              viewportSize
+            };
+          }
+          if (!target) {
+            return {
+              ready: false,
+              reason: `page canvas not found for page ${pageNumber}`,
+              selector: '#scroll-content canvas',
+              statusText,
+              canvasCount: canvases.length,
+              overlayCount: 0,
+              usedOverlayUnion: false,
+              canvasSampleNonWhitePixels: 0,
+              canvasSamplePixels: 0,
+              devicePixelRatio: window.devicePixelRatio || 1,
+              viewportSize
+            };
+          }
+
+          const targetRect = target.getBoundingClientRect();
+          let unionLeft = targetRect.left;
+          let unionTop = targetRect.top;
+          let unionRight = targetRect.right;
+          let unionBottom = targetRect.bottom;
+          let overlayCount = 0;
+
+          for (const element of Array.from(content.querySelectorAll('*'))) {
+            if (element === target || element.tagName.toLowerCase() === 'canvas') {
+              continue;
+            }
+            const style = window.getComputedStyle(element);
+            if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) {
+              continue;
+            }
+            const rect = element.getBoundingClientRect();
+            if (rect.width <= 0 || rect.height <= 0) {
+              continue;
+            }
+            const intersectsVertical = rect.bottom >= targetRect.top - 1 && rect.top <= targetRect.bottom + 1;
+            const intersectsHorizontal = rect.right >= targetRect.left - 1 && rect.left <= targetRect.right + 1;
+            if (!intersectsVertical || !intersectsHorizontal) {
+              continue;
+            }
+            overlayCount += 1;
+            unionLeft = Math.min(unionLeft, rect.left);
+            unionTop = Math.min(unionTop, rect.top);
+            unionRight = Math.max(unionRight, rect.right);
+            unionBottom = Math.max(unionBottom, rect.bottom);
+          }
+
+          const snapshotRect = {
+            x: unionLeft,
+            y: unionTop,
+            width: unionRight - unionLeft,
+            height: unionBottom - unionTop
+          };
+          let canvasSampleNonWhitePixels = 0;
+          let canvasSamplePixels = 0;
+          try {
+            const context = target.getContext('2d', { willReadFrequently: true });
+            const backingWidth = target.width;
+            const backingHeight = target.height;
+            const step = Math.max(1, Math.floor(Math.min(backingWidth, backingHeight) / 160));
+            const imageData = context.getImageData(0, 0, backingWidth, backingHeight).data;
+            for (let y = 0; y < backingHeight; y += step) {
+              for (let x = 0; x < backingWidth; x += step) {
+                const index = (y * backingWidth + x) * 4;
+                const r = imageData[index];
+                const g = imageData[index + 1];
+                const b = imageData[index + 2];
+                const a = imageData[index + 3];
+                canvasSamplePixels += 1;
+                if (a > 0 && (r < 245 || g < 245 || b < 245)) {
+                  canvasSampleNonWhitePixels += 1;
+                }
+              }
+            }
+          } catch (_) {
+            canvasSampleNonWhitePixels = -1;
+            canvasSamplePixels = -1;
+          }
+
+          return {
+            ready: true,
+            reason: 'ready',
+            selector: '#scroll-content canvas',
+            statusText,
+            canvasCount: canvases.length,
+            overlayCount,
+            usedOverlayUnion: overlayCount > 0,
+            canvasSampleNonWhitePixels,
+            canvasSamplePixels,
+            devicePixelRatio: window.devicePixelRatio || 1,
+            viewportSize,
+            canvasRect: rectObject(targetRect),
+            snapshotRect
+          };
+        })());
+        """
+    }
+
+    private func canvasDataURLScript(pageNumber: Int) -> String {
+        """
+        JSON.stringify((() => {
+          const pageNumber = \(pageNumber);
+          const content = document.querySelector('#scroll-content');
+          const canvases = content
+            ? Array.from(content.querySelectorAll('canvas')).filter((canvas) => {
+                const rect = canvas.getBoundingClientRect();
+                return rect.width > 0 && rect.height > 0 && canvas.width > 0 && canvas.height > 0;
+              })
+            : [];
+          const target = canvases[pageNumber - 1] || null;
+          if (!target) {
+            throw new Error(`page canvas not found for page ${pageNumber}`);
+          }
+          let canvasSampleNonWhitePixels = 0;
+          let canvasSamplePixels = 0;
+          const context = target.getContext('2d', { willReadFrequently: true });
+          const backingWidth = target.width;
+          const backingHeight = target.height;
+          const step = Math.max(1, Math.floor(Math.min(backingWidth, backingHeight) / 160));
+          const imageData = context.getImageData(0, 0, backingWidth, backingHeight).data;
+          for (let y = 0; y < backingHeight; y += step) {
+            for (let x = 0; x < backingWidth; x += step) {
+              const index = (y * backingWidth + x) * 4;
+              const r = imageData[index];
+              const g = imageData[index + 1];
+              const b = imageData[index + 2];
+              const a = imageData[index + 3];
+              canvasSamplePixels += 1;
+              if (a > 0 && (r < 245 || g < 245 || b < 245)) {
+                canvasSampleNonWhitePixels += 1;
+              }
+            }
+          }
+          return {
+            width: target.width,
+            height: target.height,
+            canvasSampleNonWhitePixels,
+            canvasSamplePixels,
+            dataURL: (() => {
+              const exportCanvas = document.createElement('canvas');
+              exportCanvas.width = target.width;
+              exportCanvas.height = target.height;
+              const exportContext = exportCanvas.getContext('2d');
+              exportContext.fillStyle = '#ffffff';
+              exportContext.fillRect(0, 0, exportCanvas.width, exportCanvas.height);
+              exportContext.drawImage(target, 0, 0);
+              return exportCanvas.toDataURL('image/png');
+            })()
+          };
+        })());
+        """
+    }
+
+    private func alignAndHideChromeScript(pageNumber: Int) -> String {
+        let css = """
+        #menu-bar,
+        #icon-toolbar,
+        #style-bar,
+        #status-bar,
+        #ruler-corner,
+        #h-ruler,
+        #v-ruler {
+          display: none !important;
+        }
+        """
+
+        return """
+        (() => {
+          const css = \(javaScriptStringLiteral(css));
+          let style = document.getElementById('__alhangeul_preview_capture_chrome_hide');
+          if (!style) {
+            style = document.createElement('style');
+            style.id = '__alhangeul_preview_capture_chrome_hide';
+            document.head.appendChild(style);
+          }
+          style.textContent = css;
+
+          const pageNumber = \(pageNumber);
+          const content = document.querySelector('#scroll-content');
+          const scrollContainer = document.querySelector('#scroll-container');
+          const canvases = content
+            ? Array.from(content.querySelectorAll('canvas')).filter((canvas) => {
+                const rect = canvas.getBoundingClientRect();
+                return rect.width > 0 && rect.height > 0 && canvas.width > 0 && canvas.height > 0;
+              })
+            : [];
+          const target = canvases[pageNumber - 1] || null;
+          if (target && scrollContainer) {
+            const targetRect = target.getBoundingClientRect();
+            const containerRect = scrollContainer.getBoundingClientRect();
+            scrollContainer.scrollTop += targetRect.top - containerRect.top - 24;
+            scrollContainer.scrollLeft = 0;
+          }
+          return true;
+        })();
+        """
+    }
+
+    private func settleFlagScript() -> String {
+        """
+        (() => {
+          window.__alhangeulPreviewCaptureSettled = false;
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              window.__alhangeulPreviewCaptureSettled = true;
+            });
+          });
+          return true;
+        })();
+        """
+    }
+}
+
+@main
+struct PreviewVisualDiffHarness {
+    static func main() throws {
+        NSApplication.shared.setActivationPolicy(.prohibited)
+
+        let options = try parseOptions(Array(CommandLine.arguments.dropFirst()))
+        let studioDir = options.outputDir.appendingPathComponent("studio", isDirectory: true)
+        try FileManager.default.createDirectory(at: studioDir, withIntermediateDirectories: true)
+
+        let manifest = try StudioManifest.load(from: options.resourceDir)
+        let renderer = StudioReferenceRenderer(
+            resourceDir: options.resourceDir,
+            viewportSize: options.viewportSize,
+            settleMilliseconds: options.settleMilliseconds
+        )
+
+        var failed = false
+        var summaryLines: [String] = []
+        summaryLines.append("# Preview Visual Diff Harness - Studio Reference")
+        summaryLines.append("")
+        summaryLines.append("Page: \(options.pageNumber)")
+        summaryLines.append("ResourceDir: \(options.resourceDir.path)")
+        summaryLines.append("StudioReleaseTag: \(manifest.source_release_tag)")
+        summaryLines.append("StudioResolvedCommit: \(manifest.source_resolved_commit)")
+        summaryLines.append("Viewport: \(Int(options.viewportSize.width))x\(Int(options.viewportSize.height))")
+        summaryLines.append("SettleMs: \(options.settleMilliseconds)")
+        summaryLines.append("")
+        summaryLines.append("| File | Status | Size | CanvasCount | OverlayCount | CanvasSampleNonWhite | CaptureMode | CaptureMs | StudioPNG | StudioJSON |")
+        summaryLines.append("|------|--------|------|-------------|--------------|----------------------|-------------|-----------|-----------|------------|")
+
+        for inputURL in options.inputURLs {
+            do {
+                let result = try renderer.capture(
+                    inputURL: inputURL,
+                    outputDir: studioDir,
+                    pageNumber: options.pageNumber,
+                    manifest: manifest
+                )
+                summaryLines.append([
+                    markdownCell(result.fileName),
+                    "OK",
+                    "\(result.pngWidth)x\(result.pngHeight)",
+                    "\(result.canvasCount)",
+                    "\(result.overlayCount)",
+                    "\(result.canvasSampleNonWhitePixels)/\(result.canvasSamplePixels)",
+                    result.captureMode,
+                    formatMilliseconds(result.captureMs),
+                    markdownCell(result.pngURL.path),
+                    markdownCell(result.jsonURL.path)
+                ].joined(separator: " | ").wrappedTableRow)
+                print("OK \(result.fileName): studioPNG=\(result.pngURL.path) metadata=\(result.jsonURL.path)")
+            } catch {
+                failed = true
+                summaryLines.append([
+                    markdownCell(inputURL.lastPathComponent),
+                    "FAIL: \(String(describing: error).replacingOccurrences(of: "|", with: "/"))",
+                    "-",
+                    "-",
+                    "-",
+                    "-",
+                    "-",
+                    "-",
+                    "-",
+                    "-"
+                ].joined(separator: " | ").wrappedTableRow)
+                print("FAIL \(inputURL.path): \(error)", to: &standardError)
+            }
+        }
+
+        try summaryLines.joined(separator: "\n").write(
+            to: options.outputDir.appendingPathComponent("summary.md", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        if failed {
+            Darwin.exit(1)
+        }
+    }
+
+    private static func parseOptions(_ args: [String]) throws -> HarnessOptions {
+        guard args.count >= 2 else {
+            throw PreviewHarnessError(
+                description: "usage: preview_visual_diff_harness <output-dir> [--page N] [--viewport WIDTHxHEIGHT] [--settle-ms N] [--resource-dir DIR] <hwp-or-hwpx> [...]"
+            )
+        }
+
+        var remaining = args
+        let outputDir = absoluteURL(remaining.removeFirst(), isDirectory: true)
+        var resourceDir = absoluteURL("Sources/HostApp/Resources/rhwp-studio", isDirectory: true)
+        var pageNumber = 1
+        var viewportSize = CGSize(width: 1400, height: 1800)
+        var settleMilliseconds = 120
+
+        while let first = remaining.first, first.hasPrefix("--") {
+            switch first {
+            case "--page":
+                remaining.removeFirst()
+                guard let value = remaining.first, let parsed = Int(value), parsed > 0 else {
+                    throw PreviewHarnessError(description: "--page requires a positive integer")
+                }
+                pageNumber = parsed
+                remaining.removeFirst()
+            case "--resource-dir":
+                remaining.removeFirst()
+                guard let value = remaining.first else {
+                    throw PreviewHarnessError(description: "--resource-dir requires a directory")
+                }
+                resourceDir = absoluteURL(value, isDirectory: true)
+                remaining.removeFirst()
+            case "--viewport":
+                remaining.removeFirst()
+                guard let value = remaining.first else {
+                    throw PreviewHarnessError(description: "--viewport requires WIDTHxHEIGHT")
+                }
+                viewportSize = try parseViewport(value)
+                remaining.removeFirst()
+            case "--settle-ms":
+                remaining.removeFirst()
+                guard let value = remaining.first, let parsed = Int(value), parsed >= 0 else {
+                    throw PreviewHarnessError(description: "--settle-ms requires a non-negative integer")
+                }
+                settleMilliseconds = parsed
+                remaining.removeFirst()
+            default:
+                throw PreviewHarnessError(description: "unknown option: \(first)")
+            }
+        }
+
+        guard !remaining.isEmpty else {
+            throw PreviewHarnessError(description: "missing input document")
+        }
+
+        return HarnessOptions(
+            outputDir: outputDir,
+            resourceDir: resourceDir,
+            pageNumber: pageNumber,
+            viewportSize: viewportSize,
+            settleMilliseconds: settleMilliseconds,
+            inputURLs: remaining.map { absoluteURL($0) }
+        )
+    }
+
+    private static func parseViewport(_ value: String) throws -> CGSize {
+        let parts = value.split(separator: "x", maxSplits: 1).map(String.init)
+        guard parts.count == 2,
+              let width = Double(parts[0]),
+              let height = Double(parts[1]),
+              width > 0,
+              height > 0
+        else {
+            throw PreviewHarnessError(description: "--viewport must use WIDTHxHEIGHT with positive numbers")
+        }
+        return CGSize(width: width, height: height)
+    }
+}
+
+private func absoluteURL(_ path: String, isDirectory: Bool = false) -> URL {
+    let url: URL
+    if path.hasPrefix("/") {
+        url = URL(fileURLWithPath: path, isDirectory: isDirectory)
+    } else {
+        url = URL(fileURLWithPath: FileManager.default.currentDirectoryPath, isDirectory: true)
+            .appendingPathComponent(path, isDirectory: isDirectory)
+    }
+    return url.standardizedFileURL
+}
+
+private func writeJSON<T: Encodable>(_ value: T, to url: URL) throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    let data = try encoder.encode(value)
+    try data.write(to: url, options: .atomic)
+}
+
+private func pngData(from image: NSImage) throws -> PNGOutput {
+    var proposedRect = CGRect(origin: .zero, size: image.size)
+    guard let cgImage = image.cgImage(forProposedRect: &proposedRect, context: nil, hints: nil) else {
+        throw PreviewHarnessError(description: "failed to create CGImage from snapshot")
+    }
+    let representation = NSBitmapImageRep(cgImage: cgImage)
+    guard let data = representation.representation(using: .png, properties: [:]) else {
+        throw PreviewHarnessError(description: "failed to encode snapshot PNG")
+    }
+    let sample = sampleNonWhitePixels(cgImage: cgImage)
+    return PNGOutput(
+        data: data,
+        width: cgImage.width,
+        height: cgImage.height,
+        sampleNonWhitePixels: sample.nonWhite,
+        samplePixels: sample.total
+    )
+}
+
+private func sampleNonWhitePixels(cgImage: CGImage) -> (nonWhite: Int, total: Int) {
+    let width = cgImage.width
+    let height = cgImage.height
+    guard width > 0, height > 0 else {
+        return (0, 0)
+    }
+
+    let bytesPerPixel = 4
+    let bytesPerRow = width * bytesPerPixel
+    var pixels = [UInt8](repeating: 255, count: height * bytesPerRow)
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    guard let context = CGContext(
+        data: &pixels,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: bytesPerRow,
+        space: colorSpace,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ) else {
+        return (-1, -1)
+    }
+
+    context.setFillColor(CGColor(gray: 1, alpha: 1))
+    context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+    context.draw(cgImage, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+    let step = max(1, min(width, height) / 160)
+    var nonWhite = 0
+    var total = 0
+    var y = 0
+    while y < height {
+        var x = 0
+        while x < width {
+            let index = (y * width + x) * bytesPerPixel
+            let red = pixels[index]
+            let green = pixels[index + 1]
+            let blue = pixels[index + 2]
+            let alpha = pixels[index + 3]
+            total += 1
+            if alpha > 0 && (red < 245 || green < 245 || blue < 245) {
+                nonWhite += 1
+            }
+            x += step
+        }
+        y += step
+    }
+    return (nonWhite, total)
+}
+
+private func runMainLoop(milliseconds: Int) {
+    guard milliseconds > 0 else {
+        return
+    }
+    let deadline = Date().addingTimeInterval(Double(milliseconds) / 1000)
+    while Date() < deadline {
+        RunLoop.current.run(mode: .default, before: min(deadline, Date().addingTimeInterval(0.02)))
+    }
+}
+
+private func javaScriptStringLiteral(_ string: String) -> String {
+    let data = try! JSONEncoder().encode(string)
+    return String(data: data, encoding: .utf8)!
+}
+
+private func intValue(_ value: Any?) -> Int {
+    if let value = value as? Int {
+        return value
+    }
+    if let value = value as? Double {
+        return Int(value)
+    }
+    if let value = value as? NSNumber {
+        return value.intValue
+    }
+    return 0
+}
+
+private func doubleValue(_ value: Any?, default defaultValue: Double = 0) -> Double {
+    if let value = value as? Double {
+        return value
+    }
+    if let value = value as? Int {
+        return Double(value)
+    }
+    if let value = value as? NSNumber {
+        return value.doubleValue
+    }
+    return defaultValue
+}
+
+private func markdownCell(_ value: String) -> String {
+    value.replacingOccurrences(of: "|", with: "/")
+}
+
+private func formatMilliseconds(_ value: Double) -> String {
+    String(format: "%.1f", value)
+}
+
+extension String {
+    var wrappedTableRow: String {
+        "| \(self) |"
+    }
+}
+
+private func print(_ value: String, to stream: inout FileHandle) {
+    let data = Data((value + "\n").utf8)
+    stream.write(data)
+}
+
+private var standardError = FileHandle.standardError


### PR DESCRIPTION
## 요약

- 대상 타스크: #280 rhwp-studio 기준 preview visual diff harness 구축
- 왜: v0.1.4 native preview/viewer parity 작업에서 rhwp-studio 기본 렌더와 Swift/native preview 출력 차이를 PR마다 같은 기준으로 측정하기 위함입니다.
- 무엇: bundled rhwp-studio WebKit capture, native `HwpPageImageRenderer` render, pixel diff/summary 생성 helper와 v0.1.4 sample set 문서를 추가했습니다.
- 리뷰 포인트: `canvasDataURL` reference capture 선택, native render policy 처리, diff metric 해석, #281/#282/#116/#122/#121/#110 handoff입니다.

## PR base

- base: `devel`

## 변경 내역

- **[작업 시작](https://github.com/postmelee/alhangeul-macos/blob/fdfa55748d6224ac5832ade7ceaeed762338e345/mydocs/plans/task_m014_280.md)** ([e7e3d44](https://github.com/postmelee/alhangeul-macos/commit/e7e3d44)): 수행계획서와 2026-05-25 오늘할일 작성
- **[구현 계획](https://github.com/postmelee/alhangeul-macos/blob/fdfa55748d6224ac5832ade7ceaeed762338e345/mydocs/plans/task_m014_280_impl.md)** ([eb7534d](https://github.com/postmelee/alhangeul-macos/commit/eb7534d)): 5단계 구현 계획과 수용 기준 정리
- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/fdfa55748d6224ac5832ade7ceaeed762338e345/mydocs/working/task_m014_280_stage1.md)** ([c49964e](https://github.com/postmelee/alhangeul-macos/commit/c49964e)): rhwp-studio asset, capture selector, native renderer entrypoint inventory 확정
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/fdfa55748d6224ac5832ade7ceaeed762338e345/mydocs/working/task_m014_280_stage2.md)** ([576bcec](https://github.com/postmelee/alhangeul-macos/commit/576bcec)): rhwp-studio reference capture와 Studio PNG/JSON 산출물 생성 추가
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/fdfa55748d6224ac5832ade7ceaeed762338e345/mydocs/working/task_m014_280_stage3.md)** ([cfa1f67](https://github.com/postmelee/alhangeul-macos/commit/cfa1f67)): native render, policy 옵션, diff PNG/summary metric 계산 추가
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/fdfa55748d6224ac5832ade7ceaeed762338e345/mydocs/working/task_m014_280_stage4.md)** ([b31579e](https://github.com/postmelee/alhangeul-macos/commit/b31579e)): 기본/확장 sample set과 후속 이슈별 사용 기준 문서화
- **[최종 보고](https://github.com/postmelee/alhangeul-macos/blob/fdfa55748d6224ac5832ade7ceaeed762338e345/mydocs/report/task_m014_280_report.md)** ([e6aa825](https://github.com/postmelee/alhangeul-macos/commit/e6aa825)): 최종 smoke 결과, 결론, 한계, handoff 정리
- **오늘할일 완료 시각 기록** ([fdfa557](https://github.com/postmelee/alhangeul-macos/commit/fdfa557)): PR 게시 전 완료 시각 보강

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `scripts/preview-visual-diff-harness.sh` | rhwp-studio asset 검증, Swift helper compile, output dir/input/options 전달 wrapper 추가 | 기존 build 산출물과 충돌 없이 `build.noindex/` 아래에서 반복 실행되는지 |
| `scripts/preview_visual_diff_harness.swift` | WebKit Studio capture, native page render, pixel diff PNG, JSON metadata, `summary.md` 생성 구현 | `canvasDataURL` capture와 native scale resize 비교의 한계가 명확한지 |
| `mydocs/tech/v014_preview_visual_diff_harness.md` | 사용법, 기본/확장 sample set, metric 해석, 후속 이슈 handoff 문서화 | 이후 #281/#282/#116/#122/#121/#110 PR에서 같은 기준으로 재사용 가능한지 |
| `mydocs/report/task_m014_280_report.md` | 최종 smoke 수치, Skia 관찰, 한계, 검증 결과 정리 | PR 본문과 최종 보고서의 수치/결론이 일치하는지 |

작업 문서:

- 수행 계획서: [task_m014_280.md](https://github.com/postmelee/alhangeul-macos/blob/fdfa55748d6224ac5832ade7ceaeed762338e345/mydocs/plans/task_m014_280.md)
- 구현 계획서: [task_m014_280_impl.md](https://github.com/postmelee/alhangeul-macos/blob/fdfa55748d6224ac5832ade7ceaeed762338e345/mydocs/plans/task_m014_280_impl.md)
- 최종 보고서: [task_m014_280_report.md](https://github.com/postmelee/alhangeul-macos/blob/fdfa55748d6224ac5832ade7ceaeed762338e345/mydocs/report/task_m014_280_report.md)
- 기술 문서: [v014_preview_visual_diff_harness.md](https://github.com/postmelee/alhangeul-macos/blob/fdfa55748d6224ac5832ade7ceaeed762338e345/mydocs/tech/v014_preview_visual_diff_harness.md)

## 핵심 리뷰 포인트

- 이번 PR은 측정 harness 구축입니다. Quick Look/Thumbnail production renderer, HostApp viewer UI, upstream rhwp pin, Skia default 전환은 변경하지 않습니다.
- Studio reference는 `WKWebView.takeSnapshot` 대신 `#scroll-content canvas.toDataURL('image/png')` 결과를 흰 배경에 합성합니다. smoke에서 `takeSnapshot`은 canvas backing store 문서 내용을 안정적으로 캡처하지 못했습니다.
- Diff는 Studio canvas backing store 크기를 기준으로 native PNG를 resize해 비교합니다. `ChangedPercent`는 hard gate가 아니라 후속 PR의 전후 비교 입력입니다.

## Smoke 측정 결과

최종 smoke 산출물은 로컬 `build.noindex/task280-final/`에 생성했습니다.

기준:

- Page: `1`
- NativePolicy: `coreGraphicsOnly`
- StudioReleaseTag: `v0.7.12`
- StudioResolvedCommit: `1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5`
- Viewport: `1400x1800`
- SettleMs: `120`
- DiffPixelThreshold: `12`

| 파일 | StudioSize | NativeSize | CompareSize | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | NativeBackend | NativeMs |
|---|---:|---:|---:|---:|---:|---:|---:|---|---|---:|
| `request.hwp` | `1133x1587` | `567x794` | `1133x1587` | `325488/1798071` | `18.1021%` | `11.5796` | `255` | `36,36 1061x1515` | `coreGraphics` | `1037.0ms` |
| `복학원서.hwp` | `1587x2245` | `794x1123` | `1587x2245` | `1153323/3562815` | `32.3711%` | `42.9364` | `255` | `83,45 1436x2155` | `coreGraphics` | `389.4ms` |
| `pic-crop-01.hwp` | `1587x2245` | `794x1123` | `1587x2245` | `72763/3562815` | `2.0423%` | `0.8092` | `186` | `121,234 1345x1814` | `coreGraphics` | `3.1ms` |
| `form-01.hwp` | `1587x2245` | `794x1123` | `1587x2245` | `28738/3562815` | `0.8066%` | `0.4845` | `255` | `197,234 1194x1814` | `coreGraphics` | `2.1ms` |
| `form-002.hwpx` | `1587x2244` | `794x1123` | `1587x2244` | `601515/3561228` | `16.8907%` | `17.6360` | `255` | `121,159 1345x1962` | `coreGraphics` | `25.3ms` |
| `hwpx-01.hwpx` | `1587x2245` | `794x1123` | `1587x2245` | `540973/3562815` | `15.1839%` | `15.6722` | `255` | `121,159 1345x1981` | `coreGraphics` | `29.8ms` |

모든 row는 `OK`입니다. Studio reference metadata는 모두 `captureMode=canvasDataURL`, `overlayIncluded=false`였고, `overlayCount`는 `복학원서.hwp`가 `5`, 나머지 기본 샘플이 `1`이었습니다.

## 추가 Skia 관찰

Stage 3에서 `--policy skiaOptIn` smoke를 별도로 확인했습니다.

| 파일 | StudioSize | NativeSize | ChangedPercent | MeanRGBDelta | NativeBackend | NativeMs |
|---|---:|---:|---:|---:|---|---:|
| `request.hwp` | `1133x1587` | `567x794` | `12.4856%` | `9.5936` | `skia` | `53.9ms` |

단일 샘플 기준으로 Skia는 CoreGraphics보다 changedPercent와 mean delta가 낮았습니다. 이 수치는 관찰 자료이며, Skia default 전환 판단은 M20/#259 범위로 남깁니다.

## 결론과 관찰

- rhwp-studio reference PNG, native preview PNG, diff PNG, summary를 같은 helper에서 반복 생성할 수 있게 됐습니다.
- `WKWebView.takeSnapshot`은 이번 환경에서 canvas 배경은 잡지만 문서 backing store를 빈 화면처럼 캡처했습니다. JavaScript canvas sampling에서는 non-white pixel이 확인되어, reference capture를 `canvasDataURL`로 고정했습니다.
- native 출력은 `HwpPageImageRenderer.renderPage(document:pageIndex:policy:)`를 사용하고, JSON metadata에 `policy`, `backendUsed`, `fallbackReason`, `pageSize`, `pixelSize`, `pngBytes`, `renderMs`를 남깁니다.
- `request.hwp`와 `pic-crop-01.hwp`에서 기존 renderer의 `LAYOUT_OVERFLOW` stderr가 관찰됐습니다. harness 실패는 아니지만 후속 renderer 개선에서 참고할 수 있습니다.

## 얻은 교훈 및 알게 된 점

- rhwp-studio를 reference로 삼더라도 WebKit snapshot API가 곧바로 visual oracle이 되지는 않습니다. canvas 기반 renderer는 backing store를 직접 export하는 경로를 함께 검증해야 합니다.
- scale이 다른 Studio canvas와 native point-size PNG를 비교하려면 resize 기준을 명시해야 합니다. 이번 harness는 Studio 크기를 기준으로 잡아 후속 PR의 전후 비교 일관성을 우선했습니다.
- DOM overlay는 reference PNG에서 제외되므로, PageLayerTree/overlay 작업은 `overlayCount`와 diff bounds를 함께 보고 해석해야 합니다.

## 검증

- `./scripts/verify-rhwp-studio-assets.sh`
- `./scripts/check-no-appkit.sh`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task280-final --page 1 samples/basic/request.hwp samples/복학원서.hwp samples/pic-crop-01.hwp samples/form-01.hwp samples/hwpx/form-002.hwpx samples/hwpx/hwpx-01.hwpx`
- `swiftc -parse-as-library -module-cache-path build.noindex/task280-syntax-module-cache -Xcc -fmodules-cache-path=build.noindex/task280-syntax-clang-cache -I Frameworks/modulemap Sources/RhwpCoreBridge/RhwpDocument.swift Sources/RhwpCoreBridge/RenderTree.swift Sources/RhwpCoreBridge/FontFallback.swift Sources/RhwpCoreBridge/FontResourceRegistry.swift Sources/RhwpCoreBridge/CGTreeRenderer.swift Sources/Shared/HwpPageImageRenderer.swift scripts/preview_visual_diff_harness.swift Frameworks/universal/librhwp.a -framework AppKit -framework CoreGraphics -framework CoreText -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers -framework Security -framework CoreFoundation -framework WebKit -lc++ -liconv -lz -o build.noindex/task280-syntax-check`
- `rg -n "#280|ChangedPixels|MeanRGBDelta|rhwp-studio|#116|#122|#121|#110|#282|overlayCount|DiffBounds" mydocs/report/task_m014_280_report.md mydocs/orders/20260525.md`
- `git diff --check`
- `git status --short --branch`

참고:

- Codex sandbox 안에서는 WKWebView가 WebKit/Cache/GPU/LaunchServices sandbox extension을 만들지 못해 smoke가 정상 완료되지 않았습니다. WKWebView smoke는 sandbox 밖 실행 승인을 받아 수행했습니다.
- `build.noindex/task280-final/` 산출물은 PR에 커밋하지 않습니다.

## 관련 이슈

- #283: rhwp-studio 문서 열기 normalization·external image parity 영향 조사
- #281: PageLayerTree overlay image metadata를 Swift preview 입력으로 연결
- #282: Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강
- #116: 복학원서.hwp JPEG watermark/effect
- #122: image fill mode/tile/placement
- #121: RawSvg/OLE/chart resource
- #110: Placeholder/FormObject static preview
- #259: Skia backend default 전환 readiness 판단

## 후속 이슈 제안

- 없음. 후속 작업은 M014/M20의 기존 이슈로 분리되어 있습니다.

## 남은 리스크와 Handoff

- #282 handoff: `StudioCapture=canvasDataURL`, `overlayIncluded=false` 한계를 유지한 채 `studio/*.json`의 `overlayCount`를 보고 overlay 후보 샘플을 우선 확인해야 합니다.
- #116 handoff: `복학원서.hwp`의 watermark/effect 주변 `DiffBounds`, `ChangedPercent`, `MeanRGBDelta` 전후 비교를 남깁니다.
- #122 handoff: `pic-crop-01.hwp`, `tac-img-02.hwp`, `tac-img-02.hwpx`에서 image crop/fill/tile/placement 영역 diff를 비교합니다.
- #121 handoff: `draw-group.hwp`, `eq-01.hwp` 같은 RawSvg/OLE/chart 후보에서 resource 미지원과 layout/scale 차이를 분리해 기록합니다.
- #110 handoff: `form-01.hwp`, `hwpx/form-002.hwpx`에서 placeholder/form object 영역 diff bounds와 HWP/HWPX 양쪽 개선 여부를 확인합니다.
- 이번 harness의 `ChangedPercent`는 release hard gate가 아닙니다. scale 차이, antialiasing, text shaping, editor residual 영향을 함께 봐야 합니다.

Closes #280
