### PR TITLE
Task #286: rhwp-studio visual diff harness readiness 안정화

### DIFF
--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 진행중 | M014, Stage 3 완료, Stage 4 승인 대기 |
+| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 최종 보고서 작성, PR 준비 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 진행중 | M014, Stage 1 완료, Stage 2 승인 대기 |
+| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 진행중 | M014, Stage 2 완료, Stage 3 승인 대기 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 최종 보고서 작성, PR 준비 |
+| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 5월 27일
+
+## M014 — v0.1.4 Native Preview/Viewer Parity
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 진행중 | M014, Stage 2 완료, Stage 3 승인 대기 |
+| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 진행중 | M014, Stage 3 완료, Stage 4 승인 대기 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 진행중 | M014, 구현계획서 작성 후 Stage 1 승인 대기 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 진행중 | M014, 구현계획서 작성 후 Stage 1 승인 대기 |
+| #286 | rhwp-studio preview visual diff harness readiness 안정화 | 진행중 | M014, Stage 1 완료, Stage 2 승인 대기 |

--- a/mydocs/plans/task_m014_286.md
+++ b/mydocs/plans/task_m014_286.md
@@ -1,0 +1,130 @@
+# Task M014 #286 수행계획서
+
+## 목적
+
+`rhwp-studio` preview visual diff harness의 readiness polling 실패를 안정화해 M014 후속 PR에서 `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta` 같은 visual diff metric을 반복 생성할 수 있게 한다.
+
+완료 후 작업자는 #281 이후 renderer/compositor parity PR에서 같은 harness를 재사용해 before/after 수치를 남길 수 있어야 한다. 또한 #285의 #283 조사 PR에 누락된 visual diff 측정 결과를 보강할 수 있는 output directory convention과 smoke 기준을 확보해야 한다.
+
+## 배경
+
+#280에서 `rhwp-studio` 기준 preview visual diff harness를 만들었지만, #283 Stage 2/3에서 다음 오류가 반복되어 실제 비교 수치를 얻지 못했다.
+
+- `rhwp-studio page 1 readiness timed out`
+- `WKErrorDomain Code=5`
+- JavaScript result unsupported type
+
+#283은 open pipeline 차이를 분리하는 조사 PR이므로 결론 자체는 유지할 수 있다. 그러나 #281, #282, #116, #122, #121, #110은 `rhwp-studio` reference 대비 native preview 차이를 수치로 추적해야 한다. harness readiness가 불안정하면 이후 작업의 검증 근거가 약해진다.
+
+## 범위
+
+포함:
+
+- `scripts/preview-visual-diff-harness.sh`와 `scripts/preview_visual_diff_harness.swift`의 readiness failure 재현
+- `WKWebView.evaluateJavaScript` 반환값이 property list/JSON 직렬화 가능한 primitive로 제한되도록 probe 보강
+- `pageStateScript`, `alignAndHideChromeScript`, `settleFlagScript`, `canvasDataURLScript`의 실패 원인 분리
+- readiness timeout 시 마지막 page state, JavaScript error, navigation error, capture phase를 summary/debug artifact에 남기는 보강
+- known sample set에서 `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta` 생성 여부 검증
+- #281 및 #285 보강에 재사용할 명령과 output directory convention 정리
+
+제외:
+
+- renderer/compositor parity 구현
+- #281 PageLayerTree overlay metadata 연결 구현
+- #282 flow/behind/front compositor 보강 구현
+- upstream `rhwp` 수정
+- public release gate 변경
+- #285 브랜치 직접 수정 또는 #285 merge 처리
+
+## 설계 방향
+
+이번 작업은 harness가 `rhwp-studio` reference capture를 안정적으로 완료하게 만드는 검증 기반 보정이다. 먼저 #283에서 실패한 sample로 오류를 재현하고, 실패 phase를 `navigation`, `readiness`, `settle`, `canvas export`, `snapshot`, `native render`, `diff` 중 하나로 분류할 수 있게 한다.
+
+JavaScript probe는 Swift `WKWebView.evaluateJavaScript`가 안전하게 받을 수 있도록 문자열 JSON 또는 Boolean/Number/String primitive만 반환하도록 유지한다. 복잡한 DOMRect, Element, Promise, ImageData, Error object가 그대로 반환되지 않도록 한다.
+
+capture 성공 조건은 다음을 만족해야 한다.
+
+- 대상 page canvas가 DOM에 존재한다.
+- canvas backing size가 0이 아니다.
+- canvas sample 또는 snapshot 영역이 비어 있지 않다는 최소 관찰값을 남긴다.
+- chrome hide/scroll align 이후 settle flag가 확인된다.
+- summary가 성공 sample의 diff metric과 실패 sample의 phase별 원인을 모두 기록한다.
+
+## 예상 변경 파일
+
+- `mydocs/orders/20260527.md`
+- `mydocs/plans/task_m014_286.md`
+- `mydocs/plans/task_m014_286_impl.md`
+- `mydocs/working/task_m014_286_stage{N}.md`
+- `mydocs/report/task_m014_286_report.md`
+- `scripts/preview_visual_diff_harness.swift`
+- 필요 시 `scripts/preview-visual-diff-harness.sh`
+
+## 잠정 단계
+
+1. Stage 1: 실패 재현과 readiness phase inventory
+   - #283에서 실패한 sample set으로 현재 오류를 재현한다.
+   - `evaluateJavaScript`, `pageStateScript`, `settleFlagScript`, `canvasDataURLScript`의 반환값과 실패 phase를 정리한다.
+   - 최소 보정 범위를 구현계획서에 확정한다.
+2. Stage 2: JavaScript probe와 readiness logging 보강
+   - unsupported result type을 피하도록 probe 반환값을 primitive/JSON string으로 정리한다.
+   - timeout 시 마지막 state, phase, error message를 summary에 남긴다.
+   - script syntax와 Swift compile을 확인한다.
+3. Stage 3: known sample smoke와 metric 생성 검증
+   - 기본 sample과 image-heavy sample에서 harness를 실행한다.
+   - PASS sample의 `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta`를 기록한다.
+   - 실패 sample이 있으면 readiness 문제가 아닌지 원인을 분류한다.
+4. Stage 4: #281/#285 handoff와 최종 보고
+   - #281에서 재사용할 command/output convention을 정리한다.
+   - #285에 추가할 수 있는 #283 재측정 범위와 한계를 정리한다.
+   - 최종 보고서와 오늘할일을 갱신한다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+rg -n "#286|readiness|visual diff|M014|preview visual diff" \
+  mydocs/orders/20260527.md mydocs/plans/task_m014_286.md
+git diff --check -- mydocs/orders/20260527.md mydocs/plans/task_m014_286.md
+git status --short --branch
+```
+
+구현 단계 후보:
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-readiness-baseline --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx
+sed -n '1,160p' build.noindex/task286-readiness-baseline/summary.md
+rg -n "ChangedPixels|ChangedPercent|MeanRGBDelta|WKErrorDomain|unsupported|readiness timed out" \
+  build.noindex/task286-readiness-baseline/summary.md
+git diff --check
+git status --short --branch
+```
+
+필요 시 추가 smoke:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-readiness-images --page 1 \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+sed -n '1,160p' build.noindex/task286-readiness-images/summary.md
+```
+
+## 리스크
+
+- WKWebView snapshot과 JavaScript evaluation은 로컬 macOS/WebKit 상태에 영향을 받을 수 있어 CI와 로컬 결과가 다를 수 있다.
+- sample별 실제 renderer 차이가 큰 경우 harness가 PASS해도 diff 수치가 큰 것은 정상일 수 있다.
+- `rhwp-studio` 내부 DOM 구조가 minified bundle 변경에 따라 달라질 수 있으므로 selector는 너무 좁게 고정하지 않는다.
+- #285 보강은 #286 merge 후 별도 브랜치 반영이 필요하다. #286 작업 브랜치에서 #285 PR 브랜치를 직접 수정하지 않는다.
+- #285와 #286이 모두 `mydocs/orders/20260527.md`를 추가하므로 merge 순서에 따라 orders 파일 충돌이 생길 수 있다.
+
+## 승인 요청 사항
+
+1. #286을 `rhwp-studio` preview visual diff harness readiness 안정화 작업으로 진행하는 범위 승인
+2. 이번 작업에서는 renderer/compositor 동작을 수정하지 않고 harness와 검증 산출물만 보강하는 방향 승인
+3. #286은 `devel` 기준 독립 브랜치에서 진행하고, #285의 visual diff 보강은 #286 merge 이후 별도로 반영하는 방향 승인
+4. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m014_286_impl.md`) 작성과 Stage 1 실패 재현 진행
+
+승인 전에는 Swift source, script, renderer 동작 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m014_286_impl.md
+++ b/mydocs/plans/task_m014_286_impl.md
@@ -1,0 +1,263 @@
+# Task M014 #286 구현 계획서
+
+수행계획서: `mydocs/plans/task_m014_286.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #286 rhwp-studio preview visual diff harness readiness 안정화
+- 마일스톤: M014 (`v0.1.4 Native Preview/Viewer Parity`)
+- 브랜치: `local/task286`
+- 작업 위치: `/Users/melee/Documents/projects/rhwp-mac`
+- 기준 브랜치: `devel`
+- 목표: #280 harness가 `rhwp-studio` reference PNG와 native preview PNG를 안정적으로 생성하고, #281 이후 PR에서 visual diff metric을 반복 기록할 수 있게 한다.
+
+## 구현 원칙
+
+- renderer/compositor production 동작은 수정하지 않는다.
+- #281/#282/#116/#122/#121/#110 구현을 선행하지 않는다.
+- #285 PR 브랜치는 직접 수정하지 않는다. #286 merge 후 #285 보강은 별도 반영한다.
+- JavaScript probe는 `WKWebView.evaluateJavaScript`가 안정적으로 반환할 수 있는 primitive 또는 JSON string만 반환한다.
+- 실패를 숨기지 않는다. `navigation`, `readiness`, `settle`, `canvas export`, `snapshot`, `native render`, `diff` 중 어느 phase에서 실패했는지 summary에 남긴다.
+- sample별 renderer 차이는 harness 실패와 분리한다. harness가 PASS하고 diff 수치가 큰 경우는 정상 측정 결과로 기록한다.
+
+## 현재 기준 관찰
+
+현재 harness의 핵심 위치는 다음이다.
+
+| 영역 | 파일/함수 | 관찰 |
+|------|-----------|------|
+| wrapper | `scripts/preview-visual-diff-harness.sh` | Swift harness를 빌드한 뒤 sample 목록을 전달한다. |
+| readiness wait | `scripts/preview_visual_diff_harness.swift` `waitForPageReady` | `currentPageState`가 ready를 반환할 때까지 polling한다. |
+| JS bridge | `evaluateJavaScript` | WebKit callback의 `value`를 그대로 Swift `Any?`로 받는다. |
+| page state | `pageStateScript` | `JSON.stringify(...)`로 state JSON string을 반환한다. |
+| settle | `alignPageAndHideChrome`, `settleFlagScript` | chrome hide/scroll align 후 settle flag를 확인한다. |
+| canvas export | `canvasDataURLScript` | page canvas를 data URL로 export한다. |
+| summary | `PreviewVisualDiffHarness.main` | OK/FAIL row를 `summary.md`에 기록한다. |
+
+#283에서 반복된 증상은 readiness 단계의 `WKErrorDomain Code=5`와 JavaScript unsupported result type이다. Stage 1에서 이 증상이 현재 `devel` 기준으로 재현되는지 먼저 확인한다.
+
+## 조사 산출물 구조
+
+| 파일 | 역할 |
+|------|------|
+| `mydocs/plans/task_m014_286_impl.md` | 단계별 구현 범위, 검증, 완료 기준 |
+| `mydocs/working/task_m014_286_stage1.md` | 실패 재현과 phase inventory |
+| `mydocs/working/task_m014_286_stage2.md` | probe/logging 보강 구현 보고 |
+| `mydocs/working/task_m014_286_stage3.md` | known sample metric smoke 보고 |
+| `mydocs/report/task_m014_286_report.md` | 최종 결과와 #281/#285 handoff |
+| `build.noindex/task286-*` | 재현/검증 산출물. 커밋하지 않는다. |
+
+## Stage 1. 실패 재현과 readiness phase inventory
+
+### 목표
+
+#283에서 관찰된 readiness 실패를 현재 `devel` 기준으로 재현하고, 실제 실패가 어느 phase와 JavaScript 반환값에서 발생하는지 정리한다.
+
+### 작업
+
+- #283 실패 sample set으로 baseline harness를 실행한다.
+  - `samples/basic/request.hwp`
+  - `samples/hwpx/hwpx-01.hwpx`
+  - `samples/tac-img-02.hwp`
+  - `samples/tac-img-02.hwpx`
+- `summary.md`의 실패 메시지를 수집한다.
+- `scripts/preview_visual_diff_harness.swift`에서 readiness 관련 함수의 현재 반환 계약을 정리한다.
+- 최소 보정 후보를 분류한다.
+  - JavaScript result type 보정
+  - page state JSON decode 보강
+  - timeout summary/log 보강
+  - settle/canvas export phase 분리
+
+### 산출물
+
+- `mydocs/working/task_m014_286_stage1.md`
+- `build.noindex/task286-stage1-baseline/summary.md` 또는 실패 로그
+
+### 검증
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage1-baseline --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx
+sed -n '1,180p' build.noindex/task286-stage1-baseline/summary.md
+rg -n "WKErrorDomain|unsupported|readiness timed out|ChangedPixels|MeanRGBDelta" \
+  build.noindex/task286-stage1-baseline/summary.md
+rg -n "waitForPageReady|evaluateJavaScript|pageStateScript|settleFlagScript|canvasDataURLScript" \
+  scripts/preview_visual_diff_harness.swift
+git diff --check
+```
+
+### 완료 기준
+
+- 현재 실패가 재현되거나, 재현되지 않을 경우 그 사실과 생성된 metric을 보고서에 남긴다.
+- 실패 sample별 phase와 오류 메시지를 표로 정리한다.
+- Stage 2에서 적용할 최소 변경 범위를 확정한다.
+- production source는 변경하지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #286 Stage 1: harness readiness 실패 재현
+```
+
+## Stage 2. JavaScript probe와 readiness logging 보강
+
+### 목표
+
+readiness probe와 summary logging을 보강해 unsupported JavaScript result type 오류를 피하고, 실패 원인을 phase별로 구분할 수 있게 한다.
+
+### 작업
+
+- `evaluateJavaScript` 호출 결과의 오류 메시지를 WebKit domain/code/message 중심으로 정리한다.
+- `currentPageState`와 `canvasDataURLScript` 결과가 항상 JSON string인지 검증하고, 예상하지 못한 type이면 type name과 phase를 남긴다.
+- readiness timeout 시 마지막 state와 마지막 error를 함께 남긴다.
+- sample별 FAIL row가 가능하면 `navigation/readiness/settle/canvas export/snapshot/native render/diff` 중 phase를 드러내도록 보강한다.
+- 필요 시 Swift 내부 helper type을 추가하되 harness 파일 안에 한정한다.
+
+### 산출물
+
+- `scripts/preview_visual_diff_harness.swift`
+- 필요 시 `scripts/preview-visual-diff-harness.sh`
+- `mydocs/working/task_m014_286_stage2.md`
+
+### 검증
+
+```bash
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task286-stage2-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task286-stage2-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task286-stage2-syntax-check
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage2-smoke --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+sed -n '1,180p' build.noindex/task286-stage2-smoke/summary.md
+git diff --check
+```
+
+### 완료 기준
+
+- Swift harness가 컴파일된다.
+- 기본 sample 2개에서 PASS metric이 생성되거나, FAIL이면 phase와 원인이 summary에서 구분된다.
+- Stage 1의 unsupported result type이 같은 형태로 반복되지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #286 Stage 2: readiness probe logging 보강
+```
+
+## Stage 3. known sample smoke와 metric 생성 검증
+
+### 목표
+
+M014 후속 작업에서 재사용할 sample set으로 harness metric 생성 여부를 검증한다.
+
+### 작업
+
+- 기본 sample set smoke:
+  - `samples/basic/request.hwp`
+  - `samples/hwpx/hwpx-01.hwpx`
+- image-heavy sample set smoke:
+  - `samples/tac-img-02.hwp`
+  - `samples/tac-img-02.hwpx`
+  - 필요 시 `samples/hwp-img-001.hwp`
+  - 필요 시 `samples/img-start-001.hwp`
+- `summary.md`에서 `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta`, `MaxRGBDelta`, capture mode, native backend를 기록한다.
+- 실패 sample이 있다면 harness readiness 문제인지 renderer/document 문제인지 분류한다.
+
+### 산출물
+
+- `mydocs/working/task_m014_286_stage3.md`
+- `build.noindex/task286-stage3-basic/summary.md`
+- `build.noindex/task286-stage3-images/summary.md`
+
+### 검증
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage3-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage3-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+sed -n '1,180p' build.noindex/task286-stage3-basic/summary.md
+sed -n '1,220p' build.noindex/task286-stage3-images/summary.md
+rg -n "ChangedPixels|ChangedPercent|MeanRGBDelta|FAIL|WKErrorDomain|unsupported|readiness timed out" \
+  build.noindex/task286-stage3-basic/summary.md \
+  build.noindex/task286-stage3-images/summary.md
+git diff --check
+```
+
+### 완료 기준
+
+- 최소 4개 target sample 중 PASS sample의 metric이 summary에 기록된다.
+- 실패 sample이 있으면 readiness failure와 renderer/document failure를 구분한다.
+- #281에서 사용할 smoke 명령 후보가 확정된다.
+
+### 커밋 메시지
+
+```text
+Task #286 Stage 3: harness metric smoke 검증
+```
+
+## Stage 4. #281/#285 handoff와 최종 보고
+
+### 목표
+
+#286 결과를 M014 후속 작업과 #285 보강 흐름으로 넘길 수 있게 정리한다.
+
+### 작업
+
+- #281에서 재사용할 command/output directory convention을 정리한다.
+- #285에 추가할 수 있는 #283 재측정 범위와 한계를 정리한다.
+- 완료 sample과 실패 sample을 구분해 최종 보고서에 수치와 한계를 기록한다.
+- 오늘할일 #286 행을 완료 상태로 갱신한다.
+
+### 산출물
+
+- `mydocs/report/task_m014_286_report.md`
+- `mydocs/orders/20260527.md`
+
+### 검증
+
+```bash
+rg -n "#286|readiness|ChangedPixels|ChangedPercent|MeanRGBDelta|#281|#285|#280|#283" \
+  mydocs/report/task_m014_286_report.md mydocs/orders/20260527.md
+git diff --check
+git status --short --branch
+```
+
+### 완료 기준
+
+- #286 완료 기준인 visual diff metric 생성 또는 phase별 실패 진단이 보고서에 남는다.
+- #281 후속 PR에서 재사용할 harness 실행 명령이 명시된다.
+- #285 보강 가능 범위와 merge 순서 리스크가 정리된다.
+
+### 커밋 메시지
+
+```text
+Task #286 Stage 4: harness readiness 결과 정리
+```
+
+## 승인 요청 사항
+
+1. 위 4단계 구현계획으로 #286을 진행하는 것에 대한 승인
+2. Stage 1에서 production source 수정 없이 실패 재현과 phase inventory만 수행하는 범위 승인
+3. Stage 2에서 harness script 보강을 수행하되 renderer/compositor production 경로는 수정하지 않는 범위 승인
+4. 승인 후 다음 단계: Stage 1 실패 재현과 readiness phase inventory 진행
+
+승인 전에는 Stage 1 조사 실행이나 source/script 변경을 진행하지 않는다.

--- a/mydocs/report/task_m014_286_report.md
+++ b/mydocs/report/task_m014_286_report.md
@@ -28,16 +28,16 @@
 3. sandbox 내부에서 `events=[]`, `scheme={resourceRequests=0, documentRequests=0}`가 나오면 `rhwp-studio` DOM readiness 또는 renderer 문제가 아니라 WebKit navigation 자체가 시작되지 않은 실행 환경 문제로 본다.
 4. 후속 #281/#282/#116/#122/#121/#110 작업은 이번 summary format을 before/after metric 기록용으로 사용할 수 있다.
 
-## 변경 파일
+## 변경 파일 목록과 영향 범위
 
-| 파일 | 변경 |
+| 파일 | 내용 |
 |------|------|
-| `scripts/preview_visual_diff_harness.swift` | phase-aware error, summary `Phase` column, readiness timeout detail, navigation event 기록, scheme request stats, `NSApplication.finishLaunching()`, offscreen window 표시 보정, output stem 충돌 방지 |
-| `mydocs/working/task_m014_286_stage1.md` | baseline 실패 재현 보고 |
-| `mydocs/working/task_m014_286_stage2.md` | readiness logging 보강 보고 |
-| `mydocs/working/task_m014_286_stage3.md` | metric smoke와 sandbox 분리 보고 |
-| `mydocs/report/task_m014_286_report.md` | 최종 보고 |
-| `mydocs/orders/20260527.md` | #286 완료 상태 반영 |
+| `scripts/preview_visual_diff_harness.swift` | `rhwp-studio` reference capture 실패가 renderer 문제인지 WebKit 실행 환경 문제인지 구분되도록 phase-aware error, summary `Phase` column, readiness timeout detail, navigation event, scheme request stats를 추가했다. command-line WebKit harness 안정화를 위해 `NSApplication.finishLaunching()`과 offscreen window 표시를 보정했고, 같은 basename의 HWP/HWPX 입력이 산출물을 덮어쓰지 않도록 output stem에 확장자를 포함했다. |
+| `mydocs/working/task_m014_286_stage1.md` | #283에서 관찰한 readiness timeout과 `WKErrorDomain Code=5` unsupported JavaScript result type을 현재 기준에서 재현하고, Stage 2 보정 범위를 정했다. |
+| `mydocs/working/task_m014_286_stage2.md` | JavaScript probe와 readiness logging 보강 후 실패 형태가 `navigation=pending`으로 분리된 사실과 남은 한계를 기록했다. |
+| `mydocs/working/task_m014_286_stage3.md` | sandbox 내부 WebKit navigation 미시작 문제와 sandbox 밖 정상 capture를 분리하고, 6개 sample visual diff metric을 기록했다. |
+| `mydocs/report/task_m014_286_report.md` | #286 최종 결론, 수치 비교 자료, 한계, #281/#285 handoff, merge 순서 리스크를 후속 작업에서 재사용할 수 있게 정리했다. |
+| `mydocs/orders/20260527.md` | 하이퍼-워터폴 추적을 위해 #286 상태를 완료로 갱신하고 완료 시각을 남겼다. |
 
 ## 단계별 결과
 

--- a/mydocs/report/task_m014_286_report.md
+++ b/mydocs/report/task_m014_286_report.md
@@ -1,0 +1,235 @@
+# Task M014 #286 최종 보고서 - rhwp-studio preview visual diff harness readiness 안정화
+
+## 작업 개요
+
+- 이슈: #286 rhwp-studio preview visual diff harness readiness 안정화
+- 마일스톤: M014 (`v0.1.4 Native Preview/Viewer Parity`)
+- 브랜치: `local/task286`
+- 목표: #280에서 만든 `rhwp-studio` reference 기반 preview visual diff harness가 후속 #281/#282 작업과 #285 보강에서 반복 가능한 수치 비교 자료를 만들 수 있게 한다.
+
+이번 작업은 harness 안정화와 검증 산출물 정리에 한정했다. native renderer/compositor production 동작, bundled `rhwp-studio` asset, upstream `rhwp`는 수정하지 않았다.
+
+## 최종 결론
+
+#286은 완료 기준을 충족했다.
+
+- `rhwp-studio` reference PNG 생성 성공.
+- native preview PNG 생성 성공.
+- diff PNG 생성 성공.
+- 6개 known sample에서 `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta`, `MaxRGBDelta` 기록 성공.
+- 실패 시 `navigation/readiness/settle/canvas export/snapshot/native render/diff` phase를 summary에서 구분할 수 있게 됨.
+- Codex sandbox 내부 WebKit 실행 실패와 실제 harness readiness 문제를 분리할 수 있게 됨.
+- 같은 basename을 가진 HWP/HWPX 쌍이 서로 산출물을 덮어쓰는 문제를 수정함.
+
+핵심 결론은 다음이다.
+
+1. #283에서 metric을 얻지 못한 직접 원인은 native renderer가 아니라 harness의 WebKit readiness 경로와 실행 환경 관측 부족이었다.
+2. sandbox 밖 실행에서는 custom scheme 기반 `rhwp-studio` reference capture가 정상 동작한다.
+3. sandbox 내부에서 `events=[]`, `scheme={resourceRequests=0, documentRequests=0}`가 나오면 `rhwp-studio` DOM readiness 또는 renderer 문제가 아니라 WebKit navigation 자체가 시작되지 않은 실행 환경 문제로 본다.
+4. 후속 #281/#282/#116/#122/#121/#110 작업은 이번 summary format을 before/after metric 기록용으로 사용할 수 있다.
+
+## 변경 파일
+
+| 파일 | 변경 |
+|------|------|
+| `scripts/preview_visual_diff_harness.swift` | phase-aware error, summary `Phase` column, readiness timeout detail, navigation event 기록, scheme request stats, `NSApplication.finishLaunching()`, offscreen window 표시 보정, output stem 충돌 방지 |
+| `mydocs/working/task_m014_286_stage1.md` | baseline 실패 재현 보고 |
+| `mydocs/working/task_m014_286_stage2.md` | readiness logging 보강 보고 |
+| `mydocs/working/task_m014_286_stage3.md` | metric smoke와 sandbox 분리 보고 |
+| `mydocs/report/task_m014_286_report.md` | 최종 보고 |
+| `mydocs/orders/20260527.md` | #286 완료 상태 반영 |
+
+## 단계별 결과
+
+### Stage 1. 실패 재현
+
+#283에서 관찰된 readiness 실패를 재현했다.
+
+실행:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage1-baseline --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx
+```
+
+결과:
+
+| sample | 결과 | 오류 |
+|--------|------|------|
+| `request.hwp` | FAIL | `WKErrorDomain Code=5`, unsupported JavaScript result type |
+| `hwpx-01.hwpx` | FAIL | 동일 |
+| `tac-img-02.hwp` | FAIL | 동일 |
+| `tac-img-02.hwpx` | FAIL | 동일 |
+
+이 시점에는 reference PNG가 생성되지 않았고, 모든 metric은 `-`였다.
+
+### Stage 2. phase-aware logging
+
+readiness timeout에 다음 관측값을 추가했다.
+
+- 실패 phase
+- 마지막 page state
+- 마지막 WebKit/JavaScript error
+- error count
+- navigation 상태
+- summary `Phase` column
+
+Stage 2 smoke에서는 `WKErrorDomain Code=5 / unsupported result type` 대신 다음 형태로 정리됐다.
+
+```text
+[phase:readiness] rhwp-studio page 1 readiness timed out: navigation=pending
+```
+
+이 결과로 Stage 1의 unsupported result type은 최종 원인이라기보다 main-frame navigation commit 전에 JS polling을 반복한 증상으로 분리됐다.
+
+### Stage 3. metric smoke
+
+Stage 3에서 WebKit navigation event와 custom scheme request stats를 추가했다.
+
+sandbox 내부 실패:
+
+```text
+navigation=pending; events=[]; scheme={resourceRequests=0, documentRequests=0}
+```
+
+sandbox 밖 실행:
+
+```text
+events=[didStartProvisional,didCommit,didFinish]
+```
+
+sandbox 밖에서는 6개 sample 모두 PASS했다.
+
+## 최종 smoke 명령
+
+기본 sample:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage3-basic-final --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+image-heavy sample:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage3-images-final --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+검증 산출물:
+
+- `build.noindex/task286-stage3-basic-final/summary.md`
+- `build.noindex/task286-stage3-images-final/summary.md`
+- 각 directory의 `studio/`, `native/`, `diff/` PNG/JSON
+
+## 수치 비교 자료
+
+### 기본 sample
+
+| sample | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend | NativeMs |
+|--------|---------------|----------------|--------------|-------------|---------------|---------------|----------|
+| `request.hwp` | `325488/1798071` | `18.1021%` | `11.5796` | `255` | `canvasDataURL` | `coreGraphics` | `1044.8` |
+| `hwpx-01.hwpx` | `540973/3562815` | `15.1839%` | `15.6722` | `255` | `canvasDataURL` | `coreGraphics` | `33.0` |
+
+### image-heavy sample
+
+| sample | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend | NativeMs |
+|--------|---------------|----------------|--------------|-------------|---------------|---------------|----------|
+| `tac-img-02.hwp` | `147412/3562815` | `4.1375%` | `3.7228` | `255` | `canvasDataURL` | `coreGraphics` | `1020.9` |
+| `tac-img-02.hwpx` | `129783/3562815` | `3.6427%` | `3.3924` | `255` | `canvasDataURL` | `coreGraphics` | `7.0` |
+| `hwp-img-001.hwp` | `279494/3562815` | `7.8448%` | `8.2731` | `255` | `canvasDataURL` | `coreGraphics` | `17.1` |
+| `img-start-001.hwp` | `514115/3561228` | `14.4365%` | `15.4773` | `255` | `canvasDataURL` | `coreGraphics` | `33.9` |
+
+## 관찰과 얻은 점
+
+- `WKWebView.evaluateJavaScript` 오류만 보고 있으면 readiness failure와 navigation scheduling failure가 섞인다. `didStartProvisional/didCommit/didFinish`와 scheme request count를 같이 남겨야 원인을 분리할 수 있다.
+- command-line AppKit/WebKit harness에서는 `NSApplication.shared.finishLaunching()`을 명시하는 편이 안정적이다.
+- hidden/offscreen WebKit capture라도 window를 실제로 front ordering해야 sandbox 밖 실행에서 navigation/capture 경로가 안정적으로 동작한다.
+- `tac-img-02.hwp`와 `tac-img-02.hwpx`처럼 확장자만 다른 입력은 `deletingPathExtension().lastPathComponent` 기반 output stem을 쓰면 산출물이 충돌한다. metric artifact에는 확장자를 포함한 input filename을 stem으로 쓰는 것이 맞다.
+- `ChangedPercent`가 큰 것은 harness 실패가 아니라 현재 native CoreGraphics preview와 `rhwp-studio` 기준 rendering 차이를 나타내는 측정 결과다. 이 수치가 후속 renderer/compositor 개선의 baseline이 된다.
+
+## 한계
+
+- 이번 metric은 `coreGraphicsOnly` native backend 기준이다. Skia opt-in backend의 수치는 별도 실행이 필요하다.
+- WebKit GUI 프로세스가 필요한 harness라 Codex sandbox 내부에서 그대로 재현되지 않을 수 있다. PR/로컬 smoke에서는 sandbox 밖 실행 또는 동등한 GUI 권한이 필요하다.
+- `NativeMs`는 warm-up, file format, document cache, local machine 상태에 영향을 받는다. 렌더 정확도 비교의 주 지표는 `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta`, `MaxRGBDelta`로 본다.
+- `rhwp-studio` reference는 `canvasDataURL` capture 기준이다. canvas 내부 margin/editor guide 같은 reference 특성은 후속 renderer parity 해석에서 별도로 고려해야 한다.
+- 이번 작업은 harness 안정화이며 실제 native renderer fidelity 개선은 하지 않았다.
+
+## #281 handoff
+
+#281 이후 renderer/compositor parity PR에서는 다음 순서를 권장한다.
+
+1. 변경 전 baseline으로 `build.noindex/task281-before-*` directory에 summary를 생성한다.
+2. 구현 후 `build.noindex/task281-after-*` directory에 같은 sample set을 실행한다.
+3. PR 본문에 before/after `ChangedPercent`, `MeanRGBDelta`, `MaxRGBDelta`를 같은 표로 남긴다.
+4. sandbox 내부에서 `events=[]`, `scheme={resourceRequests=0, documentRequests=0}`가 나오면 renderer regression으로 판정하지 않고 WebKit 실행 환경 문제로 분리한다.
+5. image-heavy sample에는 같은 basename HWP/HWPX 쌍이 있으므로 확장자 포함 output stem을 유지한다.
+
+권장 명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task281-basic-before --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task281-images-before --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+## #285 handoff
+
+#285는 #283 조사 PR이며, 당시 visual diff metric이 readiness 문제로 누락됐다. #286 merge 후 #285 보강에는 다음 내용을 추가할 수 있다.
+
+- #283 당시 실패 원인: reference capture 전에 readiness polling이 실패해 metric 미생성.
+- #286에서 분리한 원인: Codex sandbox 내부에서는 WebKit navigation이 시작되지 않아 `navigation=pending`, `events=[]`, `scheme={resourceRequests=0, documentRequests=0}`가 발생.
+- #286에서 확보한 수치: 기본 2개 + image-heavy 4개 sample의 PASS metric.
+- #285 보강 시 주의: #286의 harness 변경이 먼저 반영되어야 같은 summary format과 output stem을 사용할 수 있다.
+
+merge 순서 리스크:
+
+- #285와 #286 모두 `mydocs/orders/20260527.md` 계열을 건드렸으므로 merge 순서에 따라 문서 충돌이 날 수 있다.
+- #285에 metric을 직접 추가하려면 #286 merge 후 #285 branch를 rebase/merge해서 harness 변경을 포함한 뒤 재측정하는 편이 안전하다.
+- #285 PR을 먼저 merge하면 누락 metric 보강은 별도 후속 PR로 남기는 것이 낫다.
+
+## 검증 요약
+
+실행한 검증:
+
+```bash
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task286-stage3-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task286-stage3-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task286-stage3-syntax-check
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage3-basic-final --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage3-images-final --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+rg -n "ChangedPixels|ChangedPercent|MeanRGBDelta|FAIL|WKErrorDomain|unsupported|readiness timed out" \
+  build.noindex/task286-stage3-basic-final/summary.md \
+  build.noindex/task286-stage3-images-final/summary.md
+git diff --check
+```
+
+결과:
+
+- Swift compile 통과.
+- 최종 basic smoke exit code 0.
+- 최종 image-heavy smoke exit code 0.
+- 최종 summary에 `FAIL`, `WKErrorDomain`, `unsupported`, `readiness timed out` 없음.
+- `git diff --check` 통과.

