### PR TITLE
Task #287: upstream LFS smudge 실패 회피

### DIFF
--- a/.github/workflows/rhwp-upstream-sync-pr.yml
+++ b/.github/workflows/rhwp-upstream-sync-pr.yml
@@ -181,6 +181,7 @@ jobs:
           set -euo pipefail
           upstream_dir="$GITHUB_WORKSPACE/build.noindex/rhwp-upstream"
           rm -rf "$upstream_dir"
+          mkdir -p "$(dirname "$upstream_dir")"
           GIT_LFS_SKIP_SMUDGE=1 git clone "$UPSTREAM_GIT_URL" "$upstream_dir"
           git -C "$upstream_dir" config lfs.skipSmudge true
           GIT_LFS_SKIP_SMUDGE=1 git -C "$upstream_dir" checkout --detach "${{ steps.resolve.outputs.target_commit }}"

--- a/.github/workflows/rhwp-upstream-sync-pr.yml
+++ b/.github/workflows/rhwp-upstream-sync-pr.yml
@@ -181,8 +181,9 @@ jobs:
           set -euo pipefail
           upstream_dir="$GITHUB_WORKSPACE/build.noindex/rhwp-upstream"
           rm -rf "$upstream_dir"
-          git clone "$UPSTREAM_GIT_URL" "$upstream_dir"
-          git -C "$upstream_dir" checkout --detach "${{ steps.resolve.outputs.target_commit }}"
+          GIT_LFS_SKIP_SMUDGE=1 git clone "$UPSTREAM_GIT_URL" "$upstream_dir"
+          git -C "$upstream_dir" config lfs.skipSmudge true
+          GIT_LFS_SKIP_SMUDGE=1 git -C "$upstream_dir" checkout --detach "${{ steps.resolve.outputs.target_commit }}"
 
       - name: Detect rhwp-studio impact
         if: ${{ steps.resolve.outputs.current != 'true' }}

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -11,4 +11,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #287 | rhwp upstream release check LFS smudge 실패 회피 | 진행중 | M019, 수행계획서 작성 후 승인 대기 |
+| #287 | rhwp upstream release check LFS smudge 실패 회피 | 완료 | M019, 완료: 15:02, PR 준비 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -6,3 +6,9 @@
 |------|--------|------|------|
 | #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, #286 visual diff 재측정 보강: 14:30, PR 갱신 |
 | #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |
