### PR TITLE
Task #283: Document rhwp-studio open pipeline parity findings

### DIFF
--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 진행중 | M014, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 진행중 | M014, Stage 2 완료, Stage 3 승인 대기 |
+| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 진행중 | M014, Stage 3 완료, Stage 4 승인 대기 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 진행중 | M014, Stage 1 완료, Stage 2 승인 대기 |
+| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 진행중 | M014, Stage 2 완료, Stage 3 승인 대기 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 진행중 | M014, Stage 3 완료, Stage 4 승인 대기 |
+| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, Stage 4/최종 보고 완료: 12:51, PR 게시 승인 대기 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 5월 27일
+
+## M014 — v0.1.4 Native Preview/Viewer Parity
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 진행중 | M014, 구현계획서 작성 후 승인 대기 |
+| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 진행중 | M014, Stage 1 완료, Stage 2 승인 대기 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,5 +4,5 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, Stage 4/최종 보고 완료: 12:51, PR 게시 승인 대기 |
+| #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, #286 visual diff 재측정 보강: 14:30, PR 갱신 |
 | #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |

--- a/mydocs/plans/task_m014_283.md
+++ b/mydocs/plans/task_m014_283.md
@@ -1,0 +1,147 @@
+# Task M014 #283 수행계획서
+
+## 목적
+
+`rhwp-studio` 문서 열기 경로와 Swift/native preview 문서 열기 경로의 차이가 v0.1.4 preview parity에 실제로 영향을 주는지 조사한다.
+
+완료 후 작업자는 `convertToEditable`, stable paragraph id 보정, filename/base directory, external linked image population 차이가 Quick Look preview, Finder thumbnail, HostApp native viewer preview 정확도에 어느 정도 영향을 주는지 판단하고, 필요한 경우 후속 bridge/open option 이슈의 범위와 우선순위를 확정할 수 있어야 한다.
+
+## 배경
+
+#280에서 `rhwp-studio` reference PNG와 native preview PNG를 같은 sample/page 기준으로 비교하는 visual diff harness를 구축했다. 다만 visual diff가 크더라도 원인이 renderer 자체가 아니라 문서 open pipeline 차이일 수 있다.
+
+`rhwp-studio`는 WASM document 생성 뒤 editable 변환, viewport/editor 초기화, stable paragraph id 보정, sample/dev server 기반 external image population 같은 처리를 수행한다. 반면 native preview 경로는 Swift `RhwpDocument(data:filename:)`와 render tree 기반 `HwpPageImageRenderer`를 사용한다. 같은 파일 bytes를 읽더라도 filename, base directory, linked external image 접근 가능성, editable normalization 차이가 render tree나 image resource resolution에 영향을 줄 수 있다.
+
+M014의 후속 #281/#282/#116/#122/#121/#110 작업은 renderer/compositor parity를 줄이는 작업이므로, 그 전에 open pipeline 차이가 blocker인지 먼저 분리해야 한다.
+
+## 범위
+
+포함:
+
+- HostApp `rhwp-studio` WKWebView 문서 로딩 경로 inventory
+  - `DocumentViewerStore`
+  - `RhwpStudioDocumentPayload`
+  - `RhwpStudioResourceLocator`
+  - `RhwpStudioDocumentSchemeHandler`
+  - bundled `rhwp-studio` JS의 `loadDocument`/초기화 흐름
+- native preview 문서 로딩 경로 inventory
+  - `RhwpDocument(data:filename:)`
+  - `HwpPreviewPDFRenderer.loadDocument(fileURL:)`
+  - `HwpPageImageRenderer.renderPage(...)`
+  - Quick Look/Thumbnail에서 원본 file URL과 filename/base directory를 보존하는 방식
+- `convertToEditable`, stable paragraph id, filename/base directory, external linked image population 항목별 preview 영향도 판단
+- external image 후보 sample 식별과 #280 harness 기반 관찰
+- 구현이 필요한 경우 follow-up 이슈 후보와 #281/#282/#116/#122 handoff 범위 정리
+
+제외:
+
+- upstream `edwardkim/rhwp` 수정
+- unreleased rhwp commit pin 적용
+- native editor 편집 모델 구현
+- public app 기본 동작에 sample/dev server 전용 asset loading을 그대로 복제
+- Quick Look/Thumbnail renderer/compositor 자체 수정
+- watermark/effect, fill/tile, RawSvg/OLE/chart, Placeholder/FormObject parity 구현
+- signing, notarization, Homebrew 배포 작업
+
+## 설계 방향
+
+이번 작업은 구현보다 원인 분리와 의사결정이 핵심이다. 먼저 `rhwp-studio`와 native preview의 open path를 같은 항목으로 나눠 비교한다.
+
+비교 항목:
+
+- 입력 bytes: 원본 file URL에서 읽은 bytes인지, export/normalization된 bytes인지
+- filename: 확장자와 표시 이름이 core open path에 전달되는 방식
+- base directory: linked/external image resolution에 사용할 수 있는 directory 정보가 보존되는지
+- editable normalization: `convertToEditable` 또는 editor initialization이 render에 영향을 주는지
+- stable id: paragraph/object id 안정화가 preview output에 영향을 주는지
+- external image: HWP/HWPX 내부 bin data가 아닌 외부 linked image가 reference/native 양쪽에서 어떻게 보이는지
+
+측정은 #280의 `preview-visual-diff-harness.sh`를 우선 재사용한다. 새 helper가 필요하면 구현계획 승인 후 조사 전용 script 또는 문서화용 output만 최소 추가한다. 최종 판단은 “M014 blocker”, “후속 이슈 필요”, “현재 영향 낮음”, “sample/dev 전용으로 제외” 중 하나로 분류한다.
+
+## 예상 변경 파일
+
+- `mydocs/orders/20260527.md`
+- `mydocs/plans/task_m014_283.md`
+- `mydocs/plans/task_m014_283_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m014_283_stage{N}.md`
+- `mydocs/report/task_m014_283_report.md`
+- 필요 시 `mydocs/tech/v014_open_pipeline_parity.md`
+- 필요 시 조사 전용 script 또는 #280 harness 옵션 보강
+
+## 잠정 단계
+
+1. Stage 1: open pipeline inventory와 구현계획 확정
+   - HostApp `rhwp-studio` 로딩 경로와 native preview 로딩 경로를 파일/함수 단위로 정리한다.
+   - 조사 항목과 sample 후보를 고정하고 구현계획서에 Stage별 검증 기준을 작성한다.
+2. Stage 2: normalization 영향 조사
+   - `convertToEditable`, stable paragraph id, editor initialization이 render output에 영향을 줄 가능성을 코드와 bundled JS 기준으로 분리한다.
+   - preview에서 무시 가능한 항목과 후속 검증이 필요한 항목을 구분한다.
+3. Stage 3: filename/base directory/external image 영향 조사
+   - external image 후보 sample을 식별하고, #280 harness로 `rhwp-studio` reference와 native output 차이를 관찰한다.
+   - base directory 또는 linked resource population이 필요한지 판단한다.
+4. Stage 4: 결론, follow-up 범위, 최종 보고
+   - M014 blocker 여부와 #281/#282/#116/#122/#121/#110 handoff를 정리한다.
+   - 필요하면 별도 이슈 후보를 제안하고 최종 보고서를 작성한다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260527.md mydocs/plans/task_m014_283.md
+rg -n "#283|rhwp-studio|normalization|external image|base directory|M014|v0.1.4" \
+  mydocs/orders/20260527.md mydocs/plans/task_m014_283.md
+git status --short --branch
+```
+
+구현/조사 단계 후보:
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task283-open-pipeline --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp \
+  samples/pic-crop-01.hwp samples/hwpx/hwpx-01.hwpx
+rg -n "loadDocument|convertToEditable|external|image|base|filename|revision" \
+  Sources/HostApp Sources/Shared Sources/RhwpCoreBridge scripts Sources/HostApp/Resources/rhwp-studio
+git diff --check
+git status --short --branch
+```
+
+필요 시 추가 검증:
+
+```bash
+swiftc -parse-as-library -module-cache-path build.noindex/task283-syntax-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task283-syntax-clang-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task283-syntax-check
+```
+
+## 리스크
+
+- external linked image sample이 현재 저장소에 충분하지 않으면 영향도를 정량화하기 어렵다.
+- bundled `rhwp-studio` JS는 minified asset이므로 open pipeline 세부 흐름을 읽기 어렵고, upstream source 확인이 필요할 수 있다.
+- sample/dev server 전용 external image population은 public app 동작과 동일하게 볼 수 없으므로, 그대로 복제하면 제품 요구와 어긋날 수 있다.
+- #280 harness의 `canvasDataURL` capture는 DOM overlay를 포함하지 않으므로, open pipeline 차이와 overlay/compositor 차이를 분리해서 해석해야 한다.
+- native renderer의 기존 이미지 effect/fill/tile 미지원이 external image 차이처럼 보일 수 있다.
+
+## 승인 요청 사항
+
+1. #283을 `rhwp-studio`와 native preview open pipeline 차이 조사 작업으로 진행하는 범위 승인
+2. 이 작업에서는 renderer/compositor 구현을 직접 수정하지 않고, 필요한 구현은 follow-up 또는 후속 Stage 승인 후 분리하는 방향 승인
+3. external image가 sample/dev server 전용이면 public app 기본 동작에 그대로 복제하지 않고 영향도와 별도 옵션 필요성만 판단하는 방향 승인
+4. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m014_283_impl.md`) 작성과 Stage 1 inventory 진행
+
+승인 전에는 Swift source, script, renderer 동작 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m014_283_impl.md
+++ b/mydocs/plans/task_m014_283_impl.md
@@ -1,0 +1,252 @@
+# Task M014 #283 구현 계획서
+
+수행계획서: `mydocs/plans/task_m014_283.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #283 rhwp-studio 문서 열기 normalization·external image parity 영향 조사
+- 마일스톤: M014 (`v0.1.4 Native Preview/Viewer Parity`)
+- 브랜치: `local/task283`
+- 작업 위치: `/Users/melee/Documents/projects/rhwp-mac`
+- 기준 브랜치: `devel`
+- 목표: `rhwp-studio` open pipeline과 native preview open/render pipeline 차이가 v0.1.4 preview parity의 blocker인지 판단하고, 필요 시 후속 bridge/open option 범위를 확정한다.
+
+## 구현 원칙
+
+- 이번 작업은 조사와 의사결정이 핵심이다. renderer/compositor production 경로는 직접 수정하지 않는다.
+- #280의 `preview-visual-diff-harness.sh`를 우선 재사용하고, 새 script가 필요하면 조사 산출물 생성용으로만 최소화한다.
+- upstream `edwardkim/rhwp` 수정, unreleased commit pin, rhwp-studio asset 갱신은 하지 않는다.
+- sample/dev server 전용 external image population을 public app 기본 동작으로 그대로 복제하지 않는다.
+- `Sources/RhwpCoreBridge`에는 AppKit/UIKit/WebKit 의존을 추가하지 않는다.
+- 결과는 “M014 blocker”, “후속 이슈 필요”, “현재 영향 낮음”, “sample/dev 전용으로 제외” 중 하나로 분류한다.
+
+## 현재 기준 관찰
+
+수행계획 승인 직후 확인한 코드 기준으로 다음 경로를 Stage 1 inventory 대상으로 고정한다.
+
+| 영역 | 현재 관찰 | 검증 포인트 |
+|---|---|---|
+| HostApp open | `DocumentViewerStore.loadDocument(from:)`가 security scope 안에서 `Data(contentsOf:)`와 `url.lastPathComponent`를 읽고 `RhwpStudioDocumentPayload`에 저장 | base directory가 payload에 포함되지 않음 |
+| Studio URL | `RhwpStudioResourceLocator.loadURL(for:)`가 `url=alhangeul-document://current?revision=...`, `filename=...` query를 생성 | `filename`만 Web/WASM open path에 전달됨 |
+| Studio document bytes | `RhwpStudioDocumentSchemeHandler`가 current revision bytes를 `application/octet-stream`으로 응답 | original file URL/base directory는 JS에 전달되지 않음 |
+| bundled JS open | minified bundle에서 `Ul()`이 `url` query를 fetch하고 `Pl(bytes, filename, null)`을 호출 | open 직후 `X.loadDocument(bytes, filename)`와 editor init이 render에 미치는 영향 |
+| native preview | `HwpPreviewPDFRenderer.loadDocument(fileURL:)`가 `Data(contentsOf: .mappedIfSafe)`와 `fileURL.lastPathComponent`로 `RhwpDocument` 생성 | native도 base directory를 core에 전달하지 않음 |
+| Quick Look/Thumbnail | request fileURL의 `lastPathComponent`를 diagnostics에 사용하고 Shared renderer를 호출 | extension 경로도 base directory population 없음 |
+
+이 관찰은 구현계획의 출발점이며, Stage 1에서 파일/라인 기준으로 재확인한다.
+
+## 조사 산출물 구조
+
+이번 작업은 다음 문서 산출물을 만든다.
+
+| 파일 | 역할 |
+|---|---|
+| `mydocs/plans/task_m014_283_impl.md` | 단계별 조사 범위, 검증, 완료 기준 |
+| `mydocs/working/task_m014_283_stage1.md` | open pipeline inventory와 조사 항목 고정 |
+| `mydocs/working/task_m014_283_stage2.md` | normalization/editor initialization 영향 조사 |
+| `mydocs/working/task_m014_283_stage3.md` | filename/base directory/external image 영향 조사와 harness 관찰 |
+| `mydocs/report/task_m014_283_report.md` | 최종 결론, blocker 여부, 후속 이슈/handoff |
+| 필요 시 `mydocs/tech/v014_open_pipeline_parity.md` | M014 후속 작업이 참조할 open pipeline parity 메모 |
+
+## Stage 1. open pipeline inventory와 조사 기준 확정
+
+### 목표
+
+HostApp `rhwp-studio`, Quick Look, Thumbnail, Shared native renderer의 문서 open path를 파일/함수 단위로 정리하고 Stage 2-3 조사 기준을 확정한다.
+
+### 작업
+
+- HostApp open path inventory:
+  - `DocumentViewerStore.loadDocument(from:)`
+  - `RhwpStudioDocumentPayload`
+  - `RhwpStudioResourceLocator.loadURL(for:)`
+  - `RhwpStudioDocumentSchemeHandler`
+  - `RhwpStudioWebView` documentProvider update/load 흐름
+- native preview open path inventory:
+  - `HwpPreviewPDFRenderer.load(fileURL:)`
+  - `HwpPreviewPDFRenderer.inspect(fileURL:)`
+  - `HwpPreviewPDFRenderer.render(previewInfo:)`
+  - `HwpPageImageRenderer.renderFirstPage(fileURL:...)`
+  - Quick Look/Thumbnail provider call site
+- bundled `rhwp-studio` JS open path에서 다음 symbol/흐름을 확인한다.
+  - `loadFromUrlParam`
+  - `fetch(url)`
+  - `loadDocument(bytes, filename)`
+  - `initDoc`/canvas load
+  - `convertToEditable`
+  - `getExternalImageBasenames` 또는 external image population 후보
+- Stage 2-3에서 확인할 sample 후보와 판단 기준을 고정한다.
+
+### 산출물
+
+- `mydocs/working/task_m014_283_stage1.md`
+
+### 검증
+
+```bash
+rg -n "loadDocument|RhwpStudioDocumentPayload|RhwpStudioResourceLocator|RhwpStudioDocumentSchemeHandler|HwpPreviewPDFRenderer|HwpPageImageRenderer|providePreview|provideThumbnail" \
+  Sources/HostApp Sources/Shared Sources/QLExtension Sources/ThumbnailExtension
+rg -n "loadFromUrlParam|loadDocument|convertToEditable|getExternalImageBasenames|external|image|filename|url" \
+  Sources/HostApp/Resources/rhwp-studio/rhwp.d.ts \
+  Sources/HostApp/Resources/rhwp-studio/assets/index-*.js
+git diff --check
+```
+
+### 완료 기준
+
+- Studio/native/Quick Look/Thumbnail open path가 파일/함수 단위로 표에 정리된다.
+- 각 경로가 bytes, filename, base directory, external image 정보를 어떻게 전달하는지 명시된다.
+- Stage 2/3 sample 후보와 판단 기준이 보고서에 고정된다.
+
+### 커밋 메시지
+
+```text
+Task #283 Stage 1: open pipeline inventory 정리
+```
+
+## Stage 2. normalization/editor initialization 영향 조사
+
+### 목표
+
+`rhwp-studio`의 editable/editor initialization 관련 처리가 preview render output에 영향을 주는지 판단한다.
+
+### 작업
+
+- bundled JS와 `rhwp.d.ts` 기준으로 `convertToEditable`, validation warning/reflow, stable id 관련 API가 open path에서 호출되는지 확인한다.
+- `X.loadDocument(bytes, filename)` 뒤 `initDoc`/`canvasView.loadDocument()` 흐름이 render tree나 page layout을 바꾸는지 가능한 근거를 정리한다.
+- native `RhwpDocument(data:filename:)` 경로와 비교해 normalization 차이를 항목별로 분류한다.
+- 필요한 경우 #280 harness로 일반 샘플의 baseline 수치를 확인하되, renderer 차이와 open normalization 차이를 혼동하지 않도록 기록한다.
+
+### 산출물
+
+- `mydocs/working/task_m014_283_stage2.md`
+
+### 검증
+
+```bash
+rg -n "convertToEditable|validation|reflow|stable|paragraph|loadDocument|initDoc|document-changed|canvasView" \
+  Sources/HostApp/Resources/rhwp-studio/rhwp.d.ts \
+  Sources/HostApp/Resources/rhwp-studio/assets/index-*.js
+./scripts/verify-rhwp-studio-assets.sh
+git diff --check
+```
+
+필요 시:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task283-normalization --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+### 완료 기준
+
+- `convertToEditable`/stable id/editor init 항목이 preview blocker인지 아닌지 판단된다.
+- 영향이 불명확한 항목은 후속 검증 후보와 이유가 남는다.
+- production renderer/source 변경 없이 문서화로 단계가 닫힌다.
+
+### 커밋 메시지
+
+```text
+Task #283 Stage 2: normalization 영향 조사
+```
+
+## Stage 3. filename/base directory/external image 영향 조사
+
+### 목표
+
+filename/base directory/external linked image 차이가 `rhwp-studio` reference와 native preview output 차이의 원인이 되는지 확인한다.
+
+### 작업
+
+- repository sample에서 external image 후보를 식별한다.
+  - `samples/tac-img-02.hwp`
+  - `samples/tac-img-02.hwpx`
+  - `samples/hwp-img-001.hwp`
+  - `samples/img-start-001.hwp`
+  - 필요 시 `samples/images/*`와 연결 후보
+- core/WASM API에서 external image basename 조회나 population API가 현재 bridge에 노출되어 있는지 확인한다.
+- #280 harness로 후보 샘플의 Studio/native diff를 관찰한다.
+- diff가 큰 경우 원인을 external image resolution, image effect/fill/tile, overlay/compositor, font/layout 차이로 분류한다.
+- base-dir-aware open 또는 external image population bridge가 필요한지 판단한다.
+
+### 산출물
+
+- `mydocs/working/task_m014_283_stage3.md`
+- 필요 시 `build.noindex/task283-external-image/summary.md` smoke 산출물
+
+### 검증
+
+```bash
+find samples -maxdepth 3 -type f | rg -i "(tac-img|hwp-img|img-start|images|\\.hwp$|\\.hwpx$)"
+rg -n "ExternalImage|externalImage|external_image|getExternalImageBasenames|populate|imageBasename|baseDir|base directory" \
+  Sources Frameworks/generated_rhwp.h Sources/HostApp/Resources/rhwp-studio/rhwp.d.ts \
+  Sources/HostApp/Resources/rhwp-studio/assets/index-*.js
+./scripts/preview-visual-diff-harness.sh build.noindex/task283-external-image --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp samples/img-start-001.hwp
+sed -n '1,120p' build.noindex/task283-external-image/summary.md
+git diff --check
+```
+
+### 완료 기준
+
+- external image 관련 차이가 M014 blocker인지, #116/#122/#281/#282 범위인지, 별도 bridge/open option 이슈인지 분류된다.
+- sample/dev server 전용 population은 public app 기본 동작에 넣을지 말지 판단 근거가 남는다.
+- #280 harness 수치가 있을 경우 output dir, sample, 핵심 metric이 보고서에 기록된다.
+
+### 커밋 메시지
+
+```text
+Task #283 Stage 3: external image open 영향 조사
+```
+
+## Stage 4. 결론, follow-up 범위, 최종 보고
+
+### 목표
+
+Stage 1-3 결과를 종합해 M014 후속 작업의 실행 순서와 blocker 여부를 정리한다.
+
+### 작업
+
+- open pipeline 차이 항목별 최종 판정표를 작성한다.
+- #281/#282/#116/#122/#121/#110에 전달할 handoff를 정리한다.
+- 별도 follow-up 이슈가 필요하면 제목, 범위, 우선순위 초안을 작성한다.
+- 최종 보고서에 smoke 측정 결과, 결론, 한계, 남은 리스크를 기록한다.
+- 오늘할일 #283 행을 완료 상태로 갱신한다.
+
+### 산출물
+
+- `mydocs/report/task_m014_283_report.md`
+- 필요 시 `mydocs/tech/v014_open_pipeline_parity.md`
+- `mydocs/orders/20260527.md`
+
+### 검증
+
+```bash
+rg -n "#283|open pipeline|normalization|external image|base directory|#281|#282|#116|#122|#121|#110" \
+  mydocs/report/task_m014_283_report.md mydocs/orders/20260527.md
+git diff --check
+git status --short --branch
+```
+
+### 완료 기준
+
+- #283 완료 기준인 “M014 preview parity에 영향을 주는 open pipeline 차이 문서화”가 충족된다.
+- 구현 필요 항목은 후속 이슈 또는 기존 M014 이슈 handoff로 분류된다.
+- 영향이 낮은 항목은 M014 blocker에서 제외하는 근거가 남는다.
+
+### 커밋 메시지
+
+```text
+Task #283 Stage 4: open pipeline parity 결론 정리
+```
+
+## 승인 요청 사항
+
+1. 위 4단계 구현계획으로 #283을 진행하는 것에 대한 승인
+2. Stage 1에서 production source 수정 없이 inventory와 조사 기준 확정만 수행하는 범위 승인
+3. Stage 3에서 WKWebView 기반 #280 harness smoke는 sandbox 밖 실행 승인이 필요할 수 있다는 점 확인
+4. 승인 후 다음 단계: Stage 1 open pipeline inventory 진행
+
+승인 전에는 Stage 1 보고서 작성 외 조사 실행이나 source/script 변경을 진행하지 않는다.