--- a/mydocs/working/task_m014_286_stage1.md
+++ b/mydocs/working/task_m014_286_stage1.md
@@ -1,0 +1,107 @@
+# Task M014 #286 Stage 1 보고서 - harness readiness 실패 재현
+
+## 단계 개요
+
+- 이슈: #286 rhwp-studio preview visual diff harness readiness 안정화
+- 단계: Stage 1. 실패 재현과 readiness phase inventory
+- 목표: #283에서 관찰된 readiness 실패가 현재 `devel` 기준에서도 재현되는지 확인하고, Stage 2에서 보정할 최소 범위를 확정한다.
+
+이번 단계는 재현과 문서화만 수행했다. `scripts/preview_visual_diff_harness.swift`, renderer, bundled `rhwp-studio` asset은 수정하지 않았다.
+
+## 실행 환경과 입력
+
+baseline 실행:
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage1-baseline --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx
+```
+
+산출물:
+
+- `build.noindex/task286-stage1-baseline/summary.md`
+
+`studio/`, `native/`, `diff/` directory는 생성됐지만 readiness 실패가 reference capture 전에 발생해 PNG/JSON 산출물은 생성되지 않았다.
+
+## 재현 결과
+
+네 샘플 모두 #283과 같은 오류로 실패했다.
+
+| sample | 결과 | phase 판단 | 오류 |
+|--------|------|------------|------|
+| `samples/basic/request.hwp` | FAIL | readiness / `currentPageState` | `WKErrorDomain Code=5`, JavaScript execution returned unsupported type |
+| `samples/hwpx/hwpx-01.hwpx` | FAIL | readiness / `currentPageState` | 동일 |
+| `samples/tac-img-02.hwp` | FAIL | readiness / `currentPageState` | 동일 |
+| `samples/tac-img-02.hwpx` | FAIL | readiness / `currentPageState` | 동일 |
+
+`summary.md`의 FAIL row는 모두 다음 형태다.
+
+```text
+rhwp-studio page 1 readiness timed out: Error Domain=WKErrorDomain Code=5
+"JavaScript execution returned a result of an unsupported type"
+```
+
+따라서 Stage 1 기준 원인은 native renderer, diff engine, PNG write 실패가 아니라 `rhwp-studio` page state polling 단계에서 발생한다.
+
+## 현재 harness 반환 계약 inventory
+
+| 함수 | 현재 역할 | 반환/오류 처리 | Stage 1 판단 |
+|------|-----------|----------------|--------------|
+| `capture(...)` | document load 후 `waitForPageReady` -> align/settle -> page state -> canvas/snapshot capture 순서 실행 | readiness를 통과해야 PNG/JSON write로 진행 | 실패는 첫 `waitForPageReady` 안에서 발생한다. |
+| `waitForPageReady(...)` | timeout까지 `currentPageState` polling | `currentPageState` 오류를 `lastError`에 저장하고 timeout 후 단일 메시지로 보고 | 반복 오류 횟수, 마지막 성공 state, phase가 summary에 분리되지 않는다. |
+| `currentPageState(...)` | `pageStateScript` 실행 후 JSON string decode | `value as? String` 실패 또는 JS 오류를 `PreviewHarnessError`로 보고 | 현재는 WebKit error가 그대로 상위 timeout 메시지로 들어간다. |
+| `evaluateJavaScript(...)` | WKWebView `evaluateJavaScript` wrapper | callback error를 원본 `Error`로 보존 | WebKit domain/code/message를 harness phase와 함께 구조화하지 않는다. |
+| `pageStateScript(...)` | DOM canvas 상태를 `JSON.stringify(...)`로 반환 | 의도상 string JSON 반환 | 실제 실행에서는 WebKit unsupported result type error가 발생한다. |
+| `alignAndHideChrome(...)` | chrome hide/scroll align 후 settle flag 확인 | readiness 후 실행 | 이번 실패에서는 도달하지 않았다. |
+| `canvasDataURLScript(...)` | canvas data URL export | readiness/settle 후 실행 | 이번 실패에서는 도달하지 않았다. |
+
+## 관찰된 한계
+
+- `summary.md`는 최종 FAIL message만 남기므로, readiness polling 중 같은 오류가 몇 번 반복됐는지 알 수 없다.
+- WebKit error가 `currentPageState`에서 발생했다는 사실은 소스 흐름과 message로 추론 가능하지만, summary row에는 phase가 별도 column으로 남지 않는다.
+- page state JSON이 한 번이라도 성공했는지, canvas count가 증가했는지 확인할 artifact가 없다.
+- `studio` reference PNG가 생성되지 않아 `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta`는 모두 `-`로 남았다.
+
+## Stage 2 최소 보정 범위
+
+Stage 2에서는 다음을 우선 적용한다.
+
+1. JavaScript evaluation 오류를 `phase + domain/code/message` 형태로 감싸 summary에서 구분 가능하게 만든다.
+2. `waitForPageReady`가 마지막 state, 마지막 error, error count를 함께 기록하게 한다.
+3. `currentPageState`와 `canvasDataURLScript`가 예상 type이 아닐 때 Swift type description을 남긴다.
+4. 가능하면 FAIL row 또는 error message에서 `navigation/readiness/settle/canvas export/snapshot/native render/diff` phase를 드러낸다.
+5. unsupported result type 자체를 줄이기 위해 JS probe 반환값을 다시 확인하되, renderer/compositor 동작은 건드리지 않는다.
+
+Stage 2의 성공 기준은 최소 기본 샘플 2개에서 PASS metric이 생성되거나, 실패하더라도 지금처럼 단일 timeout message가 아니라 phase와 원인이 분리되어 남는 것이다.
+
+## Stage 1 검증
+
+실행:
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage1-baseline --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx
+sed -n '1,220p' build.noindex/task286-stage1-baseline/summary.md
+rg -n "WKErrorDomain|unsupported|readiness timed out|ChangedPixels|MeanRGBDelta|FAIL|OK" \
+  build.noindex/task286-stage1-baseline/summary.md
+rg -n "waitForPageReady|currentPageState|evaluateJavaScript|pageStateScript|settleFlagScript|canvasDataURLScript|alignAndHideChrome" \
+  scripts/preview_visual_diff_harness.swift
+find build.noindex/task286-stage1-baseline -maxdepth 2 -type f \( -name '*.png' -o -name '*.json' -o -name 'summary.md' \) | sort
+git diff --check
+```
+
+결과:
+
+- `verify-rhwp-studio-assets.sh`는 통과했다.
+- baseline harness는 예상대로 exit code 1로 종료됐다.
+- 네 샘플 모두 readiness timeout + `WKErrorDomain Code=5` unsupported result type으로 실패했다.
+- PNG/JSON 산출물은 없고 `summary.md`만 생성됐다.
+- Stage 1에서는 production source 수정이 없어 `git diff --check`는 문서 작성 전 기준으로 통과했다.
+
+## 다음 단계
+
+Stage 2에서는 `scripts/preview_visual_diff_harness.swift`의 JavaScript evaluation error handling과 readiness logging을 보강한다. 우선 목표는 visual metric 생성이지만, sample이 계속 실패하더라도 summary에서 실패 phase와 원인이 충분히 분리되도록 만든다.