+
+## M019 — v0.1.2
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #287 | rhwp upstream release check LFS smudge 실패 회피 | 진행중 | M019, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/plans/task_m019_287.md
+++ b/mydocs/plans/task_m019_287.md
@@ -1,0 +1,127 @@
+# Task M019 #287 수행계획서
+
+## 목적
+
+`rhwp Upstream Release Check`와 `rhwp Upstream Sync PR` workflow가 upstream `edwardkim/rhwp`의 Git LFS 대용량 객체 다운로드 실패에 영향받지 않도록 checkout 경로를 보강한다.
+
+완료 후에는 `v0.7.13` 같은 upstream release tag 확인 과정에서 LFS budget 초과가 발생해도 release compatibility check와 rhwp-studio sync PR의 upstream checkout/impact 판정 경로가 통과해야 한다. 이번 작업은 LFS 객체 자체를 받거나 upstream 저장소 구성을 고치는 작업이 아니라, 이 저장소의 CI 자동화가 필요한 source만 안정적으로 확인하도록 만드는 작업이다.
+
+## 배경
+
+2026-05-27 scheduled GitHub Actions에서 두 workflow가 같은 원인으로 실패했다.
+
+- `rhwp Upstream Release Check`: `scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13` 실행 중 upstream checkout 실패
+- `rhwp Upstream Sync PR`: `.github/workflows/rhwp-upstream-sync-pr.yml`의 `Check out upstream rhwp` 단계에서 `git clone` checkout 실패
+
+두 로그 모두 upstream `edwardkim/rhwp`의 `pdf-large/hwp3-sample10-hwp5-2022.pdf` LFS 객체 다운로드를 시도하다가 LFS budget 초과로 중단됐다. 로컬에서 `GIT_LFS_SKIP_SMUDGE=1 scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13`을 실행하면 API compatibility check는 통과했고, `v0.7.13` resolved commit은 `b3e16ef212af81ef37d973ddb86d6816d3804642`로 확인됐다.
+
+따라서 실패는 `v0.7.13`의 RustBridge 필수 API 부재가 아니라, CI용 upstream checkout이 Git LFS smudge를 켠 상태로 동작한 데서 발생한 자동화 결함이다.
+
+## 범위(포함·제외)
+
+포함:
+
+- `scripts/update-rhwp-core.sh`의 임시 upstream repository fetch/checkout 경로에서 LFS smudge 비활성화
+- `.github/workflows/rhwp-upstream-sync-pr.yml`의 `Check out upstream rhwp` 단계에서 LFS smudge 비활성화
+- release compatibility check가 `v0.7.13` target에서 통과하는지 재검증
+- sync PR workflow의 upstream checkout과 viewer impact 판정 경로를 로컬에서 가능한 범위로 재검증
+- 필요한 경우 helper 또는 workflow summary에 LFS smudge skip 의도를 짧게 남기는 보강 검토
+
+제외:
+
+- `rhwp-core.lock`을 `v0.7.13`으로 갱신
+- `RustBridge/Cargo.toml` 또는 `RustBridge/Cargo.lock`의 core dependency 갱신
+- upstream `edwardkim/rhwp`의 LFS budget, `.gitattributes`, repository 구성 수정
+- bundled `rhwp-studio` asset 갱신 또는 자동 PR 실제 생성
+- release/publish workflow 실행, signing, notarization, Homebrew 배포
+
+## 설계 방향
+
+checkout 안정화는 source 확인 목적과 asset build 목적을 분리해서 적용한다. `scripts/update-rhwp-core.sh --check`는 필수 API 문자열을 source tree에서 확인하는 경로이므로 LFS 실제 객체가 필요하지 않다. 임시 repository 생성 직후 `lfs.skipSmudge` 설정 또는 checkout 명령 환경을 통해 LFS pointer checkout만 허용하는 방향을 우선 검토한다.
+
+`rhwp-upstream-sync-pr.yml`은 viewer impact 판정과 필요 시 rhwp-studio build까지 이어질 수 있는 workflow다. 이 단계도 `pdf-large/` 같은 대용량 fixture LFS 객체는 필요하지 않으므로 upstream clone/checkout에서 LFS smudge를 비활성화한다. 이후 단계가 실제로 LFS content를 필요로 하는지 확인하고, 필요하지 않은 경로라는 점을 검증 결과에 남긴다.
+
+구현은 workflow와 script의 checkout 지점에 작게 한정한다. 전역 runner 설정이나 repository-wide 설정을 과하게 바꾸지 않고, 해당 임시 upstream repository에만 적용한다. `GIT_LFS_SKIP_SMUDGE=1` 환경 변수와 repository local `git config lfs.skipSmudge true` 중 CI 재현성과 가독성이 좋은 쪽을 구현계획서에서 확정한다.
+
+## 예상 변경 파일
+
+- `scripts/update-rhwp-core.sh`
+- `.github/workflows/rhwp-upstream-sync-pr.yml`
+- 필요 시 `scripts/ci/check-rhwp-upstream-release.sh`
+- `mydocs/orders/20260527.md`
+- `mydocs/plans/task_m019_287.md`
+- `mydocs/plans/task_m019_287_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m019_287_stage{N}.md`
+- `mydocs/report/task_m019_287_report.md`
+
+## 잠정 단계(3~6단계)
+
+1. Stage 1: 실패 경로와 checkout 요구사항 정리
+   - 두 실패 run의 로그와 현재 workflow/script checkout 방식을 대조한다.
+   - compatibility check와 sync PR impact 판정에서 실제 LFS content가 필요한지 확인한다.
+   - LFS smudge 비활성화 적용 지점을 구현계획서에 고정한다.
+2. Stage 2: 구현계획서 작성
+   - script와 workflow의 변경 방식, 검증 명령, CI 재실행 확인 항목을 정리한다.
+   - 승인 후 `task_m019_287_impl.md`를 작성한다.
+3. Stage 3: upstream checkout LFS smudge 비활성화 구현
+   - `scripts/update-rhwp-core.sh` 임시 repository 경로를 보강한다.
+   - `rhwp-upstream-sync-pr.yml` upstream clone/checkout 단계를 보강한다.
+   - syntax와 diff check를 먼저 수행한다.
+4. Stage 4: 재현 검증과 영향 경로 확인
+   - `v0.7.13` compatibility check를 로컬에서 LFS smudge skip 상태로 재검증한다.
+   - sync PR workflow의 upstream checkout/impact 판정에 대응하는 로컬 명령을 실행한다.
+   - GitHub-hosted runner에서만 확인 가능한 workflow 재실행 항목을 보고서에 남긴다.
+5. Stage 5: 최종 보고와 PR 준비
+   - 검증 결과, 남은 CI 재실행 확인 항목, 제외 범위를 최종 보고서에 정리한다.
+   - 오늘할일을 완료로 갱신하고 PR 게시 절차로 넘긴다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260527.md mydocs/plans/task_m019_287.md
+```
+
+구현 단계 후보:
+
+```bash
+bash -n scripts/update-rhwp-core.sh
+bash -n scripts/ci/check-rhwp-upstream-release.sh
+ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml"); puts "parsed"'
+scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13
+scripts/ci/check-rhwp-upstream-release.sh --target-tag v0.7.13 --run-compatibility-check true
+```
+
+sync PR checkout/impact 판정 후보:
+
+```bash
+rm -rf build.noindex/rhwp-upstream
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/edwardkim/rhwp.git build.noindex/rhwp-upstream
+git -C build.noindex/rhwp-upstream checkout --detach b3e16ef212af81ef37d973ddb86d6816d3804642
+scripts/ci/detect-rhwp-studio-impact.sh --help
+```
+
+최종 확인 기준:
+
+- `v0.7.13` target compatibility check가 LFS 객체 다운로드 없이 통과한다.
+- sync PR workflow의 upstream checkout 경로가 LFS budget 초과에 영향받지 않는다.
+- 기존 `rhwp-core.lock`, RustBridge dependency, bundled `rhwp-studio` asset은 갱신하지 않는다.
+- workflow YAML과 shell helper syntax 검증이 통과한다.
+
+## 리스크
+
+- sync PR workflow의 후속 build 단계가 예상과 달리 LFS content를 필요로 하면, checkout은 통과해도 build 단계에서 다른 실패가 발생할 수 있다.
+- `git clone`에만 환경 변수를 주고 후속 `checkout`에는 적용하지 않으면 checkout 시점 smudge가 다시 동작할 수 있다.
+- runner 전역 설정으로 해결하면 다른 checkout에 의도치 않은 영향을 줄 수 있으므로 임시 upstream repository 범위로 제한해야 한다.
+- LFS smudge skip은 upstream 대용량 fixture 내용을 실제로 검증하지 않는다는 뜻이다. 이번 작업은 CI 자동화 안정화가 목적이고 fixture 내용 검증은 범위 밖으로 둔다.
+- GitHub-hosted schedule workflow 재실행 결과는 로컬에서 완전히 대체할 수 없으므로 PR 이후 수동 재실행 또는 다음 schedule 확인이 필요하다.
+
+## 승인 요청 사항
+
+1. #287을 `devel` 기준 CI/core automation 안정화 작업으로 진행하는 방향 승인
+2. `scripts/update-rhwp-core.sh`와 `.github/workflows/rhwp-upstream-sync-pr.yml` 두 checkout 경로에 LFS smudge 비활성화를 적용하는 범위 승인
+3. `rhwp-core.lock`과 bundled `rhwp-studio` asset은 이번 작업에서 갱신하지 않는 제외 범위 승인
+4. 승인 후 구현계획서(`mydocs/plans/task_m019_287_impl.md`) 작성
+
+승인 전에는 source, workflow, helper 구현 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m019_287_impl.md
+++ b/mydocs/plans/task_m019_287_impl.md
@@ -1,0 +1,224 @@
+# Task M019 #287 구현계획서
+
+수행계획서: `mydocs/plans/task_m019_287.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #287 rhwp upstream release check가 upstream LFS smudge 실패에 영향받지 않게 수정
+- 마일스톤: M019 (`v0.1.2`)
+- 브랜치: `local/task287`
+- 작업 위치: `/Users/melee/Documents/projects/rhwp-mac`
+- 기준 브랜치: `devel`
+- 목표: upstream `edwardkim/rhwp` checkout 중 Git LFS 대용량 객체 다운로드가 실패해도 release check와 sync PR workflow가 필요한 source 확인을 계속할 수 있게 한다.
+
+## 확인된 현재 상태
+
+2026-05-27 기준 확인 결과:
+
+- `rhwp Upstream Release Check` run `26491516266`은 `scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13` 실행 중 upstream checkout에서 실패했다.
+- `rhwp Upstream Sync PR` run `26491862455`는 `.github/workflows/rhwp-upstream-sync-pr.yml`의 `Check out upstream rhwp` 단계에서 `git clone` checkout 중 실패했다.
+- 두 실패 로그 모두 `pdf-large/hwp3-sample10-hwp5-2022.pdf` LFS 객체 다운로드 시도 후 `This repository exceeded its LFS budget` 메시지를 기록했다.
+- `GIT_LFS_SKIP_SMUDGE=1 scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13`은 로컬에서 통과했고, target commit은 `b3e16ef212af81ef37d973ddb86d6816d3804642`로 확인됐다.
+- `scripts/update-rhwp-core.sh`의 `fetch_target()`은 임시 git repository를 만든 뒤 `git checkout`으로 target commit/tag를 checkout한다.
+- `.github/workflows/rhwp-upstream-sync-pr.yml`의 upstream checkout은 `git clone` 후 target commit으로 `git checkout --detach`한다.
+- `scripts/ci/detect-rhwp-studio-impact.sh`는 upstream checkout의 git diff path와 source/build input path를 사용하며, 실패한 `pdf-large/` LFS 실제 content를 필요로 하지 않는다.
+
+## 구현 원칙
+
+- LFS smudge 비활성화는 upstream 임시 checkout 경로에만 적용한다.
+- 앱 저장소 checkout이나 repository 전역 Git 설정은 바꾸지 않는다.
+- `GIT_LFS_SKIP_SMUDGE=1`을 실제 smudge가 발생하는 `clone`/`checkout` 명령에 직접 적용한다.
+- 가능하면 해당 임시 upstream repository에 `git config lfs.skipSmudge true`도 설정해 후속 checkout이 같은 정책을 유지하도록 한다.
+- `rhwp-core.lock`, `RustBridge/Cargo.toml`, `RustBridge/Cargo.lock`, bundled `rhwp-studio` asset은 갱신하지 않는다.
+- 실제 자동 PR 생성, release publish, signing/notarization, Homebrew 배포는 수행하지 않는다.
+- 검증은 로컬에서 가능한 release check와 upstream checkout/impact detection 경로까지 수행하고, GitHub-hosted schedule 재실행은 잔여 확인 항목으로 기록한다.
+
+## Stage 1. 실패 경로와 LFS skip 적용 지점 확정
+
+### 목표
+
+두 workflow 실패 경로와 LFS smudge 발생 지점을 단계 보고서에 고정하고, 실제 구현 지점을 확정한다.
+
+### 작업
+
+- `scripts/update-rhwp-core.sh`의 `init_work_repo()`와 `fetch_target()` 호출 흐름을 확인한다.
+- `.github/workflows/rhwp-upstream-sync-pr.yml`의 `Check out upstream rhwp` 단계와 후속 `Detect rhwp-studio impact` 입력을 확인한다.
+- `detect-rhwp-studio-impact.sh`가 LFS 실제 content를 요구하지 않는지 path 기준으로 확인한다.
+- Stage 2에서 적용할 방식은 다음으로 고정한다.
+  - `scripts/update-rhwp-core.sh`: 임시 repository에 `lfs.skipSmudge true` 설정, checkout 명령에 `GIT_LFS_SKIP_SMUDGE=1` 적용
+  - `rhwp-upstream-sync-pr.yml`: `git clone`과 후속 `git checkout --detach`에 `GIT_LFS_SKIP_SMUDGE=1` 적용, clone 후 upstream repository local config에 `lfs.skipSmudge true` 설정
+
+### 예상 변경 파일
+
+- `mydocs/working/task_m019_287_stage1.md`
+
+### 검증
+
+```bash
+git status --short --branch
+rg -n "fetch_target|init_work_repo|git clone|git -C .*checkout|detect-rhwp-studio-impact|pdf-large|lfs" \
+  scripts/update-rhwp-core.sh .github/workflows/rhwp-upstream-sync-pr.yml scripts/ci/detect-rhwp-studio-impact.sh
+git diff --check
+```
+
+### 완료 기준
+
+- Stage 1 보고서에 두 실패 run, 실패 명령, LFS skip 적용 지점, LFS content 불필요 근거가 기록된다.
+- Stage 2에서 수정할 파일과 방식이 확정된다.
+
+### 커밋 메시지
+
+```text
+Task #287 Stage 1: upstream checkout 실패 경로 정리
+```
+
+## Stage 2. upstream checkout LFS smudge 비활성화 구현
+
+### 목표
+
+release compatibility check와 sync PR workflow의 upstream checkout이 Git LFS smudge 실패에 영향받지 않도록 source/workflow를 수정한다.
+
+### 작업
+
+- `scripts/update-rhwp-core.sh`를 수정한다.
+  - 임시 repository 생성 직후 `git -C "$WORK_DIR" config lfs.skipSmudge true`를 설정한다.
+  - demo commit checkout과 stable tag checkout 모두 `GIT_LFS_SKIP_SMUDGE=1 git -C "$WORK_DIR" checkout ...` 형태로 실행한다.
+  - fetch 명령은 smudge가 발생하지 않는 경로이므로 기존 동작을 유지하되, 필요하면 checkout 정책을 설명하는 짧은 주석을 추가한다.
+- `.github/workflows/rhwp-upstream-sync-pr.yml`을 수정한다.
+  - `git clone "$UPSTREAM_GIT_URL" "$upstream_dir"`를 `GIT_LFS_SKIP_SMUDGE=1 git clone ...` 형태로 변경한다.
+  - clone 후 `git -C "$upstream_dir" config lfs.skipSmudge true`를 설정한다.
+  - target commit checkout도 `GIT_LFS_SKIP_SMUDGE=1 git -C "$upstream_dir" checkout --detach ...` 형태로 변경한다.
+- 변경은 checkout 단계에만 한정하고 downstream build/sync 로직은 변경하지 않는다.
+
+### 예상 변경 파일
+
+- `scripts/update-rhwp-core.sh`
+- `.github/workflows/rhwp-upstream-sync-pr.yml`
+- `mydocs/working/task_m019_287_stage2.md`
+
+### 검증
+
+```bash
+git status --short --branch
+bash -n scripts/update-rhwp-core.sh
+bash -n scripts/ci/check-rhwp-upstream-release.sh
+ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml"); puts "parsed"'
+git diff --check
+```
+
+### 완료 기준
+
+- 두 upstream checkout 경로가 LFS smudge skip 정책을 명시적으로 적용한다.
+- shell syntax와 workflow YAML parse 검증이 통과한다.
+- `rhwp-core.lock`, RustBridge dependency, bundled `rhwp-studio` asset 변경이 없다.
+
+### 커밋 메시지
+
+```text
+Task #287 Stage 2: upstream checkout LFS smudge 비활성화
+```
+
+## Stage 3. release check와 sync impact 경로 검증
+
+### 목표
+
+수정 후 `v0.7.13` release compatibility check와 sync PR upstream checkout/impact 판정 경로가 LFS 객체 다운로드 없이 통과하는지 확인한다.
+
+### 작업
+
+- `scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13`를 실행한다.
+- `scripts/ci/check-rhwp-upstream-release.sh --target-tag v0.7.13 --run-compatibility-check true`를 실행한다.
+- sync PR workflow의 upstream checkout 단계에 대응하는 로컬 명령을 실행한다.
+  - `GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/edwardkim/rhwp.git build.noindex/rhwp-upstream`
+  - `git -C build.noindex/rhwp-upstream config lfs.skipSmudge true`
+  - `GIT_LFS_SKIP_SMUDGE=1 git -C build.noindex/rhwp-upstream checkout --detach b3e16ef212af81ef37d973ddb86d6816d3804642`
+- 현재 bundled manifest의 tag/commit과 target tag/commit을 사용해 `scripts/ci/detect-rhwp-studio-impact.sh`를 실행한다.
+- 검증 전후 로컬 `build.noindex/rhwp-upstream` 부산물은 재생성 가능 산출물로 취급하고, 정리 여부와 대상 경로를 Stage 3 보고서에 기록한다.
+
+### 예상 변경 파일
+
+- `mydocs/working/task_m019_287_stage3.md`
+
+### 검증
+
+```bash
+scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13
+scripts/ci/check-rhwp-upstream-release.sh --target-tag v0.7.13 --run-compatibility-check true
+rm -rf build.noindex/rhwp-upstream build.noindex/rhwp-upstream-impact
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/edwardkim/rhwp.git build.noindex/rhwp-upstream
+git -C build.noindex/rhwp-upstream config lfs.skipSmudge true
+GIT_LFS_SKIP_SMUDGE=1 git -C build.noindex/rhwp-upstream checkout --detach b3e16ef212af81ef37d973ddb86d6816d3804642
+scripts/ci/detect-rhwp-studio-impact.sh \
+  --upstream-dir build.noindex/rhwp-upstream \
+  --current-tag "$(awk -F'\"' '/source_release_tag/ { print $4; exit }' Sources/HostApp/Resources/rhwp-studio/manifest.json)" \
+  --current-commit "$(awk -F'\"' '/source_resolved_commit/ { print $4; exit }' Sources/HostApp/Resources/rhwp-studio/manifest.json)" \
+  --target-tag v0.7.13 \
+  --target-commit b3e16ef212af81ef37d973ddb86d6816d3804642 \
+  --output-dir build.noindex/rhwp-upstream-impact
+git status --short --branch
+git diff --check
+```
+
+### 완료 기준
+
+- release compatibility check가 명시적 외부 `GIT_LFS_SKIP_SMUDGE=1` 없이 통과한다.
+- sync PR checkout 대응 명령이 LFS budget 초과 없이 target commit checkout까지 통과한다.
+- impact detection이 upstream checkout을 입력으로 정상 종료한다.
+- 검증 결과와 GitHub-hosted workflow 재실행 잔여 확인 항목이 Stage 3 보고서에 기록된다.
+
+### 커밋 메시지
+
+```text
+Task #287 Stage 3: LFS skip checkout 경로 검증
+```
+
+## Stage 4. 최종 보고와 PR 준비
+
+### 목표
+
+작업 결과와 검증 한계를 최종 보고서에 정리하고 PR 게시 전 상태를 정리한다.
+
+### 작업
+
+- `mydocs/report/task_m019_287_report.md`를 작성한다.
+- `mydocs/orders/20260527.md`의 #287 상태를 `완료`로 갱신한다.
+- 실패 run 두 개와 수정 지점, 검증 명령 결과, 잔여 확인 항목을 보고서에 기록한다.
+- `rhwp-core.lock`과 bundled `rhwp-studio` asset이 변경되지 않았음을 확인한다.
+- PR 게시 전 `git status --short --branch`와 `git diff --check`를 실행한다.
+
+### 예상 변경 파일
+
+- `mydocs/report/task_m019_287_report.md`
+- `mydocs/orders/20260527.md`
+
+### 검증
+
+```bash
+git status --short --branch
+git diff --check
+git diff --name-only devel...HEAD
+```
+
+### 완료 기준
+
+- 최종 보고서가 작성되고 오늘할일이 완료 처리된다.
+- 작업 브랜치에 미커밋 변경이 없다.
+- PR 게시 절차로 넘길 준비가 끝난다.
+
+### 커밋 메시지
+
+```text
+Task #287 Stage 4 + 최종 보고서: LFS smudge 실패 회피 검증 정리
+```
+
+## 승인 요청 사항
+
+1. 위 4단계 구현 계획 승인
+2. Stage 1에서 실패 경로와 LFS skip 적용 지점을 보고서로 고정하는 작업 승인
+3. Stage 2에서 `scripts/update-rhwp-core.sh`와 `.github/workflows/rhwp-upstream-sync-pr.yml`만 수정하는 방향 승인
+4. Stage 3에서 `v0.7.13` release check와 sync PR checkout/impact 판정 경로를 네트워크 검증하는 방향 승인
+5. 각 단계 완료 후 단계 보고서를 작성하고 승인받은 뒤 다음 단계로 진행하는 절차 승인
+
+승인 전에는 source와 workflow 구현 변경을 진행하지 않는다.

