### PR TITLE
Task #281: PageLayerTree overlay metadata 입력 연결

### DIFF
--- a/Alhangeul.xcodeproj/project.pbxproj
+++ b/Alhangeul.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		307CE14735FB510DD719EC5F /* Rhwp.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F5AFC8EC56882BF138E698C /* Rhwp.xcframework */; };
 		308D4855D7022391FEF9CCD8 /* ExtensionSystemRegistrationRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E51D4DC8276BF1D36E5FEC /* ExtensionSystemRegistrationRefresher.swift */; };
 		30D861C7707532BC347522CB /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = F6DA732CC42A781180AA2F88 /* libiconv.tbd */; };
+		329C78D1A7232AF2B5ABFD9E /* PageOverlayImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B27A9A00D195F9031B6311 /* PageOverlayImages.swift */; };
 		32DD5646758D0ACBF3392E38 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E931CF12C8BE40BCE94DC51 /* libc++.tbd */; };
 		364457423D706CF1C778334C /* ExtensionStatusModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E524F7A95D1616AB85E3F2 /* ExtensionStatusModel.swift */; };
 		37B400334D28A4A06AC40307 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4457E7F57DA695C2D4A7757 /* CoreServices.framework */; };
@@ -59,6 +60,7 @@
 		72BDAE6714CD21F62B6547CB /* DocumentTerminationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27EB9FF4728E67B683789ECF /* DocumentTerminationCoordinator.swift */; };
 		748E5560ED13294F03F1B627 /* RenderTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A01160D544F0F71CA0C3501 /* RenderTree.swift */; };
 		7499FC7614680941A929F075 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4457E7F57DA695C2D4A7757 /* CoreServices.framework */; };
+		7561FA65463CDF9CC5BED398 /* PageOverlayImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B27A9A00D195F9031B6311 /* PageOverlayImages.swift */; };
 		770901D3A2B2139FB9649377 /* ColorSync.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 82B73611C892296A43FDC8B2 /* ColorSync.framework */; };
 		7A30B489C04C957C050AB78F /* RhwpStudioResourceSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D6D965AEFE52537281289A1 /* RhwpStudioResourceSchemeHandler.swift */; };
 		7BF16A0B1E4314FB46041152 /* HwpPageImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5C316C5FBCECA08C309CF9 /* HwpPageImageRenderer.swift */; };
@@ -121,6 +123,7 @@
 		F24FA4E12F54E4B550A4788E /* Legal in Resources */ = {isa = PBXBuildFile; fileRef = C1A69E945E4D859F3B581701 /* Legal */; };
 		F302D89D0A4823F5453DF142 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D03050B560F60198F4CBBB0 /* Metal.framework */; };
 		F58AD4C2B33C40A260ACFF02 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B74C6D69DBD1D9B163C9A247 /* Security.framework */; };
+		F853A92E67C1E05F3C1C8722 /* PageOverlayImages.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B27A9A00D195F9031B6311 /* PageOverlayImages.swift */; };
 		FF0BB143C6C27AABD7D22C10 /* ImageIO.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D83D8D9F6BF5014474791FB1 /* ImageIO.framework */; };
 /* End PBXBuildFile section */
 
@@ -196,6 +199,7 @@
 		68061986E6786FDE9A0183BD /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		6A01160D544F0F71CA0C3501 /* RenderTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderTree.swift; sourceTree = "<group>"; };
 		6A6F3480DCEB0F0A30DF06A1 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
+		77B27A9A00D195F9031B6311 /* PageOverlayImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageOverlayImages.swift; sourceTree = "<group>"; };
 		7B8D5D5DECBC9E6071002C34 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
 		81391ABAF81F59C2FAE9880D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		82B73611C892296A43FDC8B2 /* ColorSync.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ColorSync.framework; path = System/Library/Frameworks/ColorSync.framework; sourceTree = SDKROOT; };
@@ -403,6 +407,7 @@
 				2B69400B5B8A2851995C68DE /* CGTreeRenderer.swift */,
 				DCF11065A3E3439B4C5B8DD7 /* FontFallback.swift */,
 				DEC2D57719DF9672E7C311D7 /* FontResourceRegistry.swift */,
+				77B27A9A00D195F9031B6311 /* PageOverlayImages.swift */,
 				6A01160D544F0F71CA0C3501 /* RenderTree.swift */,
 				423B5D870B909D2D5D87F3D6 /* RhwpDocument.swift */,
 			);
@@ -677,6 +682,7 @@
 				7BF16A0B1E4314FB46041152 /* HwpPageImageRenderer.swift in Sources */,
 				02E1371B73A762F8E64ED8EF /* HwpPreviewPDFRenderer.swift in Sources */,
 				55993B1F9BBFFBBA62397829 /* LaunchMaintenanceService.swift in Sources */,
+				329C78D1A7232AF2B5ABFD9E /* PageOverlayImages.swift in Sources */,
 				09D138398C713C14EB0266D1 /* RecentDocumentStore.swift in Sources */,
 				44CDAB1946DFA27A7CADCF6D /* RecentDocumentThumbnailRefresher.swift in Sources */,
 				D8932BD515CBB96629CADD55 /* RenderTree.swift in Sources */,
@@ -707,6 +713,7 @@
 				D6ECD4A743DEDC3A090EEEF4 /* HwpPreviewPDFRenderer.swift in Sources */,
 				8348EA8DD0B313DC71B3E9C7 /* HwpThumbnailProvider.swift in Sources */,
 				539DFB38A0293062B5A01ED9 /* HwpThumbnailRenderCache.swift in Sources */,
+				7561FA65463CDF9CC5BED398 /* PageOverlayImages.swift in Sources */,
 				6475910A39D8217C7E004CB8 /* RenderTree.swift in Sources */,
 				477B4C8AC6A0370182751D8F /* RhwpDocument.swift in Sources */,
 			);
@@ -723,6 +730,7 @@
 				DBD45292114D646A364B0B87 /* HwpPageImageRenderer.swift in Sources */,
 				D9E0E7DB88B12FDF40623328 /* HwpPreviewPDFRenderer.swift in Sources */,
 				41C5D25E1060BEF211833C8A /* HwpPreviewProvider.swift in Sources */,
+				F853A92E67C1E05F3C1C8722 /* PageOverlayImages.swift in Sources */,
 				748E5560ED13294F03F1B627 /* RenderTree.swift in Sources */,
 				BCE95338397154D9AC1C61C6 /* RhwpDocument.swift in Sources */,
 			);

--- a/RustBridge/src/lib.rs
+++ b/RustBridge/src/lib.rs
@@ -163,6 +163,17 @@ pub extern "C" fn rhwp_render_page_tree(handle: *const RhwpHandle, page: u32) ->
 }
 
 #[no_mangle]