--- a/mydocs/working/task_m014_286_stage2.md
+++ b/mydocs/working/task_m014_286_stage2.md
@@ -1,0 +1,105 @@
+# Task M014 #286 Stage 2 보고서 - readiness probe logging 보강
+
+## 단계 개요
+
+- 이슈: #286 rhwp-studio preview visual diff harness readiness 안정화
+- 단계: Stage 2. JavaScript probe와 readiness logging 보강
+- 목표: `WKWebView.evaluateJavaScript` 실패를 phase별로 분리하고, readiness timeout이 단일 메시지로만 남지 않게 한다.
+
+이번 단계는 harness 관측성 보강에 한정했다. native renderer, compositor, bundled `rhwp-studio` asset은 수정하지 않았다.
+
+## 변경 내용
+
+`scripts/preview_visual_diff_harness.swift`에 다음을 반영했다.
+
+| 변경 | 내용 |
+|------|------|
+| phase error type 추가 | `navigation`, `readiness`, `settle`, `canvas export`, `snapshot`, `native render`, `diff`, `unknown` phase를 `PreviewHarnessPhaseError`로 감싼다. |
+| JavaScript error 설명 보강 | WebKit error를 domain/code/message 중심으로 정리하고, 예상하지 못한 JavaScript value는 Swift type과 value description을 남긴다. |
+| readiness timeout 보강 | 마지막 page state, 마지막 JavaScript error, error count, navigation 상태를 timeout detail에 포함한다. |
+| page state 반환 보정 | page-state probe가 복잡한 객체를 직접 반환하지 않고 `window.__alhangeulPreviewPageStateJSON`에 JSON string을 저장한 뒤 primitive 값을 반환하게 했다. |
+| navigation gating 추가 | main-frame commit 전에는 page-state JavaScript를 평가하지 않는다. `didCommit` 전 timeout은 `navigation=pending`으로 분리한다. |
+| summary phase column 추가 | `summary.md`에 `Phase` 컬럼을 추가해 sample별 실패 phase를 별도로 볼 수 있게 했다. |
+
+## 검증
+
+컴파일 검증:
+
+```bash
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task286-stage2-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task286-stage2-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task286-stage2-syntax-check
+```
+
+결과: 통과.
+
+smoke 검증:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage2-smoke --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+결과: exit code 1. 두 샘플 모두 reference capture 전에 실패했다.
+
+## smoke 관찰 결과
+
+산출물:
+
+- `build.noindex/task286-stage2-smoke/summary.md`
+
+요약:
+
+| sample | 결과 | phase | Stage 1 대비 변화 |
+|--------|------|-------|-------------------|
+| `samples/basic/request.hwp` | FAIL | readiness | `WKErrorDomain Code=5` 대신 `navigation=pending`으로 기록됨 |
+| `samples/hwpx/hwpx-01.hwpx` | FAIL | readiness | 동일 |
+
+`summary.md`의 핵심 row:
+
+```text
+| request.hwp | FAIL: [phase:readiness] rhwp-studio page 1 readiness timed out: navigation=pending | readiness | - | ... |
+| hwpx-01.hwpx | FAIL: [phase:readiness] rhwp-studio page 1 readiness timed out: navigation=pending | readiness | - | ... |
+```
+
+`rg` 확인 결과 Stage 2 smoke summary에는 `WKErrorDomain`, `unsupported`가 남지 않았다. 따라서 Stage 1의 unsupported result type은 최종 원인이라기보다 main-frame navigation commit 전에 JavaScript polling을 반복한 증상으로 분리됐다.
+
+## 결론
+
+Stage 2 완료 기준 중 다음은 충족했다.
+
+- Swift harness 컴파일 통과.
+- FAIL row에 `Phase` 컬럼과 phase-aware error가 기록됨.
+- Stage 1의 `WKErrorDomain Code=5 / unsupported result type` 형태가 summary에서 반복되지 않음.
+- 실패 원인이 `readiness` 안의 `navigation=pending`으로 좁혀짐.
+
+아직 충족하지 못한 목표:
+
+- reference PNG 생성 실패.
+- native PNG 및 diff PNG 생성 실패.
+- `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta`, `MaxRGBDelta` metric 생성 실패.
+
+## 한계와 다음 단계 영향
+
+Stage 3은 원래 known sample metric smoke가 목표였지만, Stage 2 관찰상 먼저 main-frame navigation이 commit되지 않는 이유를 해결해야 한다. 다음 단계에서 우선 조사할 후보는 다음이다.
+
+1. `alhangeul-studio://app/index.html` main resource가 `WKURLSchemeHandler`까지 도달하는지 request count를 계측한다.
+2. main resource는 도달하지만 commit되지 않는다면 response header, MIME, custom scheme 제약, WebKit hidden-window 로딩 조건을 분리한다.
+3. URL query 기반 `fetch(alhangeul-document://...)` 경로가 commit 전 load를 막는지 확인한다.
+4. 필요하면 bundled `rhwp-studio`의 `postMessage` 기반 `hwpctl-load` 경로를 harness capture에 쓰는 방향을 검토한다.
+
+따라서 Stage 3은 기존 metric smoke 전에 navigation unblock 소단계를 먼저 수행하는 편이 안전하다. 이 변경은 renderer/compositor 동작 변경이 아니라 harness 안정화 범위 안에 포함된다.