--- a/mydocs/report/task_m019_287_report.md
+++ b/mydocs/report/task_m019_287_report.md
@@ -1,0 +1,123 @@
+# Task M019 #287 최종 보고서
+
+## 작업 요약
+
+- 이슈: #287 rhwp upstream release check가 upstream LFS smudge 실패에 영향받지 않게 수정
+- 마일스톤: M019 (`v0.1.2`)
+- 브랜치: `local/task287`
+- 기준 브랜치: `devel`
+- 단계 수: 4단계
+- 목적: upstream `edwardkim/rhwp` checkout 중 Git LFS 대용량 객체 다운로드가 실패해도 release check와 sync PR workflow가 필요한 source 확인을 계속할 수 있게 한다.
+
+## 결과
+
+두 scheduled workflow 실패의 공통 원인은 upstream `edwardkim/rhwp` checkout 중 `pdf-large/hwp3-sample10-hwp5-2022.pdf` LFS 객체 다운로드가 LFS budget 초과로 실패한 것이었다.
+
+이번 작업에서는 앱 저장소 checkout이나 전역 Git 설정을 바꾸지 않고, upstream 임시 checkout 경로에만 LFS smudge skip을 적용했다.
+
+- `scripts/update-rhwp-core.sh`: 임시 upstream repository에 `lfs.skipSmudge true` 설정, demo/stable checkout에 `GIT_LFS_SKIP_SMUDGE=1` 적용
+- `.github/workflows/rhwp-upstream-sync-pr.yml`: upstream clone과 target checkout에 `GIT_LFS_SKIP_SMUDGE=1` 적용, clone 후 local `lfs.skipSmudge true` 설정
+
+`v0.7.13` target release check와 sync PR checkout/impact 판정 경로는 로컬 네트워크 검증에서 통과했다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `.github/workflows/rhwp-upstream-sync-pr.yml` | `Check out upstream rhwp` 단계의 upstream clone/checkout에 LFS smudge skip 적용 |
+| `scripts/update-rhwp-core.sh` | release/demo target checkout용 임시 repository에 LFS smudge skip 설정 적용 |
+| `mydocs/orders/20260527.md` | #287 작업 시작과 완료 상태 기록 |
+| `mydocs/plans/task_m019_287.md` | 수행계획서 |
+| `mydocs/plans/task_m019_287_impl.md` | 구현계획서 |
+| `mydocs/working/task_m019_287_stage1.md` | 실패 경로와 LFS skip 적용 지점 조사 보고 |
+| `mydocs/working/task_m019_287_stage2.md` | checkout LFS smudge 비활성화 구현 보고 |
+| `mydocs/working/task_m019_287_stage3.md` | `v0.7.13` release check와 sync impact 검증 보고 |
+| `mydocs/report/task_m019_287_report.md` | 본 최종 보고서 |
+
+## 변경 전·후 정량 비교
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| `scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13` | LFS smudge가 대용량 PDF 다운로드를 시도해 실패 | 외부 환경 변수 없이 통과 |
+| upstream release check wrapper | `compatibility_status=failed` | `compatibility_status=passed` |
+| sync PR upstream checkout | `git clone` checkout 중 LFS budget 초과로 실패 | LFS smudge skip clone과 target checkout 통과 |
+| impact detection | checkout 실패로 미실행 | `has_viewer_impact=true`, impact path 427개 산출 |
+| 코드/workflow 변경 | 없음 | 2개 파일, checkout 명령 2곳과 local config 설정 추가 |
+
+전체 diff 기준:
+
+```text
+8 files changed, 816 insertions(+), 4 deletions(-)
+```
+
+최종 보고서와 오늘할일 완료 갱신을 포함하면 변경 파일은 9개다.
+
+## 단계별 커밋
+
+| 단계 | 커밋 | 내용 |
+|------|------|------|
+| 수행계획 | `e6ad0a1` | 수행 계획서 작성과 오늘할일 갱신 |
+| 구현계획 | `d635ed0` | 구현 계획서 작성 |
+| Stage 1 | `a623c03` | upstream checkout 실패 경로 정리 |
+| Stage 2 | `21221d4` | upstream checkout LFS smudge 비활성화 |
+| Stage 3 | `7f71409` | LFS skip checkout 경로 검증 |
+| Stage 4 | 본 커밋 | 최종 보고서와 오늘할일 완료 처리 |
+
+## 검증 결과
+
+| 수용 기준 | 결과 | 근거 |
+|-----------|------|------|
+| `v0.7.13` target compatibility check가 LFS 객체 다운로드 없이 통과 | OK | `scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13` 통과 |
+| upstream release check wrapper가 통과 | OK | `compatibility_status=passed` |
+| sync PR checkout 대응 경로가 target commit까지 checkout | OK | `b3e16ef212af81ef37d973ddb86d6816d3804642` checkout 통과 |
+| impact detection이 upstream checkout 입력으로 정상 종료 | OK | `has_viewer_impact=true`, impact path 427개 |
+| workflow YAML과 shell syntax 검증 | OK | `bash -n`, Ruby `Psych.parse_file`, `git diff --check` 통과 |
+| core lock과 bundled asset 미변경 | OK | 변경 파일 목록에 `rhwp-core.lock`, `RustBridge/*`, `Sources/HostApp/Resources/rhwp-studio/*` 없음 |
+
+실행한 주요 검증:
+
+```bash
+bash -n scripts/update-rhwp-core.sh
+bash -n scripts/ci/check-rhwp-upstream-release.sh
+ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml"); puts "parsed"'
+scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13
+scripts/ci/check-rhwp-upstream-release.sh --target-tag v0.7.13 --run-compatibility-check true
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/edwardkim/rhwp.git build.noindex/rhwp-upstream
+GIT_LFS_SKIP_SMUDGE=1 git -C build.noindex/rhwp-upstream checkout --detach b3e16ef212af81ef37d973ddb86d6816d3804642
+scripts/ci/detect-rhwp-studio-impact.sh --upstream-dir build.noindex/rhwp-upstream --current-tag v0.7.12 --current-commit 1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5 --target-tag v0.7.13 --target-commit b3e16ef212af81ef37d973ddb86d6816d3804642 --output-dir build.noindex/rhwp-upstream-impact
+git diff --check
+```
+
+참고:
+
+- Ruby YAML parse 중 `ffi-1.13.1` extension 경고가 출력됐지만 `parsed`로 종료되어 parse 실패는 아니었다.
+- Stage 3 검증 산출물 `build.noindex/rhwp-upstream`와 `build.noindex/rhwp-upstream-impact`는 최종 단계에서 정리했다.
+
+## 미수행 범위
+
+- `rhwp-core.lock`을 `v0.7.13`으로 갱신
+- `RustBridge/Cargo.toml` 또는 `RustBridge/Cargo.lock` dependency 갱신
+- bundled `rhwp-studio` asset 갱신
+- upstream `edwardkim/rhwp`의 LFS budget 또는 repository 구성 수정
+- 실제 자동 PR 생성 workflow 실행
+- release/publish workflow 실행, signing, notarization, Homebrew 배포
+
+## 잔여 위험과 후속 작업
+
+| 항목 | 내용 |
+|------|------|
+| GitHub-hosted workflow 재실행 | 로컬 검증은 통과했지만 Actions schedule runner에서의 실제 재실행은 PR merge 후 수동 dispatch 또는 다음 schedule로 확인해야 한다. |
+| sync PR 후속 build 단계 | 이번 작업은 upstream checkout과 impact detection 경로를 검증했다. 실제 bundled `rhwp-studio` build/sync/PR 생성 단계는 #204 자동화의 기존 범위다. |
+| LFS fixture 검증 제외 | LFS smudge skip은 대용량 fixture 실제 content를 받지 않는다는 뜻이다. 이번 작업의 목적은 release 감시와 sync PR 자동화 안정화이므로 허용 범위다. |
+
+## PR close 전략
+
+PR 본문에는 다음을 명시한다.
+
+```text
+Closes #287
+```
+
+## 작업지시자 승인 요청
+
+최종 보고 결과를 승인하면 PR 게시 절차로 진행한다. 다음 절차는 `publish/task287` 원격 브랜치 push와 `devel` 대상 Open PR 생성이다.