+pub extern "C" fn rhwp_page_overlay_images(handle: *const RhwpHandle, page: u32) -> *mut c_char {
+    ffi_guard!(handle, ptr::null_mut(), {
+        let h = unsafe { &*handle };
+        match h.doc.get_page_overlay_images_native(page) {
+            Ok(json) => string_to_c(json),
+            Err(_) => ptr::null_mut(),
+        }
+    })
+}
+
+#[no_mangle]
 pub extern "C" fn rhwp_render_page_png(
     handle: *const RhwpHandle,
     page: u32,

--- a/Sources/RhwpCoreBridge/PageOverlayImages.swift
+++ b/Sources/RhwpCoreBridge/PageOverlayImages.swift
@@ -151,7 +151,15 @@ extension RhwpDocument {
             return nil
         }
 
-        let supplements = renderPageTree(at: page).map {
+        return pageOverlayImages(at: page, renderTree: renderPageTree(at: page))
+    }
+
+    func pageOverlayImages(at page: Int, renderTree: RenderNode?) -> RhwpPageOverlayImageSet? {
+        guard page >= 0, page < pageCount else {
+            return nil
+        }
+
+        let supplements = renderTree.map {
             collectPageOverlaySupplements(from: $0, document: self)
         } ?? []
 
@@ -319,7 +327,7 @@ private func collectPageOverlaySupplements(
                     layer: layer,
                     bbox: node.bbox,
                     binDataId: image.binDataId,
-                    binDataAvailable: image.binDataId > 0 && document.imageData(binDataId: image.binDataId) != nil,
+                    binDataAvailable: image.binDataId > 0 && document.hasImageData(binDataId: image.binDataId),
                     effect: image.effect,
                     brightness: image.brightness,
                     contrast: image.contrast,
@@ -347,6 +355,8 @@ private func matchingSupplement(
     in supplements: [RhwpPageOverlayImageSupplement],
     used: inout Set<Int>
 ) -> RhwpPageOverlayImageSupplement? {
+    // Compact overlay JSON currently has no binDataId, so merge supplements by layer plus
+    // bbox from the same render pipeline.
     guard let index = supplements.indices.first(where: { index in
         !used.contains(index)
             && supplements[index].layer == layer
@@ -358,10 +368,13 @@ private func matchingSupplement(
     return supplements[index]
 }
 
+// Render tree and compact overlay bbox values are both in page coordinate units; this absorbs
+// JSON/Float rounding drift.
+private let pageOverlayBboxMatchingTolerance = 0.75
+
 private func bboxApproximatelyEqual(_ lhs: BBox, _ rhs: BBox) -> Bool {
-    let tolerance = 0.75
-    return abs(lhs.x - rhs.x) <= tolerance
-        && abs(lhs.y - rhs.y) <= tolerance
-        && abs(lhs.width - rhs.width) <= tolerance
-        && abs(lhs.height - rhs.height) <= tolerance
+    abs(lhs.x - rhs.x) <= pageOverlayBboxMatchingTolerance
+        && abs(lhs.y - rhs.y) <= pageOverlayBboxMatchingTolerance
+        && abs(lhs.width - rhs.width) <= pageOverlayBboxMatchingTolerance
+        && abs(lhs.height - rhs.height) <= pageOverlayBboxMatchingTolerance
 }

--- a/Sources/RhwpCoreBridge/PageOverlayImages.swift
+++ b/Sources/RhwpCoreBridge/PageOverlayImages.swift
@@ -1,0 +1,367 @@
+import Foundation
+
+struct RhwpPageOverlayImageSet {
+    let behind: [RhwpPageOverlayImage]
+    let front: [RhwpPageOverlayImage]
+    let imageCount: Int
+
+    var overlayImageCount: Int {
+        behind.count + front.count
+    }
+
+    var allImages: [RhwpPageOverlayImage] {
+        behind + front
+    }
+}
+
+enum RhwpPageOverlayLayer: String {
+    case behindText
+    case inFrontOfText
+
+    init?(textWrap: String?) {
+        guard let normalized = textWrap?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() else {
+            return nil
+        }
+        switch normalized {
+        case "behindtext", "behind_text", "behind-text":
+            self = .behindText
+        case "infrontoftext", "in_front_of_text", "in-front-of-text":
+            self = .inFrontOfText
+        default:
+            return nil
+        }
+    }
+}
+
+struct RhwpPageOverlayImage {
+    let layer: RhwpPageOverlayLayer
+    let wrap: String
+    let bbox: BBox
+    let source: RhwpPageOverlayImageSource
+    let effect: String
+    let brightness: Int
+    let contrast: Int
+    let watermarkPreset: String?
+    let bakedWatermark: Bool
+    let transform: RhwpPageOverlayTransform
+    let fillMode: String?
+    let originalSize: [Double]?
+    let originalSizeHU: [Double]?
+    let crop: [Int32]?
+
+    var hasRenderableData: Bool {
+        source.hasRenderableData
+    }
+
+    fileprivate func applying(_ supplement: RhwpPageOverlayImageSupplement?) -> RhwpPageOverlayImage {
+        guard let supplement else {
+            return self
+        }
+        return RhwpPageOverlayImage(
+            layer: layer,
+            wrap: wrap,
+            bbox: bbox,
+            source: source.applying(supplement),
+            effect: effect,
+            brightness: brightness,
+            contrast: contrast,
+            watermarkPreset: watermarkPreset,
+            bakedWatermark: bakedWatermark,
+            transform: transform,
+            fillMode: supplement.fillMode ?? fillMode,
+            originalSize: supplement.originalSize ?? originalSize,
+            originalSizeHU: supplement.originalSizeHU ?? originalSizeHU,
+            crop: supplement.crop ?? crop
+        )
+    }
+}
+
+struct RhwpPageOverlayImageSource {
+    let mime: String
+    let data: Data?
+    let base64Length: Int
+    let binDataId: UInt16?
+    let binDataAvailable: Bool?
+
+    var byteCount: Int {
+        data?.count ?? 0
+    }
+
+    var hasRenderableData: Bool {
+        byteCount > 0 || binDataAvailable == true
+    }
+
+    fileprivate func applying(_ supplement: RhwpPageOverlayImageSupplement) -> RhwpPageOverlayImageSource {
+        RhwpPageOverlayImageSource(
+            mime: mime,
+            data: data,
+            base64Length: base64Length,
+            binDataId: supplement.binDataId,
+            binDataAvailable: supplement.binDataAvailable
+        )
+    }
+}
+
+struct RhwpPageOverlayTransform: Decodable, Equatable {
+    let rotation: Double
+    let horzFlip: Bool
+    let vertFlip: Bool
+
+    static let identity = RhwpPageOverlayTransform(rotation: 0, horzFlip: false, vertFlip: false)
+
+    init(rotation: Double, horzFlip: Bool, vertFlip: Bool) {
+        self.rotation = rotation
+        self.horzFlip = horzFlip
+        self.vertFlip = vertFlip
+    }
+
+    init(_ transform: ShapeTransform) {
+        self.init(
+            rotation: transform.rotation,
+            horzFlip: transform.horzFlip,
+            vertFlip: transform.vertFlip
+        )
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        rotation = try container.decodeIfPresent(Double.self, forKey: .rotation) ?? 0
+        horzFlip = try container.decodeIfPresent(Bool.self, forKey: .horzFlip)
+            ?? container.decodeIfPresent(Bool.self, forKey: .horzFlipSnake)
+            ?? false
+        vertFlip = try container.decodeIfPresent(Bool.self, forKey: .vertFlip)
+            ?? container.decodeIfPresent(Bool.self, forKey: .vertFlipSnake)
+            ?? false
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case rotation
+        case horzFlip
+        case vertFlip
+        case horzFlipSnake = "horz_flip"
+        case vertFlipSnake = "vert_flip"
+    }
+}
+
+extension RhwpDocument {
+    func pageOverlayImages(at page: Int) -> RhwpPageOverlayImageSet? {
+        guard page >= 0, page < pageCount else {
+            return nil
+        }
+
+        let supplements = renderPageTree(at: page).map {
+            collectPageOverlaySupplements(from: $0, document: self)
+        } ?? []
+
+        if let json = pageOverlayImagesJSON(at: page),
+           let data = json.data(using: .utf8),
+           let payload = try? JSONDecoder().decode(RhwpPageOverlayImageSetPayload.self, from: data) {
+            return payload.model(merging: supplements)
+        }
+
+        guard !supplements.isEmpty else {
+            return nil
+        }
+        return RhwpPageOverlayImageSet(
+            behind: supplements
+                .filter { $0.layer == .behindText }
+                .map { $0.fallbackImage() },
+            front: supplements
+                .filter { $0.layer == .inFrontOfText }
+                .map { $0.fallbackImage() },
+            imageCount: supplements.count
+        )
+    }
+}
+
+private struct RhwpPageOverlayImageSetPayload: Decodable {
+    let behind: [RhwpPageOverlayImagePayload]
+    let front: [RhwpPageOverlayImagePayload]
+    let imageCount: Int
+
+    enum CodingKeys: String, CodingKey {
+        case behind
+        case front
+        case imageCount
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        behind = try container.decodeIfPresent([RhwpPageOverlayImagePayload].self, forKey: .behind) ?? []
+        front = try container.decodeIfPresent([RhwpPageOverlayImagePayload].self, forKey: .front) ?? []
+        imageCount = try container.decodeIfPresent(Int.self, forKey: .imageCount) ?? (behind.count + front.count)
+    }
+
+    func model(merging supplements: [RhwpPageOverlayImageSupplement]) -> RhwpPageOverlayImageSet {
+        var usedSupplementIndexes = Set<Int>()
+        let behindImages = behind.map {
+            $0.model(layer: .behindText)
+                .applying(matchingSupplement(
+                    for: $0.bbox,
+                    layer: .behindText,
+                    in: supplements,
+                    used: &usedSupplementIndexes
+                ))
+        }
+        let frontImages = front.map {
+            $0.model(layer: .inFrontOfText)
+                .applying(matchingSupplement(
+                    for: $0.bbox,
+                    layer: .inFrontOfText,
+                    in: supplements,
+                    used: &usedSupplementIndexes
+                ))
+        }
+        return RhwpPageOverlayImageSet(
+            behind: behindImages,
+            front: frontImages,
+            imageCount: imageCount
+        )
+    }
+}
+
+private struct RhwpPageOverlayImagePayload: Decodable {
+    let bbox: BBox
+    let mime: String?
+    let base64: String?
+    let effect: String?
+    let brightness: Int?
+    let contrast: Int?
+    let watermark: RhwpPageOverlayWatermarkPayload?
+    let bakedWatermark: Bool?
+    let wrap: String?
+    let transform: RhwpPageOverlayTransform?
+
+    func model(layer: RhwpPageOverlayLayer) -> RhwpPageOverlayImage {
+        let data = base64.flatMap { Data(base64Encoded: $0) }
+        return RhwpPageOverlayImage(
+            layer: layer,
+            wrap: wrap ?? layer.rawValue,
+            bbox: bbox,
+            source: RhwpPageOverlayImageSource(
+                mime: mime ?? "application/octet-stream",
+                data: data,
+                base64Length: base64?.count ?? 0,
+                binDataId: nil,
+                binDataAvailable: nil
+            ),
+            effect: effect ?? "realPic",
+            brightness: brightness ?? 0,
+            contrast: contrast ?? 0,
+            watermarkPreset: watermark?.preset,
+            bakedWatermark: bakedWatermark == true,
+            transform: transform ?? .identity,
+            fillMode: nil,
+            originalSize: nil,
+            originalSizeHU: nil,
+            crop: nil
+        )
+    }
+}
+
+private struct RhwpPageOverlayWatermarkPayload: Decodable {
+    let preset: String?
+}
+
+private struct RhwpPageOverlayImageSupplement {
+    let layer: RhwpPageOverlayLayer
+    let bbox: BBox
+    let binDataId: UInt16
+    let binDataAvailable: Bool
+    let effect: String?
+    let brightness: Int?
+    let contrast: Int?
+    let transform: RhwpPageOverlayTransform
+    let fillMode: String?
+    let originalSize: [Double]?
+    let originalSizeHU: [Double]?
+    let crop: [Int32]?
+
+    func fallbackImage() -> RhwpPageOverlayImage {
+        RhwpPageOverlayImage(
+            layer: layer,
+            wrap: layer.rawValue,
+            bbox: bbox,
+            source: RhwpPageOverlayImageSource(
+                mime: "application/octet-stream",
+                data: nil,
+                base64Length: 0,
+                binDataId: binDataId,
+                binDataAvailable: binDataAvailable
+            ),
+            effect: effect ?? "realPic",
+            brightness: brightness ?? 0,
+            contrast: contrast ?? 0,
+            watermarkPreset: nil,
+            bakedWatermark: false,
+            transform: transform,
+            fillMode: fillMode,
+            originalSize: originalSize,
+            originalSizeHU: originalSizeHU,
+            crop: crop
+        )
+    }
+}
+
+private func collectPageOverlaySupplements(
+    from root: RenderNode,
+    document: RhwpDocument
+) -> [RhwpPageOverlayImageSupplement] {
+    var supplements: [RhwpPageOverlayImageSupplement] = []
+
+    func visit(_ node: RenderNode) {
+        if case .image(let image) = node.nodeType,
+           let layer = RhwpPageOverlayLayer(textWrap: image.textWrap) {
+            supplements.append(
+                RhwpPageOverlayImageSupplement(
+                    layer: layer,
+                    bbox: node.bbox,
+                    binDataId: image.binDataId,
+                    binDataAvailable: image.binDataId > 0 && document.imageData(binDataId: image.binDataId) != nil,
+                    effect: image.effect,
+                    brightness: image.brightness,
+                    contrast: image.contrast,
+                    transform: RhwpPageOverlayTransform(image.transform),
+                    fillMode: image.fillMode,
+                    originalSize: image.originalSize,
+                    originalSizeHU: image.originalSizeHU,
+                    crop: image.crop
+                )
+            )
+        }
+
+        for child in node.children {
+            visit(child)
+        }
+    }
+
+    visit(root)
+    return supplements
+}
+
+private func matchingSupplement(
+    for bbox: BBox,
+    layer: RhwpPageOverlayLayer,
+    in supplements: [RhwpPageOverlayImageSupplement],
+    used: inout Set<Int>
+) -> RhwpPageOverlayImageSupplement? {
+    guard let index = supplements.indices.first(where: { index in
+        !used.contains(index)
+            && supplements[index].layer == layer
+            && bboxApproximatelyEqual(bbox, supplements[index].bbox)
+    }) else {
+        return nil
+    }
+    used.insert(index)
+    return supplements[index]
+}
+
+private func bboxApproximatelyEqual(_ lhs: BBox, _ rhs: BBox) -> Bool {
+    let tolerance = 0.75
+    return abs(lhs.x - rhs.x) <= tolerance
+        && abs(lhs.y - rhs.y) <= tolerance
+        && abs(lhs.width - rhs.width) <= tolerance
+        && abs(lhs.height - rhs.height) <= tolerance
+}

--- a/Sources/RhwpCoreBridge/RhwpDocument.swift
+++ b/Sources/RhwpCoreBridge/RhwpDocument.swift
@@ -136,6 +136,19 @@ class RhwpDocument {
         return json
     }
 
+    /// 특정 페이지의 overlay image compact JSON 문자열을 반환한다.
+    func pageOverlayImagesJSON(at page: Int) -> String? {
+        guard page >= 0, page < pageCount else {
+            return nil
+        }
+        guard let jsonPtr = rhwp_page_overlay_images(handle, UInt32(page)) else {
+            return nil
+        }
+        let json = String(cString: jsonPtr)
+        rhwp_free_string(jsonPtr)
+        return json
+    }
+
     /// 특정 페이지를 Skia PNG bytes로 렌더링한다.
     func renderPagePNG(
         at page: Int,

--- a/Sources/RhwpCoreBridge/RhwpDocument.swift
+++ b/Sources/RhwpCoreBridge/RhwpDocument.swift
@@ -200,6 +200,19 @@ class RhwpDocument {
         return Data(bytes: ptr, count: len)
     }
 
+    /// 이미지 바이너리의 존재 여부와 길이만 확인한다 (bin_data_id는 1-indexed).
+    func imageDataLength(binDataId: UInt16) -> Int? {
+        var len: Int = 0
+        guard rhwp_image_data(handle, binDataId, &len) != nil, len > 0 else {
+            return nil
+        }
+        return len
+    }
+
+    func hasImageData(binDataId: UInt16) -> Bool {
+        imageDataLength(binDataId: binDataId) != nil
+    }
+
     static func extractEmbeddedThumbnail(from data: Data) -> RhwpEmbeddedThumbnail? {
         guard !data.isEmpty else {
             return nil

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,6 +4,6 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, Stage 2 overlay metadata provider 구현 완료: 검증 통과, Stage 3 승인 대기 |
+| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, Stage 3 metadata smoke 검증 완료: positive overlay fixture 부재 확인, Stage 4 승인 대기 |
 | #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, #286 visual diff 재측정 보강: 14:30, PR 갱신 |
 | #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,6 +4,6 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, Stage 3 metadata smoke 검증 완료: positive overlay fixture 부재 확인, Stage 4 승인 대기 |
+| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, Stage 4 visual baseline/handoff 완료: 최종 보고 승인 대기 |
 | #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, #286 visual diff 재측정 보강: 14:30, PR 갱신 |
 | #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,6 +4,6 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, Stage 1 API inventory 완료: hybrid provider 경로 확정, Stage 2 승인 대기 |
+| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, Stage 2 overlay metadata provider 구현 완료: 검증 통과, Stage 3 승인 대기 |
 | #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, #286 visual diff 재측정 보강: 14:30, PR 갱신 |
 | #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,5 +4,6 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
+| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
 | #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, #286 visual diff 재측정 보강: 14:30, PR 갱신 |
 | #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,6 +4,6 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, v0.7.13 비교 범위 보정 및 구현계획서 작성 후 승인 대기 |
 | #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, #286 visual diff 재측정 보강: 14:30, PR 갱신 |
 | #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,6 +4,6 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, v0.7.13 비교 범위 보정 및 구현계획서 작성 후 승인 대기 |
+| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, Stage 1 API inventory 완료: hybrid provider 경로 확정, Stage 2 승인 대기 |
 | #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, #286 visual diff 재측정 보강: 14:30, PR 갱신 |
 | #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -4,6 +4,6 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 진행중 | M014, Stage 4 visual baseline/handoff 완료: 최종 보고 승인 대기 |
+| #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 완료 | M014, 완료: 15:37, PR 준비 |
 | #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, #286 visual diff 재측정 보강: 14:30, PR 갱신 |
 | #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |

--- a/mydocs/plans/task_m014_281.md
+++ b/mydocs/plans/task_m014_281.md
@@ -1,0 +1,154 @@
+# Task M014 #281 수행계획서
+
+## 목적
+
+`rhwp-studio`가 page canvas 위에 별도 layer로 합성하는 BehindText/InFrontOfText overlay image metadata를 Swift native preview 입력으로 연결한다.
+
+완료 후 작업자는 Quick Look preview, Finder thumbnail, HostApp native viewer가 `rhwp-studio` 기준 flow/overlay 합성 순서를 맞추기 위한 입력 데이터를 Swift에서 읽고 검증할 수 있어야 한다. 실제 CGContext compositor 보강은 후속 #282 범위로 남긴다.
+
+## 배경
+
+#280에서 `rhwp-studio` reference와 native preview visual diff harness를 구축했고, #286에서 readiness와 output stem을 안정화했다. #283에서는 open pipeline 차이를 조사해 `convertToEditable`, stable id, validation/reflow 차이는 M014 즉시 blocker가 아니며, filename/external linked image는 renderer 작업과 분리하는 것이 맞다고 정리했다.
+
+현재 Swift native renderer는 `RhwpDocument.renderPageTree(at:)`로 받은 `RenderNode`와 `CGTreeRenderer`를 사용한다. `RenderTree.swift`에는 `ImageNode`의 `binDataId`, `textWrap`, `effect`, `brightness`, `contrast`, `transform`, `crop` 등이 이미 존재하고, `CGTreeRenderer`는 `BehindText` 이미지를 별도 순서로 일부 처리한다. 다만 #282가 `rhwp-studio`와 같은 background, BehindText overlay, flow, InFrontOfText overlay 합성을 구현하려면 overlay 후보를 renderer 내부 순회 결과가 아니라 명시적인 Swift 입력 모델로 분리해야 한다.
+
+이번 작업은 현행 release tag 기반 rhwp에서 사용 가능한 API만 사용한다. upstream 미릴리즈 commit pin이나 core API 변경은 하지 않는다.
+
+## 범위
+
+포함:
+
+- 현재 고정된 `rhwp-core.lock` release tag에서 dedicated overlay/PageLayerTree API가 존재하는지 확인
+- dedicated API가 있으면 RustBridge C ABI와 Swift wrapper로 page overlay metadata JSON을 노출
+- dedicated API가 없으면 기존 render tree C ABI에서 Swift overlay metadata를 추출하는 fallback contract 구현
+- Swift에서 decode 가능한 `RhwpPageOverlayImage` 계열 모델 추가
+- overlay metadata에 bbox, layer/wrap, binDataId, image bytes availability, effect, brightness, contrast, transform, crop 정보를 보존
+- #282 compositor가 사용할 수 있도록 실패/빈 결과/fallback 의미를 문서화
+- #286 harness를 사용해 변경 전후 visual diff baseline과 metadata smoke 산출물 위치를 기록
+
+제외:
+
+- overlay image를 실제 CGContext에 합성하는 compositor 구현
+- upstream `edwardkim/rhwp` 수정
+- upstream rhwp unreleased commit pin 적용
+- filename field context, base directory, external linked image discovery/injection 구현
+- watermark/effect, fill/tile, RawSvg/OLE/chart, Placeholder/FormObject 렌더 품질 보정
+- signing, notarization, Homebrew 배포 작업
+
+## 설계 방향
+
+먼저 API inventory를 수행한다. `rhwp-core.lock`의 `v0.7.12` 기준 RustBridge가 호출할 수 있는 dedicated overlay/PageLayerTree API가 있으면 그 API를 C ABI로 얇게 감싸고, Swift에서는 JSON string을 decode하는 구조로 둔다.
+
+dedicated API가 현재 release에 없다면 `rhwp_render_page_tree`의 결과에서 overlay candidate를 Swift에서 추출한다. 이 fallback은 #282가 사용할 명시 모델을 먼저 안정화하기 위한 것으로, upstream release에서 dedicated overlay API가 생기면 같은 Swift 모델 뒤쪽의 provider만 교체할 수 있게 둔다.
+
+Swift 모델은 renderer 구현과 분리한다. `CGTreeRenderer`의 기존 동작은 이번 작업에서 바꾸지 않고, `RhwpDocument` 또는 별도 bridge model extension에서 page별 overlay metadata를 얻는 API만 추가한다. 실패 시 기존 `renderPageTree`와 CoreGraphics fallback은 계속 동작해야 한다.
+
+metadata 분류 기준은 다음 순서로 둔다.
+
+- `textWrap == BehindText`는 BehindText overlay 후보
+- `textWrap == InFrontOfText` 또는 그에 준하는 wrap value는 InFrontOfText overlay 후보
+- wrap 값이 없거나 flow object로 해석되는 이미지는 이번 overlay metadata에서 제외하거나 `flow`로 명시해 #282에서 판단하게 한다
+- binDataId가 있으면 `RhwpDocument.imageData(binDataId:)`로 bytes availability만 확인하고, bytes 자체를 metadata JSON에 중복 저장하지 않는다
+
+## 예상 변경 파일
+
+- `mydocs/orders/20260527.md`
+- `mydocs/plans/task_m014_281.md`
+- `mydocs/plans/task_m014_281_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m014_281_stage{N}.md`
+- `mydocs/report/task_m014_281_report.md`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+- 필요 시 `Sources/RhwpCoreBridge/PageOverlayImages.swift`
+- 필요 시 `RustBridge/src/lib.rs`
+- 필요 시 `Frameworks/generated_rhwp.h`
+- 필요 시 `Frameworks/universal/librhwp.a`
+- 필요 시 `rhwp-ffi-symbols.txt`
+- 필요 시 `rhwp-core.lock`
+- 필요 시 `scripts/preview_visual_diff_harness.swift`
+
+## 잠정 단계
+
+1. Stage 1: API inventory와 구현계획 확정
+   - 현행 rhwp release tag, RustBridge ABI, Swift render tree 모델에서 overlay metadata를 얻을 수 있는 경로를 확인한다.
+   - dedicated C ABI 경로와 render tree fallback 경로 중 실제 구현 경로를 고정한다.
+   - #286 harness의 before baseline 명령과 metadata smoke 기준을 구현계획서에 확정한다.
+2. Stage 2: Swift overlay metadata 모델과 provider 구현
+   - `RhwpPageOverlayImage` 계열 모델과 page별 metadata 조회 API를 추가한다.
+   - render tree fallback을 쓰는 경우 `RenderNode` traversal과 layer 분류를 구현한다.
+   - RustBridge를 변경하는 경우 generated header, FFI symbol, lock metadata 정합성을 함께 맞춘다.
+3. Stage 3: metadata smoke와 Swift/Rust bridge 검증
+   - image-heavy sample에서 overlay 후보 개수, layer, bbox, binDataId, bytes availability를 기록한다.
+   - Swift compile 또는 Rust bridge verify를 실행해 ABI/Swift 모델을 검증한다.
+4. Stage 4: visual diff baseline과 #282 handoff
+   - #286 harness로 #282 이전 baseline 수치를 남긴다.
+   - 이번 작업이 실제 compositor를 바꾸지 않았다는 한계와 #282가 사용할 입력 contract를 최종 보고서에 정리한다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+rg -n "#281|PageLayerTree|overlay image|RhwpPageOverlay|M014" \
+  mydocs/orders/20260527.md mydocs/plans/task_m014_281.md
+git diff --check -- mydocs/orders/20260527.md mydocs/plans/task_m014_281.md
+git status --short --branch
+```
+
+구현 단계 후보:
+
+```bash
+rg -n "build_page_render_tree|get_page_overlay|PageLayer|Overlay|textWrap|BehindText|InFrontOfText" \
+  RustBridge/src/lib.rs Sources/RhwpCoreBridge Sources/Shared
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task281-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task281-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task281-syntax-check
+./scripts/preview-visual-diff-harness.sh build.noindex/task281-before-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task281-before-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+git diff --check
+git status --short --branch
+```
+
+RustBridge ABI를 변경하는 경우 추가 검증:
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+rg -n "rhwp_.*overlay|rhwp_render_page_tree|rhwp_image_data" \
+  Frameworks/generated_rhwp.h rhwp-ffi-symbols.txt
+```
+
+## 리스크
+
+- 현재 고정된 `v0.7.12` rhwp release에 dedicated overlay/PageLayerTree native API가 없을 수 있다. 이 경우 이번 작업은 render tree fallback 모델로 진행하거나 Stage 1에서 범위 재승인을 받아야 한다.
+- `rhwp-studio`의 `getPageOverlayImages(pageIdx)`와 Swift render tree fallback의 후보 분류가 완전히 같지 않을 수 있다.
+- compositor 구현은 #282 범위이므로 이번 PR의 visual diff 수치는 크게 개선되지 않을 수 있다.
+- binDataId 기반 embedded image는 확인 가능하지만 external linked image bytes 주입은 이번 범위가 아니다.
+- RustBridge ABI를 추가하면 generated header, symbol lock, staticlib, `rhwp-core.lock` reference metadata를 함께 갱신해야 하므로 검증 비용이 커진다.
+- WebKit 기반 visual diff harness는 sandbox 내부에서 navigation이 시작되지 않을 수 있으므로 #286의 실행 환경 분리 기준을 그대로 사용해야 한다.
+
+## 승인 요청 사항
+
+1. #281을 overlay image metadata 입력 contract 작업으로 진행하는 범위 승인
+2. 현재 rhwp release에 dedicated overlay API가 없으면 render tree fallback으로 Swift 모델을 먼저 안정화하는 방향 승인
+3. 이번 작업에서는 실제 compositor와 renderer 출력 순서를 변경하지 않고, #282 handoff용 metadata API와 검증 산출물만 만드는 방향 승인
+4. upstream unreleased commit pin, filename/base directory/external image resource contract는 이번 작업에서 제외하는 방향 승인
+5. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m014_281_impl.md`) 작성과 Stage 1 API inventory 진행
+
+승인 전에는 RustBridge, Swift source, script, renderer 동작 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m014_281.md
+++ b/mydocs/plans/task_m014_281.md
@@ -12,13 +12,14 @@
 
 현재 Swift native renderer는 `RhwpDocument.renderPageTree(at:)`로 받은 `RenderNode`와 `CGTreeRenderer`를 사용한다. `RenderTree.swift`에는 `ImageNode`의 `binDataId`, `textWrap`, `effect`, `brightness`, `contrast`, `transform`, `crop` 등이 이미 존재하고, `CGTreeRenderer`는 `BehindText` 이미지를 별도 순서로 일부 처리한다. 다만 #282가 `rhwp-studio`와 같은 background, BehindText overlay, flow, InFrontOfText overlay 합성을 구현하려면 overlay 후보를 renderer 내부 순회 결과가 아니라 명시적인 Swift 입력 모델로 분리해야 한다.
 
-이번 작업은 현행 release tag 기반 rhwp에서 사용 가능한 API만 사용한다. upstream 미릴리즈 commit pin이나 core API 변경은 하지 않는다.
+이번 작업은 release tag 기반 rhwp에서 사용 가능한 API만 사용한다. 현재 앱 lock은 `rhwp-core.lock` 기준 `v0.7.12`지만, upstream `v0.7.13` 정식 릴리즈가 배포되었으므로 Stage 1에서 `v0.7.12`와 `v0.7.13`의 overlay/PageLayerTree API와 JSON schema 차이를 함께 확인한다. upstream 미릴리즈 commit pin이나 core API 변경은 하지 않는다.
 
 ## 범위
 
 포함:
 
-- 현재 고정된 `rhwp-core.lock` release tag에서 dedicated overlay/PageLayerTree API가 존재하는지 확인
+- 현재 고정된 `rhwp-core.lock` `v0.7.12`와 upstream 정식 release tag `v0.7.13`에서 dedicated overlay/PageLayerTree API와 schema 차이를 확인
+- `v0.7.13`이 #281 metadata contract에 필요한 필드 또는 렌더 정합 개선을 제공하는지 판단하고, 필요하면 별도 core update 작업으로 분리
 - dedicated API가 있으면 RustBridge C ABI와 Swift wrapper로 page overlay metadata JSON을 노출
 - dedicated API가 없으면 기존 render tree C ABI에서 Swift overlay metadata를 추출하는 fallback contract 구현
 - Swift에서 decode 가능한 `RhwpPageOverlayImage` 계열 모델 추가
@@ -37,7 +38,7 @@
 
 ## 설계 방향
 
-먼저 API inventory를 수행한다. `rhwp-core.lock`의 `v0.7.12` 기준 RustBridge가 호출할 수 있는 dedicated overlay/PageLayerTree API가 있으면 그 API를 C ABI로 얇게 감싸고, Swift에서는 JSON string을 decode하는 구조로 둔다.
+먼저 API inventory를 수행한다. `rhwp-core.lock`의 `v0.7.12` 기준 RustBridge가 호출할 수 있는 dedicated overlay/PageLayerTree API가 있으면 그 API를 C ABI로 얇게 감싸고, Swift에서는 JSON string을 decode하는 구조로 둔다. 동시에 upstream `v0.7.13` tag의 API/schema를 비교해 이번 작업 안에서 lock 갱신이 필요한지 판단하되, 필요성이 확인되면 별도 core update 작업으로 분리한다.
 
 dedicated API가 현재 release에 없다면 `rhwp_render_page_tree`의 결과에서 overlay candidate를 Swift에서 추출한다. 이 fallback은 #282가 사용할 명시 모델을 먼저 안정화하기 위한 것으로, upstream release에서 dedicated overlay API가 생기면 같은 Swift 모델 뒤쪽의 provider만 교체할 수 있게 둔다.
 
@@ -70,7 +71,8 @@ metadata 분류 기준은 다음 순서로 둔다.
 ## 잠정 단계
 
 1. Stage 1: API inventory와 구현계획 확정
-   - 현행 rhwp release tag, RustBridge ABI, Swift render tree 모델에서 overlay metadata를 얻을 수 있는 경로를 확인한다.
+   - 현행 앱 lock `v0.7.12`, upstream release tag `v0.7.13`, RustBridge ABI, Swift render tree 모델에서 overlay metadata를 얻을 수 있는 경로를 확인한다.
+   - `v0.7.13`이 #281 구현 경로에 영향을 주는지 확인하고, core update가 필요하면 이번 이슈와 분리할지 판단한다.
    - dedicated C ABI 경로와 render tree fallback 경로 중 실제 구현 경로를 고정한다.
    - #286 harness의 before baseline 명령과 metadata smoke 기준을 구현계획서에 확정한다.
 2. Stage 2: Swift overlay metadata 모델과 provider 구현
@@ -100,6 +102,8 @@ git status --short --branch
 ```bash
 rg -n "build_page_render_tree|get_page_overlay|PageLayer|Overlay|textWrap|BehindText|InFrontOfText" \
   RustBridge/src/lib.rs Sources/RhwpCoreBridge Sources/Shared
+git ls-remote --tags https://github.com/edwardkim/rhwp.git 'refs/tags/v0.7.13'
+gh release view v0.7.13 --repo edwardkim/rhwp --json tagName,name,publishedAt,isDraft,isPrerelease,body
 swiftc -parse-as-library \
   -module-cache-path build.noindex/task281-swift-module-cache \
   -Xcc -fmodules-cache-path=build.noindex/task281-clang-module-cache \
@@ -136,6 +140,7 @@ rg -n "rhwp_.*overlay|rhwp_render_page_tree|rhwp_image_data" \
 
 ## 리스크
 
+- 현재 고정된 `v0.7.12`와 upstream `v0.7.13`의 overlay/PageLayerTree schema가 다를 수 있다. #281에서 직접 core pin을 올리면 renderer 입력 변경과 dependency update가 섞이므로 Stage 1에서 분리 여부를 명확히 해야 한다.
 - 현재 고정된 `v0.7.12` rhwp release에 dedicated overlay/PageLayerTree native API가 없을 수 있다. 이 경우 이번 작업은 render tree fallback 모델로 진행하거나 Stage 1에서 범위 재승인을 받아야 한다.
 - `rhwp-studio`의 `getPageOverlayImages(pageIdx)`와 Swift render tree fallback의 후보 분류가 완전히 같지 않을 수 있다.
 - compositor 구현은 #282 범위이므로 이번 PR의 visual diff 수치는 크게 개선되지 않을 수 있다.
@@ -148,7 +153,8 @@ rg -n "rhwp_.*overlay|rhwp_render_page_tree|rhwp_image_data" \
 1. #281을 overlay image metadata 입력 contract 작업으로 진행하는 범위 승인
 2. 현재 rhwp release에 dedicated overlay API가 없으면 render tree fallback으로 Swift 모델을 먼저 안정화하는 방향 승인
 3. 이번 작업에서는 실제 compositor와 renderer 출력 순서를 변경하지 않고, #282 handoff용 metadata API와 검증 산출물만 만드는 방향 승인
-4. upstream unreleased commit pin, filename/base directory/external image resource contract는 이번 작업에서 제외하는 방향 승인
-5. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m014_281_impl.md`) 작성과 Stage 1 API inventory 진행
+4. upstream `v0.7.13`은 Stage 1 비교 대상으로 포함하되, 직접 core pin 반영은 필요성이 확인되면 별도 작업으로 분리하는 방향 승인
+5. upstream unreleased commit pin, filename/base directory/external image resource contract는 이번 작업에서 제외하는 방향 승인
+6. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m014_281_impl.md`) 작성과 Stage 1 API inventory 진행
 
 승인 전에는 RustBridge, Swift source, script, renderer 동작 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m014_281_impl.md
+++ b/mydocs/plans/task_m014_281_impl.md
@@ -1,0 +1,303 @@
+# Task M014 #281 구현 계획서
+
+수행계획서: `mydocs/plans/task_m014_281.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #281 PageLayerTree overlay image metadata를 Swift preview 입력으로 연결
+- 마일스톤: M014 (`v0.1.4 Native Preview/Viewer Parity`)
+- 브랜치: `local/task281`
+- 작업 위치: `/Users/melee/Documents/projects/rhwp-mac-task281`
+- 기준 브랜치: `devel`
+- 현재 앱 core lock: `rhwp-core.lock` `v0.7.12` (`1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5`)
+- 비교 대상 upstream release: `v0.7.13` (`b3e16ef212af81ef37d973ddb86d6816d3804642`)
+- 목표: Quick Look preview, Finder thumbnail, HostApp native viewer가 #282에서 같은 compositor 입력을 사용할 수 있도록 page overlay image metadata를 Swift 모델로 안정화한다.
+
+## 구현 원칙
+
+- 이번 작업의 1차 산출물은 overlay image metadata 입력 contract다. 실제 CGContext 합성 순서 변경은 #282에서 수행한다.
+- upstream 미릴리즈 commit pin은 사용하지 않는다.
+- `v0.7.13`은 Stage 1 비교 대상으로 포함하되, core dependency update가 필요하면 별도 작업으로 분리한다.
+- filename field context, base directory, external linked image discovery/injection은 이번 범위에서 제외한다.
+- `Sources/RhwpCoreBridge`에는 AppKit/UIKit/WebKit 의존을 추가하지 않는다.
+- RustBridge ABI를 추가하는 경우 generated header, `rhwp-ffi-symbols.txt`, staticlib, `rhwp-core.lock` 정합성을 함께 검증한다.
+- dedicated overlay/PageLayerTree API를 쓸 수 있으면 그 경로를 우선한다. 사용할 수 없거나 schema가 부족하면 render tree traversal fallback으로 Swift 모델을 먼저 안정화한다.
+
+## 현재 기준 관찰
+
+| 영역 | 현재 관찰 | 구현 판단 |
+|------|-----------|-----------|
+| Swift document wrapper | `RhwpDocument.renderPageTree(at:)`와 `imageData(binDataId:)`가 존재 | render tree fallback으로 overlay 후보와 bytes availability를 만들 수 있다. |
+| Swift render tree model | `ImageNode`가 `binDataId`, `textWrap`, `effect`, `brightness`, `contrast`, `transform`, `crop`을 decode | #282에 필요한 최소 metadata가 이미 일부 존재한다. |
+| CoreGraphics renderer | `CGTreeRenderer`가 `BehindText` 이미지를 별도 순서로 일부 처리 | 기존 renderer 동작은 이번 작업에서 바꾸지 않는다. |
+| RustBridge ABI | 현재 C ABI는 `rhwp_render_page_tree`, `rhwp_image_data`, `rhwp_render_page_png` 중심 | dedicated overlay/PageLayerTree ABI는 Stage 1에서 추가 가능성을 확인한다. |
+| upstream `v0.7.13` | 정식 release이며 HWPX 렌더링/저장 및 조판 회귀 정정 중심 | #281 입력 contract에 schema 개선이 있는지 Stage 1에서 비교한다. |
+
+## 산출물 구조
+
+| 파일 | 역할 |
+|------|------|
+| `mydocs/plans/task_m014_281_impl.md` | 단계별 구현 범위, 검증, 완료 기준 |
+| `mydocs/working/task_m014_281_stage1.md` | `v0.7.12`/`v0.7.13` API inventory와 구현 경로 결정 |
+| `mydocs/working/task_m014_281_stage2.md` | Swift overlay metadata 모델/provider 구현 보고 |
+| `mydocs/working/task_m014_281_stage3.md` | sample metadata smoke와 compile/ABI 검증 보고 |
+| `mydocs/working/task_m014_281_stage4.md` | visual diff baseline과 #282 handoff 보고 |
+| `mydocs/report/task_m014_281_report.md` | 최종 결과와 한계, 후속 작업 정리 |
+| `build.noindex/task281-*` | 검증 산출물. 커밋하지 않는다. |
+
+## Stage 1. API inventory와 구현 경로 확정
+
+### 목표
+
+현재 앱 lock `v0.7.12`와 upstream `v0.7.13`의 overlay/PageLayerTree API와 JSON schema를 비교하고, #281에서 사용할 구현 경로를 확정한다.
+
+### 작업
+
+- `rhwp-core.lock`, `RustBridge/Cargo.toml`, `Cargo.lock`의 현재 core 기준을 확인한다.
+- upstream `v0.7.13` release/tag/resolved commit을 기록한다.
+- `v0.7.12` source cache와 `v0.7.13` remote code에서 다음 API를 확인한다.
+  - `get_page_overlay_images_native`
+  - `get_page_layer_tree_native`
+  - `build_page_layer_tree`
+  - PageLayerTree image paint op JSON schema
+  - `wrap`, `bbox`, `binDataId` 또는 image resource reference, `mime`, `effect`, `brightness`, `contrast`, `watermark`, `transform`, `crop`에 해당하는 필드
+- RustBridge에서 dedicated API를 C ABI로 노출할 수 있는지 확인한다.
+- dedicated ABI가 과한 변경이면 render tree fallback으로 진행할지 결정한다.
+- `v0.7.13` pin 반영이 #281 안에서 필요한지, 별도 core update 작업으로 분리할지 판단한다.
+
+### 산출물
+
+- `mydocs/working/task_m014_281_stage1.md`
+
+### 검증
+
+```bash
+rg -n "rhwp_release_tag|rhwp_commit|rhwp_ref_kind" rhwp-core.lock
+rg -n "rhwp =|source = .*rhwp|name = \"rhwp\"" RustBridge/Cargo.toml RustBridge/Cargo.lock
+git ls-remote --tags https://github.com/edwardkim/rhwp.git 'refs/tags/v0.7.13'
+gh release view v0.7.13 --repo edwardkim/rhwp --json tagName,name,publishedAt,isDraft,isPrerelease,body
+rg -n "get_page_overlay_images_native|get_page_layer_tree_native|build_page_layer_tree|PageLayerTree|PaintOp::Image|BehindText|InFrontOfText" \
+  RustBridge/src/lib.rs Sources/RhwpCoreBridge /Users/melee/.cargo/git/checkouts/rhwp-*
+git diff --check
+```
+
+### 완료 기준
+
+- `v0.7.12`와 `v0.7.13`의 #281 관련 API/schema 차이가 표로 정리된다.
+- 이번 이슈에서 core pin update를 수행할지 여부가 명확히 결정된다.
+- Stage 2 구현 경로가 dedicated ABI 또는 render tree fallback 중 하나로 고정된다.
+- production source는 변경하지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #281 Stage 1: overlay metadata API inventory 정리
+```
+
+## Stage 2. Swift overlay metadata 모델과 provider 구현
+
+### 목표
+
+#282 compositor가 사용할 Swift overlay image metadata 모델과 page별 조회 API를 추가한다.
+
+### 작업
+
+- Swift model을 추가한다.
+  - `RhwpPageOverlayImage`
+  - `RhwpPageOverlayLayer`
+  - `RhwpPageOverlayImageSource`
+  - 필요 시 `RhwpPageOverlayImageSet`
+- page별 metadata 조회 API를 추가한다.
+  - dedicated ABI 경로: RustBridge JSON을 decode
+  - fallback 경로: `renderPageTree(at:)` 결과를 순회해 `ImageNode` 후보 추출
+- metadata에 다음 정보를 보존한다.
+  - layer/wrap
+  - bbox
+  - binDataId
+  - embedded bytes availability
+  - effect, brightness, contrast
+  - transform, crop
+- 실패/빈 결과 semantics를 정리한다.
+  - page out of range
+  - render tree unavailable
+  - overlay 없음
+  - image bytes 없음
+
+### 산출물
+
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+- 필요 시 `Sources/RhwpCoreBridge/PageOverlayImages.swift`
+- 필요 시 `RustBridge/src/lib.rs`
+- 필요 시 `Frameworks/generated_rhwp.h`, `rhwp-ffi-symbols.txt`, `Frameworks/universal/librhwp.a`, `rhwp-core.lock`
+- `mydocs/working/task_m014_281_stage2.md`
+
+### 검증
+
+```bash
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task281-stage2-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task281-stage2-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task281-stage2-syntax-check
+./scripts/check-no-appkit.sh
+git diff --check
+```
+
+RustBridge ABI를 변경하는 경우 추가 검증:
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+rg -n "rhwp_.*overlay|rhwp_.*layer|rhwp_render_page_tree|rhwp_image_data" \
+  Frameworks/generated_rhwp.h rhwp-ffi-symbols.txt
+```
+
+### 완료 기준
+
+- Swift compile이 통과한다.
+- overlay metadata API가 page별로 호출 가능한 형태가 된다.
+- 기존 `renderPageTree`, CoreGraphics render, Skia optional render fallback contract를 깨지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #281 Stage 2: overlay metadata Swift 모델 추가
+```
+
+## Stage 3. metadata smoke와 bridge 검증
+
+### 목표
+
+image-heavy sample에서 overlay metadata가 기대 필드를 보존하는지 확인한다.
+
+### 작업
+
+- sample set에서 page 1 overlay metadata를 추출한다.
+  - `samples/basic/request.hwp`
+  - `samples/hwpx/hwpx-01.hwpx`
+  - `samples/tac-img-02.hwp`
+  - `samples/tac-img-02.hwpx`
+  - `samples/hwp-img-001.hwp`
+  - `samples/img-start-001.hwp`
+- metadata smoke helper가 필요하면 `scripts/`에 최소 script를 추가하거나 기존 harness output에 metadata summary를 추가한다.
+- sample별 overlay count, layer, bbox, binDataId, bytes availability, effect/brightness/contrast/crop/transform 보존 여부를 기록한다.
+- dedicated ABI 경로를 택한 경우 generated C header와 Swift wrapper의 수명/해제 규칙을 검증한다.
+
+### 산출물
+
+- 필요 시 metadata smoke script
+- `build.noindex/task281-stage3-metadata/`
+- `mydocs/working/task_m014_281_stage3.md`
+
+### 검증
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+rg -n "RhwpPageOverlay|overlay|BehindText|InFrontOfText|binDataId|bytesAvailable" \
+  Sources/RhwpCoreBridge Sources/Shared scripts
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task281-stage3-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task281-stage3-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task281-stage3-syntax-check
+git diff --check
+```
+
+### 완료 기준
+
+- sample별 overlay metadata 결과가 보고서에 표로 기록된다.
+- overlay가 없는 sample과 추출 실패 sample이 구분된다.
+- `binDataId`가 있는 embedded image의 bytes availability가 확인된다.
+
+### 커밋 메시지
+
+```text
+Task #281 Stage 3: overlay metadata smoke 검증
+```
+
+## Stage 4. visual diff baseline과 #282 handoff
+
+### 목표
+
+#281이 renderer output을 직접 개선하지 않는 한계를 명확히 하고, #282가 사용할 입력 contract와 baseline 수치를 정리한다.
+
+### 작업
+
+- #286 harness로 #282 이전 baseline을 기록한다.
+- `studio/*.json` overlay metadata와 Swift metadata smoke 결과를 연결해 차이를 정리한다.
+- #282에서 사용할 compositor 입력 contract를 명시한다.
+  - background
+  - BehindText overlay
+  - flow
+  - InFrontOfText overlay
+- 이번 작업에서 제외한 external linked image, filename, base directory 문제를 다시 명시한다.
+- 오늘할일 #281 상태를 단계 완료 상태로 갱신한다.
+
+### 산출물
+
+- `mydocs/working/task_m014_281_stage4.md`
+- `mydocs/report/task_m014_281_report.md` 초안 또는 최종 보고 직전 handoff 메모
+- `mydocs/orders/20260527.md`
+
+### 검증
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+sed -n '1,180p' build.noindex/task281-stage4-basic/summary.md
+sed -n '1,220p' build.noindex/task281-stage4-images/summary.md
+rg -n "ChangedPixels|ChangedPercent|MeanRGBDelta|Overlay|#282|BehindText|InFrontOfText|v0.7.13" \
+  mydocs/working/task_m014_281_stage4.md mydocs/orders/20260527.md
+git diff --check
+git status --short --branch
+```
+
+### 완료 기준
+
+- #282가 바로 참조할 overlay metadata contract와 sample 관찰값이 남는다.
+- visual diff 수치가 개선되지 않아도 그 이유가 “compositor 미구현”으로 설명된다.
+- `v0.7.13` 비교 결론과 core update 분리 여부가 최종 handoff에 남는다.
+
+### 커밋 메시지
+
+```text
+Task #281 Stage 4: overlay metadata handoff 정리
+```
+
+## 승인 요청 사항
+
+1. 위 4단계 구현계획으로 #281을 진행하는 것에 대한 승인
+2. Stage 1에서 `v0.7.12`와 upstream `v0.7.13`을 비교하되 core pin 변경은 하지 않는 범위 승인
+3. Stage 2에서 dedicated ABI가 과하면 render tree fallback으로 Swift metadata contract를 먼저 구현하는 방향 승인
+4. Stage 4까지 실제 compositor 출력 변경은 하지 않고 #282 handoff로 넘기는 방향 승인
+
+승인 전에는 Stage 1 inventory 보고서 작성 외 Swift/Rust source 변경을 진행하지 않는다.

--- a/mydocs/report/task_m014_281_report.md
+++ b/mydocs/report/task_m014_281_report.md
@@ -29,18 +29,18 @@
 
 ## 변경 파일 목록과 영향 범위
 
-| 파일 | 내용 | 영향 |
-|------|------|------|
-| `RustBridge/src/lib.rs` | `rhwp_page_overlay_images` C ABI 추가 | Swift에서 page별 compact overlay JSON을 조회할 수 있다. |
-| `rhwp-ffi-symbols.txt` | 신규 ABI symbol 추가 | FFI 표면 검증 대상에 overlay API가 포함된다. |
-| `Sources/RhwpCoreBridge/RhwpDocument.swift` | `pageOverlayImagesJSON(at:)` raw JSON accessor 추가 | AppKit 의존 없이 bridge 계층에서 metadata를 읽는다. |
-| `Sources/RhwpCoreBridge/PageOverlayImages.swift` | `RhwpPageOverlayImageSet`, layer/source/transform 모델과 merge provider 추가 | #282 compositor 입력으로 사용할 typed metadata를 제공한다. |
-| `rhwp-core.lock` | Rust artifact hash 갱신 | core pin은 `v0.7.12` 그대로 유지하고 local RustBridge 산출물만 재생성했다. |
-| `Alhangeul.xcodeproj/project.pbxproj` | `PageOverlayImages.swift` source phase 반영 | HostApp, Quick Look, Thumbnail target에서 신규 Swift 모델을 빌드한다. |
-| `scripts/overlay-metadata-smoke.sh` | smoke entrypoint 추가 | sample set의 overlay/tree image metadata를 반복 측정한다. |
-| `scripts/overlay_metadata_smoke.swift` | Swift smoke probe 추가 | embedded bytes availability, wrap style, layer count를 JSON/요약으로 출력한다. |
-| `mydocs/plans/task_m014_281*.md` | 수행/구현 계획서 작성 | 하이퍼-워터폴 추적 문서. |
-| `mydocs/working/task_m014_281_stage*.md` | Stage 1-4 보고서 작성 | 단계별 결정, 검증, handoff 기록. |
+| 파일 | 내용 |
+|------|------|
+| `RustBridge/src/lib.rs` | `rhwp_page_overlay_images` C ABI를 추가해 Swift에서 page별 compact overlay JSON을 조회할 수 있게 했다. |
+| `rhwp-ffi-symbols.txt` | 신규 ABI symbol을 FFI 표면 검증 대상에 추가했다. |
+| `Sources/RhwpCoreBridge/RhwpDocument.swift` | `pageOverlayImagesJSON(at:)` raw JSON accessor와 image bytes 존재/길이 조회 helper를 추가했다. |
+| `Sources/RhwpCoreBridge/PageOverlayImages.swift` | `RhwpPageOverlayImageSet`, layer/source/transform 모델과 merge provider를 추가해 #282 compositor 입력으로 사용할 typed metadata를 제공한다. |
+| `rhwp-core.lock` | core pin은 `v0.7.12` 그대로 유지하고 local RustBridge 산출물 hash만 재생성했다. |
+| `Alhangeul.xcodeproj/project.pbxproj` | `PageOverlayImages.swift`를 HostApp, Quick Look, Thumbnail target source phase에 포함했다. |
+| `scripts/overlay-metadata-smoke.sh` | sample set의 overlay/tree image metadata를 반복 측정하는 smoke entrypoint를 추가했다. |
+| `scripts/overlay_metadata_smoke.swift` | embedded bytes availability, wrap style, layer count를 JSON/요약으로 출력하는 Swift smoke probe를 추가했다. |
+| `mydocs/plans/task_m014_281*.md` | 하이퍼-워터폴 수행/구현 계획서를 작성했다. |
+| `mydocs/working/task_m014_281_stage*.md` | 단계별 결정, 검증, handoff를 Stage 1-4 보고서로 기록했다. |
 
 ## 핵심 관찰
 
@@ -99,6 +99,7 @@ Stage 4 visual diff는 #282 이전 baseline이다. #281에서 native renderer/co
 - `./scripts/check-no-appkit.sh`
 - `./scripts/verify-rhwp-studio-assets.sh`
 - `./scripts/overlay-metadata-smoke.sh build.noindex/task281-stage3-metadata`
+- `./scripts/overlay-metadata-smoke.sh build.noindex/task281-reviewfix-metadata`
 - `./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-basic --page 1 ...`
 - `./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-images --page 1 ...`
 - `xcodegen generate`

--- a/mydocs/report/task_m014_281_report.md
+++ b/mydocs/report/task_m014_281_report.md
@@ -1,0 +1,81 @@
+# Task M014 #281 최종 보고서 초안 - PageLayerTree overlay image metadata 입력 연결
+
+## 작업 개요
+
+- 이슈: #281 PageLayerTree overlay image metadata를 Swift preview 입력으로 연결
+- 마일스톤: M014 (`v0.1.4 Native Preview/Viewer Parity`)
+- 브랜치: `local/task281`
+- 목표: #282 native compositor가 사용할 page overlay image metadata 입력 contract를 Swift/macOS bridge에 준비한다.
+
+## 최종 결론 초안
+
+#281은 renderer 출력 개선 작업이 아니라 compositor 입력 contract 작업으로 완료됐다.
+
+- upstream `get_page_overlay_images_native`를 `rhwp_page_overlay_images` C ABI로 노출했다.
+- Swift `RhwpPageOverlayImageSet` provider를 추가했다.
+- compact overlay JSON을 primary source로 사용하고, render tree traversal로 `binDataId`, bytes availability, crop/fill/original size를 보충한다.
+- `v0.7.13`의 `bakedWatermark` field를 optional로 수용해 core update 후 이중 watermark/filter 처리를 피할 수 있게 했다.
+- smoke script로 sample별 overlay metadata와 embedded image bytes availability를 반복 측정할 수 있게 했다.
+- visual diff baseline을 생성했지만, 아직 compositor가 metadata를 사용하지 않으므로 수치는 개선 결과가 아니라 #282 이전 기준값이다.
+
+## 변경 요약
+
+| 영역 | 내용 |
+|------|------|
+| RustBridge | `rhwp_page_overlay_images` ABI 추가 |
+| FFI manifest/lock | `rhwp-ffi-symbols.txt`, `rhwp-core.lock` 갱신 |
+| Swift bridge | `pageOverlayImagesJSON(at:)`, `RhwpPageOverlayImageSet`, `RhwpPageOverlayImage` 추가 |
+| Xcode project | `PageOverlayImages.swift`를 HostApp/QLExtension/ThumbnailExtension에 포함 |
+| Smoke | `scripts/overlay-metadata-smoke.sh`, `scripts/overlay_metadata_smoke.swift` 추가 |
+| Reports | Stage 1-4 보고서 작성 |
+
+## 핵심 관찰
+
+- `v0.7.12`와 `v0.7.13` 모두 overlay/PageLayerTree native API를 제공한다.
+- `v0.7.13`은 `PaintOp::Image`에 resolved payload와 `bakedWatermark` 의미를 추가한다.
+- compact overlay JSON은 Studio path와 가깝지만 `binDataId`, `crop`, `fillMode`, `originalSize`를 직접 제공하지 않는다.
+- 현재 repository sample set에서는 `BehindText`/`InFrontOfText` positive fixture를 찾지 못했다.
+- `imageCount`는 page의 전체 image op count일 수 있으며 behind/front overlay 수와 다르다.
+- Studio capture `overlayCount`는 DOM snapshot rect union용 metadata라 Swift overlay image count와 직접 비교하면 안 된다.
+
+## Visual Baseline
+
+| sample | ChangedPercent | MeanRGBDelta | MaxRGBDelta |
+|--------|----------------|--------------|-------------|
+| `request.hwp` | `18.1021%` | `11.5796` | `255` |
+| `hwpx-01.hwpx` | `15.1839%` | `15.6722` | `255` |
+| `tac-img-02.hwp` | `4.1375%` | `3.7228` | `255` |
+| `tac-img-02.hwpx` | `3.6427%` | `3.3924` | `255` |
+| `hwp-img-001.hwp` | `7.8448%` | `8.2731` | `255` |
+| `img-start-001.hwp` | `14.4365%` | `15.4773` | `255` |
+
+## #282 Handoff
+
+#282는 다음 순서로 진행하는 것이 좋다.
+
+1. overlay-positive fixture를 확보한다.
+2. `RhwpDocument.pageOverlayImages(at:)`를 compositor 입력으로 연결한다.
+3. background -> `behind` -> flow -> `front` 순서의 pass를 명시한다.
+4. `source.data`를 우선 사용하고, 필요하면 `source.binDataId`로 fallback한다.
+5. `bakedWatermark == true`이면 watermark/filter를 중복 적용하지 않는다.
+6. 같은 sample set으로 before/after visual diff를 비교한다.
+
+## 남은 한계
+
+- `v0.7.13` core pin update는 아직 하지 않았다.
+- `bakedWatermark` actual payload는 현재 lock에서 관찰하지 못했다.
+- external linked image, filename, base directory 개선은 별도 작업이다.
+- LaunchServices local DB에는 Stage 3 xcodebuild 후 삭제된 DerivedData app 경로가 stale entry로 남았다. provider root는 `/Applications/Alhangeul.app`만 보였고, 전역 reset은 수행하지 않았다.
+
+## 검증 요약
+
+- `./scripts/build-rust-macos.sh --update-lock`
+- `./scripts/build-rust-macos.sh --verify-lock`
+- `./scripts/check-no-appkit.sh`
+- `./scripts/verify-rhwp-studio-assets.sh`
+- `./scripts/overlay-metadata-smoke.sh build.noindex/task281-stage3-metadata`
+- `./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-basic --page 1 ...`
+- `./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-images --page 1 ...`
+- `xcodegen generate`
+- `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task281-stage3 CODE_SIGNING_ALLOWED=NO build`
+- `git diff --check`

--- a/mydocs/report/task_m014_281_report.md
+++ b/mydocs/report/task_m014_281_report.md
@@ -1,4 +1,4 @@
-# Task M014 #281 최종 보고서 초안 - PageLayerTree overlay image metadata 입력 연결
+# Task M014 #281 최종 보고서 - PageLayerTree overlay image metadata 입력 연결
 
 ## 작업 개요
 
@@ -7,9 +7,18 @@
 - 브랜치: `local/task281`
 - 목표: #282 native compositor가 사용할 page overlay image metadata 입력 contract를 Swift/macOS bridge에 준비한다.
 
-## 최종 결론 초안
+## 작업 요약
 
-#281은 renderer 출력 개선 작업이 아니라 compositor 입력 contract 작업으로 완료됐다.
+#281은 #282 native compositor가 사용할 overlay image 입력 contract를 Swift/macOS bridge까지 연결하는 작업이다. 이번 PR은 실제 compositor 순서나 CGContext drawing을 변경하지 않고, core가 제공하는 PageLayerTree/overlay image metadata를 Swift preview 계층에서 사용할 수 있는 구조와 smoke 측정 기반을 준비했다.
+
+- Stage 1: `v0.7.12` lock과 upstream `v0.7.13`의 overlay/PageLayerTree API 차이를 inventory로 정리했다.
+- Stage 2: RustBridge C ABI와 Swift 모델/provider를 추가했다.
+- Stage 3: overlay metadata smoke script와 Xcode project 반영을 완료했다.
+- Stage 4: visual diff baseline과 #282 handoff를 문서화했다.
+
+## 최종 결론
+
+#281은 renderer 출력 개선 작업이 아니라 compositor 입력 contract 작업으로 완료됐다. 따라서 visual diff 수치는 아직 개선값이 아니라 #282 이전 기준값이다.
 
 - upstream `get_page_overlay_images_native`를 `rhwp_page_overlay_images` C ABI로 노출했다.
 - Swift `RhwpPageOverlayImageSet` provider를 추가했다.
@@ -18,16 +27,20 @@
 - smoke script로 sample별 overlay metadata와 embedded image bytes availability를 반복 측정할 수 있게 했다.
 - visual diff baseline을 생성했지만, 아직 compositor가 metadata를 사용하지 않으므로 수치는 개선 결과가 아니라 #282 이전 기준값이다.
 
-## 변경 요약
+## 변경 파일 목록과 영향 범위
 
-| 영역 | 내용 |
-|------|------|
-| RustBridge | `rhwp_page_overlay_images` ABI 추가 |
-| FFI manifest/lock | `rhwp-ffi-symbols.txt`, `rhwp-core.lock` 갱신 |
-| Swift bridge | `pageOverlayImagesJSON(at:)`, `RhwpPageOverlayImageSet`, `RhwpPageOverlayImage` 추가 |
-| Xcode project | `PageOverlayImages.swift`를 HostApp/QLExtension/ThumbnailExtension에 포함 |
-| Smoke | `scripts/overlay-metadata-smoke.sh`, `scripts/overlay_metadata_smoke.swift` 추가 |
-| Reports | Stage 1-4 보고서 작성 |
+| 파일 | 내용 | 영향 |
+|------|------|------|
+| `RustBridge/src/lib.rs` | `rhwp_page_overlay_images` C ABI 추가 | Swift에서 page별 compact overlay JSON을 조회할 수 있다. |
+| `rhwp-ffi-symbols.txt` | 신규 ABI symbol 추가 | FFI 표면 검증 대상에 overlay API가 포함된다. |
+| `Sources/RhwpCoreBridge/RhwpDocument.swift` | `pageOverlayImagesJSON(at:)` raw JSON accessor 추가 | AppKit 의존 없이 bridge 계층에서 metadata를 읽는다. |
+| `Sources/RhwpCoreBridge/PageOverlayImages.swift` | `RhwpPageOverlayImageSet`, layer/source/transform 모델과 merge provider 추가 | #282 compositor 입력으로 사용할 typed metadata를 제공한다. |
+| `rhwp-core.lock` | Rust artifact hash 갱신 | core pin은 `v0.7.12` 그대로 유지하고 local RustBridge 산출물만 재생성했다. |
+| `Alhangeul.xcodeproj/project.pbxproj` | `PageOverlayImages.swift` source phase 반영 | HostApp, Quick Look, Thumbnail target에서 신규 Swift 모델을 빌드한다. |
+| `scripts/overlay-metadata-smoke.sh` | smoke entrypoint 추가 | sample set의 overlay/tree image metadata를 반복 측정한다. |
+| `scripts/overlay_metadata_smoke.swift` | Swift smoke probe 추가 | embedded bytes availability, wrap style, layer count를 JSON/요약으로 출력한다. |
+| `mydocs/plans/task_m014_281*.md` | 수행/구현 계획서 작성 | 하이퍼-워터폴 추적 문서. |
+| `mydocs/working/task_m014_281_stage*.md` | Stage 1-4 보고서 작성 | 단계별 결정, 검증, handoff 기록. |
 
 ## 핵심 관찰
 
@@ -38,7 +51,24 @@
 - `imageCount`는 page의 전체 image op count일 수 있으며 behind/front overlay 수와 다르다.
 - Studio capture `overlayCount`는 DOM snapshot rect union용 metadata라 Swift overlay image count와 직접 비교하면 안 된다.
 
-## Visual Baseline
+## 변경 전·후 정량 비교
+
+### Overlay Metadata Smoke
+
+Stage 3 smoke는 기본 sample 6개와 image-heavy candidate 15개를 통과했다. 기본 sample에서는 upstream image op가 있는 문서도 compact overlay layer는 모두 `0`이었다. 이는 현재 fixture가 behind/front overlay positive case가 아니라는 뜻이며, #282에서 positive fixture 확보가 필요하다.
+
+| sample | upstream imageCount | Swift overlay images | render tree images | embedded bytes |
+|--------|---------------------|----------------------|--------------------|----------------|
+| `samples/basic/request.hwp` | `1` | `0` | `1` | `1/1` |
+| `samples/hwpx/hwpx-01.hwpx` | `2` | `0` | `2` | `2/2` |
+| `samples/tac-img-02.hwp` | `1` | `0` | `1` | `1/1` |
+| `samples/tac-img-02.hwpx` | `1` | `0` | `1` | `1/1` |
+| `samples/hwp-img-001.hwp` | `4` | `0` | `4` | `4/4` |
+| `samples/img-start-001.hwp` | `0` | `0` | `0` | `0/0` |
+
+Image-heavy 추가 후보 15개도 smoke 기준은 통과했고, 관찰한 최대 upstream imageCount는 `draw-group.hwp`의 `17`이었다. 그러나 이 후보군에서도 behind/front overlay positive case는 확보하지 못했다.
+
+### Visual Baseline
 
 | sample | ChangedPercent | MeanRGBDelta | MaxRGBDelta |
 |--------|----------------|--------------|-------------|
@@ -48,6 +78,8 @@
 | `tac-img-02.hwpx` | `3.6427%` | `3.3924` | `255` |
 | `hwp-img-001.hwp` | `7.8448%` | `8.2731` | `255` |
 | `img-start-001.hwp` | `14.4365%` | `15.4773` | `255` |
+
+Stage 4 visual diff는 #282 이전 baseline이다. #281에서 native renderer/compositor drawing path는 변경하지 않았으므로 위 수치가 개선되거나 악화되는 것을 목표로 삼지 않았다.
 
 ## #282 Handoff
 
@@ -60,14 +92,7 @@
 5. `bakedWatermark == true`이면 watermark/filter를 중복 적용하지 않는다.
 6. 같은 sample set으로 before/after visual diff를 비교한다.
 
-## 남은 한계
-
-- `v0.7.13` core pin update는 아직 하지 않았다.
-- `bakedWatermark` actual payload는 현재 lock에서 관찰하지 못했다.
-- external linked image, filename, base directory 개선은 별도 작업이다.
-- LaunchServices local DB에는 Stage 3 xcodebuild 후 삭제된 DerivedData app 경로가 stale entry로 남았다. provider root는 `/Applications/Alhangeul.app`만 보였고, 전역 reset은 수행하지 않았다.
-
-## 검증 요약
+## 검증 결과
 
 - `./scripts/build-rust-macos.sh --update-lock`
 - `./scripts/build-rust-macos.sh --verify-lock`
@@ -79,3 +104,15 @@
 - `xcodegen generate`
 - `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task281-stage3 CODE_SIGNING_ALLOWED=NO build`
 - `git diff --check`
+
+## 잔여 위험과 한계
+
+- `v0.7.13` core pin update는 아직 하지 않았다. #281은 `v0.7.12` lock 기준으로 forward-compatible optional decode만 준비했다.
+- `bakedWatermark` actual payload는 현재 lock에서 관찰하지 못했다. core update 후 별도 smoke가 필요하다.
+- 현재 sample set에서는 `BehindText`/`InFrontOfText` positive fixture를 찾지 못했다. #282 전 또는 #282 초기에 fixture를 확보해야 compositor pass 검증이 가능하다.
+- external linked image, filename, base directory 개선은 별도 upstream/downstream 작업이다.
+- LaunchServices local DB에는 Stage 3 xcodebuild 후 삭제된 DerivedData app 경로가 stale entry로 남았다. provider root는 `/Applications/Alhangeul.app`만 보였고, 전역 reset은 수행하지 않았다.
+
+## 작업지시자 승인 요청
+
+이 보고서를 기준으로 #281 PR을 `devel` 대상으로 게시하고 리뷰를 요청한다. PR merge 후에는 `pr-merge-cleanup` 절차로 이슈 close, publish branch 삭제, local branch/worktree 정리를 수행한다.

--- a/mydocs/working/task_m014_281_stage1.md
+++ b/mydocs/working/task_m014_281_stage1.md
@@ -1,0 +1,124 @@
+# Task M014 #281 Stage 1 보고서 - overlay metadata API inventory 정리
+
+## 단계 개요
+
+- 이슈: #281 PageLayerTree overlay image metadata를 Swift preview 입력으로 연결
+- 단계: Stage 1. API inventory와 구현 경로 확정
+- 목표: 현재 앱 lock `v0.7.12`와 upstream release `v0.7.13`의 overlay/PageLayerTree API와 JSON schema를 비교하고, #281에서 사용할 구현 경로를 확정한다.
+
+이번 단계는 조사와 문서화만 수행했다. `RustBridge`, Swift source, bundled `rhwp-studio` asset, `rhwp-core.lock`은 수정하지 않았다.
+
+## 기준 버전과 입력
+
+| 항목 | 값 |
+|------|----|
+| 현재 앱 core lock | `v0.7.12` |
+| 현재 앱 resolved commit | `1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5` |
+| 현재 앱 enabled feature | `native-skia` |
+| 비교 대상 upstream release | `v0.7.13` |
+| 비교 대상 resolved commit | `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| release 성격 | 정식 release, draft/pre-release 아님 |
+
+`v0.7.13` release note 기준 주요 범위는 HWPX 렌더링/저장 호환성, 조판 회귀 정정, rhwp-studio/extension UX 보강이다. #281에서 직접 필요한지 확인한 항목은 overlay image metadata, PageLayerTree image paint op, Studio overlay render path다.
+
+## upstream API inventory
+
+| 영역 | `v0.7.12` | `v0.7.13` | #281 영향 |
+|------|-----------|-----------|-----------|
+| `build_page_layer_tree` | 존재 | 존재 | PageLayerTree 기반 metadata 소스는 두 버전 모두 가능하다. |
+| `get_page_layer_tree_native` | 존재 | 존재 | RustBridge C ABI로 문자열 JSON을 노출할 수 있는 upstream 진입점이 이미 있다. |
+| `get_page_overlay_images_native` | 존재 | 존재 | Studio overlay path와 가장 가까운 compact JSON 진입점이다. |
+| `LayerFilter` | `All`, `FlowOnly`, `WrapOnly` | 동일 | behind/front overlay 분리 의미는 유지된다. |
+| PageLayerTree schema minor | `11` | `14` | minor schema가 증가했으므로 Swift decoder는 unknown field를 허용해야 한다. |
+| `PaintOp::Image` | `bbox`, `image` | `bbox`, `image`, optional `resolved` | `v0.7.13`은 resolved image payload를 통해 변환/워터마크 bake 결과를 전달한다. |
+| compact overlay top-level | `behind`, `front`, `imageCount` | 동일 | Swift 입력 contract는 top-level shape를 안정적으로 둘 수 있다. |
+| compact overlay image fields | `bbox`, `mime`, `base64`, `effect`, `brightness`, `contrast`, `wrap`, optional `watermark`, `transform` | 동일 + optional `bakedWatermark` | `bakedWatermark`는 forward-compatible optional field로 모델에 포함할 필요가 있다. |
+| compact overlay의 resource id | 없음 | 없음 | `binDataId`, bytes availability, crop/fill/original size는 compact overlay JSON만으로는 부족하다. |
+| PageLayerTree image JSON | image payload, fill/crop/effect/transform 계열 포함 | resolved payload와 `bakedWatermark` 추가 | 전체 PageLayerTree를 쓰면 더 많은 속성을 얻지만, Swift에서 파싱할 범위가 커진다. |
+
+핵심은 `v0.7.13`이 overlay API를 교체하지 않고 같은 public surface 위에 image payload semantics를 보강했다는 점이다. 따라서 #281에서 입력 contract를 만들 때 `v0.7.12`만 보고 좁게 설계하면 `v0.7.13` update 직후 다시 모델을 고쳐야 한다.
+
+## Studio render path 비교
+
+| 항목 | `v0.7.12` | `v0.7.13` | 판단 |
+|------|-----------|-----------|------|
+| Studio overlay source | `wasm.getPageOverlayImages(pageIdx)` 우선, 실패 시 PageLayerTree fallback | 동일 | native preview도 같은 compact overlay JSON을 우선 입력으로 쓰는 편이 Studio parity에 맞다. |
+| `OverlayImageInfo` | `bbox`, `mime`, `base64`, `effect`, `brightness`, `contrast`, optional `watermark`, `wrap`, `transform` | 동일 + `bakedWatermark?: boolean` | Swift model에 `bakedWatermark` optional을 넣어야 다음 core update를 흡수할 수 있다. |
+| CSS filter/watermark 처리 | effect/brightness/contrast, watermark를 overlay layer에서 적용 | `bakedWatermark`이면 CSS filter와 watermark blend를 건너뜀 | #282 compositor가 `bakedWatermark`를 모르면 v0.7.13 전환 후 워터마크를 이중 처리할 위험이 있다. |
+| CanvasKit/Skia Studio backend | 제한적 | backend/profile 선택 경로 추가 | #281은 backend 전환보다 overlay metadata contract를 먼저 고정한다. |
+
+현재 앱에 bundled된 `Sources/HostApp/Resources/rhwp-studio/rhwp.js`에는 `getPageOverlayImages` wrapper가 있지만, `rhwp.d.ts`에서는 `getPageLayerTree` 선언만 확인되고 `getPageOverlayImages` 선언은 보이지 않는다. 이는 bundled Studio type declaration의 불완전성으로 보이며, Swift bridge 구현 판단에는 직접 blocker가 아니다.
+
+## 앱 bridge inventory
+
+| 영역 | 현재 상태 | 판단 |
+|------|-----------|------|
+| `RustBridge/src/lib.rs` | `rhwp_render_page_tree`, `rhwp_render_page_png`, `rhwp_image_data` 중심 | dedicated overlay/PageLayerTree C ABI는 아직 없다. |
+| `rhwp-ffi-symbols.txt` | `rhwp_image_data`, `rhwp_render_page_png`, `rhwp_render_page_tree` 등만 기록 | 새 ABI를 추가하면 symbol manifest도 함께 갱신해야 한다. |
+| `Sources/RhwpCoreBridge/RhwpDocument.swift` | render tree JSON, page PNG, image data wrapper 보유 | overlay JSON wrapper를 붙일 Swift entry point가 있다. |
+| `Sources/RhwpCoreBridge/RenderTree.swift` `ImageNode` | `binDataId`, `fillMode`, `originalSize`, `originalSizeHU`, `effect`, `brightness`, `contrast`, `textWrap`, `transform`, `crop` decode | compact overlay JSON이 부족한 resource/crop/fill metadata는 render tree fallback/merge로 보충할 수 있다. |
+
+현재 Swift render tree traversal만으로도 overlay 후보와 `binDataId` 기반 bytes availability는 만들 수 있다. 다만 Studio가 실제로 쓰는 overlay bytes와 `v0.7.13`의 resolved/baked payload 의미는 render tree JSON만으로는 얻기 어렵다.
+
+## 구현 경로 결정
+
+Stage 2 구현 경로는 hybrid provider로 고정한다.
+
+1. 1차 입력은 RustBridge C ABI를 새로 추가해 upstream `get_page_overlay_images_native` JSON을 Swift로 전달한다.
+2. Swift model은 compact overlay JSON shape를 기준으로 `behind`, `front`, `imageCount`, image별 `bbox`, `mime`, `base64`, `effect`, `brightness`, `contrast`, `watermark`, `wrap`, `transform`, optional `bakedWatermark`를 decode한다.
+3. `binDataId`, bytes availability, `fillMode`, `originalSize`, `crop`처럼 compact overlay JSON에 없는 정보는 기존 `renderPageTree(at:)` traversal 결과와 병합하거나 보조 provider로 제공한다.
+4. PageLayerTree 전체 JSON C ABI는 Stage 2의 1차 구현 대상에서 제외한다. compact overlay + render tree 보충으로 #282 입력 contract를 만들고, 전체 PageLayerTree parser는 필요한 필드가 더 늘어날 때 별도 판단한다.
+5. #281 안에서는 core pin을 `v0.7.13`으로 올리지 않는다. `v0.7.13`은 `bakedWatermark`/resolved image payload 때문에 preview 정확도에 의미가 있지만, dependency update와 metadata contract 구현을 한 PR에 섞으면 검증 원인이 흐려진다.
+
+## `v0.7.13` 반영 판단
+
+`v0.7.13`은 #281의 구현 방향을 바꿀 만큼 중요하지만, 지금 즉시 pin update를 섞을 필요는 없다.
+
+| 판단 | 이유 |
+|------|------|
+| Stage 2 model에는 `bakedWatermark`를 포함 | `v0.7.13` compact overlay JSON과 Studio path가 이미 이 field를 사용한다. |
+| Stage 2 ABI는 현재 lock `v0.7.12` 기준으로 추가 가능 | `get_page_overlay_images_native`가 `v0.7.12`에도 존재한다. |
+| core update는 별도 작업으로 분리 | `v0.7.13`은 PageLayerTree schema minor와 renderer semantics를 바꾸므로 #281 검증과 dependency update 검증을 분리하는 편이 추적 가능하다. |
+| #282 전 또는 #282 초기에 update 여부 재판단 | `bakedWatermark`가 실제 visual diff에 영향을 줄 수 있으므로 compositor 구현 전후에 별도 core update smoke를 두는 것이 좋다. |
+
+## 관찰된 한계
+
+- `/private/tmp/rhwp-v0.7.13` source 확인 중 Git LFS smudge가 quota 오류로 실패했다. 필요한 Rust/TypeScript source file은 checkout되어 static inventory에는 충분했지만, 해당 임시 clone을 완전한 working tree로 취급하지 않았다.
+- 이번 단계는 source inventory라서 sample별 overlay count나 visual diff 수치는 만들지 않았다. metadata smoke와 수치 비교는 Stage 3-4에서 수행한다.
+- compact overlay JSON은 Studio parity에는 좋지만 `binDataId`, `crop`, `fillMode`, `originalSize`가 없다. 따라서 #282가 resource identity나 crop/fill-aware CGContext 합성을 요구하면 render tree 보충이 필요하다.
+- `v0.7.13`의 resolved payload는 preview 정확도에 유리하지만 현재 앱 lock은 `v0.7.12`다. Stage 2 구현은 optional field 중심으로 forward-compatible하게 두고, 실제 resolved payload 관찰은 core update 이후 가능하다.
+
+## Stage 1 검증
+
+실행:
+
+```bash
+rg -n "rhwp_release_tag|rhwp_commit|rhwp_ref_kind|rhwp_enabled_features" rhwp-core.lock
+rg -n "rhwp =|source = .*rhwp|name = \"rhwp\"" RustBridge/Cargo.toml RustBridge/Cargo.lock
+git ls-remote --tags https://github.com/edwardkim/rhwp.git 'refs/tags/v0.7.13'
+gh release view v0.7.13 --repo edwardkim/rhwp --json tagName,targetCommitish,name,publishedAt,body,isDraft,isPrerelease
+rg -n "get_page_overlay_images_native|get_page_layer_tree_native|build_page_layer_tree|schema_minor_version|ResolvedImagePayload|bakedWatermark|PaintOp::Image|enum LayerFilter" \
+  /Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/1899ef9/src \
+  /private/tmp/rhwp-v0.7.13/src
+rg -n "getPageOverlayImages|getPageLayerTree|bakedWatermark|OverlayImageInfo|createOverlayLayer|CanvasKitLayerRenderer|backend" \
+  /Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/1899ef9/rhwp-studio/src \
+  /private/tmp/rhwp-v0.7.13/rhwp-studio/src \
+  Sources/HostApp/Resources/rhwp-studio/rhwp.d.ts \
+  Sources/HostApp/Resources/rhwp-studio/rhwp.js
+rg -n "rhwp_render_page_tree|rhwp_image_data|rhwp_render_page_png|overlay|layer_tree" \
+  RustBridge/src/lib.rs rhwp-ffi-symbols.txt Sources/RhwpCoreBridge
+git diff --check
+```
+
+결과:
+
+- 현재 lock은 `v0.7.12` release tag와 resolved commit `1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5`로 확인했다.
+- `v0.7.13` release tag는 `b3e16ef212af81ef37d973ddb86d6816d3804642`로 확인했다.
+- `v0.7.12`와 `v0.7.13` 모두 `get_page_overlay_images_native`, `get_page_layer_tree_native`, `build_page_layer_tree`를 제공한다.
+- `v0.7.13`은 `PaintOp::Image`에 resolved image payload와 `bakedWatermark` JSON semantics를 추가한다.
+- 현재 앱 RustBridge에는 overlay/PageLayerTree 전용 C ABI가 없다.
+- 문서 작성 전 production source diff는 없었고, `git diff --check`는 통과했다.
+
+## 다음 단계
+
+Stage 2에서는 위 결정에 따라 RustBridge compact overlay JSON C ABI와 Swift overlay metadata model/provider를 추가한다. 구현은 현재 lock `v0.7.12`에서 동작하게 만들고, model은 `v0.7.13`의 `bakedWatermark`를 optional field로 수용한다. Stage 2 진행은 작업지시자 승인 후 시작한다.

--- a/mydocs/working/task_m014_281_stage2.md
+++ b/mydocs/working/task_m014_281_stage2.md
@@ -1,0 +1,151 @@
+# Task M014 #281 Stage 2 보고서 - overlay metadata Swift 모델 추가
+
+## 단계 개요
+
+- 이슈: #281 PageLayerTree overlay image metadata를 Swift preview 입력으로 연결
+- 단계: Stage 2. Swift overlay metadata 모델과 provider 구현
+- 목표: #282 compositor가 사용할 page별 overlay image metadata 입력 contract를 Swift에서 호출 가능한 형태로 추가한다.
+
+이번 단계에서는 `v0.7.13` core pin update를 하지 않았다. 현재 lock인 `v0.7.12` 위에서 upstream compact overlay API를 C ABI로 노출하고, Swift model은 `v0.7.13`의 `bakedWatermark` field를 optional로 수용하도록 구현했다.
+
+## 변경 파일
+
+| 파일 | 변경 |
+|------|------|
+| `RustBridge/src/lib.rs` | `rhwp_page_overlay_images` C ABI 추가. upstream `DocumentCore::get_page_overlay_images_native(page)` 결과 JSON을 caller-owned C string으로 반환한다. |
+| `rhwp-ffi-symbols.txt` | 새 ABI symbol `rhwp_page_overlay_images` 추가. |
+| `Sources/RhwpCoreBridge/RhwpDocument.swift` | `pageOverlayImagesJSON(at:)` wrapper 추가. page range를 Swift에서 먼저 검증하고 Rust string lifetime을 해제한다. |
+| `Sources/RhwpCoreBridge/PageOverlayImages.swift` | Swift overlay metadata model/provider 추가. compact overlay JSON decode와 render tree supplemental merge를 담당한다. |
+| `rhwp-core.lock` | 같은 `v0.7.12` resolved commit을 유지한 채 RustBridge ABI 변경으로 생성 산출물 sha256/size 갱신. |
+
+`Frameworks/`와 `build.noindex/`는 검증 중 생성된 ignored 산출물이며 커밋 대상이 아니다.
+
+## Swift 입력 contract
+
+추가한 주요 타입:
+
+| 타입 | 역할 |
+|------|------|
+| `RhwpPageOverlayImageSet` | page 단위 overlay metadata container. `behind`, `front`, upstream `imageCount`, 계산값 `overlayImageCount`를 제공한다. |
+| `RhwpPageOverlayLayer` | `behindText`, `inFrontOfText` layer 분류. upstream compact JSON camelCase와 render tree PascalCase를 모두 normalize한다. |
+| `RhwpPageOverlayImage` | bbox, source, effect/brightness/contrast, watermark, `bakedWatermark`, transform, crop/fill/original size를 보존한다. |
+| `RhwpPageOverlayImageSource` | compact overlay의 decoded bytes와 render tree에서 보충한 `binDataId`/bytes availability를 함께 표현한다. |
+| `RhwpPageOverlayTransform` | compact overlay JSON의 `horzFlip`/`vertFlip`과 render tree의 `horz_flip`/`vert_flip` 양쪽 key를 decode한다. |
+
+provider 호출:
+
+```swift
+let overlays = document.pageOverlayImages(at: pageIndex)
+```
+
+처리 순서:
+
+1. page range를 확인한다.
+2. render tree를 읽어 `BehindText`/`InFrontOfText` image node의 `binDataId`, bytes availability, crop/fill/original size를 supplemental metadata로 수집한다.
+3. 새 C ABI `rhwp_page_overlay_images`로 compact overlay JSON을 가져온다.
+4. compact JSON의 `behind`/`front` image를 decode하고 bbox + layer 기준으로 supplemental metadata를 병합한다.
+5. compact JSON이 실패하면 render tree supplemental metadata만으로 fallback image set을 만든다.
+
+## 구현 판단
+
+compact overlay JSON은 Studio path와 가장 가까운 입력이다. 다만 upstream `v0.7.12`와 `v0.7.13` 모두 compact overlay JSON에는 `binDataId`, `crop`, `fillMode`, `originalSize`가 없다. 그래서 Stage 2에서는 compact overlay를 primary source로 두고 render tree traversal을 supplemental source로 병합했다.
+
+`bakedWatermark`는 현재 lock `v0.7.12`에서는 나오지 않지만 `v0.7.13`에서 추가된 field다. Swift model에 optional로 포함했으므로 core update 후 #282 compositor가 이중 watermark/filter 처리를 피할 수 있다.
+
+PageLayerTree 전체 JSON parser는 이번 단계에서 만들지 않았다. #282의 1차 compositor 입력에는 compact overlay + render tree 보충이 더 작고 안정적이며, 전체 PageLayerTree parser는 필요한 field가 더 늘어나는 시점에 별도 판단한다.
+
+## smoke 관찰
+
+임시 probe를 `build.noindex/task281_overlay_probe.swift`로 작성해 커밋하지 않고 실행했다.
+
+실행:
+
+```bash
+build.noindex/task281-overlay-probe \
+  samples/basic/request.hwp \
+  samples/tac-img-02.hwp \
+  samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp \
+  samples/img-start-001.hwp
+```
+
+결과:
+
+| sample | upstream imageCount | overlayImageCount | behind | front | renderable | binLinked |
+|--------|---------------------|-------------------|--------|-------|------------|-----------|
+| `request.hwp` | 1 | 0 | 0 | 0 | 0 | 0 |
+| `tac-img-02.hwp` | 1 | 0 | 0 | 0 | 0 | 0 |
+| `tac-img-02.hwpx` | 1 | 0 | 0 | 0 | 0 | 0 |
+| `hwp-img-001.hwp` | 4 | 0 | 0 | 0 | 0 | 0 |
+| `img-start-001.hwp` | 0 | 0 | 0 | 0 | 0 | 0 |
+
+추가 후보 샘플도 확인했다.
+
+```bash
+build.noindex/task281-overlay-probe \
+  samples/pic-crop-01.hwp samples/pic-in-head-01.hwp samples/pic-in-head-02.hwp \
+  samples/20250130-hongbo.hwp samples/20250130-hongbo-no.hwp \
+  samples/20250130-hongbo_saved.hwp samples/honbo-save.hwp \
+  samples/k-water-rfp.hwp samples/kps-ai.hwp samples/exam_math.hwp \
+  samples/exam_kor.hwp samples/group-drawing-02.hwp samples/draw-group.hwp \
+  samples/group-box.hwp samples/shape-group-02.hwp
+```
+
+관찰:
+
+- 새 C ABI와 Swift provider 호출은 정상 동작했다.
+- 확인한 샘플에서는 `imageCount`가 1-17인 문서가 있었지만 `behind`/`front` overlay는 모두 0이었다.
+- upstream compact overlay의 `imageCount`는 behind/front overlay 수가 아니라 page의 전체 image op count를 포함할 수 있다. 그래서 Swift model에 `imageCount`와 별도로 `overlayImageCount`를 제공했다.
+- 일부 샘플에서 `LAYOUT_OVERFLOW` 로그가 출력됐지만 probe 자체는 성공했다. 이 로그는 기존 core layout 진단 출력이며 새 provider 실패는 아니다.
+
+## 검증
+
+실행:
+
+```bash
+./scripts/build-rust-macos.sh --update-lock
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-studio-assets.sh
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task281-stage2-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task281-stage2-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/PageOverlayImages.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task281-stage2-syntax-check
+rg -n "rhwp_page_overlay_images|RhwpPageOverlay|bakedWatermark|binDataAvailable|imageCount" \
+  RustBridge/src/lib.rs rhwp-ffi-symbols.txt Sources/RhwpCoreBridge
+rg -n "rhwp_page_overlay_images|sha256|size" \
+  Frameworks/generated_rhwp.h Frameworks/modulemap/rhwp.h rhwp-core.lock rhwp-ffi-symbols.txt
+git diff --check
+```
+
+결과:
+
+- `build-rust-macos.sh --update-lock` 통과. generated header와 local `Frameworks/Rhwp.xcframework`에 `rhwp_page_overlay_images`가 포함됐다.
+- `build-rust-macos.sh --verify-lock` 통과. source lock, generated header hash, FFI symbol manifest, staticlib artifact 정합성을 확인했다.
+- `check-no-appkit.sh` 통과. `Sources/RhwpCoreBridge`에 AppKit/UIKit 의존은 추가하지 않았다.
+- `verify-rhwp-studio-assets.sh` 통과.
+- Swift compile 검증 통과.
+- `git diff --check` 통과.
+
+## 한계와 다음 단계
+
+- Stage 2는 metadata provider까지만 구현했다. 실제 CGContext 합성 순서 변경과 visual diff 개선은 #282 범위다.
+- 이번 샘플 smoke에서는 behind/front overlay-positive 문서를 찾지 못했다. Stage 3에서는 더 넓은 sample scan 또는 fixture를 통해 overlay-positive case를 확보해야 한다.
+- `v0.7.13`의 resolved image payload와 `bakedWatermark` 실제 값은 현재 lock `v0.7.12`에서 관찰할 수 없다. core update task 이후 재측정이 필요하다.
+- compact overlay JSON이 resource identity를 직접 주지 않기 때문에 bbox + layer matching으로 render tree metadata를 보충한다. 동일 bbox overlay가 여러 개일 경우 matching은 순서에 의존한다.
+
+Stage 3에서는 metadata smoke를 정식 script 또는 harness output으로 고정하고, sample별 overlay count, bytes availability, `binDataId`, crop/fill/transform 보존 여부를 보고서에 남긴다.

--- a/mydocs/working/task_m014_281_stage3.md
+++ b/mydocs/working/task_m014_281_stage3.md
@@ -1,0 +1,170 @@
+# Task M014 #281 Stage 3 보고서 - overlay metadata smoke 검증
+
+## 단계 개요
+
+- 이슈: #281 PageLayerTree overlay image metadata를 Swift preview 입력으로 연결
+- 단계: Stage 3. metadata smoke와 bridge 검증
+- 목표: Stage 2에서 추가한 overlay metadata provider가 샘플 문서에서 반복 실행 가능한 검증 명령으로 동작하는지 확인하고, sample별 metadata 결과를 기록한다.
+
+이번 단계에서는 renderer output을 변경하지 않았다. Stage 3 산출물은 smoke script, Xcode project 재생성 반영, 검증 보고서다.
+
+## 변경 파일
+
+| 파일 | 변경 |
+|------|------|
+| `scripts/overlay-metadata-smoke.sh` | overlay metadata smoke shell wrapper 추가. Framework/modulemap 확인, Swift helper compile, 기본 sample set 실행을 담당한다. |
+| `scripts/overlay_metadata_smoke.swift` | page별 overlay compact JSON, Swift provider 결과, render tree image summary를 `summary.md`, `metadata.jsonl`, per-file JSON으로 출력한다. |
+| `Alhangeul.xcodeproj/project.pbxproj` | `xcodegen generate`로 `PageOverlayImages.swift`를 HostApp, QLExtension, ThumbnailExtension source phase에 반영했다. |
+| `mydocs/orders/20260527.md` | #281 Stage 3 완료와 Stage 4 승인 대기 상태로 갱신했다. |
+
+## smoke script contract
+
+실행 예:
+
+```bash
+./scripts/overlay-metadata-smoke.sh build.noindex/task281-stage3-metadata
+./scripts/overlay-metadata-smoke.sh build.noindex/task281-stage3-metadata --page 1 samples/basic/request.hwp
+```
+
+기본 입력은 #281 계획서의 page 1 sample set이다.
+
+- `samples/basic/request.hwp`
+- `samples/hwpx/hwpx-01.hwpx`
+- `samples/tac-img-02.hwp`
+- `samples/tac-img-02.hwpx`
+- `samples/hwp-img-001.hwp`
+- `samples/img-start-001.hwp`
+
+출력:
+
+| artifact | 내용 |
+|----------|------|
+| `summary.md` | sample별 status, upstream imageCount, overlay count, render tree image/bytes availability 요약 |
+| `metadata.jsonl` | input당 JSON object 1개 |
+| `metadata/*-overlay.json` | input별 pretty-printed metadata |
+
+## 기본 sample 결과
+
+실행:
+
+```bash
+./scripts/overlay-metadata-smoke.sh build.noindex/task281-stage3-metadata
+```
+
+결과:
+
+| sample | status | pageCount | upstream imageCount | overlay | behind | front | tree images | tree embedded available | wraps |
+|--------|--------|-----------|---------------------|---------|--------|-------|-------------|-------------------------|-------|
+| `request.hwp` | OK | 1 | 1 | 0 | 0 | 0 | 1 | 1/1 | `TopAndBottom:1` |
+| `hwpx-01.hwpx` | OK | 9 | 2 | 0 | 0 | 0 | 2 | 2/2 | `TopAndBottom:2` |
+| `tac-img-02.hwp` | OK | 66 | 1 | 0 | 0 | 0 | 1 | 1/1 | `TopAndBottom:1` |
+| `tac-img-02.hwpx` | OK | 69 | 1 | 0 | 0 | 0 | 1 | 1/1 | `TopAndBottom:1` |
+| `hwp-img-001.hwp` | OK | 1 | 4 | 0 | 0 | 0 | 4 | 4/4 | `Square:1, TopAndBottom:3` |
+| `img-start-001.hwp` | OK | 3 | 0 | 0 | 0 | 0 | 0 | 0/0 | `-` |
+
+관찰:
+
+- 여섯 샘플 모두 문서 open, overlay JSON 호출, Swift provider decode, render tree scan이 성공했다.
+- `upstream imageCount`는 overlay 수가 아니라 page layer tree의 전체 image op count로 해석해야 한다. `request.hwp`처럼 imageCount가 1이어도 behind/front overlay count는 0일 수 있다.
+- 기본 sample set에는 `BehindText`/`InFrontOfText` overlay-positive case가 없었다.
+- embedded image가 있는 기본 샘플은 모두 `imageData(binDataId:)` bytes availability가 확인됐다.
+- 일부 샘플에서 `LAYOUT_OVERFLOW` 로그가 출력됐지만 smoke exit status는 성공이었다. 기존 core layout diagnostic 출력이며 provider failure는 아니다.
+
+## 추가 image-heavy 후보 scan
+
+overlay-positive fixture가 있는지 확인하기 위해 image-heavy 후보 15개를 추가로 실행했다.
+
+```bash
+./scripts/overlay-metadata-smoke.sh build.noindex/task281-stage3-metadata-candidates \
+  samples/pic-crop-01.hwp samples/pic-in-head-01.hwp samples/pic-in-head-02.hwp \
+  samples/20250130-hongbo.hwp samples/20250130-hongbo-no.hwp \
+  samples/20250130-hongbo_saved.hwp samples/honbo-save.hwp \
+  samples/k-water-rfp.hwp samples/kps-ai.hwp samples/exam_math.hwp \
+  samples/exam_kor.hwp samples/group-drawing-02.hwp samples/draw-group.hwp \
+  samples/group-box.hwp samples/shape-group-02.hwp
+```
+
+결과 요약:
+
+| 범위 | 결과 |
+|------|------|
+| 성공 sample | 15/15 |
+| upstream imageCount 최대값 | `draw-group.hwp` 17 |
+| behind/front overlay-positive sample | 0 |
+| embedded image bytes availability | image가 있는 sample은 모두 available |
+
+따라서 현재 repository sample set 기준으로는 overlay provider 호출과 bytes 보존은 검증됐지만, 실제 `BehindText`/`InFrontOfText` overlay metadata 병합은 positive fixture 없이 정적 경로 검증에 머물렀다.
+
+## bridge와 build 검증
+
+실행:
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+rg -n "RhwpPageOverlay|overlay|BehindText|InFrontOfText|binDataId|bytesAvailable|binDataAvailable|rhwp_page_overlay_images" \
+  Sources/RhwpCoreBridge Sources/Shared scripts
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task281-stage3-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task281-stage3-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/PageOverlayImages.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task281-stage3-syntax-check
+./scripts/build-rust-macos.sh --verify-lock
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task281-stage3 \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+git diff --check
+```
+
+결과:
+
+- `verify-rhwp-studio-assets.sh` 통과.
+- `check-no-appkit.sh` 통과.
+- Swift compile 검증 통과.
+- `build-rust-macos.sh --verify-lock` 통과. `rhwp_page_overlay_images` symbol, generated header, `rhwp-core.lock` 정합성이 유지된다.
+- `xcodegen generate` 후 `PageOverlayImages.swift`가 HostApp, QLExtension, ThumbnailExtension source phase에 포함됐다.
+- `xcodebuild` HostApp Debug build 통과. QLExtension/ThumbnailExtension도 dependency로 함께 build됐다.
+
+## registration hygiene 관찰
+
+`xcodebuild`가 `build.noindex/DerivedData-task281-stage3/.../Alhangeul.app`을 LaunchServices에 등록했다. 정책상 개발 등록을 남기지 않기 위해 다음을 수행했다.
+
+```bash
+./scripts/check-extension-registration-hygiene.sh --cleanup-dev-registrations
+rm -rf build.noindex/DerivedData-task281-stage3
+/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister -gc
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+최종 상태:
+
+- 개발 app bundle 파일은 제거됐다.
+- PlugInKit provider root는 `/Applications/Alhangeul.app`만 보였다.
+- 그러나 LaunchServices dump에는 삭제된 `build.noindex/DerivedData-task281-stage3/.../Alhangeul.app` 경로가 stale entry로 계속 남아 `check-extension-registration-hygiene.sh --check-only`가 실패했다.
+
+이번 stale entry는 Stage 3 source 변경의 기능 회귀가 아니라 local LaunchServices DB 잔류로 판단한다. 다음 Quick Look/Thumbnail registration smoke 전에 hygiene check를 다시 실행해 사라졌는지 확인해야 한다. 전역 LaunchServices reset은 수행하지 않았다.
+
+## 한계와 다음 단계
+
+- 현재 sample set에서는 `BehindText`/`InFrontOfText` positive case를 찾지 못했다. Stage 4 또는 #282에서는 positive fixture 확보가 필요하다.
+- `v0.7.13`의 `bakedWatermark` actual payload는 현재 lock `v0.7.12`에서 관찰할 수 없다. core update 후 같은 smoke로 재측정해야 한다.
+- Stage 3는 metadata 추출과 build 검증만 수행했다. native compositor 합성과 visual diff 개선은 #282 범위다.
+
+Stage 4에서는 이 입력 contract를 #282 handoff로 정리하고, visual diff baseline과 한계를 명확히 기록한다.

--- a/mydocs/working/task_m014_281_stage4.md
+++ b/mydocs/working/task_m014_281_stage4.md
@@ -1,0 +1,147 @@
+# Task M014 #281 Stage 4 보고서 - overlay metadata handoff 정리
+
+## 단계 개요
+
+- 이슈: #281 PageLayerTree overlay image metadata를 Swift preview 입력으로 연결
+- 단계: Stage 4. visual diff baseline과 #282 handoff
+- 목표: #281이 renderer output을 직접 개선하지 않는 한계를 명확히 하고, #282가 사용할 입력 contract와 baseline 수치를 정리한다.
+
+이번 단계에서는 production renderer/compositor 동작을 변경하지 않았다. Stage 2-3에서 만든 overlay metadata provider를 #282의 입력 contract로 고정하고, #286 harness로 #282 이전 visual baseline을 기록했다.
+
+## visual diff baseline
+
+공통 조건:
+
+- Page: 1
+- Native policy: `coreGraphicsOnly`
+- Studio release: `v0.7.12`
+- Studio resolved commit: `1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5`
+- Viewport: `1400x1800`
+- Settle: `120ms`
+- Diff pixel threshold: `12`
+
+기본 sample:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+image-heavy sample:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+결과:
+
+| sample | Status | StudioSize | NativeSize | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend | NativeMs |
+|--------|--------|------------|------------|---------------|----------------|--------------|-------------|---------------|---------------|----------|
+| `request.hwp` | OK | `1133x1587` | `567x794` | `325488/1798071` | `18.1021%` | `11.5796` | `255` | `canvasDataURL` | `coreGraphics` | `1004.2` |
+| `hwpx-01.hwpx` | OK | `1587x2245` | `794x1123` | `540973/3562815` | `15.1839%` | `15.6722` | `255` | `canvasDataURL` | `coreGraphics` | `40.0` |
+| `tac-img-02.hwp` | OK | `1587x2245` | `794x1123` | `147412/3562815` | `4.1375%` | `3.7228` | `255` | `canvasDataURL` | `coreGraphics` | `1029.2` |
+| `tac-img-02.hwpx` | OK | `1587x2245` | `794x1123` | `129783/3562815` | `3.6427%` | `3.3924` | `255` | `canvasDataURL` | `coreGraphics` | `7.8` |
+| `hwp-img-001.hwp` | OK | `1587x2245` | `794x1123` | `279494/3562815` | `7.8448%` | `8.2731` | `255` | `canvasDataURL` | `coreGraphics` | `19.3` |
+| `img-start-001.hwp` | OK | `1587x2244` | `794x1123` | `514115/3561228` | `14.4365%` | `15.4773` | `255` | `canvasDataURL` | `coreGraphics` | `34.6` |
+
+산출물:
+
+- `build.noindex/task281-stage4-basic/summary.md`
+- `build.noindex/task281-stage4-images/summary.md`
+- 각 directory의 `studio/`, `native/`, `diff/` PNG/JSON
+
+## Studio capture metadata와 Swift metadata 비교
+
+`studio/*.json`의 `overlayCount`는 Studio snapshot rect 계산에서 사용한 DOM overlay 후보 수다. Stage 3의 Swift `overlayImageCount`는 upstream `get_page_overlay_images_native`의 `behind`/`front` image 수다. 두 값은 같은 개념이 아니다.
+
+| sample | Studio overlayCount | Studio usedOverlayUnion | Swift upstream imageCount | Swift overlayImageCount | TreeImages | EmbeddedAvailable | Wraps |
+|--------|---------------------|-------------------------|---------------------------|-------------------------|------------|-------------------|-------|
+| `request.hwp` | 1 | true | 1 | 0 | 1 | 1/1 | `TopAndBottom:1` |
+| `hwpx-01.hwpx` | 1 | true | 2 | 0 | 2 | 2/2 | `TopAndBottom:2` |
+| `tac-img-02.hwp` | 0 | false | 1 | 0 | 1 | 1/1 | `TopAndBottom:1` |
+| `tac-img-02.hwpx` | 1 | true | 1 | 0 | 1 | 1/1 | `TopAndBottom:1` |
+| `hwp-img-001.hwp` | 1 | true | 4 | 0 | 4 | 4/4 | `Square:1, TopAndBottom:3` |
+| `img-start-001.hwp` | 1 | true | 0 | 0 | 0 | 0/0 | `-` |
+
+해석:
+
+- #281 provider는 page별 overlay JSON 호출과 render tree supplemental scan을 정상 수행한다.
+- 현재 sample set은 `BehindText`/`InFrontOfText` positive fixture가 아니므로 Swift overlay image array는 비어 있다.
+- `imageCount`가 0보다 커도 wrap이 `TopAndBottom` 또는 `Square`이면 #282 overlay compositor 대상이 아니다.
+- Studio capture의 DOM overlayCount는 canvas/snapshot union 보정용 metadata라 renderer overlay image count로 해석하면 안 된다.
+
+## #282 compositor 입력 contract
+
+#282는 다음 네 계층을 명시적으로 다루는 compositor로 진행한다.
+
+| 계층 | 입력 | #281 제공 여부 | #282 처리 |
+|------|------|---------------|-----------|
+| Background | render tree page background, existing `CGTreeRenderer` background path | 기존 renderer 제공 | 현행 동작 유지 또는 background pass 명시화 |
+| BehindText overlay | `RhwpPageOverlayImageSet.behind` | 제공 | flow content 전에 image source를 합성 |
+| Flow | 기존 render tree traversal | 기존 renderer 제공 | 현재 CoreGraphics render path 유지 |
+| InFrontOfText overlay | `RhwpPageOverlayImageSet.front` | 제공 | flow content 후 image source를 합성 |
+
+`RhwpPageOverlayImage`에서 #282가 우선 사용할 field:
+
+| field | 목적 |
+|-------|------|
+| `layer`, `wrap` | behind/front 분리와 원본 wrap 의미 보존 |
+| `bbox` | page coordinate 기준 draw rect |
+| `source.data` | compact overlay JSON에서 온 resolved/converted image bytes |
+| `source.binDataId`, `source.binDataAvailable` | render tree supplemental resource identity와 fallback bytes lookup |
+| `effect`, `brightness`, `contrast` | image effect/filter 적용 판단 |
+| `watermarkPreset`, `bakedWatermark` | watermark 이중 처리 방지, `v0.7.13` forward compatibility |
+| `transform` | rotation/flip 적용 |
+| `fillMode`, `originalSize`, `originalSizeHU`, `crop` | compact JSON에 없는 fill/crop/original size 보충 |
+
+권장 합성 순서:
+
+1. page background를 그린다.
+2. `overlays.behind`를 bbox/transform/crop/fill 기준으로 그린다.
+3. flow render tree를 그린다.
+4. `overlays.front`를 그린다.
+5. `bakedWatermark == true`인 image에는 별도 watermark/filter를 중복 적용하지 않는다.
+
+## 제외 범위와 follow-up
+
+이번 #281에서 제외한 항목:
+
+| 항목 | 이유 | 후속 |
+|------|------|------|
+| 실제 CGContext 합성 변경 | #281은 input contract 작업 | #282 |
+| `v0.7.13` core pin update | dependency update와 metadata contract 구현을 분리 | 별도 core update 또는 #282 초입 재판단 |
+| `bakedWatermark` actual payload 검증 | 현재 lock `v0.7.12`에서는 field가 나오지 않음 | `v0.7.13` update 후 smoke 재측정 |
+| external linked image discovery/injection | 앱 open contract/base directory 문제와 얽힘 | 별도 upstream/downstream task |
+| filename/base directory 전달 개선 | #281 overlay metadata 범위 밖 | 별도 open contract task |
+| positive overlay fixture 확보 | 현재 sample set에서 없음 | #282 전 fixture 추가 또는 upstream sample 확보 |
+
+## 결론
+
+#281은 #282가 사용할 metadata 입력을 준비했다. 하지만 renderer가 이 metadata를 아직 사용하지 않으므로 Stage 4 visual diff 수치는 개선 결과가 아니라 #282 이전 baseline이다.
+
+현재 baseline의 `ChangedPercent` 범위는 `3.6427%`부터 `18.1021%`까지다. 이 차이에는 overlay compositor 미구현뿐 아니라 text/layout/image effect 차이도 포함될 수 있으므로, #282는 overlay-positive fixture를 확보한 뒤 before/after diff를 따로 측정해야 한다.
+
+## Stage 4 검증
+
+실행:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+sed -n '1,180p' build.noindex/task281-stage4-basic/summary.md
+sed -n '1,220p' build.noindex/task281-stage4-images/summary.md
+jq -r '[.fileName, .upstreamImageCount, .overlayImageCount, .behindCount, .frontCount, .treeImageCount] | @tsv' \
+  build.noindex/task281-stage3-metadata/metadata.jsonl
+git diff --check
+```
+
+결과:
+
+- visual diff harness는 6개 sample 모두 OK.
+- Stage 3 metadata artifact와 Stage 4 Studio capture artifact를 연결해 overlay count 개념 차이를 확인했다.
+- `git diff --check` 통과.

--- a/rhwp-core.lock
+++ b/rhwp-core.lock
@@ -4,15 +4,15 @@ rhwp_ref_kind = "release-tag"
 rhwp_release_tag = "v0.7.12"
 rhwp_commit = "1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5"
 rhwp_enabled_features = "native-skia"
-built_at = "2026-05-18T04:14:34Z"
+built_at = "2026-05-27T06:08:40Z"
 ffi_symbols_file = "rhwp-ffi-symbols.txt"
 
 [[artifacts]]
 path = "Frameworks/universal/librhwp.a"
-sha256 = "771bfd8808c1a8a47ea4e18df8c75061d895db45c5de8ab018d767f050808eb3"
-size = 200487096
+sha256 = "d0513faa5fddd6b1575a15756f74712686d68910a36614f61db9077caaec6360"
+size = 200488800
 
 [[artifacts]]
 path = "Frameworks/generated_rhwp.h"
-sha256 = "96e887f748a97223c1da04fddbd454638b0c40cf49b62dc2a55a18700c303d0c"
-size = 1978
+sha256 = "31ed496ccbe86082885a82c584166669e1913a552dba26556ef5182842959601"
+size = 2059

--- a/rhwp-ffi-symbols.txt
+++ b/rhwp-ffi-symbols.txt
@@ -5,6 +5,7 @@ rhwp_free_string
 rhwp_image_data
 rhwp_open
 rhwp_page_count
+rhwp_page_overlay_images
 rhwp_page_size
 rhwp_render_page_png
 rhwp_render_page_svg

--- a/scripts/overlay-metadata-smoke.sh
+++ b/scripts/overlay-metadata-smoke.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PAGE_NUMBER=1
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 <output-dir> [--page N] [hwp-or-hwpx ...]
+
+Builds and runs an overlay metadata smoke helper. When no input documents are
+provided, the #281 default sample set is used. Page numbers are 1-based.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -lt 1 ]; then
+  usage
+  exit 1
+fi
+
+OUT_DIR="$1"
+shift
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --page)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --page requires a positive integer" >&2
+        exit 1
+      fi
+      PAGE_NUMBER="$2"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "ERROR: unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+case "$PAGE_NUMBER" in
+  ''|*[!0-9]*)
+    echo "ERROR: --page must be a positive integer" >&2
+    exit 1
+    ;;
+  0)
+    echo "ERROR: --page must be greater than 0" >&2
+    exit 1
+    ;;
+esac
+
+INPUTS=("$@")
+if [ "${#INPUTS[@]}" -eq 0 ]; then
+  INPUTS=(
+    "$ROOT/samples/basic/request.hwp"
+    "$ROOT/samples/hwpx/hwpx-01.hwpx"
+    "$ROOT/samples/tac-img-02.hwp"
+    "$ROOT/samples/tac-img-02.hwpx"
+    "$ROOT/samples/hwp-img-001.hwp"
+    "$ROOT/samples/img-start-001.hwp"
+  )
+fi
+
+LIB="$ROOT/Frameworks/universal/librhwp.a"
+MODULEMAP_DIR="$ROOT/Frameworks/modulemap"
+if [ ! -f "$LIB" ]; then
+  echo "ERROR: missing $LIB" >&2
+  echo "Run: $ROOT/scripts/build-rust-macos.sh" >&2
+  exit 1
+fi
+if [ ! -f "$MODULEMAP_DIR/module.modulemap" ]; then
+  echo "ERROR: missing $MODULEMAP_DIR/module.modulemap" >&2
+  echo "Run: $ROOT/scripts/build-rust-macos.sh" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+BIN="$OUT_DIR/overlay_metadata_smoke"
+SWIFT_MODULE_CACHE="$OUT_DIR/swift-module-cache-overlay-metadata"
+CLANG_MODULE_CACHE="$OUT_DIR/clang-module-cache-overlay-metadata"
+rm -rf "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
+mkdir -p "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
+
+swiftc -parse-as-library \
+  -module-cache-path "$SWIFT_MODULE_CACHE" \
+  -Xcc -fmodules-cache-path="$CLANG_MODULE_CACHE" \
+  -I "$MODULEMAP_DIR" \
+  "$ROOT/Sources/RhwpCoreBridge/RhwpDocument.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/PageOverlayImages.swift" \
+  "$ROOT/scripts/overlay_metadata_smoke.swift" \
+  "$LIB" \
+  -framework CoreGraphics \
+  -framework CoreText \
+  -framework ImageIO \
+  -framework Security \
+  -framework CoreFoundation \
+  -lc++ \
+  -liconv \
+  -lz \
+  -o "$BIN"
+
+"$BIN" "$OUT_DIR" --page "$PAGE_NUMBER" "${INPUTS[@]}"

--- a/scripts/overlay_metadata_smoke.swift
+++ b/scripts/overlay_metadata_smoke.swift
@@ -1,0 +1,395 @@
+import Foundation
+
+struct OverlaySmokeError: Error, CustomStringConvertible {
+    let description: String
+}
+
+struct OverlaySampleReport: Encodable {
+    let fileName: String
+    let filePath: String
+    let fileBytes: Int
+    let status: String
+    let error: String?
+    let pageNumber: Int
+    let pageIndex: Int
+    let pageCount: Int?
+    let overlayJSONBytes: Int?
+    let upstreamImageCount: Int?
+    let overlayImageCount: Int?
+    let behindCount: Int?
+    let frontCount: Int?
+    let overlayRenderableCount: Int?
+    let overlayBinLinkedCount: Int?
+    let overlayBakedWatermarkCount: Int?
+    let overlayBase64Bytes: Int?
+    let treeImageCount: Int?
+    let treeEmbeddedImageCount: Int?
+    let treeEmbeddedAvailableCount: Int?
+    let treeOverlayCandidateCount: Int?
+    let treeWrapHistogram: [String: Int]
+    let overlayImages: [OverlayImageReport]
+}
+
+struct OverlayImageReport: Encodable {
+    let layer: String
+    let wrap: String
+    let bbox: BBoxReport
+    let mime: String
+    let byteCount: Int
+    let base64Length: Int
+    let binDataId: UInt16?
+    let binDataAvailable: Bool?
+    let effect: String
+    let brightness: Int
+    let contrast: Int
+    let watermarkPreset: String?
+    let bakedWatermark: Bool
+    let transform: TransformReport
+    let fillMode: String?
+    let originalSize: [Double]?
+    let originalSizeHU: [Double]?
+    let crop: [Int32]?
+}
+
+struct BBoxReport: Encodable {
+    let x: Double
+    let y: Double
+    let width: Double
+    let height: Double
+
+    init(_ bbox: BBox) {
+        x = bbox.x
+        y = bbox.y
+        width = bbox.width
+        height = bbox.height
+    }
+}
+
+struct TransformReport: Encodable {
+    let rotation: Double
+    let horzFlip: Bool
+    let vertFlip: Bool
+
+    init(_ transform: RhwpPageOverlayTransform) {
+        rotation = transform.rotation
+        horzFlip = transform.horzFlip
+        vertFlip = transform.vertFlip
+    }
+}
+
+struct TreeImageStats {
+    var imageCount = 0
+    var embeddedImageCount = 0
+    var embeddedAvailableCount = 0
+    var overlayCandidateCount = 0
+    var wrapHistogram: [String: Int] = [:]
+}
+
+@main
+struct OverlayMetadataSmoke {
+    static func main() throws {
+        var args = Array(CommandLine.arguments.dropFirst())
+        guard !args.isEmpty else {
+            throw OverlaySmokeError(description: "usage: overlay_metadata_smoke <output-dir> [--page N] <hwp-or-hwpx> [...]")
+        }
+
+        let outputDir = URL(fileURLWithPath: args.removeFirst(), isDirectory: true)
+        var pageNumber = 1
+
+        while let first = args.first, first.hasPrefix("--") {
+            switch first {
+            case "--page":
+                args.removeFirst()
+                guard let value = args.first, let parsed = Int(value), parsed > 0 else {
+                    throw OverlaySmokeError(description: "--page requires a positive integer")
+                }
+                pageNumber = parsed
+                args.removeFirst()
+            case "--help", "-h":
+                print("usage: overlay_metadata_smoke <output-dir> [--page N] <hwp-or-hwpx> [...]")
+                return
+            default:
+                throw OverlaySmokeError(description: "unknown option: \(first)")
+            }
+        }
+
+        guard !args.isEmpty else {
+            throw OverlaySmokeError(description: "missing input document")
+        }
+
+        let metadataDir = outputDir.appendingPathComponent("metadata", isDirectory: true)
+        try FileManager.default.createDirectory(at: metadataDir, withIntermediateDirectories: true)
+
+        var reports: [OverlaySampleReport] = []
+        for input in args {
+            let inputURL = URL(fileURLWithPath: input)
+            let report = inspect(inputURL: inputURL, pageNumber: pageNumber, metadataDir: metadataDir)
+            reports.append(report)
+            try writeDetail(report, metadataDir: metadataDir)
+            print(rowSummary(report))
+        }
+
+        try writeJSONLines(reports, outputDir: outputDir)
+        try writeSummary(reports, outputDir: outputDir)
+
+        if reports.contains(where: { $0.status != "OK" }) {
+            throw OverlaySmokeError(description: "one or more overlay metadata smoke checks failed")
+        }
+    }
+
+    private static func inspect(
+        inputURL: URL,
+        pageNumber: Int,
+        metadataDir: URL
+    ) -> OverlaySampleReport {
+        let fileName = inputURL.lastPathComponent
+        let fileBytes = (try? inputURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        let pageIndex = pageNumber - 1
+
+        do {
+            let data = try Data(contentsOf: inputURL)
+            let document = try RhwpDocument(data: data, filename: fileName)
+            guard pageIndex >= 0, pageIndex < document.pageCount else {
+                return failureReport(
+                    inputURL: inputURL,
+                    fileBytes: fileBytes,
+                    pageNumber: pageNumber,
+                    pageIndex: pageIndex,
+                    pageCount: document.pageCount,
+                    error: "page \(pageNumber) is out of range: pageCount=\(document.pageCount)"
+                )
+            }
+
+            let overlayJSON = document.pageOverlayImagesJSON(at: pageIndex)
+            let overlays = document.pageOverlayImages(at: pageIndex)
+            let tree = document.renderPageTree(at: pageIndex)
+            let treeStats = tree.map { collectTreeImageStats($0, document: document) } ?? TreeImageStats()
+            let overlayImages = overlays?.allImages.map(overlayImageReport) ?? []
+
+            return OverlaySampleReport(
+                fileName: fileName,
+                filePath: inputURL.path,
+                fileBytes: fileBytes,
+                status: "OK",
+                error: nil,
+                pageNumber: pageNumber,
+                pageIndex: pageIndex,
+                pageCount: document.pageCount,
+                overlayJSONBytes: overlayJSON?.utf8.count,
+                upstreamImageCount: overlays?.imageCount,
+                overlayImageCount: overlays?.overlayImageCount,
+                behindCount: overlays?.behind.count,
+                frontCount: overlays?.front.count,
+                overlayRenderableCount: overlayImages.filter { $0.byteCount > 0 || $0.binDataAvailable == true }.count,
+                overlayBinLinkedCount: overlayImages.filter { $0.binDataId != nil }.count,
+                overlayBakedWatermarkCount: overlayImages.filter(\.bakedWatermark).count,
+                overlayBase64Bytes: overlayImages.reduce(0) { $0 + $1.byteCount },
+                treeImageCount: treeStats.imageCount,
+                treeEmbeddedImageCount: treeStats.embeddedImageCount,
+                treeEmbeddedAvailableCount: treeStats.embeddedAvailableCount,
+                treeOverlayCandidateCount: treeStats.overlayCandidateCount,
+                treeWrapHistogram: treeStats.wrapHistogram,
+                overlayImages: overlayImages
+            )
+        } catch {
+            return failureReport(
+                inputURL: inputURL,
+                fileBytes: fileBytes,
+                pageNumber: pageNumber,
+                pageIndex: pageIndex,
+                pageCount: nil,
+                error: String(describing: error)
+            )
+        }
+    }
+
+    private static func failureReport(
+        inputURL: URL,
+        fileBytes: Int,
+        pageNumber: Int,
+        pageIndex: Int,
+        pageCount: Int?,
+        error: String
+    ) -> OverlaySampleReport {
+        OverlaySampleReport(
+            fileName: inputURL.lastPathComponent,
+            filePath: inputURL.path,
+            fileBytes: fileBytes,
+            status: "FAIL",
+            error: error,
+            pageNumber: pageNumber,
+            pageIndex: pageIndex,
+            pageCount: pageCount,
+            overlayJSONBytes: nil,
+            upstreamImageCount: nil,
+            overlayImageCount: nil,
+            behindCount: nil,
+            frontCount: nil,
+            overlayRenderableCount: nil,
+            overlayBinLinkedCount: nil,
+            overlayBakedWatermarkCount: nil,
+            overlayBase64Bytes: nil,
+            treeImageCount: nil,
+            treeEmbeddedImageCount: nil,
+            treeEmbeddedAvailableCount: nil,
+            treeOverlayCandidateCount: nil,
+            treeWrapHistogram: [:],
+            overlayImages: []
+        )
+    }
+
+    private static func collectTreeImageStats(_ root: RenderNode, document: RhwpDocument) -> TreeImageStats {
+        var stats = TreeImageStats()
+
+        func visit(_ node: RenderNode) {
+            if case .image(let image) = node.nodeType {
+                stats.imageCount += 1
+                let wrapKey = image.textWrap?.isEmpty == false ? image.textWrap! : "nil"
+                stats.wrapHistogram[wrapKey, default: 0] += 1
+
+                if image.binDataId > 0 {
+                    stats.embeddedImageCount += 1
+                    if document.imageData(binDataId: image.binDataId) != nil {
+                        stats.embeddedAvailableCount += 1
+                    }
+                }
+
+                if RhwpPageOverlayLayer(textWrap: image.textWrap) != nil {
+                    stats.overlayCandidateCount += 1
+                }
+            }
+
+            for child in node.children {
+                visit(child)
+            }
+        }
+
+        visit(root)
+        return stats
+    }
+
+    private static func overlayImageReport(_ image: RhwpPageOverlayImage) -> OverlayImageReport {
+        OverlayImageReport(
+            layer: image.layer.rawValue,
+            wrap: image.wrap,
+            bbox: BBoxReport(image.bbox),
+            mime: image.source.mime,
+            byteCount: image.source.byteCount,
+            base64Length: image.source.base64Length,
+            binDataId: image.source.binDataId,
+            binDataAvailable: image.source.binDataAvailable,
+            effect: image.effect,
+            brightness: image.brightness,
+            contrast: image.contrast,
+            watermarkPreset: image.watermarkPreset,
+            bakedWatermark: image.bakedWatermark,
+            transform: TransformReport(image.transform),
+            fillMode: image.fillMode,
+            originalSize: image.originalSize,
+            originalSizeHU: image.originalSizeHU,
+            crop: image.crop
+        )
+    }
+
+    private static func writeDetail(_ report: OverlaySampleReport, metadataDir: URL) throws {
+        let outputURL = metadataDir.appendingPathComponent("\(report.fileName)-page\(report.pageNumber)-overlay.json")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(report)
+        try data.write(to: outputURL)
+    }
+
+    private static func writeJSONLines(_ reports: [OverlaySampleReport], outputDir: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        var lines: [String] = []
+        for report in reports {
+            let data = try encoder.encode(report)
+            guard let line = String(data: data, encoding: .utf8) else {
+                throw OverlaySmokeError(description: "failed to encode JSONL row")
+            }
+            lines.append(line)
+        }
+        try lines.joined(separator: "\n").appending("\n")
+            .write(to: outputDir.appendingPathComponent("metadata.jsonl"), atomically: true, encoding: .utf8)
+    }
+
+    private static func writeSummary(_ reports: [OverlaySampleReport], outputDir: URL) throws {
+        var lines: [String] = []
+        lines.append("# Overlay Metadata Smoke")
+        lines.append("")
+        lines.append("| File | Status | PageCount | UpstreamImages | Overlay | Behind | Front | Renderable | BinLinked | TreeImages | TreeEmbeddedAvailable | Wraps | Error |")
+        lines.append("|------|--------|-----------|----------------|---------|--------|-------|------------|-----------|------------|-----------------------|-------|-------|")
+        for report in reports {
+            lines.append([
+                markdownCode(report.fileName),
+                report.status,
+                intCell(report.pageCount),
+                intCell(report.upstreamImageCount),
+                intCell(report.overlayImageCount),
+                intCell(report.behindCount),
+                intCell(report.frontCount),
+                intCell(report.overlayRenderableCount),
+                intCell(report.overlayBinLinkedCount),
+                intCell(report.treeImageCount),
+                treeEmbeddedCell(report),
+                wrapHistogramCell(report.treeWrapHistogram),
+                markdownCell(report.error ?? "")
+            ].joined(separator: " | ").wrappedTableRow())
+        }
+        lines.append("")
+        lines.append("Artifacts:")
+        lines.append("")
+        lines.append("- `metadata.jsonl`: one JSON object per input")
+        lines.append("- `metadata/*.json`: pretty-printed per-input metadata")
+        lines.append("")
+        try lines.joined(separator: "\n").appending("\n")
+            .write(to: outputDir.appendingPathComponent("summary.md"), atomically: true, encoding: .utf8)
+    }
+
+    private static func rowSummary(_ report: OverlaySampleReport) -> String {
+        if report.status != "OK" {
+            return "FAIL \(report.fileName): \(report.error ?? "unknown error")"
+        }
+        return "OK \(report.fileName): page=\(report.pageNumber) upstreamImages=\(report.upstreamImageCount ?? 0) overlay=\(report.overlayImageCount ?? 0) behind=\(report.behindCount ?? 0) front=\(report.frontCount ?? 0) treeImages=\(report.treeImageCount ?? 0) treeEmbeddedAvailable=\(report.treeEmbeddedAvailableCount ?? 0)/\(report.treeEmbeddedImageCount ?? 0)"
+    }
+
+    private static func intCell(_ value: Int?) -> String {
+        value.map(String.init) ?? "-"
+    }
+
+    private static func treeEmbeddedCell(_ report: OverlaySampleReport) -> String {
+        guard let available = report.treeEmbeddedAvailableCount,
+              let total = report.treeEmbeddedImageCount else {
+            return "-"
+        }
+        return "\(available)/\(total)"
+    }
+
+    private static func wrapHistogramCell(_ histogram: [String: Int]) -> String {
+        guard !histogram.isEmpty else {
+            return "-"
+        }
+        return histogram
+            .keys
+            .sorted()
+            .map { "\($0):\(histogram[$0] ?? 0)" }
+            .joined(separator: ", ")
+    }
+
+    private static func markdownCode(_ value: String) -> String {
+        "`\(markdownCell(value))`"
+    }
+
+    private static func markdownCell(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "|", with: "\\|")
+            .replacingOccurrences(of: "\n", with: " ")
+    }
+}
+
+private extension String {
+    func wrappedTableRow() -> String {
+        "| \(self) |"
+    }
+}


### PR DESCRIPTION
## 요약

- 대상 타스크: #281 PageLayerTree overlay image metadata를 Swift preview 입력으로 연결
- 왜: #282 native compositor가 rhwp PageLayerTree/overlay image metadata를 사용할 수 있도록 Swift 입력 contract를 먼저 고정합니다.
- 무엇: `rhwp_page_overlay_images` C ABI, Swift overlay metadata 모델/provider, overlay smoke script, Stage 1-4 보고서를 추가했습니다.
- 리뷰 포인트: renderer 출력 개선 PR이 아니라 compositor 입력 준비 PR이며, visual diff 수치는 #282 이전 baseline입니다.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/825d04e937432af09788beb0e1f228b180f51de3/mydocs/working/task_m014_281_stage1.md)** ([8af7eb3](https://github.com/postmelee/alhangeul-macos/commit/8af7eb3b20ce5ff67f575fcd553ce5c9cb71bf89)): `v0.7.12` lock과 upstream `v0.7.13`의 overlay/PageLayerTree API inventory를 정리했습니다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/825d04e937432af09788beb0e1f228b180f51de3/mydocs/working/task_m014_281_stage2.md)** ([800b813](https://github.com/postmelee/alhangeul-macos/commit/800b813c155ff5a5dc951aeb2870ca213429afde)): RustBridge C ABI와 Swift `RhwpPageOverlayImageSet` provider를 추가했습니다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/825d04e937432af09788beb0e1f228b180f51de3/mydocs/working/task_m014_281_stage3.md)** ([538e1a9](https://github.com/postmelee/alhangeul-macos/commit/538e1a9e8011b24bd51d7d7fbb381e06ddecfa1c)): overlay metadata smoke와 Xcode project source phase 반영을 완료했습니다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/825d04e937432af09788beb0e1f228b180f51de3/mydocs/working/task_m014_281_stage4.md)** ([44124ad](https://github.com/postmelee/alhangeul-macos/commit/44124ad0dfd70ca54853cdd35185f99e1205b589)): visual diff baseline과 #282 handoff를 정리했습니다.
- **최종 보고** ([40886fe](https://github.com/postmelee/alhangeul-macos/commit/40886feecee54431286eae7d075a3140714e4eff)): 최종 보고서와 오늘할일 완료 상태를 정리했습니다.
- **Review 반영** ([825d04e](https://github.com/postmelee/alhangeul-macos/commit/825d04e937432af09788beb0e1f228b180f51de3)): Copilot review의 성능/확장성/문서 컨벤션 지적을 반영했습니다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| RustBridge | `rhwp_page_overlay_images` ABI 추가 | symbol manifest와 lock hash가 함께 갱신됐습니다. |
| Swift bridge | `PageOverlayImages.swift` 모델/provider 추가 | compact overlay JSON을 primary로 쓰고 render tree metadata를 보충합니다. |
| Project | `PageOverlayImages.swift` target source phase 포함 | HostApp, Quick Look, Thumbnail target 모두 빌드 대상입니다. |
| Smoke | `overlay-metadata-smoke.sh` 추가 | overlay-positive fixture 부재를 수치로 드러내는 측정 도구입니다. |
| Docs | Stage 보고서와 최종 보고서 추가 | #282 handoff와 한계를 명시했습니다. |

- 수행 계획서: [task_m014_281.md](https://github.com/postmelee/alhangeul-macos/blob/825d04e937432af09788beb0e1f228b180f51de3/mydocs/plans/task_m014_281.md)
- 구현 계획서: [task_m014_281_impl.md](https://github.com/postmelee/alhangeul-macos/blob/825d04e937432af09788beb0e1f228b180f51de3/mydocs/plans/task_m014_281_impl.md)
- 최종 보고서: [task_m014_281_report.md](https://github.com/postmelee/alhangeul-macos/blob/825d04e937432af09788beb0e1f228b180f51de3/mydocs/report/task_m014_281_report.md)

## 핵심 리뷰 포인트

- `RhwpDocument.pageOverlayImages(at:)`는 compact overlay JSON을 기준으로 삼고, render tree traversal 결과로 `binDataId`, embedded bytes availability, crop/fill/original size를 보충합니다. render tree를 이미 가진 호출자는 overload로 중복 decode를 피할 수 있습니다.
- `bakedWatermark`는 `v0.7.13` 이후 payload를 대비해 optional decode로 열어두었고, 이번 PR에서는 core pin을 올리지 않았습니다.
- #281은 CGContext compositor를 연결하지 않습니다. 실제 drawing pass 순서와 before/after visual diff 개선은 #282 범위입니다.

## 검증

- `./scripts/build-rust-macos.sh --update-lock`
- `./scripts/build-rust-macos.sh --verify-lock`
- `./scripts/check-no-appkit.sh`
- `./scripts/verify-rhwp-studio-assets.sh`
- `swiftc` probe로 `PageOverlayImages.swift` decode/provider 경로 확인
- `./scripts/overlay-metadata-smoke.sh build.noindex/task281-stage3-metadata`
- `./scripts/overlay-metadata-smoke.sh build.noindex/task281-reviewfix-metadata`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-basic --page 1 samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task281-stage4-images --page 1 samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp samples/img-start-001.hwp`
- `xcodegen generate`
- `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task281-stage3 CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

참고: Stage 3 xcodebuild 후 삭제된 DerivedData app 경로가 LaunchServices local DB에 stale entry로 남아 `check-extension-registration-hygiene.sh --check-only`는 깨끗한 상태까지 회복하지 못했습니다. `pluginkit` provider root는 `/Applications/Alhangeul.app`만 보였고, 전역 LaunchServices reset은 수행하지 않았습니다.

## 관련 이슈

- #282: #281 metadata를 실제 native compositor 입력으로 사용하는 후속 작업
- #286: visual diff harness readiness 안정화
- #280: native preview visual diff baseline/harness 계열 작업

## 후속 이슈 제안

- #282 시작 전 또는 초기에 `BehindText`/`InFrontOfText` overlay-positive fixture를 확보합니다.
- upstream `v0.7.13` 이상 core update 후 `bakedWatermark` actual payload smoke를 추가합니다.
- external linked image, filename, base directory 주입/조회 API는 별도 upstream/downstream 작업으로 분리합니다.

## 남은 리스크

- 현재 sample set에서는 Swift overlay image count가 모두 `0`이므로 positive compositor pass 검증은 아직 불가능합니다.
- visual diff baseline은 #282 이전 기준값이며, 이번 PR 자체가 preview fidelity 수치를 개선하지는 않습니다.
- LaunchServices stale entry는 로컬 DB 잔류 관찰로 남겼고, PR 산출물에는 개발 app bundle이 포함되지 않습니다.