--- a/mydocs/working/task_m014_286_stage3.md
+++ b/mydocs/working/task_m014_286_stage3.md
@@ -1,0 +1,132 @@
+# Task M014 #286 Stage 3 보고서 - harness metric smoke 검증
+
+## 단계 개요
+
+- 이슈: #286 rhwp-studio preview visual diff harness readiness 안정화
+- 단계: Stage 3. known sample smoke와 metric 생성 검증
+- 목표: `rhwp-studio` reference PNG, native preview PNG, diff PNG와 visual diff metric을 known sample set에서 반복 생성할 수 있는지 확인한다.
+
+Stage 2에서 `navigation=pending`으로 좁혀진 문제를 Stage 3에서 계속 추적했다. 결론부터 말하면 Codex sandbox 내부 실행에서는 WebKit navigation 자체가 시작되지 않았고, sandbox 밖 실행에서는 custom scheme 경로가 정상 동작했다.
+
+## 변경 내용
+
+`scripts/preview_visual_diff_harness.swift`에 다음을 반영했다.
+
+| 변경 | 내용 |
+|------|------|
+| `NSApplication.finishLaunching()` 호출 | command-line harness에서 AppKit/WebKit 초기화를 명시 완료한다. |
+| offscreen window 표시 방식 변경 | `orderBack(nil)` 대신 offscreen 위치에서 `orderFrontRegardless()`를 사용한다. |
+| navigation event 기록 | 실패 시 `didStartProvisional`, `didCommit`, `didFinish`, `didFail*` 이벤트를 timeout detail에 남긴다. |
+| scheme request stats 기록 | 실패 시 resource/document custom scheme request count와 요청 path/failure를 남긴다. |
+| output stem 충돌 방지 | `tac-img-02.hwp`와 `tac-img-02.hwpx`처럼 basename이 같은 파일이 서로 PNG/JSON을 덮어쓰지 않도록 output stem에 확장자를 포함했다. |
+
+## sandbox 분리 관찰
+
+기본 sandbox 실행에서는 다음 형태로 실패했다.
+
+```text
+navigation=pending; events=[]; scheme={resourceRequests=0, documentRequests=0}
+```
+
+동시에 WebKit 관련 sandbox extension 오류가 터미널에 출력됐다. 즉 이 경우는 `rhwp-studio` DOM readiness 문제가 아니라, WebKit navigation/request scheduling이 시작되지 않는 실행 환경 문제로 분류한다.
+
+sandbox 밖 실행에서는 다음이 확인됐다.
+
+- custom scheme top-level navigation 정상 시작
+- `didStartProvisional`, `didCommit`, `didFinish` 발생
+- `rhwp-studio` reference PNG 생성
+- native PNG 생성
+- diff PNG와 metric 생성
+
+따라서 Codex/automation 환경에서 이 harness smoke는 WebKit GUI 프로세스 권한을 고려해 sandbox 밖 실행이 필요할 수 있다.
+
+## 최종 smoke 명령
+
+기본 sample:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage3-basic-final --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+image-heavy sample:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage3-images-final --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+산출물:
+
+- `build.noindex/task286-stage3-basic-final/summary.md`
+- `build.noindex/task286-stage3-images-final/summary.md`
+- 각 directory의 `studio/`, `native/`, `diff/` PNG/JSON
+
+## 수치 결과
+
+기본 sample:
+
+| sample | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend | NativeMs |
+|--------|---------------|----------------|--------------|-------------|---------------|---------------|----------|
+| `request.hwp` | `325488/1798071` | `18.1021%` | `11.5796` | `255` | `canvasDataURL` | `coreGraphics` | `1044.8` |
+| `hwpx-01.hwpx` | `540973/3562815` | `15.1839%` | `15.6722` | `255` | `canvasDataURL` | `coreGraphics` | `33.0` |
+
+image-heavy sample:
+
+| sample | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend | NativeMs |
+|--------|---------------|----------------|--------------|-------------|---------------|---------------|----------|
+| `tac-img-02.hwp` | `147412/3562815` | `4.1375%` | `3.7228` | `255` | `canvasDataURL` | `coreGraphics` | `1020.9` |
+| `tac-img-02.hwpx` | `129783/3562815` | `3.6427%` | `3.3924` | `255` | `canvasDataURL` | `coreGraphics` | `7.0` |
+| `hwp-img-001.hwp` | `279494/3562815` | `7.8448%` | `8.2731` | `255` | `canvasDataURL` | `coreGraphics` | `17.1` |
+| `img-start-001.hwp` | `514115/3561228` | `14.4365%` | `15.4773` | `255` | `canvasDataURL` | `coreGraphics` | `33.9` |
+
+## 검증 결과
+
+실행:
+
+```bash
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task286-stage3-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task286-stage3-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task286-stage3-syntax-check
+```
+
+결과:
+
+- Swift harness 컴파일 통과.
+- 기본 sample 2개 PASS.
+- image-heavy sample 4개 PASS.
+- 최종 summary에서 `FAIL`, `WKErrorDomain`, `unsupported`, `readiness timed out` 없음.
+- 같은 basename의 HWP/HWPX 쌍도 별도 PNG/JSON/diff 산출물로 분리됨.
+
+## 결론
+
+Stage 3 완료 기준을 충족했다.
+
+- 최소 4개 target sample 중 6개가 PASS했고 metric이 기록됐다.
+- 실패 sample은 없었다.
+- Codex sandbox 내부 실패와 실제 harness readiness 문제를 분리했다.
+- #281 이후 PR에서 사용할 smoke command와 output directory convention을 확보했다.
+
+## 다음 단계 영향
+
+#281/#285 handoff에는 다음을 명시해야 한다.
+
+1. visual diff smoke는 WebKit GUI 프로세스가 정상 동작하는 권한에서 실행해야 한다.
+2. Codex sandbox 내부에서 `events=[]`, `scheme={resourceRequests=0, documentRequests=0}` 형태가 나오면 renderer 차이가 아니라 실행 환경 문제로 본다.
+3. `build.noindex/task286-stage3-basic-final`과 `build.noindex/task286-stage3-images-final`의 summary format을 #281 이후 PR의 before/after metric template으로 재사용한다.
+4. 기존 #285 보강 시에는 #283의 누락 metric으로 기본 2개와 image-heavy 4개 수치를 인용할 수 있다.