--- a/mydocs/working/task_m019_287_stage1.md
+++ b/mydocs/working/task_m019_287_stage1.md
@@ -1,0 +1,159 @@
+# Task M019 #287 Stage 1 완료 보고서
+
+## 단계 목적
+
+`rhwp Upstream Release Check`와 `rhwp Upstream Sync PR` workflow의 실패 경로를 확인하고, Stage 2에서 적용할 Git LFS smudge 비활성화 지점을 고정한다.
+
+이번 단계는 조사와 보고 단계이며 source, workflow, lock, bundled asset은 변경하지 않았다.
+
+## 확인 시각
+
+- 2026-05-27 14:50 KST
+
+## 산출물
+
+| 파일 | 요약 |
+|------|------|
+| `mydocs/working/task_m019_287_stage1.md` | 두 실패 run의 실패 지점, 현재 checkout 명령, LFS skip 적용 지점, 다음 단계 영향 정리 |
+
+참조한 기존 파일:
+
+| 파일 | 확인 내용 |
+|------|----------|
+| `scripts/update-rhwp-core.sh` | `fetch_target()`가 임시 upstream repository를 만든 뒤 `git checkout`으로 demo commit 또는 stable tag를 checkout |
+| `.github/workflows/rhwp-upstream-sync-pr.yml` | `Check out upstream rhwp` 단계가 `git clone` 후 target commit으로 `git checkout --detach` 수행 |
+| `scripts/ci/detect-rhwp-studio-impact.sh` | upstream checkout의 git diff path와 source/build input path를 사용하며 실패한 `pdf-large/` LFS 실제 content를 요구하지 않음 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 source 변경 없음.
+- workflow 변경 없음.
+- `rhwp-core.lock`, `RustBridge/Cargo.toml`, `RustBridge/Cargo.lock` 변경 없음.
+- bundled `rhwp-studio` asset 변경 없음.
+- 신규 단계 보고서만 추가했다.
+
+## 확인한 실패 경로
+
+### `rhwp Upstream Release Check`
+
+- 실패 run: `26491516266`
+- 실패 job: `Compare rhwp-core.lock with upstream release`
+- 실패 step: `Check upstream rhwp release`
+- 실행 경로: `scripts/ci/check-rhwp-upstream-release.sh` -> `scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13`
+- 현재 `scripts/update-rhwp-core.sh` 흐름:
+  - `init_work_repo()`에서 임시 directory에 `git init` 후 upstream remote 추가
+  - stable channel에서 `git fetch --depth 1 origin "refs/tags/$TAG:refs/tags/$TAG"`
+  - `git -C "$WORK_DIR" checkout -q --detach "$TAG"`
+- LFS smudge 발생 가능 지점: `git checkout`
+
+### `rhwp Upstream Sync PR`
+
+- 실패 run: `26491862455`
+- 실패 job: `Create rhwp-studio sync PR candidate`
+- 실패 step: `Check out upstream rhwp`
+- 현재 workflow 흐름:
+  - `git clone "$UPSTREAM_GIT_URL" "$upstream_dir"`
+  - `git -C "$upstream_dir" checkout --detach "${{ steps.resolve.outputs.target_commit }}"`
+- LFS smudge 발생 가능 지점: `git clone`의 기본 checkout, 후속 `git checkout --detach`
+
+두 실패 로그 모두 다음 upstream LFS 객체 다운로드 실패를 기록했다.
+
+```text
+pdf-large/hwp3-sample10-hwp5-2022.pdf
+This repository exceeded its LFS budget.
+fatal: pdf-large/hwp3-sample10-hwp5-2022.pdf: smudge filter lfs failed
+```
+
+로컬 확인에서는 `GIT_LFS_SKIP_SMUDGE=1 scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13`이 통과했다. 따라서 실패는 `v0.7.13`의 필수 API 부재가 아니라 checkout 과정에서 LFS 실제 객체를 받으려 한 자동화 문제로 판단한다.
+
+## LFS 실제 content 불필요 근거
+
+`scripts/update-rhwp-core.sh --check`는 target checkout 후 `check_required_apis()`에서 다음 API 문자열을 `src` 아래에서 찾는다.
+
+- `build_page_render_tree`
+- `get_bin_data`
+- `render_page_svg_native`
+- `get_page_info_native`
+- `extract_thumbnail_only`
+
+이 경로는 `pdf-large/` fixture content가 필요하지 않다.
+
+`rhwp-upstream-sync-pr.yml`의 다음 단계인 `Detect rhwp-studio impact`는 `scripts/ci/detect-rhwp-studio-impact.sh`에 upstream checkout 경로와 current/target tag/commit을 넘긴다. helper의 impact 판정은 다음 path 계열을 git diff 결과로 분류한다.
+
+- `rhwp-studio/*`
+- `pkg/*`
+- `Cargo.toml`, `Cargo.lock`, `rust-toolchain*`, `.cargo/*`, `crates/*`, `src/*`
+- `package.json`, lockfile, `vite.config.*`, `tsconfig*.json`
+- font/license/provenance 관련 파일
+
+실패한 `pdf-large/hwp3-sample10-hwp5-2022.pdf`의 실제 LFS content는 이 판정에 필요하지 않다. diff path 확인에는 LFS pointer checkout만으로 충분하다.
+
+## Stage 2 적용 지점
+
+Stage 2 수정 범위는 두 checkout 경로로 한정한다.
+
+### `scripts/update-rhwp-core.sh`
+
+- `init_work_repo()`에서 임시 upstream repository 생성 직후 `git -C "$WORK_DIR" config lfs.skipSmudge true`를 설정한다.
+- demo channel의 `git checkout -q --detach FETCH_HEAD`에 `GIT_LFS_SKIP_SMUDGE=1`을 적용한다.
+- stable channel의 `git checkout -q --detach "$TAG"`에 `GIT_LFS_SKIP_SMUDGE=1`을 적용한다.
+- `git fetch`는 checkout smudge를 발생시키지 않으므로 기존 명령을 유지한다.
+
+### `.github/workflows/rhwp-upstream-sync-pr.yml`
+
+- `git clone "$UPSTREAM_GIT_URL" "$upstream_dir"`에 `GIT_LFS_SKIP_SMUDGE=1`을 적용한다.
+- clone 후 `git -C "$upstream_dir" config lfs.skipSmudge true`를 설정한다.
+- 후속 `git -C "$upstream_dir" checkout --detach <target>`에도 `GIT_LFS_SKIP_SMUDGE=1`을 적용한다.
+
+이 방식은 앱 저장소 checkout이나 runner 전역 Git 설정을 바꾸지 않고, upstream 임시 checkout 경로에만 적용된다.
+
+## 검증 결과
+
+```bash
+git status --short --branch
+```
+
+결과: `## local/task287`, Stage 1 조사 전 미커밋 변경 없음.
+
+```bash
+rg -n "fetch_target|init_work_repo|git clone|git -C .*checkout|detect-rhwp-studio-impact|pdf-large|lfs" \
+  scripts/update-rhwp-core.sh .github/workflows/rhwp-upstream-sync-pr.yml scripts/ci/detect-rhwp-studio-impact.sh
+```
+
+결과:
+
+```text
+scripts/update-rhwp-core.sh:309:init_work_repo() {
+scripts/update-rhwp-core.sh:315:fetch_target() {
+scripts/update-rhwp-core.sh:323:    git -C "$WORK_DIR" checkout -q --detach FETCH_HEAD
+scripts/update-rhwp-core.sh:329:    git -C "$WORK_DIR" checkout -q --detach "$TAG"
+.github/workflows/rhwp-upstream-sync-pr.yml:184:          git clone "$UPSTREAM_GIT_URL" "$upstream_dir"
+.github/workflows/rhwp-upstream-sync-pr.yml:185:          git -C "$upstream_dir" checkout --detach "${{ steps.resolve.outputs.target_commit }}"
+.github/workflows/rhwp-upstream-sync-pr.yml:194:          scripts/ci/detect-rhwp-studio-impact.sh \
+```
+
+```bash
+git diff --check
+```
+
+결과: 통과.
+
+## 잔여 위험
+
+- Stage 1은 조사와 적용 지점 확정만 수행했으므로 CI 실패는 아직 수정되지 않았다.
+- `rhwp-upstream-sync-pr.yml` 후속 build 단계가 예상과 달리 LFS 실제 content를 필요로 하면 Stage 3 검증 이후 별도 보강이 필요할 수 있다.
+- GitHub-hosted schedule workflow 재실행은 로컬에서 완전히 대체할 수 없다. PR 이후 수동 재실행 또는 다음 schedule 확인이 필요하다.
+- LFS smudge skip은 upstream 대용량 fixture의 실제 content를 검증하지 않는다는 뜻이다. 이번 작업은 release 감시와 sync PR 자동화 안정화가 목적이므로 이 제한은 허용 범위로 둔다.
+
+## 다음 단계 영향
+
+Stage 2에서는 실제 source/workflow 변경을 수행한다.
+
+1. `scripts/update-rhwp-core.sh` 임시 upstream repository에 `lfs.skipSmudge true`를 설정한다.
+2. `scripts/update-rhwp-core.sh`의 demo/stable checkout에 `GIT_LFS_SKIP_SMUDGE=1`을 적용한다.
+3. `.github/workflows/rhwp-upstream-sync-pr.yml`의 upstream `git clone`과 target `git checkout`에 `GIT_LFS_SKIP_SMUDGE=1`을 적용한다.
+4. shell syntax, workflow YAML parse, `git diff --check`를 실행한다.
+
+## 승인 요청
+
+Stage 1 결과를 승인하면 Stage 2 `upstream checkout LFS smudge 비활성화 구현`으로 진행한다.