--- a/mydocs/report/task_m014_283_report.md
+++ b/mydocs/report/task_m014_283_report.md
@@ -1,0 +1,171 @@
+# Task M014 #283 최종 결과보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#283](https://github.com/postmelee/alhangeul-macos/issues/283) |
+| 마일스톤 | M014 — v0.1.4 Native Preview/Viewer Parity |
+| 작업명 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 |
+| 단계 수 | 4단계 |
+| 최종 PR base 판단 | `devel` |
+
+이번 작업은 `rhwp-studio` reference path와 Quick Look/Thumbnail/HostApp native preview path의 문서 open contract 차이가 v0.1.4 preview parity의 blocker인지 분리한 조사 작업이다.
+
+production Swift source, Rust bridge, bundled `rhwp-studio` asset, renderer/compositor 구현은 수정하지 않았다. 결과적으로 `convertToEditable`, stable id, validation/reflow는 M014 즉시 blocker로 보지 않고, `filename`과 external linked image는 renderer보다 앞선 open contract 후속 범위로 분리하는 것이 맞다고 판단했다.
+
+## 단계별 결과
+
+| 단계 | 커밋 | 결과 |
+|------|------|------|
+| task-start | `c4d55f5` | #283 수행계획서와 오늘할일을 작성했다. |
+| 구현계획 | `c1ed7f3` | Stage 1-4 구현계획서를 작성했다. |
+| Stage 1 | `cfade5b` | HostApp Studio, Quick Look, Thumbnail, Shared native renderer의 open pipeline inventory를 정리했다. |
+| Stage 2 | `81c46db` | `convertToEditable`, stable id, validation/reflow, filename setter 차이를 분류했다. |
+| Stage 3 | `520f8cc` | filename/base directory/external image 영향과 native image render sanity를 조사했다. |
+| Stage 4 | 최종 커밋 | 최종 결론, 후속 handoff, 보고서, 오늘할일 갱신을 수행했다. |
+
+## 최종 판정
+
+| 항목 | 최종 판정 | M014 처리 |
+|------|-----------|-----------|
+| 입력 bytes 전달 | 영향 낮음 | 양쪽 모두 원본 bytes를 읽어 core에 넘긴다. |
+| `convertToEditable()` | 즉시 blocker 아님 | 배포용/읽기전용 sample이 생기면 별도 검증한다. |
+| stable paragraph id | 영향 낮음 | editor navigation/selection 안정화 성격으로 보이며 preview output blocker 근거 없음. |
+| validation warning / `reflowLinesegs()` | 기본 open path 영향 낮음 | 사용자 선택 후 auto-fix 경로로 보이며 자동 render 변경 경로로 보지 않는다. |
+| filename field context | 후속 open contract 필요 | native `filename` 인자가 core document state에 전달되지 않는다. |
+| base directory | 현재 app/extension 공통 미지원 | source directory는 HostApp/Quick Look/Thumbnail 모두 core에 전달하지 않는다. |
+| external linked image | 후속 resource contract 필요 | Studio/WASM에는 basename 조회/inject API가 있지만 native C ABI와 Swift open pipeline에는 없다. |
+| embedded image | 기존 native path로 처리 가능 | `rhwp_image_data`와 render tree image node로 후보 샘플 PNG 생성 확인. |
+| PageLayerTree 전환 | external image 직접 해결책 아님 | document state에 bytes가 없으면 PageLayerTree도 같은 누락을 가진다. |
+
+## M014 blocker 판단
+
+이번 조사 기준으로 `convertToEditable`, stable id, validation/reflow 차이는 #281, #282, #116, #122, #121, #110 진행을 막는 blocker로 보지 않는다.
+
+반면 `filename`과 external linked image는 정확도에 영향을 줄 수 있지만, v0.1.4의 현재 목표가 bundled `rhwp-studio` 기본 렌더와 Swift/native fallback parity를 줄이는 것이라면 별도 open/resource contract 후속으로 분리하는 편이 낫다. 이유는 다음과 같다.
+
+- 현재 M014의 주요 후속은 overlay, compositor, watermark, fill/tile, RawSvg/OLE/chart, Placeholder/FormObject 같은 renderer/compositor parity다.
+- filename/external linked image는 renderer 구현이 아니라 document open 시점의 state 주입 문제다.
+- external linked image를 release acceptance에 포함하면 source directory 보존, sandbox 권한, C ABI, Swift bridge, cache invalidation까지 같이 설계해야 하므로 M014의 렌더러 parity 범위를 넘는다.
+
+따라서 #283의 결론은 다음과 같다.
+
+- M014 후속 renderer 작업은 진행 가능하다.
+- external linked image parity는 M014 release blocker로 즉시 포함하지 않는다.
+- filename field context와 external resource contract는 별도 후속 이슈 또는 upstream contract 개선 경로로 분리한다.
+
+## smoke 측정 결과
+
+### Studio/native visual diff harness
+
+Stage 2와 Stage 3에서 #280 harness를 재사용했지만, Studio readiness polling 오류로 visual diff metric을 얻지 못했다.
+
+| 실행 | sample | 결과 | 관찰 |
+|------|--------|------|------|
+| Stage 2 normalization smoke | `samples/basic/request.hwp` | FAIL | `rhwp-studio page 1 readiness timed out`, `WKErrorDomain Code=5`, JavaScript result unsupported type |
+| Stage 2 normalization smoke | `samples/hwpx/hwpx-01.hwpx` | FAIL | 동일 |
+| Stage 3 external image smoke | `samples/tac-img-02.hwp` | FAIL | 동일 |
+| Stage 3 external image smoke | `samples/tac-img-02.hwpx` | FAIL | 동일 |
+| Stage 3 external image smoke | `samples/hwp-img-001.hwp` | FAIL | 동일 |
+| Stage 3 external image smoke | `samples/img-start-001.hwp` | FAIL | 동일 |
+
+이번 작업에서 `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta`는 생성되지 않았다. 이 실패는 open pipeline parity 결론을 무효화하지 않지만, #281 이후 PR별 수치 회귀 검증을 하려면 #280 harness readiness 문제를 먼저 안정화해야 한다.
+
+### native render-debug sanity
+
+Studio reference 비교가 실패했기 때문에 Stage 3에서는 native 경로가 image-heavy 후보를 최소한 render tree/PNG로 처리하는지만 보조 확인했다.
+
+| sample | pageCount | renderTree bytes | native PNG | native non-white pixels | textRuns | image nodes | 결론 |
+|--------|----------:|-----------------:|------------|------------------------:|---------:|------------:|------|
+| `tac-img-02.hwp` | 66 | 36,221 | `794x1123` | 38,551 | 19 | 1 | native render OK |
+| `tac-img-02.hwpx` | 69 | 38,894 | `794x1123` | 32,799 | 21 | 1 | native render OK, `LAYOUT_OVERFLOW` 2.4px warning |
+| `hwp-img-001.hwp` | 1 | 121,964 | `794x1123` | 57,797 | 67 | 4 | native render OK |
+| `img-start-001.hwp` | 3 | 209,463 | `794x1123` | 108,951 | 131 | 0 | native render OK |
+
+이 표는 Studio/native parity 수치가 아니라 native render sanity check다. `render-debug-compare`의 core SVG raster diff는 `qlmanage rasterize failed`로 생성되지 않았다.
+
+## 얻은 교훈
+
+1. `rhwp-studio` reference와 native preview의 차이를 renderer output 차이로 바로 해석하면 안 된다. open contract, document context, resource population을 먼저 분리해야 한다.
+2. filename은 단순 표시용 문자열이 아니라 머리말/꼬리말 필드 치환에 쓰이는 document context다.
+3. external linked image는 PageLayerTree나 Skia 전환만으로 해결되지 않는다. renderer 입력 전에 document state에 image bytes가 들어와야 한다.
+4. app-bundled `rhwp-studio`의 `/samples/<basename>` fetch는 public app의 source directory resolution으로 보기 어렵다. 개발 서버 편의 경로와 제품 open policy를 분리해야 한다.
+5. #280 harness는 v0.1.4 품질 판단의 핵심 도구지만, 현재 readiness failure를 별도 안정화하지 않으면 정량 비교 자료를 반복 생산하기 어렵다.
+
+## 후속 handoff
+
+| 대상 | 상태 | handoff |
+|------|------|---------|
+| [#280](https://github.com/postmelee/alhangeul-macos/issues/280) | CLOSED | harness 자체는 구축됐지만 readiness polling 실패가 반복됐다. 이후 PR 수치 검증 전에 JS result unsupported type 원인과 settle 조건을 재점검해야 한다. |
+| [#281](https://github.com/postmelee/alhangeul-macos/issues/281) | OPEN | PageLayerTree overlay metadata 연결은 진행 가능하다. external linked image bytes 누락은 #281 범위로 끌어오지 않는다. |
+| [#282](https://github.com/postmelee/alhangeul-macos/issues/282) | OPEN | flow/behind/front compositor 보강은 진행 가능하다. base directory/resource injection과 별개로 overlay z-order를 다룬다. |
+| [#116](https://github.com/postmelee/alhangeul-macos/issues/116) | OPEN | watermark 효과/투명키는 embedded/resolved image와 compositor 위에서 다룬다. external linked image open contract와 분리한다. |
+| [#122](https://github.com/postmelee/alhangeul-macos/issues/122) | OPEN | fill mode, tile, placement parity는 renderer geometry 범위다. 외부 이미지 resource discovery/injection과 분리한다. |
+| [#121](https://github.com/postmelee/alhangeul-macos/issues/121) | OPEN | RawSvg/OLE/chart 리소스 렌더링 보강은 현재 open pipeline 조사 결과와 직접 충돌 없음. |
+| [#110](https://github.com/postmelee/alhangeul-macos/issues/110) | OPEN | Placeholder/FormObject 정적 프리뷰 보강은 현재 open pipeline 조사 결과와 직접 충돌 없음. |
+
+## upstream 연계
+
+이번 조사에서 확인된 filename/external image 문제는 downstream renderer 구현만으로 닫기보다 upstream `rhwp`의 멀티 렌더러 contract와 맞춰 가는 것이 적절하다.
+
+이를 위해 별도 upstream 이슈를 생성했다.
+
+| upstream issue | 역할 |
+|----------------|------|
+| [edwardkim/rhwp#1141](https://github.com/edwardkim/rhwp/issues/1141) | Skia/CanvasKit direct replay 문서 컨텍스트·외부 리소스 정합 상위 이슈 |
+| [edwardkim/rhwp#1144](https://github.com/edwardkim/rhwp/issues/1144) | filename field context 멀티 렌더러 경로 일관화 |
+| [edwardkim/rhwp#1142](https://github.com/edwardkim/rhwp/issues/1142) | external image reference discovery contract |
+| [edwardkim/rhwp#1143](https://github.com/edwardkim/rhwp/issues/1143) | external image bytes injection/resource resolver contract |
+
+GitHub native Sub-issues 연결은 maintainer 권한이 필요해 현재 계정으로는 실패했다. #1141 본문에는 하위 이슈 체크리스트와 실행 순서를 남겨 두었다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/plans/task_m014_283.md` | 수행계획서 |
+| `mydocs/plans/task_m014_283_impl.md` | 구현계획서 |
+| `mydocs/working/task_m014_283_stage1.md` | open pipeline inventory 보고서 |
+| `mydocs/working/task_m014_283_stage2.md` | normalization 영향 조사 보고서 |
+| `mydocs/working/task_m014_283_stage3.md` | filename/base directory/external image 영향 조사 보고서 |
+| `mydocs/report/task_m014_283_report.md` | 최종 결과보고서 |
+| `mydocs/orders/20260527.md` | #283 오늘할일 상태 갱신 |
+
+제품 source, renderer, bridge, bundled resource는 변경하지 않았다.
+
+## 검증 결과
+
+| 검증 | 결과 | 비고 |
+|------|------|------|
+| `./scripts/verify-rhwp-studio-assets.sh` | OK | Stage 2에서 통과 |
+| #280 visual diff harness | FAIL | Stage 2/3 모두 readiness 오류. 비교 수치 없음 |
+| native render-debug PNG 생성 | OK | Stage 3 후보 4개 sample 모두 native PNG 생성 |
+| `git diff --check` | OK | Stage 1-3 및 Stage 4 최종 문서 검증에서 통과 |
+
+Stage 4에서는 새 production 검증을 추가하지 않았다. 이번 단계의 검증은 보고서와 오늘할일 문서가 Stage 1-3 결론을 빠짐없이 참조하는지 확인하는 문서 검증이다.
+
+## 잔여 위험
+
+| 항목 | 위험 | 처리 |
+|------|------|------|
+| visual diff metric 부재 | 정량 parity 판단을 못 했다. | #280 readiness 안정화 후 #281 이후 PR에서 다시 수치화한다. |
+| external linked image sample 부족 | 현재 repo sample만으로 실제 sibling external image 요구를 확정하지 못했다. | upstream/resource contract 후속 또는 별도 fixture 확보 시 재검증한다. |
+| filename field sample 부족 | 파일명 필드 치환이 실제 output diff로 이어지는 sample을 이번 단계에서 확보하지 못했다. | filename field fixture 확보 후 upstream #1144 또는 downstream bridge 이슈에서 검증한다. |
+| app-bundled Studio `/samples` fetch | 실제 warning/runtime timing을 직접 캡처하지 못했다. | harness 안정화 뒤 console/log capture로 재확인한다. |
+| external image async timing | `populateExternalImagesFromDevServer()`가 `await`되지 않는다. | reference capture settle 조건에 image injection 완료 여부가 포함되는지 별도 확인한다. |
+
+## PR 게시 준비
+
+| 항목 | 값 |
+|------|----|
+| 작업 브랜치 | `local/task283` |
+| 게시 브랜치 | `publish/task283` |
+| PR base | `devel` |
+| PR 제목 후보 | `Document rhwp-studio open pipeline parity findings` |
+
+PR 본문에는 source 변경이 없는 조사 PR임을 명시하고, visual diff metric 미생성 원인, native sanity 측정값, #281/#282/#116/#122/#121/#110 handoff, upstream #1141-#1144 연결을 포함하면 된다.
+
+## 작업지시자 승인 요청
+
+최종 결과보고서 작성과 오늘할일 상태 갱신을 마쳤다. 이 보고서 기준으로 `publish/task283` 원격 브랜치 push와 `devel` 대상 Open PR 생성을 진행하려면 작업지시자 승인이 필요하다.

--- a/mydocs/report/task_m014_283_report.md
+++ b/mydocs/report/task_m014_283_report.md
@@ -59,7 +59,7 @@ production Swift source, Rust bridge, bundled `rhwp-studio` asset, renderer/comp
 
 ### Studio/native visual diff harness
 
-Stage 2와 Stage 3에서 #280 harness를 재사용했지만, Studio readiness polling 오류로 visual diff metric을 얻지 못했다.
+Stage 2와 Stage 3의 최초 실행에서는 #280 harness를 재사용했지만, Studio readiness polling 오류로 visual diff metric을 얻지 못했다.
 
 | 실행 | sample | 결과 | 관찰 |
 |------|--------|------|------|
@@ -70,7 +70,35 @@ Stage 2와 Stage 3에서 #280 harness를 재사용했지만, Studio readiness po
 | Stage 3 external image smoke | `samples/hwp-img-001.hwp` | FAIL | 동일 |
 | Stage 3 external image smoke | `samples/img-start-001.hwp` | FAIL | 동일 |
 
-이번 작업에서 `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta`는 생성되지 않았다. 이 실패는 open pipeline parity 결론을 무효화하지 않지만, #281 이후 PR별 수치 회귀 검증을 하려면 #280 harness readiness 문제를 먼저 안정화해야 한다.
+#286에서 harness readiness를 안정화한 뒤 같은 브랜치에서 재측정했다. 재측정은 WebKit GUI 프로세스가 정상 동작하는 sandbox 밖 권한으로 실행했고, 기본 2개와 image-heavy 4개 sample 모두 PASS했다.
+
+실행:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task283-visual-diff-basic-final --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task283-visual-diff-images-final --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+기본 sample:
+
+| sample | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend |
+|--------|---------------|----------------|--------------|-------------|---------------|---------------|
+| `request.hwp` | `325488/1798071` | `18.1021%` | `11.5796` | `255` | `canvasDataURL` | `coreGraphics` |
+| `hwpx-01.hwpx` | `540973/3562815` | `15.1839%` | `15.6722` | `255` | `canvasDataURL` | `coreGraphics` |
+
+image-heavy sample:
+
+| sample | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend |
+|--------|---------------|----------------|--------------|-------------|---------------|---------------|
+| `tac-img-02.hwp` | `147412/3562815` | `4.1375%` | `3.7228` | `255` | `canvasDataURL` | `coreGraphics` |
+| `tac-img-02.hwpx` | `129783/3562815` | `3.6427%` | `3.3924` | `255` | `canvasDataURL` | `coreGraphics` |
+| `hwp-img-001.hwp` | `279494/3562815` | `7.8448%` | `8.2731` | `255` | `canvasDataURL` | `coreGraphics` |
+| `img-start-001.hwp` | `514115/3561228` | `14.4365%` | `15.4773` | `255` | `canvasDataURL` | `coreGraphics` |
+
+이 수치는 native/CoreGraphics preview와 `rhwp-studio` reference 사이의 현재 baseline 차이다. #283의 open pipeline 결론을 뒤집지는 않지만, #281 이후 renderer/compositor parity PR에서 before/after 비교 기준으로 재사용할 수 있다.
 
 ### native render-debug sanity
 
@@ -91,13 +119,13 @@ Studio reference 비교가 실패했기 때문에 Stage 3에서는 native 경로
 2. filename은 단순 표시용 문자열이 아니라 머리말/꼬리말 필드 치환에 쓰이는 document context다.
 3. external linked image는 PageLayerTree나 Skia 전환만으로 해결되지 않는다. renderer 입력 전에 document state에 image bytes가 들어와야 한다.
 4. app-bundled `rhwp-studio`의 `/samples/<basename>` fetch는 public app의 source directory resolution으로 보기 어렵다. 개발 서버 편의 경로와 제품 open policy를 분리해야 한다.
-5. #280 harness는 v0.1.4 품질 판단의 핵심 도구지만, 현재 readiness failure를 별도 안정화하지 않으면 정량 비교 자료를 반복 생산하기 어렵다.
+5. #280 harness는 v0.1.4 품질 판단의 핵심 도구다. #286 이후에는 sandbox 밖 WebKit 실행 조건에서 정량 비교 자료를 반복 생산할 수 있으며, sandbox 내부 `events=[]`, `scheme={resourceRequests=0, documentRequests=0}` 실패는 renderer 문제가 아니라 실행 환경 문제로 분리해야 한다.
 
 ## 후속 handoff
 
 | 대상 | 상태 | handoff |
 |------|------|---------|
-| [#280](https://github.com/postmelee/alhangeul-macos/issues/280) | CLOSED | harness 자체는 구축됐지만 readiness polling 실패가 반복됐다. 이후 PR 수치 검증 전에 JS result unsupported type 원인과 settle 조건을 재점검해야 한다. |
+| [#280](https://github.com/postmelee/alhangeul-macos/issues/280) | CLOSED | harness 자체는 구축됐고 #286에서 readiness와 sandbox 분리 진단이 안정화됐다. 이후 PR 수치 검증은 #286 summary format과 sandbox 밖 WebKit 실행 조건을 사용한다. |
 | [#281](https://github.com/postmelee/alhangeul-macos/issues/281) | OPEN | PageLayerTree overlay metadata 연결은 진행 가능하다. external linked image bytes 누락은 #281 범위로 끌어오지 않는다. |
 | [#282](https://github.com/postmelee/alhangeul-macos/issues/282) | OPEN | flow/behind/front compositor 보강은 진행 가능하다. base directory/resource injection과 별개로 overlay z-order를 다룬다. |
 | [#116](https://github.com/postmelee/alhangeul-macos/issues/116) | OPEN | watermark 효과/투명키는 embedded/resolved image와 compositor 위에서 다룬다. external linked image open contract와 분리한다. |
@@ -139,7 +167,7 @@ GitHub native Sub-issues 연결은 maintainer 권한이 필요해 현재 계정�
 | 검증 | 결과 | 비고 |
 |------|------|------|
 | `./scripts/verify-rhwp-studio-assets.sh` | OK | Stage 2에서 통과 |
-| #280 visual diff harness | FAIL | Stage 2/3 모두 readiness 오류. 비교 수치 없음 |
+| #280 visual diff harness | OK | Stage 2/3 최초 실행은 readiness 오류였으나, #286 merge 후 재측정에서 6개 sample 모두 PASS하고 visual diff metric 생성 |
 | native render-debug PNG 생성 | OK | Stage 3 후보 4개 sample 모두 native PNG 생성 |
 | `git diff --check` | OK | Stage 1-3 및 Stage 4 최종 문서 검증에서 통과 |
 
@@ -149,7 +177,7 @@ Stage 4에서는 새 production 검증을 추가하지 않았다. 이번 단계�
 
 | 항목 | 위험 | 처리 |
 |------|------|------|
-| visual diff metric 부재 | 정량 parity 판단을 못 했다. | #280 readiness 안정화 후 #281 이후 PR에서 다시 수치화한다. |
+| visual diff metric 해석 | 재측정 수치는 현재 native/CoreGraphics와 `rhwp-studio` reference의 baseline 차이며, #283 open contract 원인만을 단독으로 설명하지 않는다. | #281 이후 PR에서 같은 sample set으로 before/after 비교한다. |
 | external linked image sample 부족 | 현재 repo sample만으로 실제 sibling external image 요구를 확정하지 못했다. | upstream/resource contract 후속 또는 별도 fixture 확보 시 재검증한다. |
 | filename field sample 부족 | 파일명 필드 치환이 실제 output diff로 이어지는 sample을 이번 단계에서 확보하지 못했다. | filename field fixture 확보 후 upstream #1144 또는 downstream bridge 이슈에서 검증한다. |
 | app-bundled Studio `/samples` fetch | 실제 warning/runtime timing을 직접 캡처하지 못했다. | harness 안정화 뒤 console/log capture로 재확인한다. |
@@ -164,7 +192,7 @@ Stage 4에서는 새 production 검증을 추가하지 않았다. 이번 단계�
 | PR base | `devel` |
 | PR 제목 후보 | `Document rhwp-studio open pipeline parity findings` |
 
-PR 본문에는 source 변경이 없는 조사 PR임을 명시하고, visual diff metric 미생성 원인, native sanity 측정값, #281/#282/#116/#122/#121/#110 handoff, upstream #1141-#1144 연결을 포함하면 된다.
+PR 본문에는 source 변경이 없는 조사 PR임을 명시하고, 최초 readiness 실패와 #286 이후 재측정 수치, native sanity 측정값, #281/#282/#116/#122/#121/#110 handoff, upstream #1141-#1144 연결을 포함하면 된다.
 
 ## 작업지시자 승인 요청
 

--- a/mydocs/working/task_m014_283_stage1.md
+++ b/mydocs/working/task_m014_283_stage1.md
@@ -1,0 +1,121 @@
+# Task M014 #283 Stage 1 보고서 - open pipeline inventory 정리
+
+## 단계 개요
+
+- 이슈: #283 rhwp-studio 문서 열기 normalization·external image parity 영향 조사
+- 단계: Stage 1. open pipeline inventory와 조사 기준 확정
+- 목표: HostApp `rhwp-studio`, Quick Look, Thumbnail, Shared native renderer의 문서 open path를 파일/함수 단위로 정리하고 Stage 2-3 조사 기준을 고정한다.
+
+이번 단계는 조사와 문서화만 수행했다. production renderer, bridge, bundled `rhwp-studio` asset은 수정하지 않았다.
+
+## 현재 open pipeline inventory
+
+| 영역 | 파일/함수 | 입력 전달 | base directory 전달 | 관찰 |
+|---|---|---|---|---|
+| HostApp store | `Sources/HostApp/Stores/DocumentViewerStore.swift` `loadDocument(from:)` | security scoped `URL`에서 `Data(contentsOf:)`, `url.lastPathComponent` | 없음 | `RecentDocumentItem`은 reveal/save용 source로 저장되지만 Studio payload에는 포함되지 않는다. |
+| HostApp payload | `Sources/HostApp/Services/RhwpStudioDocumentPayload.swift` | `data`, `filename`, `revision` | 없음 | payload type 자체가 bytes, filename, revision만 가진다. |
+| Studio entry URL | `Sources/HostApp/Services/RhwpStudioResourceLocator.swift` `loadURL(for:)` | `url=alhangeul-document://current?revision=...`, `filename=...` query | 없음 | Web/WASM open path에는 current document scheme URL과 filename만 전달된다. |
+| Studio document bytes | `Sources/HostApp/Services/RhwpStudioDocumentSchemeHandler.swift` | current revision payload bytes | 없음 | `application/octet-stream`, `Cache-Control: no-store`, CORS header로 bytes를 응답한다. |
+| Studio WebView | `Sources/HostApp/Views/RhwpStudioWebView.swift` coordinator `update(...)` | documentProvider에 payload 설정 후 `RhwpStudioResourceLocator.loadURL(for:)` 로드 | 없음 | `sourceDocument`는 Swift side save/reveal/share 흐름에 남고 JS query로 전달되지 않는다. |
+| Shared PDF preview | `Sources/Shared/HwpPreviewPDFRenderer.swift` `load(fileURL:)`, `inspect(fileURL:)` | `Data(contentsOf: fileURL, options: [.mappedIfSafe])`, `fileURL.lastPathComponent` | 없음 | `RhwpDocument(data:filename:)`를 직접 만든 뒤 page count와 page size를 확인한다. |
+| Shared page image | `Sources/Shared/HwpPageImageRenderer.swift` `renderFirstPage(fileURL:...)` | `Data(contentsOf: fileURL, options: [.mappedIfSafe])`, `fileURL.lastPathComponent` | 없음 | Thumbnail 경로의 첫 페이지 render도 같은 `RhwpDocument(data:filename:)` 생성 경로다. |
+| Quick Look | `Sources/QLExtension/HwpPreviewProvider.swift` `providePreview` | request `fileURL`을 Shared PDF renderer에 전달 | 없음 | 단일 페이지는 loaded document context로 PNG, 다중 페이지는 PDF로 렌더한다. |
+| Thumbnail | `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`, `HwpThumbnailRenderCache.swift` | request `fileURL`을 render request로 넘긴 뒤 Shared page image renderer 호출 | 없음 | cache worker에서 `HwpPageImageRenderer.renderFirstPage(...)`를 호출한다. |
+
+핵심 결론은 HostApp Studio 진입 경로와 Quick Look/Thumbnail native 진입 경로가 모두 Swift layer에서는 bytes + filename만 core에 넘긴다는 점이다. 따라서 base directory 미전달은 둘 중 한쪽만의 차이가 아니라 현재 앱 전체 open contract의 공통 제약이다.
+
+## bundled rhwp-studio open 흐름
+
+번들된 `Sources/HostApp/Resources/rhwp-studio/assets/index-*.js`는 minified asset이지만 다음 흐름을 확인했다.
+
+| 단계 | 확인된 호출 | 의미 |
+|---|---|---|
+| URL query parse | `Ul()`이 `url`과 `filename` query를 읽음 | HostApp이 만든 `alhangeul-document://current?...`와 filename을 Studio에 전달하는 지점 |
+| bytes fetch | `fetch(url)` 후 signature 확인 | HostApp document scheme handler가 제공한 bytes를 읽음 |
+| document open | `Pl(bytes, filename, null)` | file handle 없이 bytes와 filename으로 문서 open |
+| WASM load | `X.loadDocument(bytes, filename)` | `new HwpDocument(bytes)` 뒤 editor용 초기화 수행 |
+| editable 변환 | `doc.convertToEditable()` | native preview에는 대응 호출이 없다. Stage 2 핵심 조사 대상이다. |
+| stable id 보정 | `ensureParagraphStableIds()` | editor interaction용 id 보정으로 보이며 render 영향은 Stage 2에서 판단한다. |
+| filename 설정 | `doc.setFileName(filename)` | native `RhwpDocument(data:filename:)`의 filename 전달과 성격이 유사한지 Stage 2에서 확인한다. |
+| external image population | `populateExternalImagesFromDevServer()` | `getExternalImageBasenames()` 후 `/samples/<basename>` fetch, `injectExternalImage(...)` 호출을 시도한다. Stage 3 핵심 조사 대상이다. |
+| canvas/editor init | `Ml(...)`에서 font load, `Q?.loadDocument()`, toolbar init, input handler activate | 실제 Studio reference capture 전에 일어나는 초기화다. validation warning이 있으면 사용자 선택에 따라 `reflowLinesegs()`가 호출될 수 있다. |
+
+`rhwp.d.ts`에서는 `convertToEditable`, `setFileName`, `getValidationWarnings`, `reflowLinesegs` 선언을 확인했다. 반면 이번 grep 기준으로 external image basename/inject API 선언은 `rhwp.d.ts`에서 확인되지 않았고, minified JS bundle 내부 호출로만 확인됐다. Stage 3에서는 generated header와 bridge 노출 여부를 별도로 확인해야 한다.
+
+## Studio와 native preview의 차이 후보
+
+| 후보 | 현재 판정 | 다음 조사 |
+|---|---|---|
+| bytes 전달 | 차이 낮음 | 양쪽 모두 파일 bytes를 직접 읽어 core에 넘긴다. |
+| filename 전달 | 차이 낮음, 단 API 형태는 다름 | Studio는 open 후 `setFileName`, native는 constructor `filename` 인자다. Stage 2에서 영향 확인. |
+| base directory | 공통 미지원 | HostApp과 extension 모두 전달하지 않는다. external linked image에는 영향 가능성이 있으므로 Stage 3에서 확인. |
+| `convertToEditable()` | 차이 있음 | Studio만 호출한다. render tree/page layout 영향이 있으면 M014 blocker가 될 수 있어 Stage 2에서 조사. |
+| `ensureParagraphStableIds()` | 차이 있음 | editor interaction용으로 보이나 page render 영향 여부를 Stage 2에서 확인. |
+| validation/reflow | 조건부 차이 | Studio는 validation warning 후 사용자 선택 시 reflow 가능하다. 자동 기본 경로인지 Stage 2에서 확인. |
+| external image dev-server population | 차이 있음 | Studio bundle은 `/samples/<basename>` fetch를 시도한다. public app HostApp URL에서는 source directory와 무관하므로 Stage 3에서 실제 영향과 sample/dev 전용 여부를 분리. |
+| font loading/editor init | 차이 있음 | Studio capture reference에는 web font load와 canvas init timing이 포함된다. Stage 2에서 normalization과 분리해 기록. |
+
+## Stage 2 조사 기준
+
+Stage 2는 normalization/editor initialization 영향만 본다.
+
+확인 대상:
+
+- `convertToEditable()` 호출이 page layout, render tree, text visibility, PUA 표시 경로에 영향을 주는지
+- `ensureParagraphStableIds()`가 render output에 관여하는지
+- `setFileName(filename)`이 native constructor filename과 같은 의미인지
+- `getValidationWarnings()`와 `reflowLinesegs()`가 기본 open path에서 자동으로 render를 바꾸는지, 아니면 사용자 선택 후에만 바뀌는지
+- `Ml(...)`의 `Q?.loadDocument()`와 font load가 #280 Studio capture settle 조건에 어떤 영향을 주는지
+
+Stage 2 완료 판정은 각 항목을 `M014 blocker`, `후속 이슈 필요`, `현재 영향 낮음`, `sample/dev 전용으로 제외` 중 하나로 분류하는 것이다.
+
+## Stage 3 조사 기준
+
+Stage 3는 filename/base directory/external image 영향을 본다.
+
+sample 후보:
+
+- `samples/tac-img-02.hwp`
+- `samples/tac-img-02.hwpx`
+- `samples/hwp-img-001.hwp`
+- `samples/img-start-001.hwp`
+- 필요 시 `samples/images/*`
+
+확인 대상:
+
+- `getExternalImageBasenames` / `injectExternalImage` 계열 API가 native bridge나 generated header에 노출되어 있는지
+- bundled Studio의 `/samples/<basename>` fetch가 #280 harness reference capture에서 실제로 성공하는지
+- public HostApp open path에서 source document directory를 기준으로 external image를 resolve할 수 있는지
+- external image 미해결 diff가 #116/#122/#281/#282 범위인지, 별도 base-dir-aware open/bridge 이슈인지
+
+## Stage 1 검증
+
+실행:
+
+```bash
+rg -n "loadDocument|RhwpStudioDocumentPayload|RhwpStudioResourceLocator|RhwpStudioDocumentSchemeHandler|HwpPreviewPDFRenderer|HwpPageImageRenderer|providePreview|provideThumbnail" \
+  Sources/HostApp Sources/Shared Sources/QLExtension Sources/ThumbnailExtension
+rg -n "loadFromUrlParam|loadDocument|convertToEditable|getExternalImageBasenames|external|image|filename|url" \
+  Sources/HostApp/Resources/rhwp-studio/rhwp.d.ts \
+  Sources/HostApp/Resources/rhwp-studio/assets/index-*.js
+git diff --check
+```
+
+결과:
+
+- HostApp open path는 `DocumentViewerStore` -> `RhwpStudioDocumentPayload` -> `RhwpStudioResourceLocator` -> `RhwpStudioDocumentSchemeHandler` -> `RhwpStudioWebView` 흐름으로 확인했다.
+- Quick Look/Thumbnail open path는 provider -> Shared renderer -> `RhwpDocument(data:filename:)` 흐름으로 확인했다.
+- bundled Studio JS에서 `loadFromUrlParam`, `X.loadDocument`, `convertToEditable`, `ensureParagraphStableIds`, `populateExternalImagesFromDevServer`, `Pl`, `Ml` 흐름을 확인했다.
+- minified JS는 한 줄 또는 긴 줄에 여러 symbol이 함께 있어 line reference의 가독성은 낮다. 보고서에는 symbol과 파일 단위 근거로 기록했다.
+- `git diff --check` 결과 whitespace 오류는 없었다.
+
+## 리스크와 보류 판단
+
+- 이번 단계는 static inventory라서 실제 render diff 수치는 만들지 않았다. 수치 관찰은 Stage 2/3에서 #280 harness를 사용해 진행한다.
+- bundled JS의 external image population은 async이며 `loadDocument()`에서 await하지 않는다. #280 harness capture가 이 비동기 inject 이후를 관찰하는지는 Stage 3에서 별도 확인해야 한다.
+- HostApp과 extension 모두 source directory를 넘기지 않으므로 base-dir-aware open을 추가하려면 앱, extension, bridge contract를 함께 설계해야 한다. 이번 단계에서는 구현하지 않았다.
+- external image API가 `rhwp.d.ts`와 generated header에 완전히 정리되어 있는지는 Stage 3에서 다시 확인한다.
+
+## 다음 단계
+
+Stage 2에서는 source를 수정하지 않고 normalization/editor initialization 차이를 조사한다. 특히 `convertToEditable()`와 validation/reflow가 preview parity의 blocker인지 먼저 결론 내린다. Stage 2 진행은 작업지시자 승인 후 시작한다.

--- a/mydocs/working/task_m014_283_stage2.md
+++ b/mydocs/working/task_m014_283_stage2.md
@@ -1,0 +1,112 @@
+# Task M014 #283 Stage 2 보고서 - normalization 영향 조사
+
+## 단계 개요
+
+- 이슈: #283 rhwp-studio 문서 열기 normalization·external image parity 영향 조사
+- 단계: Stage 2. normalization/editor initialization 영향 조사
+- 목표: `rhwp-studio`의 editable/editor initialization 관련 처리가 Quick Look/Thumbnail native preview render output에 영향을 주는지 판단한다.
+
+이번 단계는 조사와 문서화만 수행했다. production Swift source, Rust bridge, bundled `rhwp-studio` asset은 수정하지 않았다.
+
+## 확인한 현재 구조
+
+### rhwp-studio open 후 처리
+
+bundled `rhwp-studio`의 minified JS 기준 HostApp URL open은 `Ul()` -> `Pl(bytes, filename, null)` -> `X.loadDocument(bytes, filename)` -> `Ml(info, statusText)` 흐름이다.
+
+`X.loadDocument(bytes, filename)`에서 확인된 핵심 호출은 다음과 같다.
+
+| 호출 | 확인 위치 | 의미 |
+|---|---|---|
+| `new HwpDocument(bytes)` | `assets/index-*.js` | WASM 문서 생성 |
+| `doc.convertToEditable()` | `assets/index-*.js`, `rhwp.d.ts` | 배포용/읽기전용 문서를 편집 가능한 일반 문서로 변환 |
+| `ensureParagraphStableIds()` | `assets/index-*.js` | editor navigation/selection에 필요한 stable id 보정 |
+| `doc.setFileName(filename)` | `assets/index-*.js`, `rhwp.d.ts` | 머리말/꼬리말 필드 치환용 파일명 설정 |
+| `populateExternalImagesFromDevServer()` | `assets/index-*.js` | 외부 이미지 basename을 `/samples/<basename>`로 fetch 시도. Stage 3 범위 |
+
+`Ml(...)`에서는 web font 로드 후 `Q?.loadDocument()`로 canvas view를 로드하고, toolbar와 input handler를 활성화한다. 그 뒤 `getValidationWarnings()`를 확인하고 warning이 있으면 사용자 선택 UI를 띄운다. `reflowLinesegs()`는 사용자가 `auto-fix`를 선택한 경우에만 호출된다.
+
+### native preview open/render 경로
+
+Swift native preview는 `RhwpDocument(data:filename:)`를 생성하지만, 현재 C bridge 호출은 `rhwp_open(data, len)`뿐이다. `filename`은 parse error message에만 쓰이고 core handle에는 전달되지 않는다.
+
+현재 `Frameworks/generated_rhwp.h`가 제공하는 native render 관련 ABI는 다음 범위다.
+
+| ABI | 역할 |
+|---|---|
+| `rhwp_open(data, len)` | 문서 open |
+| `rhwp_page_count` / `rhwp_page_size` | page metadata |
+| `rhwp_render_page_tree` | Swift `CGTreeRenderer`용 render tree JSON |
+| `rhwp_render_page_png` | Skia PNG render |
+| `rhwp_image_data` | render tree 이미지 bin data 조회 |
+
+native bridge에는 `convertToEditable`, `setFileName`, `getValidationWarnings`, `reflowLinesegs`, `ensureParagraphStableIds` 대응 ABI가 없다.
+
+## 항목별 판단
+
+| 항목 | Stage 2 판단 | 근거 | 후속 |
+|---|---|---|---|
+| `convertToEditable()` | M014 즉시 blocker로 보지는 않는다. 다만 배포용/읽기전용 문서 sample 검증은 필요하다. | `rhwp.d.ts` 설명은 읽기전용 문서를 편집 가능하게 변환하는 API다. 현재 확인 범위에서는 render API 호출 전에 항상 실행되지만, page layout을 직접 바꾸는 호출이라는 근거는 없다. | 배포용/읽기전용 sample이 생기면 Studio/native render tree 또는 visual diff로 별도 확인. |
+| `ensureParagraphStableIds()` | 현재 영향 낮음 | bundle에서 function 존재 여부를 확인하고 있으면 호출, 실패하면 warning만 남긴다. editor navigation/selection 안정화 용도로 보이며 native render tree ABI에는 대응 상태가 없다. | render output 차이가 관찰될 때만 후속 확인. |
+| `setFileName(filename)` | 후속 이슈 또는 Stage 3 handoff 필요 | Studio는 core에 파일명을 명시 설정한다. native Swift의 `filename` 인자는 core로 전달되지 않는다. 파일명 필드, 머리말/꼬리말 필드 치환 문서는 Studio와 native preview가 달라질 수 있다. | Stage 3에서 filename/base directory 항목으로 분리해 영향 sample과 bridge 필요성을 판단. |
+| validation warning / `reflowLinesegs()` | 기본 open path 기준 영향 낮음 | `reflowLinesegs()`는 `getValidationWarnings()` 이후 사용자 선택이 `auto-fix`일 때만 호출된다. 자동 기본 open에서 즉시 render를 바꾸는 경로로 보이지 않는다. | lineseg warning sample은 #116/#122 계열 renderer/layout 이슈와 분리해 필요 시 별도 검증. |
+| `Ml(...)` editor/canvas init | native open normalization blocker는 아님 | font load와 `Q?.loadDocument()`는 Studio canvas capture readiness/timing 문제다. native core 문서 상태를 바꾸는 ABI 차이는 아니다. | #280 harness settle/readiness 안정화 쪽으로 handoff. |
+| PUA 표시 문자열/렌더 경로 | Swift layer가 막는 구조는 보이지 않는다. 단 current core tag에서는 #982 반영 여부를 검증하지 않는다. | native CoreGraphics 경로는 `rhwp_render_page_tree`가 반환한 `TextRunNode.text`를 그대로 `NSAttributedString`으로 그린다. Swift code에 PUA/display string 별도 변환은 없다. Skia 경로는 `rhwp_render_page_png` 결과를 그대로 decode한다. | #982가 포함된 새 rhwp release로 갱신된 뒤 `render_page_tree`/`render_page_png` output에 fix가 들어오는지 확인하면 된다. |
+
+## preview parity 관점의 결론
+
+Stage 2 범위에서 `convertToEditable()`와 stable id 보정만을 이유로 Quick Look/Thumbnail renderer를 `pagelayertree` 방식으로 즉시 전환해야 한다는 근거는 확인하지 못했다.
+
+반대로 실제 차이 후보는 `filename`이다. HostApp Studio는 `setFileName(filename)`을 호출하지만 native preview는 core에 filename을 전달하지 않는다. 따라서 파일명 필드 또는 머리말/꼬리말 필드 치환이 있는 문서는 preview parity 차이가 생길 수 있다. 이 항목은 Stage 3의 filename/base directory 조사에서 sample 기반으로 확인해야 한다.
+
+PUA/#982 계열 변경은 Swift native renderer가 자체 문자열 normalization을 하지 않기 때문에, core의 render tree 또는 Skia PNG 경로에 반영되면 native preview도 따라갈 가능성이 높다. 다만 현재 lock은 `rhwp-core.lock` 기준 `v0.7.12` / `1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5`이므로 #982 포함 release 검증은 이번 작업 범위에서 제외한다.
+
+## smoke 관찰
+
+일반 sample baseline을 보려고 #280 harness를 한 번 실행했다.
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task283-normalization --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+결과는 두 샘플 모두 실패했다.
+
+| sample | 결과 | 원인 |
+|---|---|---|
+| `samples/basic/request.hwp` | FAIL | `rhwp-studio page 1 readiness timed out`, `WKErrorDomain Code=5`, JavaScript result unsupported type |
+| `samples/hwpx/hwpx-01.hwpx` | FAIL | 동일 |
+
+산출물은 `build.noindex/task283-normalization/summary.md`에 남았다. 이 실패는 Studio/native 렌더 차이가 아니라 harness readiness polling의 JavaScript evaluation 문제다. 따라서 Stage 2에서는 수치 비교값을 만들지 못했고, 이 결과를 normalization 판단 근거로 사용하지 않는다.
+
+## Stage 2 검증
+
+실행:
+
+```bash
+rg -n "convertToEditable|validation|reflow|stable|paragraph|loadDocument|initDoc|document-changed|canvasView" \
+  Sources/HostApp/Resources/rhwp-studio/rhwp.d.ts \
+  Sources/HostApp/Resources/rhwp-studio/assets/index-*.js
+./scripts/verify-rhwp-studio-assets.sh
+rg -n "rhwp_.*convert|rhwp_.*reflow|rhwp_.*validation|rhwp_.*set_file|rhwp_render_page|rhwp_open|rhwp_page" \
+  Frameworks/generated_rhwp.h Sources/RhwpCoreBridge
+git diff --check
+```
+
+결과:
+
+- bundled Studio open path에서 `convertToEditable`, `ensureParagraphStableIds`, `setFileName`, validation/reflow 흐름을 확인했다.
+- `./scripts/verify-rhwp-studio-assets.sh`는 `OK`로 통과했다.
+- native C bridge에는 editor normalization 계열 ABI가 없고 render/page/image ABI만 있음을 확인했다.
+- `git diff --check` 결과 whitespace 오류는 없었다.
+
+## 리스크와 보류 판단
+
+- `convertToEditable()`의 내부 구현은 현재 앱 repo에 없어서 static call graph만으로 render 영향이 0이라고 단정할 수 없다. 배포용/읽기전용 sample이 필요하다.
+- `setFileName(filename)` 차이는 실제 render 차이 가능성이 있으나, 이번 단계에서는 sample 수치가 없다. Stage 3에서 filename/base directory와 함께 확인한다.
+- #280 harness smoke는 readiness 오류로 실패했다. #283 결론을 막는 문제는 아니지만, 이후 Stage 3 수치 관찰 전에는 harness 오류 재현 여부를 다시 확인해야 한다.
+- #982/PUA 반영 여부는 현재 core lock으로 판단하지 않는다. 새 rhwp release 반영 후 같은 경로에서 재확인해야 한다.
+
+## 다음 단계
+
+Stage 3에서는 filename/base directory/external image 영향을 확인한다. 특히 `setFileName` 차이와 external image population이 실제 sample diff로 이어지는지, 그리고 bridge/open option 후속 이슈가 필요한지 판단한다. Stage 3 진행은 작업지시자 승인 후 시작한다.

--- a/mydocs/working/task_m014_283_stage3.md
+++ b/mydocs/working/task_m014_283_stage3.md
@@ -1,0 +1,173 @@
+# Task M014 #283 Stage 3 보고서 - external image open 영향 조사
+
+## 단계 개요
+
+- 이슈: #283 rhwp-studio 문서 열기 normalization·external image parity 영향 조사
+- 단계: Stage 3. filename/base directory/external image 영향 조사
+- 목표: filename/base directory/external linked image 차이가 `rhwp-studio` reference와 native preview output 차이의 원인이 되는지 판단한다.
+
+이번 단계는 조사와 문서화만 수행했다. production Swift source, Rust bridge, bundled `rhwp-studio` asset은 수정하지 않았다.
+
+## sample 후보와 파일 관찰
+
+Stage 3 후보 파일은 모두 repository에 존재했다.
+
+| 후보 | 관찰 |
+|---|---|
+| `samples/tac-img-02.hwp` | HWP 5.x, native render tree에서 page 1 image node 1개 확인 |
+| `samples/tac-img-02.hwpx` | HWPX zip, `BinData/image*.JPG/BMP/PNG` embedded image 파일 다수 확인, native render tree에서 page 1 image node 1개 확인 |
+| `samples/hwp-img-001.hwp` | HWP 5.x, native render tree에서 page 1 image node 4개 확인 |
+| `samples/img-start-001.hwp` | HWP 5.x, page 1 native render는 가능하나 image node는 0개 확인 |
+| `samples/images/*` | `tiger01.jpg`, `san-serif.jpg`, `splatoon01.jpg`, `younghi.jpg`, `moogung.jpg` 존재 |
+
+`tac-img-02.hwpx`는 zip 목록 기준 외부 sibling image가 아니라 package 내부 `BinData` 이미지가 들어 있다. HWP binary sample은 `strings`만으로 명확한 sibling file basename을 확인하지 못했다. 따라서 이번 단계의 샘플은 “image-heavy/native image 경로 후보”로는 유효하지만, external linked image가 실제로 필요한 문서라고 단정할 수는 없다.
+
+## Studio/WASM external image 경로
+
+bundled Studio open path는 `loadDocument(bytes, filename)`에서 다음 순서로 동작한다.
+
+| 항목 | 현재 동작 | 의미 |
+|---|---|---|
+| document 생성 | `new HwpDocument(bytes)` | bytes만으로 WASM document 생성 |
+| editor normalization | `convertToEditable()`, `ensureParagraphStableIds()` | Stage 2에서 별도 판단 |
+| filename 설정 | `doc.setFileName(this._fileName)` | 머리말/꼬리말 필드 치환용 파일명 설정 |
+| external image population | `this.populateExternalImagesFromDevServer()` | `await`하지 않고 비동기로 실행 |
+
+`rhwp.js` wrapper에는 다음 API가 있다.
+
+| API | 확인 내용 |
+|---|---|
+| `getExternalImageBasenames()` | HWP3 file path 그림의 basename 목록을 JSON 배열로 반환한다고 주석에 명시 |
+| `injectExternalImage(basename, data, display_path)` | JS가 fetch한 외부 image bytes를 document에 inject |
+| `setFileName(name)` | 파일 이름을 core document에 설정 |
+
+minified bundle의 `populateExternalImagesFromDevServer()`는 basename마다 `/samples/<basename>`를 fetch하고, 성공하면 `injectExternalImage(...)`를 호출한다. 실패하면 warning만 남기고 계속 진행한다.
+
+## HostApp resource scheme 영향
+
+현재 HostApp resource scheme은 `rhwp-studio` bundled resource directory 아래 파일만 제공한다.
+
+- `RhwpStudioResourceLocator.resourceDirectoryURL(...)`는 app bundle의 `rhwp-studio` directory를 기준으로 한다.
+- `RhwpStudioResourceSchemeHandler.resolveResource(for:)`는 request path를 이 directory 아래 relative path로 해석한다.
+- `RhwpStudioResourceLocator.isBundledResourceURL(...)`로 directory 밖 접근을 차단한다.
+- `Sources/HostApp/Resources/rhwp-studio` 아래에는 `/samples/` resource가 없다.
+
+따라서 app-bundled Studio에서 `/samples/<basename>` fetch는 원본 문서의 sibling directory가 아니라 `rhwp-studio/samples/<basename>`를 찾는 동작이다. 현재 bundle에는 해당 resource가 없으므로 public app 기본 경로에서 dev-server style external image population이 성공한다고 볼 근거가 없다.
+
+## native bridge 노출 상태
+
+현재 native C ABI와 Swift bridge는 external image population과 filename setter를 노출하지 않는다.
+
+| 항목 | Studio/WASM | native Swift/C bridge |
+|---|---|---|
+| open | `new HwpDocument(bytes)` | `rhwp_open(data, len)` |
+| filename | `doc.setFileName(filename)` | `RhwpDocument(data:filename:)`의 `filename`은 parse error에만 사용 |
+| external basename 조회 | `getExternalImageBasenames()` | 없음 |
+| external image inject | `injectExternalImage(...)` | 없음 |
+| embedded image lookup | Studio 내부 API | `rhwp_image_data(handle, bin_data_id, len)` |
+| render | Studio canvas/page layer | `rhwp_render_page_tree`, `rhwp_render_page_png` |
+
+이 차이는 renderer 선택과 별개의 open contract 차이다. `pagelayertree` 방식으로 전환해도 document handle에 external image bytes가 inject되지 않으면 같은 external image 누락이 남는다.
+
+## #280 harness smoke 결과
+
+실행:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task283-external-image --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+결과:
+
+| sample | 결과 | 원인 |
+|---|---|---|
+| `samples/tac-img-02.hwp` | FAIL | `rhwp-studio page 1 readiness timed out`, `WKErrorDomain Code=5`, JavaScript result unsupported type |
+| `samples/tac-img-02.hwpx` | FAIL | 동일 |
+| `samples/hwp-img-001.hwp` | FAIL | 동일 |
+| `samples/img-start-001.hwp` | FAIL | 동일 |
+
+산출물:
+
+- `build.noindex/task283-external-image/summary.md`
+
+이번 smoke에서는 `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta` 같은 Studio/native 비교 수치를 얻지 못했다. 실패 원인은 Stage 2와 같은 harness readiness polling 문제이며, external image 또는 native renderer의 실제 visual diff로 해석하지 않는다.
+
+## native render-debug 보조 관찰
+
+Studio reference 비교가 실패했기 때문에 native 경로가 후보 샘플을 최소한 render tree/PNG로 처리하는지만 보조 확인했다.
+
+실행:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task283-native-image-debug --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp samples/img-start-001.hwp
+./scripts/render-debug-compare.sh build.noindex/task283-native-image-debug-hwp --page 1 samples/tac-img-02.hwp
+./scripts/render-debug-compare.sh build.noindex/task283-native-image-debug-hwpx --page 1 samples/tac-img-02.hwpx
+```
+
+첫 명령은 `tac-img-02.hwp`와 `tac-img-02.hwpx`가 같은 basename을 사용해 출력 파일이 덮어써졌다. 그래서 두 `tac-img-02` sample은 분리 output으로 다시 실행했다.
+
+| sample | pageCount | renderTree bytes | native PNG | native non-white pixels | textRuns | image nodes | 비고 |
+|---|---:|---:|---|---:|---:|---:|---|
+| `tac-img-02.hwp` | 66 | 36,221 | `794x1123` | 38,551 | 19 | 1 | native render OK |
+| `tac-img-02.hwpx` | 69 | 38,894 | `794x1123` | 32,799 | 21 | 1 | native render OK, `LAYOUT_OVERFLOW` 2.4px warning |
+| `hwp-img-001.hwp` | 1 | 121,964 | `794x1123` | 57,797 | 67 | 4 | native render OK |
+| `img-start-001.hwp` | 3 | 209,463 | `794x1123` | 108,951 | 131 | 0 | native render OK |
+
+`render-debug-compare`의 core SVG raster diff는 `qlmanage rasterize failed`로 생성되지 않았다. 위 표는 native render sanity check일 뿐 Studio/native parity 수치가 아니다.
+
+## 항목별 판단
+
+| 항목 | Stage 3 판단 | 근거 | 후속 |
+|---|---|---|---|
+| filename | 후속 bridge/open option 필요 | Studio는 `setFileName(filename)`로 core document 상태를 바꾸지만 native `filename` 인자는 `rhwp_open`에 전달되지 않는다. | 파일명 필드, 머리말/꼬리말 필드 치환 sample이 있으면 `rhwp_set_file_name` 또는 open option ABI 필요성을 확인. |
+| base directory | 현재 app/extension 공통 미지원 | HostApp payload와 Quick Look/Thumbnail path 모두 bytes + filename만 보존한다. source directory는 core에 전달되지 않는다. | linked external image를 제품 요구로 포함하려면 source directory 보존, sandbox 권한, bridge API를 함께 설계. |
+| external linked image | 새 rhwp release 반영만으로는 충분하다고 보기 어렵다 | Studio JS에는 basename 조회/inject API가 있지만 native C ABI에는 없다. app-bundled Studio의 `/samples/<basename>` fetch도 source directory 기반이 아니다. | 별도 base-dir-aware open 또는 external image injection bridge가 필요. |
+| embedded image | native path는 기존 ABI로 처리 가능 | `rhwp_image_data`와 render tree image node로 `tac-img-02`, `hwp-img-001` native render가 가능했다. | image effect/fill/tile/clip 차이는 #116/#122/#281/#282 renderer 범위로 분리. |
+| pagelayertree 전환 | external image 해결책으로는 부족 | external image bytes가 document state에 들어오지 않으면 page layer tree도 동일하게 누락된다. | 전환 여부와 별개로 open contract를 먼저 맞춰야 한다. |
+
+## preview parity 관점의 결론
+
+Stage 3 기준으로 filename과 external linked image는 renderer 구현보다 앞선 open contract 문제다. `rhwp` 새 release를 반영하면 core render tree 또는 Skia PNG 내부 수정은 Quick Look/Thumbnail에도 따라올 수 있지만, Studio JS wrapper에만 있는 `setFileName`, `getExternalImageBasenames`, `injectExternalImage` 경로는 native C ABI와 Swift open pipeline이 사용하지 않는 한 자동으로 반영되지 않는다.
+
+따라서 external linked image parity가 M014 release acceptance에 포함된다면 별도 blocker 또는 follow-up 이슈로 잡아야 한다. 반대로 M014의 v0.1.4 목표를 embedded image, layout, text, PUA/render output parity로 한정한다면 external linked image는 명시적 한계로 두고 다음 마일스톤으로 넘길 수 있다.
+
+`pagelayertree` 전환은 external image/base directory 문제를 직접 해결하지 않는다. 먼저 document open 시점에 filename과 external image bytes를 core document state에 반영할 API가 필요하고, 그 뒤에 render tree/Skia/page layer 중 어느 출력 경로를 쓸지 판단해야 한다.
+
+## Stage 3 검증
+
+실행:
+
+```bash
+find samples -maxdepth 3 -type f | rg -i "(tac-img|hwp-img|img-start|images|\\.hwp$|\\.hwpx$)"
+rg -n "ExternalImage|externalImage|external_image|getExternalImageBasenames|populate|imageBasename|baseDir|base directory" \
+  Sources Frameworks/generated_rhwp.h Sources/HostApp/Resources/rhwp-studio/rhwp.d.ts \
+  Sources/HostApp/Resources/rhwp-studio/assets/index-*.js
+./scripts/preview-visual-diff-harness.sh build.noindex/task283-external-image --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp samples/img-start-001.hwp
+sed -n '1,120p' build.noindex/task283-external-image/summary.md
+./scripts/render-debug-compare.sh build.noindex/task283-native-image-debug --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp samples/img-start-001.hwp
+./scripts/render-debug-compare.sh build.noindex/task283-native-image-debug-hwp --page 1 samples/tac-img-02.hwp
+./scripts/render-debug-compare.sh build.noindex/task283-native-image-debug-hwpx --page 1 samples/tac-img-02.hwpx
+```
+
+결과:
+
+- sample 후보와 `samples/images/*` 존재를 확인했다.
+- Studio/WASM wrapper의 `getExternalImageBasenames`, `injectExternalImage`, `setFileName` 경로를 확인했다.
+- native generated header와 Swift bridge에는 external basename 조회, external image inject, filename setter ABI가 없음을 확인했다.
+- #280 harness는 네 샘플 모두 readiness 오류로 실패했다. 비교 수치는 생성하지 못했다.
+- native render-debug는 네 샘플 모두 render tree와 native PNG 생성에 성공했다.
+
+## 리스크와 보류 판단
+
+- HWP binary sample의 external linked image 여부를 현재 앱 repo의 native ABI만으로 직접 조회할 수 없다. Studio/WASM에는 basename 조회 API가 있지만 native bridge에는 없어, 이번 단계에서는 static evidence와 harness 실패 결과만 남긴다.
+- app-bundled Studio의 `/samples/<basename>` fetch가 실제 런타임에서 어떤 warning을 남기는지는 #280 harness readiness 실패 때문에 직접 관찰하지 못했다.
+- external image population은 `loadDocument()`에서 `await`하지 않는다. harness가 안정화되더라도 capture settle 조건이 inject 완료 후인지 별도 확인이 필요하다.
+- `img-start-001.hwp`는 이름상 image 후보지만 page 1 render tree에서는 image node가 확인되지 않았다. 다른 page나 layout 흐름에서 image가 나올 가능성은 이번 단계에서 보지 않았다.
+
+## 다음 단계
+
+Stage 4에서는 Stage 1-3 결론을 종합해 최종 보고서를 작성한다. 특히 M014 기준에서 external linked image를 release blocker로 볼지, 별도 follow-up으로 분리할지 결정하고 #281/#282/#116/#122/#280에 전달할 handoff를 정리한다. Stage 4 진행은 작업지시자 승인 후 시작한다.


### PR DESCRIPTION
## 요약

- 대상 타스크: Closes #283
- 왜: M014 렌더러 parity 작업 전에 `rhwp-studio` reference와 native preview의 open pipeline 차이가 blocker인지 분리하기 위해서입니다.
- 무엇: open pipeline inventory, normalization 영향, filename/base directory/external image 영향, #286 이후 visual diff 재측정 결과, 최종 handoff 보고서를 문서화했습니다.
- 리뷰 포인트: `filename`/external linked image를 renderer 문제가 아니라 후속 open/resource contract로 분리한 결론과 #281 이후 진행 가능 판단입니다.

## PR base

- base: `devel`

## 변경 내역

- **[계획](https://github.com/postmelee/alhangeul-macos/blob/8b19077a74c91c77750f1c75bf1c250172fea4a2/mydocs/plans/task_m014_283.md)** ([c4d55f5](https://github.com/postmelee/alhangeul-macos/commit/c4d55f5cc4ef58e8e8ec3947cd86f530557f9151)): #283 수행 계획과 오늘할일을 등록했습니다.
- **[구현 계획](https://github.com/postmelee/alhangeul-macos/blob/8b19077a74c91c77750f1c75bf1c250172fea4a2/mydocs/plans/task_m014_283_impl.md)** ([c1ed7f3](https://github.com/postmelee/alhangeul-macos/commit/c1ed7f37eb1bfdac31b945dc2035eb4490f33466)): 4단계 구현/검증 계획을 확정했습니다.
- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/8b19077a74c91c77750f1c75bf1c250172fea4a2/mydocs/working/task_m014_283_stage1.md)** ([cfade5b](https://github.com/postmelee/alhangeul-macos/commit/cfade5b9a713458f7134701c4f85dadb5479b6b3)): HostApp Studio, Quick Look, Thumbnail, Shared native renderer의 open pipeline inventory를 정리했습니다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/8b19077a74c91c77750f1c75bf1c250172fea4a2/mydocs/working/task_m014_283_stage2.md)** ([81c46db](https://github.com/postmelee/alhangeul-macos/commit/81c46db6d57426fff071ebe3dc4c8ec661c141a8)): `convertToEditable`, stable id, validation/reflow, filename setter 차이를 분류했습니다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/8b19077a74c91c77750f1c75bf1c250172fea4a2/mydocs/working/task_m014_283_stage3.md)** ([520f8cc](https://github.com/postmelee/alhangeul-macos/commit/520f8ccc9b3301d45c296f8450fcf86422a5cb68)): filename/base directory/external image 영향과 native image render sanity를 조사했습니다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/8b19077a74c91c77750f1c75bf1c250172fea4a2/mydocs/report/task_m014_283_report.md)** ([d041788](https://github.com/postmelee/alhangeul-macos/commit/d0417887863d5bd364035d0aee1e537ded5a985a)): 최종 결론, 후속 handoff, upstream 연계를 정리했습니다.
- **[#286 merge 반영](https://github.com/postmelee/alhangeul-macos/blob/8b19077a74c91c77750f1c75bf1c250172fea4a2/mydocs/report/task_m014_286_report.md)** ([38d7e26](https://github.com/postmelee/alhangeul-macos/commit/38d7e26eef4063fa6607438a860acf0a41a3a3a7)): 최신 `devel`을 병합해 #286 harness 안정화 변경을 포함했습니다.
- **[Visual diff 보강](https://github.com/postmelee/alhangeul-macos/blob/8b19077a74c91c77750f1c75bf1c250172fea4a2/mydocs/report/task_m014_283_report.md)** ([8b19077](https://github.com/postmelee/alhangeul-macos/commit/8b19077a74c91c77750f1c75bf1c250172fea4a2)): #286 이후 6개 sample 재측정 결과와 PR handoff를 보강했습니다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| 조사 문서 | Stage 1-3 보고서와 최종 보고서 작성 | `filename`/external linked image를 M014 renderer blocker가 아닌 open/resource contract 후속으로 분리한 판단 |
| visual diff | #286 이후 basic 2개, image-heavy 4개 sample을 재측정 | 수치가 open contract 단독 원인이 아니라 native/CoreGraphics와 `rhwp-studio` reference의 baseline 차이임을 명시 |
| 오늘할일 | #283, #286 행 충돌을 정리하고 #283 PR 보강 상태 기록 | merge 후 문서 상태 확인 |

- 수행 계획서: [task_m014_283.md](https://github.com/postmelee/alhangeul-macos/blob/8b19077a74c91c77750f1c75bf1c250172fea4a2/mydocs/plans/task_m014_283.md)
- 구현 계획서: [task_m014_283_impl.md](https://github.com/postmelee/alhangeul-macos/blob/8b19077a74c91c77750f1c75bf1c250172fea4a2/mydocs/plans/task_m014_283_impl.md)
- 최종 보고서: [task_m014_283_report.md](https://github.com/postmelee/alhangeul-macos/blob/8b19077a74c91c77750f1c75bf1c250172fea4a2/mydocs/report/task_m014_283_report.md)

## 핵심 리뷰 포인트

- `convertToEditable`, stable id, validation/reflow는 #281/#282/#116/#122/#121/#110 진행 blocker로 보지 않았습니다.
- `filename`과 external linked image는 renderer 구현보다 앞선 document open/resource contract 문제로 분리했습니다.
- PageLayerTree 전환만으로 external linked image가 해결되지는 않는다는 결론을 남겼습니다.
- #286 이후 visual diff metric은 생성되지만, 현재 native/CoreGraphics와 `rhwp-studio` reference의 baseline 차이로 해석해야 합니다.

## 검증

- `./scripts/verify-rhwp-studio-assets.sh`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task283-visual-diff-basic-final --page 1 samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task283-visual-diff-images-final --page 1 samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp samples/img-start-001.hwp`
- `rg -n "ChangedPixels|ChangedPercent|MeanRGBDelta|FAIL|WKErrorDomain|unsupported|readiness timed out" build.noindex/task283-visual-diff-basic-final/summary.md build.noindex/task283-visual-diff-images-final/summary.md`
- Stage 3 후보 4개 sample의 native render-debug PNG 생성 확인
- `rg -n "#283|#286|ChangedPixels|ChangedPercent|MeanRGBDelta|visual diff|readiness|#281|#285|external image|open contract" mydocs/report/task_m014_283_report.md mydocs/orders/20260527.md`
- `git diff --check`

Visual diff smoke는 WebKit GUI 프로세스가 정상 동작하는 sandbox 밖 권한으로 실행했습니다. 최종 basic/image-heavy summary는 exit code 0이고, `FAIL`, `WKErrorDomain`, `unsupported`, `readiness timed out`는 남지 않았습니다.

## 관련 이슈

- #280
- #281
- #282
- #116
- #122
- #121
- #110
- #286
- edwardkim/rhwp#1141
- edwardkim/rhwp#1144
- edwardkim/rhwp#1142
- edwardkim/rhwp#1143

## 후속 이슈 제안

- 별도 downstream 이슈는 아직 만들지 않았습니다.
- `filename`/external linked image는 upstream edwardkim/rhwp#1141 하위 이슈 흐름을 먼저 따라가는 것을 제안합니다.

## 남은 리스크

- #286 이후 visual diff metric은 확보했지만, 이 수치는 open contract 원인만을 단독으로 설명하지 않는 baseline입니다.
- 현재 repo sample만으로 실제 sibling external linked image 요구를 확정하지 못했습니다.
- filename field 치환 sample을 확보하지 못해 output diff는 직접 관찰하지 못했습니다.
- upstream native Sub-issues 연결은 maintainer 권한이 필요해 #1141 본문 체크리스트로만 남아 있습니다.