--- a/scripts/preview_visual_diff_harness.swift
+++ b/scripts/preview_visual_diff_harness.swift
@@ -439,45 +439,75 @@ final class StudioDocumentSchemeHandler: NSObject, WKURLSchemeHandler {
 }
 
 final class StudioSchemeRequestStats {
-    private(set) var resourceRequestCount = 0
-    private(set) var documentRequestCount = 0
-    private(set) var resourcePaths: [String] = []
-    private(set) var failures: [String] = []
+    private struct Snapshot {
+        let resourceRequestCount: Int
+        let documentRequestCount: Int
+        let resourcePaths: [String]
+        let failures: [String]
+    }
+
+    private let lock = NSLock()
+    private var resourceRequestCount = 0
+    private var documentRequestCount = 0
+    private var resourcePaths: [String] = []
+    private var failures: [String] = []
 
     func recordResource(path: String) {
-        resourceRequestCount += 1
-        if resourcePaths.count < 12 {
-            resourcePaths.append(path)
+        withLock {
+            resourceRequestCount += 1
+            if resourcePaths.count < 12 {
+                resourcePaths.append(path)
+            }
         }
     }
 
     func recordDocument() {
-        documentRequestCount += 1
+        withLock {
+            documentRequestCount += 1
+        }
     }
 
     func recordFailure(message: String, url: URL?) {
-        guard failures.count < 8 else {
-            return
-        }
+        let entry: String
         if let url {
-            failures.append("\(message) url=\(url.absoluteString)")
+            entry = "\(message) url=\(url.absoluteString)"
         } else {
-            failures.append(message)
+            entry = message
+        }
+        withLock {
+            guard failures.count < 8 else {
+                return
+            }
+            failures.append(entry)
         }
     }
 
     var summary: String {
-        var parts = [
-            "resourceRequests=\(resourceRequestCount)",
-            "documentRequests=\(documentRequestCount)"
-        ]
-        if !resourcePaths.isEmpty {
-            parts.append("resourcePaths=[\(resourcePaths.joined(separator: ","))]")
+        let snapshot = withLock {
+            Snapshot(
+                resourceRequestCount: resourceRequestCount,
+                documentRequestCount: documentRequestCount,
+                resourcePaths: resourcePaths,
+                failures: failures
+            )
         }
-        if !failures.isEmpty {
-            parts.append("requestFailures=[\(failures.joined(separator: "; "))]")
+        var parts = [
+            "resourceRequests=\(snapshot.resourceRequestCount)",
+            "documentRequests=\(snapshot.documentRequestCount)"
+        ]
+        if !snapshot.resourcePaths.isEmpty {
+            parts.append("resourcePaths=[\(snapshot.resourcePaths.joined(separator: ","))]")
+        }
+        if !snapshot.failures.isEmpty {
+            parts.append("requestFailures=[\(snapshot.failures.joined(separator: "; "))]")
         }
         return parts.joined(separator: ", ")
+    }
+
+    private func withLock<T>(_ work: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return work()
     }
 }
 

--- a/scripts/preview_visual_diff_harness.swift
+++ b/scripts/preview_visual_diff_harness.swift
@@ -10,6 +10,26 @@ struct PreviewHarnessError: Error, CustomStringConvertible {
     let description: String
 }
 
+enum PreviewHarnessPhase: String {
+    case navigation
+    case readiness
+    case settle
+    case canvasExport = "canvas export"
+    case snapshot
+    case nativeRender = "native render"
+    case diff
+    case unknown
+}
+
+struct PreviewHarnessPhaseError: Error, CustomStringConvertible {
+    let phase: PreviewHarnessPhase
+    let detail: String
+
+    var description: String {
+        "[phase:\(phase.rawValue)] \(detail)"
+    }
+}
+
 struct HarnessOptions {
     let outputDir: URL
     let resourceDir: URL
@@ -419,6 +439,7 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
     private var resourceSchemeHandler: StudioResourceSchemeHandler?
     private var documentSchemeHandler: StudioDocumentSchemeHandler?
     private var navigationResult: Result<Void, Error>?
+    private var navigationDidCommit = false
 
     init(resourceDir: URL, viewportSize: CGSize, settleMilliseconds: Int) {
         self.resourceDir = resourceDir
@@ -449,6 +470,7 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             resourceSchemeHandler = nil
             documentSchemeHandler = nil
             navigationResult = nil
+            navigationDidCommit = false
         }
 
         let startTime = Date()
@@ -540,6 +562,10 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         navigationResult = .success(())
     }
 
+    func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        navigationDidCommit = true
+    }
+
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
         navigationResult = .failure(error)
     }
@@ -591,14 +617,20 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         self.documentSchemeHandler = documentHandler
         self.webView = webView
         self.window = window
+        navigationDidCommit = false
     }
 
     private func waitForPageReady(pageNumber: Int, timeout: TimeInterval) throws {
         let deadline = Date().addingTimeInterval(timeout)
         var lastState: PageState?
         var lastError: Error?
+        var errorCount = 0
         while Date() < deadline {
             try throwIfNavigationFailed()
+            guard navigationDidCommit else {
+                RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+                continue
+            }
             do {
                 let state = try currentPageState(pageNumber: pageNumber)
                 if state.ready {
@@ -607,52 +639,98 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
                 lastState = state
             } catch {
                 lastError = error
+                errorCount += 1
             }
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
         }
-        let reason = lastState.map {
-            "\($0.reason), canvasCount=\($0.canvasCount), status=\($0.statusText)"
-        } ?? lastError.map {
-            String(describing: $0)
-        } ?? "no page state"
-        throw PreviewHarnessError(description: "rhwp-studio page \(pageNumber) readiness timed out: \(reason)")
+        var details: [String] = []
+        if let lastState {
+            details.append("lastState={reason=\(lastState.reason), canvasCount=\(lastState.canvasCount), status=\(lastState.statusText)}")
+        }
+        if let lastError {
+            details.append("lastError={\(lastError)}")
+        }
+        details.append("navigation=\(navigationStatusDescription)")
+        if errorCount > 0 {
+            details.append("errorCount=\(errorCount)")
+        }
+        if details.isEmpty {
+            details.append("no page state")
+        }
+        throw PreviewHarnessPhaseError(
+            phase: .readiness,
+            detail: "rhwp-studio page \(pageNumber) readiness timed out: \(details.joined(separator: "; "))"
+        )
     }
 
     private func throwIfNavigationFailed() throws {
         if case .failure(let error) = navigationResult {
-            throw PreviewHarnessError(description: "rhwp-studio navigation failed: \(error)")
+            throw PreviewHarnessPhaseError(
+                phase: .navigation,
+                detail: "rhwp-studio navigation failed: \(describeError(error))"
+            )
+        }
+    }
+
+    private var navigationStatusDescription: String {
+        switch navigationResult {
+        case .none:
+            return navigationDidCommit ? "committed" : "pending"
+        case .success:
+            return "finished"
+        case .failure(let error):
+            return "failed(\(describeError(error)))"
         }
     }
 
     private func alignPageAndHideChrome(pageNumber: Int) throws {
-        _ = try evaluateJavaScript(alignAndHideChromeScript(pageNumber: pageNumber), timeout: 5)
-        _ = try evaluateJavaScript(settleFlagScript(), timeout: 5)
+        _ = try evaluateJavaScript(alignAndHideChromeScript(pageNumber: pageNumber), timeout: 5, phase: .settle)
+        _ = try evaluateJavaScript(settleFlagScript(), timeout: 5, phase: .settle)
 
         let deadline = Date().addingTimeInterval(1)
         while Date() < deadline {
-            let settled = try evaluateJavaScript("window.__alhangeulPreviewCaptureSettled === true", timeout: 2) as? Bool ?? false
+            let settled = try evaluateJavaScript(
+                "window.__alhangeulPreviewCaptureSettled === true",
+                timeout: 2,
+                phase: .settle
+            ) as? Bool ?? false
             if settled {
                 return
             }
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
         }
-        throw PreviewHarnessError(description: "rhwp-studio capture settle timed out for page \(pageNumber)")
+        throw PreviewHarnessPhaseError(
+            phase: .settle,
+            detail: "rhwp-studio capture settle timed out for page \(pageNumber)"
+        )
     }
 
     private func currentPageState(pageNumber: Int) throws -> PageState {
-        let value = try evaluateJavaScript(pageStateScript(pageNumber: pageNumber), timeout: 5)
+        _ = try evaluateJavaScript(pageStateScript(pageNumber: pageNumber), timeout: 5, phase: .readiness)
+        let value = try evaluateJavaScript(
+            "String(window.__alhangeulPreviewPageStateJSON || '')",
+            timeout: 5,
+            phase: .readiness
+        )
         guard let json = value as? String,
               let data = json.data(using: .utf8),
               let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any]
         else {
-            throw PreviewHarnessError(description: "unexpected page state result: \(String(describing: value))")
+            throw PreviewHarnessPhaseError(
+                phase: .readiness,
+                detail: "unexpected page state result: \(describeJavaScriptValue(value))"
+            )
         }
         return PageState(dictionary: dictionary)
     }
 