--- a/mydocs/working/task_m019_287_stage2.md
+++ b/mydocs/working/task_m019_287_stage2.md
@@ -1,0 +1,116 @@
+# Task M019 #287 Stage 2 완료 보고서
+
+## 단계 목적
+
+release compatibility check와 sync PR workflow의 upstream checkout이 Git LFS smudge 실패에 영향받지 않도록 source와 workflow의 checkout 지점을 보강한다.
+
+이번 단계는 구현 단계이며, `rhwp-core.lock`, RustBridge dependency, bundled `rhwp-studio` asset은 변경하지 않았다.
+
+## 산출물
+
+| 파일 | 요약 |
+|------|------|
+| `scripts/update-rhwp-core.sh` | 임시 upstream repository에 `lfs.skipSmudge true` 설정, demo/stable checkout에 `GIT_LFS_SKIP_SMUDGE=1` 적용 |
+| `.github/workflows/rhwp-upstream-sync-pr.yml` | upstream `git clone`과 target commit checkout에 `GIT_LFS_SKIP_SMUDGE=1` 적용, clone 후 local `lfs.skipSmudge true` 설정 |
+| `mydocs/working/task_m019_287_stage2.md` | 본 Stage 2 구현/검증 보고서 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 앱 source 변경 없음.
+- `rhwp-core.lock`, `RustBridge/Cargo.toml`, `RustBridge/Cargo.lock` 변경 없음.
+- bundled `Sources/HostApp/Resources/rhwp-studio` asset 변경 없음.
+- CI/helper checkout 명령만 변경했다.
+
+## 구현 내용
+
+### `scripts/update-rhwp-core.sh`
+
+임시 upstream repository 생성 직후 local config를 추가했다.
+
+```text
+git -C "$WORK_DIR" config lfs.skipSmudge true
+```
+
+demo/stable target checkout에는 명령 단위 환경 변수를 적용했다.
+
+```text
+GIT_LFS_SKIP_SMUDGE=1 git -C "$WORK_DIR" checkout -q --detach FETCH_HEAD
+GIT_LFS_SKIP_SMUDGE=1 git -C "$WORK_DIR" checkout -q --detach "$TAG"
+```
+
+`git fetch`는 checkout smudge를 발생시키지 않으므로 기존 명령을 유지했다.
+
+### `.github/workflows/rhwp-upstream-sync-pr.yml`
+
+upstream clone과 target commit checkout에 같은 정책을 적용했다.
+
+```text
+GIT_LFS_SKIP_SMUDGE=1 git clone "$UPSTREAM_GIT_URL" "$upstream_dir"
+git -C "$upstream_dir" config lfs.skipSmudge true
+GIT_LFS_SKIP_SMUDGE=1 git -C "$upstream_dir" checkout --detach "${{ steps.resolve.outputs.target_commit }}"
+```
+
+이 변경은 workflow의 `Check out upstream rhwp` 단계에만 적용된다. 앱 저장소 checkout, workflow permissions, impact detection, build/sync/PR 생성 로직은 변경하지 않았다.
+
+## 검증 결과
+
+```bash
+git status --short --branch
+```
+
+결과:
+
+```text
+## local/task287
+ M .github/workflows/rhwp-upstream-sync-pr.yml
+ M scripts/update-rhwp-core.sh
+```
+
+```bash
+bash -n scripts/update-rhwp-core.sh
+```
+
+결과: 통과.
+
+```bash
+bash -n scripts/ci/check-rhwp-upstream-release.sh
+```
+
+결과: 통과.
+
+```bash
+ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml"); puts "parsed"'
+```
+
+결과:
+
+```text
+Ignoring ffi-1.13.1 because its extensions are not built. Try: gem pristine ffi --version 1.13.1
+parsed
+```
+
+YAML parse는 성공했다. `ffi-1.13.1` 메시지는 로컬 Ruby gem extension 경고이며, workflow parse 실패가 아니다.
+
+```bash
+git diff --check
+```
+
+결과: 통과.
+
+## 잔여 위험
+
+- Stage 2는 syntax와 YAML parse 중심 검증이다. 실제 `v0.7.13` checkout 재현은 Stage 3에서 수행한다.
+- GitHub-hosted runner에서 schedule workflow가 같은 방식으로 통과하는지는 PR 이후 수동 재실행 또는 다음 schedule에서 확인해야 한다.
+- sync PR workflow 후속 build 단계가 LFS 실제 content를 필요로 하면 별도 실패가 나타날 수 있다. 현재 impact detection 경로는 LFS 실제 content를 요구하지 않는 것으로 Stage 1에서 확인했다.
+
+## 다음 단계 영향
+
+Stage 3에서는 다음을 확인한다.
+
+1. `scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13`가 외부 `GIT_LFS_SKIP_SMUDGE=1` 없이 통과하는지 확인한다.
+2. `scripts/ci/check-rhwp-upstream-release.sh --target-tag v0.7.13 --run-compatibility-check true`가 통과하는지 확인한다.
+3. sync PR workflow의 upstream checkout 대응 명령과 `detect-rhwp-studio-impact.sh`를 로컬에서 실행한다.
+
+## 승인 요청
+
+Stage 2 결과를 승인하면 Stage 3 `release check와 sync impact 경로 검증`으로 진행한다.