-    private func evaluateJavaScript(_ script: String, timeout: TimeInterval) throws -> Any? {
+    private func evaluateJavaScript(
+        _ script: String,
+        timeout: TimeInterval,
+        phase: PreviewHarnessPhase
+    ) throws -> Any? {
         guard let webView else {
-            throw PreviewHarnessError(description: "WKWebView is not available")
+            throw PreviewHarnessPhaseError(phase: phase, detail: "WKWebView is not available")
         }
 
         var result: Result<Any?, Error>?
@@ -670,9 +748,16 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         }
 
         guard let result else {
-            throw PreviewHarnessError(description: "JavaScript evaluation timed out")
+            throw PreviewHarnessPhaseError(phase: phase, detail: "JavaScript evaluation timed out")
         }
-        return try result.get()
+        do {
+            return try result.get()
+        } catch {
+            throw PreviewHarnessPhaseError(
+                phase: phase,
+                detail: "JavaScript evaluation failed: \(describeError(error))"
+            )
+        }
     }
 
     private func visibleSnapshotRect(_ rect: CGRect) throws -> CGRect {
@@ -734,13 +819,16 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
     }
 
     private func exportCanvasPNG(pageNumber: Int) throws -> PNGOutput {
-        let value = try evaluateJavaScript(canvasDataURLScript(pageNumber: pageNumber), timeout: 10)
+        let value = try evaluateJavaScript(canvasDataURLScript(pageNumber: pageNumber), timeout: 10, phase: .canvasExport)
         guard let json = value as? String,
               let data = json.data(using: .utf8),
               let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let dataURL = dictionary["dataURL"] as? String
         else {
-            throw PreviewHarnessError(description: "unexpected canvas export result: \(String(describing: value))")
+            throw PreviewHarnessPhaseError(
+                phase: .canvasExport,
+                detail: "unexpected canvas export result: \(describeJavaScriptValue(value))"
+            )
         }
 
         let marker = "base64,"
@@ -790,137 +878,157 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
 
     private func pageStateScript(pageNumber: Int) -> String {
         """
-        JSON.stringify((() => {
-          const pageNumber = \(pageNumber);
-          const content = document.querySelector('#scroll-content');
-          const canvases = content
-            ? Array.from(content.querySelectorAll('canvas')).filter((canvas) => {
-                const rect = canvas.getBoundingClientRect();
-                return rect.width > 0 && rect.height > 0 && canvas.width > 0 && canvas.height > 0;
-              })
-            : [];
-          const target = canvases[pageNumber - 1] || null;
-          const statusText = (document.querySelector('#sb-message')?.textContent || '').trim();
-          const rectObject = (rect) => ({
-            x: rect.left,
-            y: rect.top,
-            width: rect.width,
-            height: rect.height
-          });
-          const viewportSize = {
-            width: window.innerWidth,
-            height: window.innerHeight
+        (() => {
+          const writeState = (state) => {
+            window.__alhangeulPreviewPageStateJSON = JSON.stringify(state);
+            return true;
           };
-          if (!content) {
-            return {
-              ready: false,
-              reason: 'missing #scroll-content',
-              selector: '#scroll-content canvas',
-              statusText,
-              canvasCount: 0,
-              overlayCount: 0,
-              usedOverlayUnion: false,
-              canvasSampleNonWhitePixels: 0,
-              canvasSamplePixels: 0,
-              devicePixelRatio: window.devicePixelRatio || 1,
-              viewportSize
+          try {
+            const pageNumber = \(pageNumber);
+            const content = document.querySelector('#scroll-content');
+            const canvases = content
+              ? Array.from(content.querySelectorAll('canvas')).filter((canvas) => {
+                  const rect = canvas.getBoundingClientRect();
+                  return rect.width > 0 && rect.height > 0 && canvas.width > 0 && canvas.height > 0;
+                })
+              : [];
+            const target = canvases[pageNumber - 1] || null;
+            const statusText = (document.querySelector('#sb-message')?.textContent || '').trim();
+            const rectObject = (rect) => ({
+              x: Number(rect.left) || 0,
+              y: Number(rect.top) || 0,
+              width: Number(rect.width) || 0,
+              height: Number(rect.height) || 0
+            });
+            const viewportSize = {
+              width: Number(window.innerWidth) || 0,
+              height: Number(window.innerHeight) || 0
             };
-          }
-          if (!target) {
-            return {
-              ready: false,
-              reason: `page canvas not found for page ${pageNumber}`,
+            if (!content) {
+              return writeState({
+                ready: false,
+                reason: 'missing #scroll-content',
+                selector: '#scroll-content canvas',
+                statusText,
+                canvasCount: 0,
+                overlayCount: 0,
+                usedOverlayUnion: false,
+                canvasSampleNonWhitePixels: 0,
+                canvasSamplePixels: 0,
+                devicePixelRatio: Number(window.devicePixelRatio) || 1,
+                viewportSize
+              });
+            }
+            if (!target) {
+              return writeState({
+                ready: false,
+                reason: `page canvas not found for page ${pageNumber}`,
+                selector: '#scroll-content canvas',
+                statusText,
+                canvasCount: canvases.length,
+                overlayCount: 0,
+                usedOverlayUnion: false,
+                canvasSampleNonWhitePixels: 0,
+                canvasSamplePixels: 0,
+                devicePixelRatio: Number(window.devicePixelRatio) || 1,
+                viewportSize
+              });
+            }
+
+            const targetRect = target.getBoundingClientRect();
+            let unionLeft = targetRect.left;
+            let unionTop = targetRect.top;
+            let unionRight = targetRect.right;
+            let unionBottom = targetRect.bottom;
+            let overlayCount = 0;
+
+            for (const element of Array.from(content.querySelectorAll('*'))) {
+              if (element === target || element.tagName.toLowerCase() === 'canvas') {
+                continue;
+              }
+              const style = window.getComputedStyle(element);
+              if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) {
+                continue;
+              }
+              const rect = element.getBoundingClientRect();
+              if (rect.width <= 0 || rect.height <= 0) {
+                continue;
+              }
+              const intersectsVertical = rect.bottom >= targetRect.top - 1 && rect.top <= targetRect.bottom + 1;
+              const intersectsHorizontal = rect.right >= targetRect.left - 1 && rect.left <= targetRect.right + 1;
+              if (!intersectsVertical || !intersectsHorizontal) {
+                continue;
+              }
+              overlayCount += 1;
+              unionLeft = Math.min(unionLeft, rect.left);
+              unionTop = Math.min(unionTop, rect.top);
+              unionRight = Math.max(unionRight, rect.right);
+              unionBottom = Math.max(unionBottom, rect.bottom);
+            }
+
+            const snapshotRect = {
+              x: Number(unionLeft) || 0,
+              y: Number(unionTop) || 0,
+              width: Number(unionRight - unionLeft) || 0,
+              height: Number(unionBottom - unionTop) || 0
+            };
+            let canvasSampleNonWhitePixels = 0;
+            let canvasSamplePixels = 0;
+            try {
+              const context = target.getContext('2d', { willReadFrequently: true });
+              const backingWidth = target.width;
+              const backingHeight = target.height;
+              const step = Math.max(1, Math.floor(Math.min(backingWidth, backingHeight) / 160));
+              const imageData = context.getImageData(0, 0, backingWidth, backingHeight).data;
+              for (let y = 0; y < backingHeight; y += step) {
+                for (let x = 0; x < backingWidth; x += step) {
+                  const index = (y * backingWidth + x) * 4;
+                  const r = imageData[index];
+                  const g = imageData[index + 1];
+                  const b = imageData[index + 2];
+                  const a = imageData[index + 3];
+                  canvasSamplePixels += 1;
+                  if (a > 0 && (r < 245 || g < 245 || b < 245)) {
+                    canvasSampleNonWhitePixels += 1;
+                  }
+                }
+              }
+            } catch (_) {
+              canvasSampleNonWhitePixels = -1;
+              canvasSamplePixels = -1;
+            }
+
+            return writeState({
+              ready: true,
+              reason: 'ready',
               selector: '#scroll-content canvas',
               statusText,
               canvasCount: canvases.length,
+              overlayCount,
+              usedOverlayUnion: overlayCount > 0,
+              canvasSampleNonWhitePixels,
+              canvasSamplePixels,
+              devicePixelRatio: Number(window.devicePixelRatio) || 1,
+              viewportSize,
+              canvasRect: rectObject(targetRect),
+              snapshotRect
+            });
+          } catch (error) {
+            return writeState({
+              ready: false,
+              reason: `page state probe error: ${error && error.message ? error.message : String(error)}`,
+              selector: '#scroll-content canvas',
+              statusText: '',
+              canvasCount: 0,
               overlayCount: 0,
               usedOverlayUnion: false,
-              canvasSampleNonWhitePixels: 0,
-              canvasSamplePixels: 0,
-              devicePixelRatio: window.devicePixelRatio || 1,
-              viewportSize
-            };
+              canvasSampleNonWhitePixels: -1,
+              canvasSamplePixels: -1,
+              devicePixelRatio: Number(window.devicePixelRatio) || 1,
+              viewportSize: { width: Number(window.innerWidth) || 0, height: Number(window.innerHeight) || 0 }
+            });
           }
-
-          const targetRect = target.getBoundingClientRect();
-          let unionLeft = targetRect.left;
-          let unionTop = targetRect.top;
-          let unionRight = targetRect.right;
-          let unionBottom = targetRect.bottom;
-          let overlayCount = 0;
-
-          for (const element of Array.from(content.querySelectorAll('*'))) {
-            if (element === target || element.tagName.toLowerCase() === 'canvas') {
-              continue;
-            }
-            const style = window.getComputedStyle(element);
-            if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) {
-              continue;
-            }
-            const rect = element.getBoundingClientRect();
-            if (rect.width <= 0 || rect.height <= 0) {
-              continue;
-            }
-            const intersectsVertical = rect.bottom >= targetRect.top - 1 && rect.top <= targetRect.bottom + 1;
-            const intersectsHorizontal = rect.right >= targetRect.left - 1 && rect.left <= targetRect.right + 1;
-            if (!intersectsVertical || !intersectsHorizontal) {
-              continue;
-            }
-            overlayCount += 1;
-            unionLeft = Math.min(unionLeft, rect.left);
-            unionTop = Math.min(unionTop, rect.top);
-            unionRight = Math.max(unionRight, rect.right);
-            unionBottom = Math.max(unionBottom, rect.bottom);
-          }
-
-          const snapshotRect = {
-            x: unionLeft,
-            y: unionTop,
-            width: unionRight - unionLeft,
-            height: unionBottom - unionTop
-          };
-          let canvasSampleNonWhitePixels = 0;
-          let canvasSamplePixels = 0;
-          try {
-            const context = target.getContext('2d', { willReadFrequently: true });
-            const backingWidth = target.width;
-            const backingHeight = target.height;
-            const step = Math.max(1, Math.floor(Math.min(backingWidth, backingHeight) / 160));
-            const imageData = context.getImageData(0, 0, backingWidth, backingHeight).data;
-            for (let y = 0; y < backingHeight; y += step) {
-              for (let x = 0; x < backingWidth; x += step) {
-                const index = (y * backingWidth + x) * 4;
-                const r = imageData[index];
-                const g = imageData[index + 1];
-                const b = imageData[index + 2];
-                const a = imageData[index + 3];
-                canvasSamplePixels += 1;
-                if (a > 0 && (r < 245 || g < 245 || b < 245)) {
-                  canvasSampleNonWhitePixels += 1;
-                }
-              }
-            }
-          } catch (_) {
-            canvasSampleNonWhitePixels = -1;
-            canvasSamplePixels = -1;
-          }
-
-          return {
-            ready: true,
-            reason: 'ready',
-            selector: '#scroll-content canvas',
-            statusText,
-            canvasCount: canvases.length,
-            overlayCount,
-            usedOverlayUnion: overlayCount > 0,
-            canvasSampleNonWhitePixels,
-            canvasSamplePixels,
-            devicePixelRatio: window.devicePixelRatio || 1,
-            viewportSize,
-            canvasRect: rectObject(targetRect),
-            snapshotRect
-          };
-        })());
+        })()
         """
     }
 
@@ -1276,8 +1384,8 @@ struct PreviewVisualDiffHarness {
         summaryLines.append("SettleMs: \(options.settleMilliseconds)")
         summaryLines.append("DiffPixelThreshold: 12")
         summaryLines.append("")
-        summaryLines.append("| File | Status | StudioSize | NativeSize | CompareSize | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | StudioCapture | NativeBackend | NativeMs | StudioPNG | NativePNG | DiffPNG |")
-        summaryLines.append("|------|--------|------------|------------|-------------|---------------|----------------|--------------|-------------|------------|---------------|---------------|----------|-----------|-----------|---------|")
+        summaryLines.append("| File | Status | Phase | StudioSize | NativeSize | CompareSize | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | StudioCapture | NativeBackend | NativeMs | StudioPNG | NativePNG | DiffPNG |")
+        summaryLines.append("|------|--------|-------|------------|------------|-------------|---------------|----------------|--------------|-------------|------------|---------------|---------------|----------|-----------|-----------|---------|")
 
         for inputURL in options.inputURLs {
             do {
@@ -1304,6 +1412,7 @@ struct PreviewVisualDiffHarness {
                 summaryLines.append([
                     markdownCell(result.fileName),
                     "OK",
+                    "-",
                     "\(result.pngWidth)x\(result.pngHeight)",
                     "\(native.pixelWidth)x\(native.pixelHeight)",
                     "\(diff.compareWidth)x\(diff.compareHeight)",
@@ -1326,7 +1435,8 @@ struct PreviewVisualDiffHarness {
                 failed = true
                 let failureCells = [
                     markdownCell(inputURL.lastPathComponent),
-                    "FAIL: \(String(describing: error).replacingOccurrences(of: "|", with: "/"))"
+                    "FAIL: \(String(describing: error).replacingOccurrences(of: "|", with: "/"))",
+                    failurePhase(for: error).rawValue
                 ] + Array(repeating: "-", count: 14)
                 summaryLines.append(failureCells.joined(separator: " | ").wrappedTableRow)
                 print("FAIL \(inputURL.path): \(error)", to: &standardError)
@@ -1571,6 +1681,56 @@ private func doubleValue(_ value: Any?, default defaultValue: Double = 0) -> Dou
 
 private func markdownCell(_ value: String) -> String {
     value.replacingOccurrences(of: "|", with: "/")
+}
+
+private func describeError(_ error: Error) -> String {
+    if let phaseError = error as? PreviewHarnessPhaseError {
+        return phaseError.description
+    }
+
+    let nsError = error as NSError
+    let message = nsError.localizedDescription
+    guard nsError.domain != NSCocoaErrorDomain || nsError.code != 0 else {
+        return message
+    }
+    return "\(nsError.domain) Code=\(nsError.code) \"\(message)\""
+}
+
+private func describeJavaScriptValue(_ value: Any?) -> String {
+    guard let value else {
+        return "nil"
+    }
+    return "\(type(of: value)) \(String(describing: value))"
+}
+
+private func failurePhase(for error: Error) -> PreviewHarnessPhase {
+    if let phaseError = error as? PreviewHarnessPhaseError {
+        return phaseError.phase
+    }
+
+    let description = String(describing: error).lowercased()
+    if description.contains("navigation") {
+        return .navigation
+    }
+    if description.contains("ready") || description.contains("page state") || description.contains("rect is unavailable") {
+        return .readiness
+    }
+    if description.contains("settle") {
+        return .settle
+    }
+    if description.contains("canvas") || description.contains("dataurl") {
+        return .canvasExport
+    }
+    if description.contains("snapshot") {
+        return .snapshot
+    }
+    if description.contains("native") || description.contains("render") {
+        return .nativeRender
+    }
+    if description.contains("diff") || description.contains("compare") {
+        return .diff
+    }
+    return .unknown
 }
 
 private func formatMilliseconds(_ value: Double) -> String {

--- a/scripts/preview_visual_diff_harness.swift
+++ b/scripts/preview_visual_diff_harness.swift
@@ -261,10 +261,12 @@ final class StudioResourceSchemeHandler: NSObject, WKURLSchemeHandler {
 
     private let resourceDir: URL
     private let fileManager: FileManager
+    private let stats: StudioSchemeRequestStats
 
-    init(resourceDir: URL, fileManager: FileManager = .default) {
+    init(resourceDir: URL, fileManager: FileManager = .default, stats: StudioSchemeRequestStats) {
         self.resourceDir = resourceDir.standardizedFileURL
         self.fileManager = fileManager
+        self.stats = stats
     }
 
     func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
@@ -277,6 +279,7 @@ final class StudioResourceSchemeHandler: NSObject, WKURLSchemeHandler {
         }
 
         let relativePath = normalizedRelativePath(from: url)
+        stats.recordResource(path: relativePath)
         let fileURL = resourceDir.appendingPathComponent(relativePath, isDirectory: false).standardizedFileURL
         guard isResourceFile(fileURL) else {
             fail("missing rhwp-studio resource: \(relativePath)", url: url, task: urlSchemeTask)
@@ -357,6 +360,7 @@ final class StudioResourceSchemeHandler: NSObject, WKURLSchemeHandler {
     }
 
     private func fail(_ message: String, url: URL?, task: WKURLSchemeTask) {
+        stats.recordFailure(message: message, url: url)
         var userInfo: [String: Any] = [NSLocalizedDescriptionKey: message]
         if let url {
             userInfo[NSURLErrorFailingURLErrorKey] = url
@@ -371,10 +375,12 @@ final class StudioDocumentSchemeHandler: NSObject, WKURLSchemeHandler {
 
     private let data: Data
     private let revision: Int
+    private let stats: StudioSchemeRequestStats
 
-    init(data: Data, revision: Int) {
+    init(data: Data, revision: Int, stats: StudioSchemeRequestStats) {
         self.data = data
         self.revision = revision
+        self.stats = stats
     }
 
     func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
@@ -386,6 +392,7 @@ final class StudioDocumentSchemeHandler: NSObject, WKURLSchemeHandler {
             return
         }
 
+        stats.recordDocument()
         guard requestedRevision(from: url) == revision else {
             fail("requested document revision does not match", url: url, task: urlSchemeTask)
             return
@@ -422,11 +429,55 @@ final class StudioDocumentSchemeHandler: NSObject, WKURLSchemeHandler {
     }
 
     private func fail(_ message: String, url: URL?, task: WKURLSchemeTask) {
+        stats.recordFailure(message: message, url: url)
         var userInfo: [String: Any] = [NSLocalizedDescriptionKey: message]
         if let url {
             userInfo[NSURLErrorFailingURLErrorKey] = url
         }
         task.didFailWithError(NSError(domain: "PreviewVisualDiffStudioDocument", code: -1, userInfo: userInfo))
+    }
+}
+
+final class StudioSchemeRequestStats {
+    private(set) var resourceRequestCount = 0
+    private(set) var documentRequestCount = 0
+    private(set) var resourcePaths: [String] = []
+    private(set) var failures: [String] = []
+
+    func recordResource(path: String) {
+        resourceRequestCount += 1
+        if resourcePaths.count < 12 {
+            resourcePaths.append(path)
+        }
+    }
+
+    func recordDocument() {
+        documentRequestCount += 1
+    }
+
+    func recordFailure(message: String, url: URL?) {
+        guard failures.count < 8 else {
+            return
+        }
+        if let url {
+            failures.append("\(message) url=\(url.absoluteString)")
+        } else {
+            failures.append(message)
+        }
+    }
+
+    var summary: String {
+        var parts = [
+            "resourceRequests=\(resourceRequestCount)",
+            "documentRequests=\(documentRequestCount)"
+        ]
+        if !resourcePaths.isEmpty {
+            parts.append("resourcePaths=[\(resourcePaths.joined(separator: ","))]")
+        }
+        if !failures.isEmpty {
+            parts.append("requestFailures=[\(failures.joined(separator: "; "))]")
+        }
+        return parts.joined(separator: ", ")
     }
 }
 
@@ -440,6 +491,8 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
     private var documentSchemeHandler: StudioDocumentSchemeHandler?
     private var navigationResult: Result<Void, Error>?
     private var navigationDidCommit = false
+    private var navigationEvents: [String] = []
+    private var schemeStats = StudioSchemeRequestStats()
 
     init(resourceDir: URL, viewportSize: CGSize, settleMilliseconds: Int) {
         self.resourceDir = resourceDir
@@ -455,7 +508,7 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
     ) throws -> StudioCaptureResult {
         let data = try Data(contentsOf: inputURL)
         let loadURL = try makeLoadURL(filename: inputURL.lastPathComponent, revision: 1)
-        let baseName = inputURL.deletingPathExtension().lastPathComponent
+        let baseName = outputStem(for: inputURL)
         let outputBase = "\(baseName)-page\(pageNumber)"
         let pngURL = outputDir.appendingPathComponent("\(outputBase)-studio.png", isDirectory: false)
         let jsonURL = outputDir.appendingPathComponent("\(outputBase)-studio.json", isDirectory: false)
@@ -471,10 +524,20 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             documentSchemeHandler = nil
             navigationResult = nil
             navigationDidCommit = false
+            navigationEvents = []
+            schemeStats = StudioSchemeRequestStats()
         }
 
         let startTime = Date()
-        webView?.load(URLRequest(url: loadURL))
+        let navigation: WKNavigation?
+        if loadURL.isFileURL {
+            navigation = webView?.loadFileURL(loadURL, allowingReadAccessTo: resourceDir)
+        } else {
+            navigation = webView?.load(URLRequest(url: loadURL))
+        }
+        if navigation == nil {
+            recordNavigationEvent("loadReturnedNil:\(loadURL.scheme ?? "nil")")
+        }
         try waitForPageReady(pageNumber: pageNumber, timeout: 30)
         try alignPageAndHideChrome(pageNumber: pageNumber)
         runMainLoop(milliseconds: settleMilliseconds)
@@ -559,19 +622,34 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        recordNavigationEvent("didFinish")
         navigationResult = .success(())
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+        recordNavigationEvent("didCommit")
         navigationDidCommit = true
     }
 
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        recordNavigationEvent("didStartProvisional")
+    }
+
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        recordNavigationEvent("didFail:\(describeError(error))")
         navigationResult = .failure(error)
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        recordNavigationEvent("didFailProvisional:\(describeError(error))")
         navigationResult = .failure(error)
+    }
+
+    private func recordNavigationEvent(_ event: String) {
+        guard navigationEvents.count < 16 else {
+            return
+        }
+        navigationEvents.append(event)
     }
 
     private var chromeSelectors: [String] {
@@ -588,8 +666,10 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
 
     private func createWebView(documentData: Data, revision: Int) throws {
         navigationResult = nil
-        let resourceHandler = StudioResourceSchemeHandler(resourceDir: resourceDir)
-        let documentHandler = StudioDocumentSchemeHandler(data: documentData, revision: revision)
+        navigationEvents = []
+        schemeStats = StudioSchemeRequestStats()
+        let resourceHandler = StudioResourceSchemeHandler(resourceDir: resourceDir, stats: schemeStats)
+        let documentHandler = StudioDocumentSchemeHandler(data: documentData, revision: revision, stats: schemeStats)
         let configuration = WKWebViewConfiguration()
         configuration.websiteDataStore = .nonPersistent()
         configuration.setURLSchemeHandler(resourceHandler, forURLScheme: StudioResourceSchemeHandler.scheme)
@@ -611,7 +691,7 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         window.alphaValue = 1
         window.ignoresMouseEvents = true
         window.setFrameOrigin(NSPoint(x: -20000, y: -20000))
-        window.orderBack(nil)
+        window.orderFrontRegardless()
 
         self.resourceSchemeHandler = resourceHandler
         self.documentSchemeHandler = documentHandler
@@ -651,6 +731,8 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             details.append("lastError={\(lastError)}")
         }
         details.append("navigation=\(navigationStatusDescription)")
+        details.append("events=[\(navigationEvents.joined(separator: ","))]")
+        details.append("scheme={\(schemeStats.summary)}")
         if errorCount > 0 {
             details.append("errorCount=\(errorCount)")
         }
@@ -1170,7 +1252,7 @@ enum NativePreviewRenderer {
             throw PreviewHarnessError(description: "page \(pageNumber) is out of range: pageCount=\(document.pageCount)")
         }
 
-        let baseName = inputURL.deletingPathExtension().lastPathComponent
+        let baseName = outputStem(for: inputURL)
         let outputBase = "\(baseName)-page\(pageNumber)"
         let pngURL = outputDir.appendingPathComponent("\(outputBase)-native.png", isDirectory: false)
         let jsonURL = outputDir.appendingPathComponent("\(outputBase)-native.json", isDirectory: false)
@@ -1355,6 +1437,7 @@ enum VisualDiffEngine {
 struct PreviewVisualDiffHarness {
     static func main() throws {
         NSApplication.shared.setActivationPolicy(.prohibited)
+        NSApplication.shared.finishLaunching()
 
         let options = try parseOptions(Array(CommandLine.arguments.dropFirst()))
         let studioDir = options.outputDir.appendingPathComponent("studio", isDirectory: true)
@@ -1401,7 +1484,7 @@ struct PreviewVisualDiffHarness {
                     pageNumber: options.pageNumber,
                     policy: options.policy
                 )
-                let baseName = inputURL.deletingPathExtension().lastPathComponent
+                let baseName = outputStem(for: inputURL)
                 let diff = try VisualDiffEngine.compare(
                     studioPNG: result.pngURL,
                     nativeImage: native.image,
@@ -1560,6 +1643,10 @@ private func absoluteURL(_ path: String, isDirectory: Bool = false) -> URL {
             .appendingPathComponent(path, isDirectory: isDirectory)
     }
     return url.standardizedFileURL
+}
+
+private func outputStem(for url: URL) -> String {
+    url.lastPathComponent
 }
 
 private func writeJSON<T: Encodable>(_ value: T, to url: URL) throws {


### PR DESCRIPTION
## 요약

- 대상 타스크: Closes #286
- 왜: #280 visual diff harness가 #283/#285에서 readiness 실패로 metric을 만들지 못해 후속 preview parity 작업의 수치 기준이 부족했다.
- 무엇: rhwp-studio reference capture의 phase-aware 실패 진단, WebKit navigation/request 관측, output artifact naming 보정, 6개 sample smoke metric 보고서를 추가했다.
- 리뷰 포인트: `scripts/preview_visual_diff_harness.swift`의 WebKit 초기화/진단 변경과 `mydocs/report/task_m014_286_report.md`의 #281/#285 handoff를 먼저 보면 된다.

## PR base

- base: `devel`

## 변경 내역

- **[계획](https://github.com/postmelee/alhangeul-macos/blob/233506b7aaf182151bcf425f394732d49930dd77/mydocs/plans/task_m014_286.md)** ([235134d](https://github.com/postmelee/alhangeul-macos/commit/235134d0fa051ac403fc6ea27b2ec597b816b86e)): #286 수행 계획과 오늘할일을 등록했다.
- **[구현 계획](https://github.com/postmelee/alhangeul-macos/blob/233506b7aaf182151bcf425f394732d49930dd77/mydocs/plans/task_m014_286_impl.md)** ([75532e1](https://github.com/postmelee/alhangeul-macos/commit/75532e16422ecd4adaa5f3ae8e21354c250d99a7)): 4단계 구현/검증 계획을 확정했다.
- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/233506b7aaf182151bcf425f394732d49930dd77/mydocs/working/task_m014_286_stage1.md)** ([10912f1](https://github.com/postmelee/alhangeul-macos/commit/10912f1909dfa15bc1fad37301eb8e9061dcafd5)): baseline에서 readiness timeout과 `WKErrorDomain Code=5`를 재현했다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/233506b7aaf182151bcf425f394732d49930dd77/mydocs/working/task_m014_286_stage2.md)** ([21a1795](https://github.com/postmelee/alhangeul-macos/commit/21a1795cca243bb964a631749f254b051bd76b55)): phase-aware error, summary `Phase` column, readiness detail logging을 추가했다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/233506b7aaf182151bcf425f394732d49930dd77/mydocs/working/task_m014_286_stage3.md)** ([c2fe5d9](https://github.com/postmelee/alhangeul-macos/commit/c2fe5d946e3cb22760dad62b46d93ec5748e44b2)): WebKit navigation/request stats와 artifact naming 보정 후 6개 sample metric을 생성했다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/233506b7aaf182151bcf425f394732d49930dd77/mydocs/report/task_m014_286_report.md)** ([2c066f3](https://github.com/postmelee/alhangeul-macos/commit/2c066f3b2a2a720af087337f5c7ca0f85efd0044)): 최종 보고서와 #281/#285 handoff를 정리했다.
- **[Copilot review 반영](https://github.com/postmelee/alhangeul-macos/blob/233506b7aaf182151bcf425f394732d49930dd77/scripts/preview_visual_diff_harness.swift)** ([233506b](https://github.com/postmelee/alhangeul-macos/commit/233506b7aaf182151bcf425f394732d49930dd77)): scheme request stats를 thread-safe하게 만들고 최종 보고서 표준 섹션 형식을 맞췄다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `scripts/preview_visual_diff_harness.swift` | phase-aware error, navigation event, scheme request stats, `finishLaunching()`, offscreen window ordering, output stem 보정 | 실패가 renderer 문제인지 WebKit 실행 환경 문제인지 분리되는지 확인 |
| `mydocs/working/` | Stage 1-3 관찰과 smoke 결과 문서화 | Stage별 결론이 최종 보고서와 일치하는지 확인 |
| `mydocs/report/task_m014_286_report.md` | 최종 수치, 한계, #281/#285 handoff 정리 | 후속 PR에서 재사용할 명령과 리스크가 충분한지 확인 |
| `mydocs/orders/20260527.md` | #286 완료 처리 | 하이퍼-워터폴 상태 기록 확인 |

- 수행 계획서: [task_m014_286.md](https://github.com/postmelee/alhangeul-macos/blob/233506b7aaf182151bcf425f394732d49930dd77/mydocs/plans/task_m014_286.md)
- 구현 계획서: [task_m014_286_impl.md](https://github.com/postmelee/alhangeul-macos/blob/233506b7aaf182151bcf425f394732d49930dd77/mydocs/plans/task_m014_286_impl.md)
- 최종 보고서: [task_m014_286_report.md](https://github.com/postmelee/alhangeul-macos/blob/233506b7aaf182151bcf425f394732d49930dd77/mydocs/report/task_m014_286_report.md)

## 핵심 리뷰 포인트

- Codex sandbox 내부 실패는 `events=[]`, `scheme={resourceRequests=0, documentRequests=0}`로 드러나며 renderer regression으로 취급하지 않는다.
- `tac-img-02.hwp`와 `tac-img-02.hwpx`처럼 basename이 같은 입력이 PNG/JSON/diff를 덮어쓰지 않도록 output stem에 확장자를 포함했다.
- 이번 PR은 harness 안정화이며 native renderer fidelity 자체는 개선하지 않는다.

## 검증

- `swiftc -parse-as-library ... scripts/preview_visual_diff_harness.swift ... -o build.noindex/task286-stage3-syntax-check`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage3-basic-final --page 1 samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task286-stage3-images-final --page 1 samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp samples/img-start-001.hwp`
- `rg -n "ChangedPixels|ChangedPercent|MeanRGBDelta|FAIL|WKErrorDomain|unsupported|readiness timed out" build.noindex/task286-stage3-basic-final/summary.md build.noindex/task286-stage3-images-final/summary.md`
- `rg -n "#286|readiness|ChangedPixels|ChangedPercent|MeanRGBDelta|#281|#285|#280|#283" mydocs/report/task_m014_286_report.md mydocs/orders/20260527.md`
- `git diff --check`

WebKit smoke는 sandbox 밖 권한으로 실행했다. 최종 basic/image-heavy summary 모두 exit code 0이고, `FAIL`, `WKErrorDomain`, `unsupported`, `readiness timed out`는 남지 않았다.

## 관련 이슈

- #280
- #281
- #283
- #285

## 후속 이슈 제안

- 없음. #281 이후 기존 renderer/compositor parity 이슈에서 이번 harness summary format을 재사용한다.

## 남은 리스크

- WebKit GUI 프로세스가 필요한 harness라 Codex sandbox 내부에서 `navigation=pending`으로 실패할 수 있다.
- 이번 수치는 `coreGraphicsOnly` native backend 기준이며 Skia opt-in backend는 별도 실행이 필요하다.
- `ChangedPercent`가 큰 값은 현재 native preview와 rhwp-studio reference의 fidelity 차이를 나타내는 baseline이며, 이번 PR에서 직접 개선하지 않는다.