--- a/mydocs/working/task_m019_287_stage3.md
+++ b/mydocs/working/task_m019_287_stage3.md
@@ -1,0 +1,178 @@
+# Task M019 #287 Stage 3 완료 보고서
+
+## 단계 목적
+
+Stage 2에서 적용한 LFS smudge skip 변경이 실제 upstream `v0.7.13` release check와 sync PR checkout/impact 판정 경로에서 동작하는지 확인한다.
+
+이번 단계는 검증 단계이며 source, workflow, lock, bundled asset은 변경하지 않았다.
+
+## 산출물
+
+| 파일 | 요약 |
+|------|------|
+| `mydocs/working/task_m019_287_stage3.md` | `v0.7.13` release check, upstream checkout, impact detection 검증 결과 |
+
+검증 중 생성된 재생성 가능 산출물:
+
+| 경로 | 크기 | 상태 |
+|------|------|------|
+| `build.noindex/rhwp-upstream` | 605M | ignored build 산출물, target commit checkout 검증에 사용 |
+| `build.noindex/rhwp-upstream-impact` | 104K | ignored build 산출물, impact detection output |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 source 변경 없음.
+- workflow 변경 없음.
+- `rhwp-core.lock`, `RustBridge/Cargo.toml`, `RustBridge/Cargo.lock` 변경 없음.
+- bundled `Sources/HostApp/Resources/rhwp-studio` asset 변경 없음.
+- 신규 단계 보고서만 추가했다.
+
+## 검증 결과
+
+### `update-rhwp-core.sh --check`
+
+```bash
+scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13
+```
+
+결과: 통과.
+
+```text
+From https://github.com/edwardkim/rhwp
+ * [new tag]         v0.7.13    -> v0.7.13
+Checked rhwp core target:
+  channel: stable
+  tag:     v0.7.13
+  commit:  b3e16ef212af81ef37d973ddb86d6816d3804642
+```
+
+외부에서 `GIT_LFS_SKIP_SMUDGE=1`을 주지 않았는데도 통과했다. 즉 `scripts/update-rhwp-core.sh` 내부 변경만으로 release compatibility check checkout 경로가 LFS budget 실패를 회피했다.
+
+### upstream release check wrapper
+
+```bash
+scripts/ci/check-rhwp-upstream-release.sh --target-tag v0.7.13 --run-compatibility-check true
+```
+
+결과: 통과.
+
+```text
+current_tag=v0.7.12
+latest_tag=v0.7.13
+target_tag=v0.7.13
+outdated=true
+compatibility_status=passed
+```
+
+summary에는 target URL `https://github.com/edwardkim/rhwp/releases/tag/v0.7.13`, release name `v0.7.13 — HWPX 렌더링/저장 호환성 + 시험지/공공기관 문서 회귀 정정`, published at `2026-05-26T13:57:15Z`가 기록됐다.
+
+### sync PR checkout 대응 명령
+
+검증 전 `build.noindex/rhwp-upstream`와 `build.noindex/rhwp-upstream-impact`는 존재하지 않았다.
+
+```bash
+GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/edwardkim/rhwp.git build.noindex/rhwp-upstream
+git -C build.noindex/rhwp-upstream config lfs.skipSmudge true
+GIT_LFS_SKIP_SMUDGE=1 git -C build.noindex/rhwp-upstream checkout --detach b3e16ef212af81ef37d973ddb86d6816d3804642
+```
+
+결과: clone과 target commit checkout 모두 통과.
+
+```text
+HEAD is now at b3e16ef2 docs: add extension store submission notes
+```
+
+확인:
+
+```bash
+git -C build.noindex/rhwp-upstream rev-parse HEAD
+git -C build.noindex/rhwp-upstream status --short
+```
+
+결과:
+
+```text
+b3e16ef212af81ef37d973ddb86d6816d3804642
+```
+
+`git status --short` 출력은 비어 있었다.
+
+### impact detection
+
+```bash
+scripts/ci/detect-rhwp-studio-impact.sh \
+  --upstream-dir build.noindex/rhwp-upstream \
+  --current-tag v0.7.12 \
+  --current-commit 1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5 \
+  --target-tag v0.7.13 \
+  --target-commit b3e16ef212af81ef37d973ddb86d6816d3804642 \
+  --output-dir build.noindex/rhwp-upstream-impact
+```
+
+결과: 통과.
+
+```text
+changed paths: `1347`
+impact paths: `427`
+has viewer impact: `true`
+current_tag=v0.7.12
+current_commit=1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5
+target_tag=v0.7.13
+target_commit=b3e16ef212af81ef37d973ddb86d6816d3804642
+has_viewer_impact=true
+impact_reason_count=427
+```
+
+output 파일 line 수:
+
+```text
+1347 build.noindex/rhwp-upstream-impact/changed-v0.7.12-to-v0.7.13.txt
+ 427 build.noindex/rhwp-upstream-impact/impact-v0.7.12-to-v0.7.13.txt
+ 427 build.noindex/rhwp-upstream-impact/impact-details-v0.7.12-to-v0.7.13.tsv
+```
+
+impact path에는 `rhwp-studio/*`, `Cargo.toml`, `rust-toolchain.toml`, `src/*` 등 viewer/WASM/core 영향 경로가 포함됐다.
+
+### 작업트리 검증
+
+```bash
+git status --short --branch
+git diff --check
+```
+
+결과:
+
+```text
+## local/task287
+```
+
+`git diff --check`는 통과했다. `build.noindex/` 산출물은 ignored 경로라 git status에 나타나지 않았다.
+
+## 완료 기준 확인
+
+| 기준 | 결과 |
+|------|------|
+| `v0.7.13` target compatibility check가 LFS 객체 다운로드 없이 통과 | 통과 |
+| upstream release check wrapper가 `compatibility_status=passed` 기록 | 통과 |
+| sync PR checkout 대응 명령이 target commit checkout까지 통과 | 통과 |
+| impact detection이 upstream checkout 입력으로 정상 종료 | 통과 |
+| `rhwp-core.lock`, RustBridge dependency, bundled asset 미변경 | 확인 |
+
+## 잔여 위험
+
+- GitHub-hosted schedule workflow 재실행은 아직 확인하지 않았다. PR 이후 수동 재실행 또는 다음 schedule에서 확인해야 한다.
+- `rhwp-upstream-sync-pr.yml`의 후속 build/sync/PR 생성 단계는 이번 Stage 3의 로컬 검증 범위가 아니다.
+- `build.noindex/rhwp-upstream`는 605M의 재생성 가능 산출물이다. 최종 보고 또는 PR 준비 단계에서 정리 여부를 결정한다.
+
+## 다음 단계 영향
+
+Stage 4에서는 최종 보고서를 작성하고, 오늘할일 #287을 완료 처리한다. 최종 보고서에는 다음을 남긴다.
+
+- 수정 파일과 변경 요약
+- Stage 3 검증 명령과 결과
+- GitHub-hosted workflow 재실행 잔여 확인 항목
+- `rhwp-core.lock`과 bundled `rhwp-studio` asset을 갱신하지 않았다는 제외 범위 확인
+
+## 승인 요청
+
+Stage 3 결과를 승인하면 Stage 4 `최종 보고와 PR 준비`로 진행한다.

--- a/scripts/update-rhwp-core.sh
+++ b/scripts/update-rhwp-core.sh
@@ -310,6 +310,7 @@ init_work_repo() {
   WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/rhwp-core.XXXXXX")"
   git -C "$WORK_DIR" init -q
   git -C "$WORK_DIR" remote add origin "$RHWP_REPO"
+  git -C "$WORK_DIR" config lfs.skipSmudge true
 }
 
 fetch_target() {
@@ -320,13 +321,13 @@ fetch_target() {
       echo "ERROR: dependency fetch failure: could not fetch demo commit $REV" >&2
       exit 1
     fi
-    git -C "$WORK_DIR" checkout -q --detach FETCH_HEAD
+    GIT_LFS_SKIP_SMUDGE=1 git -C "$WORK_DIR" checkout -q --detach FETCH_HEAD
   else
     if ! git -C "$WORK_DIR" fetch --depth 1 origin "refs/tags/$TAG:refs/tags/$TAG"; then
       echo "ERROR: release lookup failure: could not fetch release tag $TAG" >&2
       exit 1
     fi
-    git -C "$WORK_DIR" checkout -q --detach "$TAG"
+    GIT_LFS_SKIP_SMUDGE=1 git -C "$WORK_DIR" checkout -q --detach "$TAG"
   fi
 
   TARGET_COMMIT="$(git -C "$WORK_DIR" rev-parse HEAD)"


### PR DESCRIPTION
## 요약

- 대상 타스크: #287
- 왜: upstream `edwardkim/rhwp` LFS budget 초과가 release 감시와 sync PR workflow를 불필요하게 실패시켰습니다.
- 무엇: upstream 임시 checkout 경로에만 LFS smudge skip을 적용했습니다.
- 리뷰 포인트: 앱 저장소 checkout이나 core/studio provenance 갱신 없이 `scripts/update-rhwp-core.sh`와 `rhwp-upstream-sync-pr.yml`의 upstream checkout만 좁게 바꿨습니다.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/9da8f3555c5e456eb95e3827c757b287dbccf75b/mydocs/working/task_m019_287_stage1.md)** ([a623c03](https://github.com/postmelee/alhangeul-macos/commit/a623c03)): 두 Actions 실패 경로와 LFS smudge 발생 지점을 정리했습니다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/9da8f3555c5e456eb95e3827c757b287dbccf75b/mydocs/working/task_m019_287_stage2.md)** ([21221d4](https://github.com/postmelee/alhangeul-macos/commit/21221d4)): upstream clone/checkout 경로에 `GIT_LFS_SKIP_SMUDGE=1`과 local `lfs.skipSmudge true`를 적용했습니다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/9da8f3555c5e456eb95e3827c757b287dbccf75b/mydocs/working/task_m019_287_stage3.md)** ([7f71409](https://github.com/postmelee/alhangeul-macos/commit/7f71409)): `v0.7.13` release check와 sync checkout/impact detection을 검증했습니다.
- **Stage 4** ([9da8f35](https://github.com/postmelee/alhangeul-macos/commit/9da8f35)): 최종 보고서와 오늘할일 완료 처리를 정리했습니다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `scripts/update-rhwp-core.sh` | 임시 upstream repo에 `lfs.skipSmudge true` 설정, demo/stable checkout에 `GIT_LFS_SKIP_SMUDGE=1` 적용 | `git fetch`는 유지하고 checkout에만 적용했는지 |
| `rhwp-upstream-sync-pr.yml` | upstream clone과 target checkout에 LFS smudge skip 적용 | 앱 저장소 checkout이나 workflow 권한을 바꾸지 않았는지 |
| 작업 문서 | 수행/구현/단계/최종 보고서 추가 | 검증 결과와 잔여 확인 항목이 충분한지 |

- 수행 계획서: [task_m019_287.md](https://github.com/postmelee/alhangeul-macos/blob/9da8f3555c5e456eb95e3827c757b287dbccf75b/mydocs/plans/task_m019_287.md)
- 구현 계획서: [task_m019_287_impl.md](https://github.com/postmelee/alhangeul-macos/blob/9da8f3555c5e456eb95e3827c757b287dbccf75b/mydocs/plans/task_m019_287_impl.md)
- 최종 보고서: [task_m019_287_report.md](https://github.com/postmelee/alhangeul-macos/blob/9da8f3555c5e456eb95e3827c757b287dbccf75b/mydocs/report/task_m019_287_report.md)

## 핵심 리뷰 포인트

- LFS smudge skip이 upstream 임시 checkout 경로에만 적용되어 있는지 확인해 주세요.
- `rhwp-core.lock`, RustBridge dependency, bundled `rhwp-studio` asset을 갱신하지 않은 것이 의도한 범위입니다.
- GitHub-hosted schedule 재실행은 PR merge 이후 수동 dispatch 또는 다음 schedule에서 확인해야 합니다.

## 검증

- `bash -n scripts/update-rhwp-core.sh`
- `bash -n scripts/ci/check-rhwp-upstream-release.sh`
- `ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml"); puts "parsed"'`
- `scripts/update-rhwp-core.sh --check --channel stable --tag v0.7.13`
- `scripts/ci/check-rhwp-upstream-release.sh --target-tag v0.7.13 --run-compatibility-check true`
- `GIT_LFS_SKIP_SMUDGE=1 git clone https://github.com/edwardkim/rhwp.git build.noindex/rhwp-upstream`
- `GIT_LFS_SKIP_SMUDGE=1 git -C build.noindex/rhwp-upstream checkout --detach b3e16ef212af81ef37d973ddb86d6816d3804642`
- `scripts/ci/detect-rhwp-studio-impact.sh --upstream-dir build.noindex/rhwp-upstream --current-tag v0.7.12 --current-commit 1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5 --target-tag v0.7.13 --target-commit b3e16ef212af81ef37d973ddb86d6816d3804642 --output-dir build.noindex/rhwp-upstream-impact`
- `git diff --check devel...HEAD`

## 관련 이슈

- #204
- [실패 run: rhwp Upstream Release Check](https://github.com/postmelee/alhangeul-macos/actions/runs/26491516266/job/78010134497)
- [실패 run: rhwp Upstream Sync PR](https://github.com/postmelee/alhangeul-macos/actions/runs/26491862455)

## 후속 이슈 제안

- 없음

## 남은 리스크

- GitHub-hosted schedule workflow 재실행은 아직 확인하지 않았습니다.
- sync PR workflow의 후속 build/sync/PR 생성 단계는 이번 로컬 검증 범위가 아닙니다.
- LFS smudge skip은 upstream 대용량 fixture 실제 content를 받지 않는 정책입니다.

Closes #287
