### PR TITLE
Task #293: preview visual diff overlay DOM 캡처 보강

### DIFF
--- a/mydocs/orders/20260529.md
+++ b/mydocs/orders/20260529.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #293 | preview visual diff harness가 rhwp-studio overlay DOM을 포함해 캡처하도록 수정 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+| #293 | preview visual diff harness가 rhwp-studio overlay DOM을 포함해 캡처하도록 수정 | 진행중 | M014, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260529.md
+++ b/mydocs/orders/20260529.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #293 | preview visual diff harness가 rhwp-studio overlay DOM을 포함해 캡처하도록 수정 | 진행중 | M014, 구현계획서 작성 후 승인 대기 |
+| #293 | preview visual diff harness가 rhwp-studio overlay DOM을 포함해 캡처하도록 수정 | 완료 | M014, 완료: 12:46, 최종 보고서 작성 후 PR 승인 대기 |

--- a/mydocs/orders/20260529.md
+++ b/mydocs/orders/20260529.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 5월 29일
+
+## M014 — v0.1.4 Native Preview/Viewer Parity
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #293 | preview visual diff harness가 rhwp-studio overlay DOM을 포함해 캡처하도록 수정 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/plans/task_m014_293.md
+++ b/mydocs/plans/task_m014_293.md
@@ -1,0 +1,138 @@
+# Task M014 #293 수행계획서
+
+## 목적
+
+`preview visual diff harness`가 `rhwp-studio`의 실제 WebView 표시와 같은 reference PNG를 생성하도록 캡처 경로를 보정한다.
+
+완료 후 `samples/복학원서.hwp` 1페이지 reference PNG에는 좌상단 로고와 중앙 BehindText 워터마크가 포함되어야 하며, #282 compositor 보강과 #116 watermark parity 작업에서 신뢰 가능한 `rhwp-studio` 기준선을 재사용할 수 있어야 한다.
+
+## 배경
+
+#282 Stage 3 검증 중 `samples/복학원서.hwp`에서 `rhwp-studio` 웹 화면에는 overlay 이미지가 보였지만, harness가 생성한 studio reference PNG에는 좌상단 로고와 중앙 워터마크가 빠진 상태가 확인됐다.
+
+관찰된 metadata는 다음 상태였다.
+
+```text
+captureMode=canvasDataURL
+overlayCount=5
+usedOverlayUnion=true
+overlayIncluded=false
+```
+
+이는 harness가 overlay DOM 존재와 union rect는 감지했지만 최종 이미지 생성 시 page canvas `toDataURL()` 경로를 우선 사용해 DOM/image overlay layer를 누락했음을 뜻한다. 이 상태에서는 `rhwp-studio` reference가 실제 웹 표시와 달라지고, 이후 visual diff 수치가 native renderer/compositor 차이가 아닌 reference capture 오류를 포함하게 된다.
+
+## 범위
+
+포함:
+
+- `scripts/preview_visual_diff_harness.swift`의 `rhwp-studio` capture decision 점검과 수정
+- overlay DOM이 존재하는 page에서 canvas-only export 대신 WebView snapshot을 선택하도록 보강
+- snapshot rect가 page canvas와 overlay union을 포함하는지 확인하고, 필요 시 rect 산출 또는 metadata 기록 보정
+- `captureMode`, `overlayIncluded`, `overlayCount`, `usedOverlayUnion` metadata가 실제 캡처 방식과 일치하도록 정리
+- `samples/복학원서.hwp`와 기존 v0.1.4 image sample set smoke 재측정
+- 변경 전후 capture metadata와 visual diff 수치 보고
+
+제외:
+
+- Swift native renderer의 워터마크 톤, opacity, effect 수정
+- #282 Quick Look/Thumbnail compositor 구현 변경
+- #116 watermark parity 구현 변경
+- upstream `rhwp` 수정
+- Skia/PageLayerTree backend 전환 또는 z-order policy 변경
+- Quick Look/Thumbnail runtime 코드 변경
+
+## 설계 방향
+
+이번 작업은 renderer 결과를 바꾸는 작업이 아니라 `rhwp-studio` reference capture의 진실성을 회복하는 harness 보정이다. 먼저 현행 harness에서 `복학원서.hwp`의 capture mode와 overlay metadata를 재현하고, overlay DOM이 있는 경우 canvas export가 선택되는 decision 지점을 찾는다.
+
+capture policy는 다음 기준으로 정리한다.
+
+- overlay DOM이 없고 page canvas만 의미 있는 문서는 기존 canvas-only export 경로를 유지한다.
+- overlay DOM 또는 overlay union이 존재하는 문서는 WebView snapshot을 사용한다.
+- snapshot rect는 page canvas bounds와 overlay bounds의 union을 사용하되, viewport/scroll alignment 이후 실제 캡처 가능한 좌표계로 변환한다.
+- metadata는 선택된 캡처 경로와 포함 여부를 사후 해석 가능한 값으로 남긴다.
+
+Swift/WKWebView JavaScript probe는 #286에서 안정화한 primitive/JSON string 반환 원칙을 유지한다. DOMRect, Element, ImageData 같은 unsupported result type을 직접 반환하지 않고, 실패 시 summary/debug artifact에서 phase를 분리할 수 있게 한다.
+
+## 예상 변경 파일
+
+- `mydocs/orders/20260529.md`
+- `mydocs/plans/task_m014_293.md`
+- `mydocs/plans/task_m014_293_impl.md`
+- `mydocs/working/task_m014_293_stage{N}.md`
+- `mydocs/report/task_m014_293_report.md`
+- `scripts/preview_visual_diff_harness.swift`
+- 필요 시 `scripts/preview-visual-diff-harness.sh`
+
+## 잠정 단계
+
+1. Stage 1: 현행 capture decision 재현과 원인 inventory
+   - `samples/복학원서.hwp`에서 현재 metadata와 reference PNG 누락을 재현한다.
+   - overlay DOM 감지, overlay union 산출, canvasDataURL 선택 지점을 분리해 기록한다.
+   - 기존 overlay 없는 sample의 capture path를 확인해 회귀 위험을 정리한다.
+2. Stage 2: overlay-aware snapshot 선택 보강
+   - overlay DOM 또는 overlay union이 있는 page에서 WebView snapshot을 선택하도록 decision을 수정한다.
+   - snapshot rect가 canvas와 overlay union을 포함하도록 좌표 산출을 점검한다.
+   - metadata 값이 실제 capture mode와 일치하도록 보정한다.
+3. Stage 3: sample set smoke와 visual diff 재측정
+   - `복학원서.hwp` reference PNG에 좌상단 로고와 중앙 워터마크가 포함되는지 확인한다.
+   - overlay 없는 canvas-only sample에서 기존 경로가 유지되는지 확인한다.
+   - 기존 v0.1.4 image sample set으로 summary metric을 다시 생성한다.
+4. Stage 4: #282/#116 handoff와 최종 보고
+   - 변경 전후 capture metadata와 visual diff 수치를 정리한다.
+   - #282 후속 Stage와 #116 watermark parity에서 재사용할 output directory, 명령, 해석 기준을 남긴다.
+   - 최종 보고서와 오늘할일을 갱신한다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+rg -n "#293|overlay DOM|captureMode|overlayIncluded|M014|preview visual diff" \
+  mydocs/orders/20260529.md mydocs/plans/task_m014_293.md
+git diff --check -- mydocs/orders/20260529.md mydocs/plans/task_m014_293.md
+git status --short --branch
+```
+
+구현 단계 후보:
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-baseline --page 1 \
+  samples/복학원서.hwp
+sed -n '1,200p' build.noindex/task293-baseline/summary.md
+rg -n "captureMode|overlayIncluded|overlayCount|usedOverlayUnion|ChangedPixels|ChangedPercent|MeanRGBDelta" \
+  build.noindex/task293-baseline
+```
+
+보정 후 smoke 후보:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-overlay-snapshot --page 1 \
+  samples/복학원서.hwp samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp
+sed -n '1,220p' build.noindex/task293-overlay-snapshot/summary.md
+rg -n "captureMode|overlayIncluded|overlayCount|usedOverlayUnion|ChangedPixels|ChangedPercent|MeanRGBDelta" \
+  build.noindex/task293-overlay-snapshot
+git diff --check
+git status --short --branch
+```
+
+필요 시 PNG 확인은 generated artifact를 직접 열어 `복학원서.hwp-page1-studio.png`의 좌상단 로고와 중앙 워터마크 포함 여부를 시각 확인한다.
+
+## 리스크
+
+- WebView snapshot은 canvas `toDataURL()`보다 실행 환경, scroll offset, device scale factor, viewport 상태에 더 민감할 수 있다.
+- overlay DOM selector가 `rhwp-studio` bundle 내부 구조에 과도하게 결합되면 향후 bundle 갱신 시 다시 깨질 수 있다.
+- snapshot rect가 너무 넓으면 editor chrome 또는 주변 여백이 reference에 섞일 수 있고, 너무 좁으면 overlay가 다시 잘릴 수 있다.
+- `복학원서.hwp`는 overlay positive fixture로 중요하지만, sample별 renderer 차이가 큰 경우 visual diff 수치 자체는 여전히 클 수 있다.
+- #282 작업 branch와 output artifact가 이미 존재하므로, 이번 작업은 독립 브랜치에서 harness만 수정하고 #282 branch를 직접 수정하지 않는다.
+
+## 승인 요청 사항
+
+1. #293을 `rhwp-studio` overlay DOM 포함 reference capture 보정 작업으로 진행하는 범위 승인
+2. overlay DOM이 있는 문서에서는 canvas-only export보다 WebView snapshot을 우선하는 capture policy 승인
+3. 이번 작업에서는 native renderer, compositor, watermark rendering 자체를 수정하지 않고 harness와 검증 산출물만 보강하는 방향 승인
+4. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m014_293_impl.md`) 작성과 Stage 1 현행 capture decision 재현 진행
+
+승인 전에는 Swift source, script, renderer 동작 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m014_293_impl.md
+++ b/mydocs/plans/task_m014_293_impl.md
@@ -1,0 +1,273 @@
+# Task M014 #293 구현 계획서
+
+수행계획서: `mydocs/plans/task_m014_293.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #293 preview visual diff harness가 rhwp-studio overlay DOM을 포함해 캡처하도록 수정
+- 마일스톤: M014 (`v0.1.4 Native Preview/Viewer Parity`)
+- 브랜치: `local/task293`
+- 작업 위치: `/Users/melee/Documents/projects/rhwp-mac-task293`
+- 기준 브랜치: `devel`
+- 목표: overlay DOM이 있는 `rhwp-studio` page reference를 canvas-only export가 아니라 WebView snapshot으로 캡처해 실제 웹 표시와 같은 기준 PNG를 만든다.
+
+## 구현 원칙
+
+- renderer/compositor production 동작은 수정하지 않는다.
+- #282 compositor, #116 watermark parity 구현을 선행하지 않는다.
+- #282 작업 branch나 artifact는 직접 수정하지 않는다.
+- overlay 없는 문서의 canvas-only capture path는 가능한 한 유지한다.
+- overlay DOM 또는 overlay union이 있는 문서는 WebView snapshot을 선택한다.
+- snapshot rect는 page canvas와 overlay union을 포함해야 하며, rect가 viewport 밖이면 viewport/좌표 문제로 분리해 보고한다.
+- JavaScript probe는 `WKWebView.evaluateJavaScript`가 안정적으로 받을 수 있는 JSON string/primitive 반환 원칙을 유지한다.
+- metadata는 실제 capture decision을 사후 검증할 수 있게 `captureMode`, `overlayIncluded`, `overlayCount`, `usedOverlayUnion`, sample pixel 값을 일관되게 남긴다.
+
+## 현재 기준 관찰
+
+현재 harness의 핵심 위치는 다음이다.
+
+| 영역 | 파일/함수 | 관찰 |
+|------|-----------|------|
+| wrapper | `scripts/preview-visual-diff-harness.sh` | Swift harness를 빌드하고 resource dir, viewport, settle, sample 목록을 전달한다. |
+| page capture | `scripts/preview_visual_diff_harness.swift` `StudioReferenceRenderer.capture` | `pageState.canvasSampleNonWhitePixels > 0`이면 canvas export를 우선 선택한다. |
+| snapshot capture | `captureSnapshotPNG` / `takeSnapshot` | WebView snapshot rect를 PNG로 인코딩한다. |
+| canvas export | `exportCanvasPNG` / `canvasDataURLScript` | target page canvas의 `toDataURL()` 결과를 PNG로 사용한다. |
+| page state | `currentPageState` / `pageStateScript` | canvas rect, overlay count, overlay union snapshot rect, canvas sample을 JSON string으로 반환한다. |
+| metadata | `StudioCaptureMetadata` | `captureMode`, `overlayIncluded`, `overlayCount`, `usedOverlayUnion`, canvas/snapshot sample 값을 기록한다. |
+| summary | `PreviewVisualDiffHarness.main` | sample별 `StudioCapture`와 diff metric을 `summary.md`에 기록한다. |
+
+문제 후보는 `overlayCount > 0`과 `usedOverlayUnion=true`인 상태에서도 `canvasSampleNonWhitePixels > 0` 조건이 먼저 적용되어 `captureMode=canvasDataURL`, `overlayIncluded=false`가 되는 decision 순서다.
+
+## 조사 산출물 구조
+
+| 파일 | 역할 |
+|------|------|
+| `mydocs/plans/task_m014_293_impl.md` | 단계별 구현 범위, 검증, 완료 기준 |
+| `mydocs/working/task_m014_293_stage1.md` | 현행 capture decision 재현과 원인 inventory |
+| `mydocs/working/task_m014_293_stage2.md` | overlay-aware snapshot 선택 구현 보고 |
+| `mydocs/working/task_m014_293_stage3.md` | sample set smoke와 visual diff 재측정 보고 |
+| `mydocs/report/task_m014_293_report.md` | 최종 결과와 #282/#116 handoff |
+| `build.noindex/task293-*` | 재현/검증 산출물. 커밋하지 않는다. |
+
+## Stage 1. 현행 capture decision 재현과 원인 inventory
+
+### 목표
+
+`samples/복학원서.hwp`에서 현재 reference PNG가 overlay를 누락하는 상태를 재현하고, capture decision이 `canvasDataURL`로 가는 조건과 overlay metadata를 정리한다.
+
+### 작업
+
+- `rhwp-studio` asset provenance와 harness build 가능 여부를 확인한다.
+- `samples/복학원서.hwp` baseline harness를 실행한다.
+- baseline `summary.md`와 `*-studio.json`에서 다음 값을 수집한다.
+  - `captureMode`
+  - `overlayIncluded`
+  - `overlayCount`
+  - `usedOverlayUnion`
+  - `canvasSampleNonWhitePixels`
+  - `snapshotSampleNonWhitePixels`
+  - `rect` / `canvasRect`
+- 생성된 `*-studio.png`가 좌상단 로고와 중앙 워터마크를 포함하는지 확인한다.
+- overlay 없는 대표 sample에서 현재 canvas-only path를 확인해 Stage 2 회귀 방지 기준을 잡는다.
+- `StudioReferenceRenderer.capture`의 decision 순서와 `pageStateScript`의 overlay union 산출 기준을 보고서에 정리한다.
+
+### 산출물
+
+- `mydocs/working/task_m014_293_stage1.md`
+- `build.noindex/task293-stage1-baseline/summary.md`
+- `build.noindex/task293-stage1-baseline/*-studio.json`
+- `build.noindex/task293-stage1-baseline/*-studio.png`
+
+### 검증
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage1-baseline --page 1 \
+  samples/복학원서.hwp samples/basic/request.hwp
+sed -n '1,200p' build.noindex/task293-stage1-baseline/summary.md
+rg -n "captureMode|overlayIncluded|overlayCount|usedOverlayUnion|canvasSampleNonWhitePixels|snapshotSampleNonWhitePixels" \
+  build.noindex/task293-stage1-baseline
+rg -n "captureMode|overlayIncluded|overlayCount|usedOverlayUnion|canvasSampleNonWhitePixels|captureSnapshotPNG|exportCanvasPNG" \
+  scripts/preview_visual_diff_harness.swift
+git diff --check
+```
+
+### 완료 기준
+
+- `복학원서.hwp`의 현행 capture metadata와 PNG 포함/누락 여부가 보고서에 남는다.
+- overlay-positive sample과 overlay 없는 sample의 capture path가 구분된다.
+- Stage 2에서 수정할 최소 decision 조건이 확정된다.
+- production source는 변경하지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #293 Stage 1: overlay capture decision 재현
+```
+
+## Stage 2. overlay-aware snapshot 선택 보강
+
+### 목표
+
+overlay DOM 또는 overlay union이 있는 page에서 canvas-only export 대신 WebView snapshot을 선택하도록 harness capture policy를 수정한다.
+
+### 작업
+
+- `StudioReferenceRenderer.capture`의 capture decision을 `pageState.overlayCount > 0` 또는 `pageState.usedOverlayUnion` 우선으로 재정렬한다.
+- WebView snapshot 선택 시 `captureMode=webViewSnapshot`, `overlayIncluded=true`가 기록되게 한다.
+- canvas-only 선택 시에도 snapshot sample을 가능한 경우 측정해 비교 정보를 유지한다.
+- overlay-positive인데 snapshot이 실패하면 canvas fallback으로 조용히 넘어가지 않고 phase/error가 드러나도록 처리한다.
+- 필요 시 helper를 추가해 decision 의미를 코드에서 읽기 쉽게 만든다.
+- `pageStateScript`의 overlay union rect 산출은 Stage 1 결과상 부족한 경우에만 최소 보정한다.
+
+### 산출물
+
+- `scripts/preview_visual_diff_harness.swift`
+- 필요 시 `scripts/preview-visual-diff-harness.sh`
+- `mydocs/working/task_m014_293_stage2.md`
+- `build.noindex/task293-stage2-smoke/summary.md`
+
+### 검증
+
+```bash
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task293-stage2-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task293-stage2-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task293-stage2-syntax-check
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage2-smoke --page 1 \
+  samples/복학원서.hwp samples/basic/request.hwp
+sed -n '1,200p' build.noindex/task293-stage2-smoke/summary.md
+rg -n "captureMode|overlayIncluded|overlayCount|usedOverlayUnion|ChangedPixels|ChangedPercent|MeanRGBDelta" \
+  build.noindex/task293-stage2-smoke
+git diff --check
+```
+
+### 완료 기준
+
+- Swift harness가 컴파일된다.
+- `복학원서.hwp` metadata에서 overlay-positive capture가 `webViewSnapshot`과 `overlayIncluded=true`로 기록된다.
+- overlay 없는 `request.hwp`는 기존 canvas-only path를 유지하거나, 변경된 경우 근거가 보고서에 남는다.
+- snapshot 실패가 조용한 canvas fallback으로 숨겨지지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #293 Stage 2: overlay snapshot capture 선택 보강
+```
+
+## Stage 3. sample set smoke와 visual diff 재측정
+
+### 목표
+
+overlay-positive sample과 기존 v0.1.4 image sample set에서 보정 후 metadata와 visual diff metric을 다시 생성한다.
+
+### 작업
+
+- `복학원서.hwp` overlay snapshot smoke를 실행한다.
+- 기존 v0.1.4 image sample set을 실행한다.
+  - `samples/basic/request.hwp`
+  - `samples/hwpx/hwpx-01.hwpx`
+  - `samples/tac-img-02.hwp`
+  - `samples/tac-img-02.hwpx`
+  - `samples/hwp-img-001.hwp`
+- `summary.md`의 `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta`, `MaxRGBDelta`, `StudioCapture`, native backend를 기록한다.
+- `복학원서.hwp-page1-studio.png`의 좌상단 로고와 중앙 BehindText 워터마크 포함 여부를 확인한다.
+- Stage 1 baseline과 Stage 3 결과의 metadata 차이를 표로 정리한다.
+
+### 산출물
+
+- `mydocs/working/task_m014_293_stage3.md`
+- `build.noindex/task293-stage3-overlay/summary.md`
+- `build.noindex/task293-stage3-samples/summary.md`
+
+### 검증
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage3-overlay --page 1 \
+  samples/복학원서.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage3-samples --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp
+sed -n '1,200p' build.noindex/task293-stage3-overlay/summary.md
+sed -n '1,240p' build.noindex/task293-stage3-samples/summary.md
+rg -n "captureMode|overlayIncluded|overlayCount|usedOverlayUnion|ChangedPixels|ChangedPercent|MeanRGBDelta|FAIL" \
+  build.noindex/task293-stage3-overlay build.noindex/task293-stage3-samples
+git diff --check
+```
+
+### 완료 기준
+
+- `복학원서.hwp` studio reference PNG가 실제 `rhwp-studio` 웹 표시처럼 좌상단 로고와 중앙 워터마크를 포함한다.
+- overlay-positive metadata에서 `captureMode=webViewSnapshot`, `overlayIncluded=true`가 기록된다.
+- overlay 없는 sample의 기존 capture path가 회귀하지 않는다.
+- smoke sample의 PASS/FAIL과 visual diff metric이 보고서에 남는다.
+
+### 커밋 메시지
+
+```text
+Task #293 Stage 3: overlay snapshot smoke 재측정
+```
+
+## Stage 4. #282/#116 handoff와 최종 보고
+
+### 목표
+
+보정된 `rhwp-studio` reference capture 기준을 #282 후속 Stage와 #116 watermark parity 작업에서 재사용할 수 있게 정리한다.
+
+### 작업
+
+- 변경 전후 capture metadata를 최종 보고서에 정리한다.
+- `복학원서.hwp` reference PNG 포함 여부와 visual diff 수치를 기록한다.
+- #282에서 재사용할 harness 명령과 output directory convention을 남긴다.
+- #116에서 해석해야 할 watermark parity 잔여 차이와 reference capture 오류가 분리됐음을 설명한다.
+- 오늘할일 #293 행을 완료 상태로 갱신한다.
+
+### 산출물
+
+- `mydocs/report/task_m014_293_report.md`
+- `mydocs/orders/20260529.md`
+
+### 검증
+
+```bash
+rg -n "#293|overlay|captureMode|overlayIncluded|webViewSnapshot|canvasDataURL|#282|#116|ChangedPixels|MeanRGBDelta" \
+  mydocs/report/task_m014_293_report.md mydocs/orders/20260529.md
+git diff --check
+git status --short --branch
+```
+
+### 완료 기준
+
+- #293 완료 기준인 overlay 포함 studio reference PNG와 metadata 일치가 최종 보고서에 남는다.
+- #282/#116 후속 작업에서 사용할 명령과 해석 기준이 명시된다.
+- 최종 보고서와 오늘할일 갱신이 커밋된다.
+
+### 커밋 메시지
+
+```text
+Task #293 Stage 4: overlay capture 기준 정리
+```
+
+## 승인 요청 사항
+
+1. 위 4단계 구현계획으로 #293을 진행하는 것에 대한 승인
+2. Stage 1에서 production source 수정 없이 현행 capture decision과 artifact만 재현하는 범위 승인
+3. Stage 2에서 harness capture decision을 수정하되 renderer/compositor production 경로는 수정하지 않는 범위 승인
+4. 승인 후 다음 단계: Stage 1 현행 capture decision 재현과 원인 inventory 진행
+
+승인 전에는 Stage 1 조사 실행이나 source/script 변경을 진행하지 않는다.

--- a/mydocs/report/task_m014_293_report.md
+++ b/mydocs/report/task_m014_293_report.md
@@ -1,0 +1,114 @@
+# Task M014 #293 최종 결과보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#293](https://github.com/postmelee/alhangeul-macos/issues/293) preview visual diff harness가 rhwp-studio overlay DOM을 포함해 캡처하도록 수정 |
+| 마일스톤 | M014 — v0.1.4 Native Preview/Viewer Parity |
+| 브랜치 | `local/task293` |
+| 단계 수 | 4단계 |
+| 최종 기준 | overlay-positive `rhwp-studio` reference는 `domComposite`, overlay 없는 canvas 문서는 `canvasDataURL` |
+
+이번 작업은 `rhwp-studio` 웹 화면에는 보이는 DOM overlay가 visual diff harness의 studio reference PNG에서 누락되는 문제를 수정했다. `복학원서.hwp` 기준으로 좌상단 고려대학교 로고, 중앙 BehindText 워터마크, 하단 우측 붉은 도장이 최종 studio reference PNG에 포함되는 것을 확인했다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `scripts/preview_visual_diff_harness.swift` | overlay-positive 문서에서 canvas-only export 대신 DOM drawable composite PNG를 생성하도록 capture decision과 `compositeDataURLScript`를 추가했다. |
+| `mydocs/plans/task_m014_293.md` | 수행계획서. 범위, 제외 항목, 검증 계획, 승인 요청 사항을 기록했다. |
+| `mydocs/plans/task_m014_293_impl.md` | 구현계획서. Stage 1-4의 산출물과 검증 기준을 정의했다. |
+| `mydocs/working/task_m014_293_stage1.md` | 현행 `canvasDataURL` capture decision과 overlay 누락 재현 결과를 기록했다. |
+| `mydocs/working/task_m014_293_stage2.md` | `webViewSnapshot` 우선 선택 구현과 smoke 결과, snapshot blank 위험을 기록했다. |
+| `mydocs/working/task_m014_293_stage3.md` | WebKit snapshot blank를 확인하고 `domComposite`로 회복한 최종 smoke 결과를 기록했다. |
+| `mydocs/report/task_m014_293_report.md` | 최종 결과, 검증, #282/#116 handoff, 잔여 위험을 정리했다. |
+| `mydocs/orders/20260529.md` | #293 상태를 완료로 갱신했다. |
+
+## 변경 전·후 정량 비교
+
+`복학원서.hwp` studio reference metadata:
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| `captureMode` | `canvasDataURL` | `domComposite` |
+| `overlayIncluded` | `false` | `true` |
+| `overlayCount` | `5` | `5` |
+| `usedOverlayUnion` | `true` | `true` |
+| PNG size | `1587x2245` | `1587x2245` |
+| ChangedPixels | `1141965/3562815` | `1140387/3562815` |
+| ChangedPercent | `32.0523%` | `32.0080%` |
+| MeanRGBDelta | `42.2623` | `37.8073` |
+
+Stage 3 sample set 최종 수치:
+
+| File | Status | StudioCapture | ChangedPercent | MeanRGBDelta |
+|------|--------|---------------|----------------|--------------|
+| `복학원서.hwp` | OK | `domComposite` | `32.0080%` | `37.8073` |
+| `request.hwp` | OK | `domComposite` | `17.8542%` | `11.0716` |
+| `hwpx-01.hwpx` | OK | `domComposite` | `15.0285%` | `15.2088` |
+| `tac-img-02.hwp` | OK | `canvasDataURL` | `4.1153%` | `3.6698` |
+| `tac-img-02.hwpx` | OK | `domComposite` | `4.1153%` | `3.6698` |
+| `hwp-img-001.hwp` | OK | `domComposite` | `7.8277%` | `8.1872` |
+
+## 검증 결과
+
+| 수용 기준 | 결과 | 근거 |
+|-----------|------|------|
+| `복학원서.hwp` 1페이지 studio reference PNG에 좌상단 로고와 중앙 워터마크 포함 | OK | Stage 3 visual check에서 좌상단 로고, 중앙 BehindText 워터마크, 하단 우측 붉은 도장 확인 |
+| overlay-positive metadata에서 `overlayIncluded=true` 기록 | OK | `복학원서.hwp`: `captureMode=domComposite`, `overlayIncluded=true`, `overlayCount=5` |
+| overlay 없는 canvas-only 문서의 기존 capture 경로 유지 | OK | `tac-img-02.hwp`: `captureMode=canvasDataURL`, `overlayIncluded=false`, `overlayCount=0` |
+| v0.1.4 sample set summary 재생성 | OK | `build.noindex/task293-stage3-samples/summary.md`에서 5개 sample 모두 OK |
+| #282/#116에서 사용할 handoff 정리 | OK | 본 보고서의 `#282/#116 Handoff` 섹션 참조 |
+
+실행한 주요 검증:
+
+```bash
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/build-rust-macos.sh
+swiftc -parse-as-library ... -o build.noindex/task293-stage3-syntax-check
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage3-overlay --page 1 samples/복학원서.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage3-samples --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp
+git diff --check
+```
+
+Stage 4 보고 검증:
+
+```bash
+rg -n "#293|overlay|captureMode|overlayIncluded|webViewSnapshot|canvasDataURL|#282|#116|ChangedPixels|MeanRGBDelta" \
+  mydocs/report/task_m014_293_report.md mydocs/orders/20260529.md
+git diff --check
+git status --short --branch
+```
+
+## #282/#116 Handoff
+
+#282 후속 Stage에서 `복학원서.hwp`를 rhwp-studio 기준 reference로 사용할 때는 `captureMode=domComposite`, `overlayIncluded=true`를 기준으로 해석한다. 기존 `canvasDataURL` baseline은 DOM overlay가 빠진 과거 기준이므로 compositor parity 판단에 사용하지 않는다.
+
+#116 watermark parity 작업에서는 중앙 BehindText 워터마크가 이제 studio reference에 포함된다. 따라서 이후 수치 차이는 reference capture 오류가 아니라 native renderer/compositor의 watermark opacity, image effect, z-order, placement 차이로 분리해 볼 수 있다.
+
+권장 명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-after-task293 --page 1 \
+  samples/복학원서.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx
+```
+
+해석 기준:
+
+- `복학원서.hwp`: overlay-positive reference. `domComposite`와 `overlayIncluded=true`가 기대값이다.
+- `tac-img-02.hwp`: overlay 없는 canvas-only 회귀 기준. `canvasDataURL`와 `overlayIncluded=false`가 기대값이다.
+- `request.hwp` 등 일부 일반 sample은 현행 detector에서 `overlayCount=1`로 잡혀 `domComposite`가 선택된다. 이는 detector 과검출 가능성을 포함하므로 수치 해석 시 capture mode를 함께 확인한다.
+
+## 잔여 위험과 후속 작업
+
+- `domComposite`는 현재 canvas와 `img` element를 DOM order/z-index 기준으로 합성한다. CSS transform, background-image, SVG element, blend mode 같은 복잡한 paint feature는 아직 일반화하지 않았다.
+- WebKit `takeSnapshot`은 이 harness 환경에서 단색 배경만 반환하는 한계가 재확인됐다. 향후에도 WebKit snapshot 재시도보다 DOM drawable composite 보강이 현실적인 방향이다.
+- 현행 overlay detector는 일부 일반 sample에서 `overlayCount=1`을 기록한다. 필요하면 detector가 실제 image overlay와 wrapper/DOM artifact를 구분하도록 후속 이슈를 등록하는 것이 좋다.
+- 이번 작업은 reference capture 보정이다. native renderer/compositor, watermark opacity/effect, Quick Look/Thumbnail runtime은 수정하지 않았다.
+
+## 작업지시자 승인 요청
+
+#293의 구현, Stage 보고, 최종 보고서 작성, 오늘할일 완료 처리를 완료했다. PR 게시 전 최종 승인 요청한다.

--- a/mydocs/working/task_m014_293_stage1.md
+++ b/mydocs/working/task_m014_293_stage1.md
@@ -1,0 +1,159 @@
+# Task M014 #293 Stage 1 보고서 - overlay capture decision 재현
+
+## 단계 목적
+
+`samples/복학원서.hwp`에서 `rhwp-studio` reference PNG가 overlay DOM을 누락하는 현재 상태를 재현하고, harness의 capture decision이 `canvasDataURL`로 가는 조건과 metadata를 정리했다.
+
+이번 단계에서는 production source와 harness script를 수정하지 않았다.
+
+## 산출물
+
+| 구분 | 경로 | 요약 |
+|------|------|------|
+| Stage 보고서 | `mydocs/working/task_m014_293_stage1.md` | 현행 capture decision, baseline metadata, Stage 2 보정 범위 정리 |
+| baseline summary | `build.noindex/task293-stage1-baseline/summary.md` | `복학원서.hwp`, `request.hwp` baseline visual diff 결과 |
+| baseline metadata | `build.noindex/task293-stage1-baseline/studio/*-studio.json` | capture mode, overlay count, rect, sample pixel metadata |
+| baseline PNG | `build.noindex/task293-stage1-baseline/studio/*-studio.png` | 현행 studio reference PNG |
+| sample scan summary | `build.noindex/task293-stage1-sample-scan/summary.md` | overlayCount 0 회귀 기준 후보 확인 |
+
+`build.noindex/`, `Frameworks/`, `RustBridge/target/`는 로컬 검증 산출물이며 커밋하지 않는다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 소스와 script 본문 변경 없음.
+- 문서 신규 추가만 수행.
+- `Frameworks/` 산출물은 `./scripts/build-rust-macos.sh`로 생성했지만 ignored build artifact로 유지한다.
+
+## 검증 결과
+
+### rhwp-studio asset 검증
+
+```text
+OK: rhwp-studio assets verified at /Users/melee/Documents/projects/rhwp-mac-task293/Sources/HostApp/Resources/rhwp-studio
+```
+
+분리 worktree에는 `Frameworks/universal/librhwp.a`가 없어서 최초 harness 실행은 다음 오류로 중단됐다.
+
+```text
+ERROR: missing /Users/melee/Documents/projects/rhwp-mac-task293/Frameworks/universal/librhwp.a
+Run: /Users/melee/Documents/projects/rhwp-mac-task293/scripts/build-rust-macos.sh
+```
+
+표준 스크립트로 local Frameworks 산출물을 생성했다.
+
+```text
+Architectures in the fat file: /Users/melee/Documents/projects/rhwp-mac-task293/Frameworks/universal/librhwp.a are: x86_64 arm64
+Done: /Users/melee/Documents/projects/rhwp-mac-task293/Frameworks/Rhwp.xcframework
+194M    /Users/melee/Documents/projects/rhwp-mac-task293/Frameworks/universal/librhwp.a
+194M    /Users/melee/Documents/projects/rhwp-mac-task293/Frameworks/Rhwp.xcframework
+```
+
+### baseline harness
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage1-baseline --page 1 \
+  samples/복학원서.hwp samples/basic/request.hwp
+```
+
+summary 결과:
+
+| File | Status | StudioSize | ChangedPixels | ChangedPercent | MeanRGBDelta | StudioCapture |
+|------|--------|------------|---------------|----------------|--------------|---------------|
+| `복학원서.hwp` | OK | `1587x2245` | `1141965/3562815` | `32.0523%` | `42.2623` | `canvasDataURL` |
+| `request.hwp` | OK | `1133x1587` | `321031/1798071` | `17.8542%` | `11.0716` | `canvasDataURL` |
+
+`복학원서.hwp` studio metadata:
+
+| 항목 | 값 |
+|------|----|
+| `captureMode` | `canvasDataURL` |
+| `overlayIncluded` | `false` |
+| `overlayCount` | `5` |
+| `usedOverlayUnion` | `true` |
+| `canvasSampleNonWhitePixels` | `1859 / 44250` |
+| `snapshotSampleNonWhitePixels` | `44250 / 44250` |
+| `canvasRect` | `x=20.09375, y=10, width=793.5, height=1122.5` |
+| `rect` | `x=20.09375, y=10, width=793.5, height=1122.5` |
+| PNG size | `1587x2245` |
+
+핵심 재현 결과:
+
+- `overlayCount=5`, `usedOverlayUnion=true`가 기록되어 overlay DOM 존재 감지는 이미 되고 있다.
+- 그런데 `captureMode=canvasDataURL`, `overlayIncluded=false`라서 최종 PNG는 target canvas export 결과다.
+- canvas `toDataURL()`은 DOM overlay layer를 포함할 수 없으므로, 현재 생성된 `복학원서.hwp` studio reference PNG는 좌상단 로고와 중앙 BehindText 워터마크를 포함하지 않는 경로로 생성됐다고 판단한다.
+
+### overlayCount 0 기준 후보 확인
+
+`request.hwp`도 현행 detector 기준으로 `overlayCount=1`, `usedOverlayUnion=true`가 나와 overlay 없는 회귀 기준으로 쓰기 어렵다. Stage 1에서 추가 sample scan을 실행했다.
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage1-sample-scan --page 1 \
+  samples/hwpx/hwpx-01.hwpx samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+sample scan 결과:
+
+| File | Status | StudioCapture | overlayCount | usedOverlayUnion | overlayIncluded |
+|------|--------|---------------|--------------|------------------|-----------------|
+| `hwpx-01.hwpx` | OK | `canvasDataURL` | `1` | `true` | `false` |
+| `tac-img-02.hwp` | OK | `canvasDataURL` | `0` | `false` | `false` |
+| `tac-img-02.hwpx` | OK | `canvasDataURL` | `1` | `true` | `false` |
+| `hwp-img-001.hwp` | OK | `canvasDataURL` | `1` | `true` | `false` |
+| `img-start-001.hwp` | OK | `canvasDataURL` | `1` | `true` | `false` |
+
+Stage 2의 canvas-only 회귀 기준은 `request.hwp`가 아니라 `samples/tac-img-02.hwp`로 잡는 것이 더 정확하다.
+
+### capture decision 원인
+
+현재 `StudioReferenceRenderer.capture`의 decision은 다음 순서다.
+
+```swift
+if pageState.canvasSampleNonWhitePixels > 0 {
+    png = try exportCanvasPNG(pageNumber: pageNumber)
+    if let snapshotPNG = try? captureSnapshotPNG(rect: snapshotRectMetadata.cgRect) {
+        snapshotSampleNonWhitePixels = snapshotPNG.sampleNonWhitePixels
+        snapshotSamplePixels = snapshotPNG.samplePixels
+    }
+} else {
+    png = try captureSnapshotPNG(rect: snapshotRectMetadata.cgRect)
+    captureMode = "webViewSnapshot"
+    overlayIncluded = true
+    snapshotSampleNonWhitePixels = png.sampleNonWhitePixels
+    snapshotSamplePixels = png.samplePixels
+}
+```
+
+따라서 overlay DOM이 있어도 canvas에 non-white pixel이 있으면 canvas export가 우선된다. `pageStateScript`는 overlay DOM을 세고 `usedOverlayUnion`을 설정하지만, 그 값이 capture decision에 사용되지 않는다.
+
+### 명령 검증
+
+```text
+git diff --check
+```
+
+통과했다.
+
+## 잔여 위험
+
+- 현재 overlay detector는 여러 일반 sample에서 `overlayCount=1`을 기록한다. Stage 2에서 `overlayCount > 0`만으로 snapshot을 강제하면 생각보다 많은 sample이 snapshot path로 바뀔 수 있다.
+- `request.hwp`, `hwpx-01.hwpx`, `tac-img-02.hwpx`, `hwp-img-001.hwp`, `img-start-001.hwp`의 `overlayCount=1`이 실제 overlay인지, page wrapper/DOM artifact 과검출인지 Stage 2에서 selector 또는 classification을 점검해야 한다.
+- `snapshotSampleNonWhitePixels`가 `snapshotSamplePixels`와 같은 값으로 기록되는 sample이 많다. snapshot sampling이 배경/투명/white 판단과 다른 좌표계 영향을 받는지 Stage 2에서 해석을 조심해야 한다.
+- WebView snapshot은 viewport와 scroll alignment에 민감하므로, Stage 2에서 snapshot 실패를 canvas fallback으로 숨기지 않아야 한다.
+
+## 다음 단계 영향
+
+Stage 2 최소 변경 범위는 다음으로 확정한다.
+
+1. `pageState.usedOverlayUnion == true` 또는 의미 있는 overlay classification이 확인된 경우 canvas export보다 WebView snapshot을 우선한다.
+2. `samples/tac-img-02.hwp`는 `overlayCount=0`, `usedOverlayUnion=false` 기준으로 canvas-only path 유지 여부를 검증한다.
+3. `request.hwp` 등 `overlayCount=1` sample은 과검출 가능성이 있으므로, 단순 count 기준 변경이 과도하게 snapshot을 선택하는지 별도 관찰한다.
+4. `복학원서.hwp`는 Stage 2 완료 기준상 `captureMode=webViewSnapshot`, `overlayIncluded=true`가 되어야 한다.
+
+## 승인 요청
+
+Stage 1은 현행 capture decision 재현과 원인 inventory를 완료했다. Stage 2에서 `scripts/preview_visual_diff_harness.swift`의 overlay-aware snapshot 선택 보강으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m014_293_stage2.md
+++ b/mydocs/working/task_m014_293_stage2.md
@@ -1,0 +1,173 @@
+# Task M014 #293 Stage 2 보고서 - overlay snapshot capture 선택 보강
+
+## 단계 목적
+
+overlay DOM 또는 overlay union이 있는 `rhwp-studio` page에서 canvas-only export 대신 WebView snapshot을 선택하도록 `preview visual diff harness`의 capture decision을 보강했다.
+
+## 산출물
+
+| 구분 | 경로 | 요약 |
+|------|------|------|
+| source | `scripts/preview_visual_diff_harness.swift` | overlay 감지 시 `captureSnapshotPNG`를 우선 선택하도록 decision 순서 변경 |
+| Stage 보고서 | `mydocs/working/task_m014_293_stage2.md` | 구현 내용, smoke 결과, 잔여 위험 정리 |
+| smoke summary | `build.noindex/task293-stage2-smoke/summary.md` | `복학원서.hwp`, `request.hwp` 보정 후 capture 결과 |
+| canvas 기준 summary | `build.noindex/task293-stage2-canvas-baseline/summary.md` | `tac-img-02.hwp` canvas-only path 유지 확인 |
+
+`build.noindex/`, `Frameworks/`, `RustBridge/target/`는 로컬 검증 산출물이며 커밋하지 않는다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- `StudioReferenceRenderer.capture` 내부 decision만 수정했다.
+- JavaScript probe, wrapper script, renderer/compositor production path는 수정하지 않았다.
+- 기존 canvas export path는 overlay가 없고 canvas가 non-empty인 경우 그대로 유지한다.
+
+변경 전 decision:
+
+```swift
+if pageState.canvasSampleNonWhitePixels > 0 {
+    png = try exportCanvasPNG(pageNumber: pageNumber)
+    ...
+} else {
+    png = try captureSnapshotPNG(rect: snapshotRectMetadata.cgRect)
+    captureMode = "webViewSnapshot"
+    overlayIncluded = true
+    ...
+}
+```
+
+변경 후 decision:
+
+```swift
+let hasOverlayDOM = pageState.overlayCount > 0 || pageState.usedOverlayUnion
+let shouldCaptureSnapshot = hasOverlayDOM || pageState.canvasSampleNonWhitePixels <= 0
+if shouldCaptureSnapshot {
+    png = try captureSnapshotPNG(rect: snapshotRectMetadata.cgRect)
+    captureMode = "webViewSnapshot"
+    overlayIncluded = hasOverlayDOM
+    ...
+} else {
+    png = try exportCanvasPNG(pageNumber: pageNumber)
+    ...
+}
+```
+
+이제 overlay-positive 문서에서 snapshot 실패가 발생하면 canvas fallback으로 조용히 숨지 않고 Stage 2 smoke가 실패한다.
+
+## 검증 결과
+
+### Swift compile
+
+명령:
+
+```bash
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task293-stage2-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task293-stage2-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task293-stage2-syntax-check
+```
+
+결과: 성공.
+
+### Stage 2 smoke
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage2-smoke --page 1 \
+  samples/복학원서.hwp samples/basic/request.hwp
+```
+
+summary 결과:
+
+| File | Status | StudioSize | ChangedPixels | ChangedPercent | MeanRGBDelta | StudioCapture |
+|------|--------|------------|---------------|----------------|--------------|---------------|
+| `복학원서.hwp` | OK | `1588x2246` | `3504631/3566648` | `98.2612%` | `48.7462` | `webViewSnapshot` |
+| `request.hwp` | OK | `1134x1588` | `1723444/1800792` | `95.7048%` | `21.2012` | `webViewSnapshot` |
+
+`복학원서.hwp` metadata:
+
+| 항목 | Stage 1 | Stage 2 |
+|------|---------|---------|
+| `captureMode` | `canvasDataURL` | `webViewSnapshot` |
+| `overlayIncluded` | `false` | `true` |
+| `overlayCount` | `5` | `5` |
+| `usedOverlayUnion` | `true` | `true` |
+| PNG size | `1587x2245` | `1588x2246` |
+| PNG bytes | `327525` | `67706` |
+
+`request.hwp`도 Stage 1에서 `overlayCount=1`, `usedOverlayUnion=true`로 감지됐기 때문에 이번 policy에서는 snapshot으로 바뀌었다. Stage 1 결론대로 `request.hwp`는 overlay 없는 canvas-only 회귀 기준으로 보지 않는다.
+
+### canvas-only 기준 smoke
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage2-canvas-baseline --page 1 \
+  samples/tac-img-02.hwp
+```
+
+summary 결과:
+
+| File | Status | StudioSize | ChangedPixels | ChangedPercent | MeanRGBDelta | StudioCapture |
+|------|--------|------------|---------------|----------------|--------------|---------------|
+| `tac-img-02.hwp` | OK | `1587x2245` | `146622/3562815` | `4.1153%` | `3.6698` | `canvasDataURL` |
+
+`tac-img-02.hwp` metadata:
+
+| 항목 | 값 |
+|------|----|
+| `captureMode` | `canvasDataURL` |
+| `overlayIncluded` | `false` |
+| `overlayCount` | `0` |
+| `usedOverlayUnion` | `false` |
+| `canvasSampleNonWhitePixels` | `2017 / 44250` |
+| `snapshotSampleNonWhitePixels` | `44250 / 44250` |
+
+### PNG 속성 확인
+
+```text
+복학원서.hwp stage2 studio PNG: 1588x2246, hasAlpha=yes, bitsPerSample=8
+request.hwp stage2 studio PNG: 1134x1588, hasAlpha=yes, bitsPerSample=8
+tac-img-02.hwp canvas baseline PNG: 1587x2245, hasAlpha=yes, bitsPerSample=8
+```
+
+### diff check
+
+```text
+git diff --check
+```
+
+통과했다.
+
+## 잔여 위험
+
+- Snapshot path의 visual diff 수치가 Stage 1보다 크게 증가했다. 이는 reference capture mode가 실제 WebView snapshot으로 바뀐 결과이지만, Stage 3에서 overlay 포함 여부와 snapshot PNG 해석을 다시 확인해야 한다.
+- `request.hwp`처럼 일반 sample도 `overlayCount=1`로 잡히는 경우가 있다. 이번 Stage 2는 이슈 목표에 맞춰 detector가 overlay를 감지하면 snapshot을 선택하지만, detector 과검출 여부는 Stage 3 sample set smoke에서 계속 관찰해야 한다.
+- `snapshotSampleNonWhitePixels`가 전체 sample pixel과 같은 값으로 나오는 경향이 있다. 현재는 기존 metadata를 유지했지만, 이 값은 snapshot path에서 page background/alpha 해석 영향을 받을 수 있다.
+- `복학원서.hwp`의 PNG가 실제로 좌상단 로고와 중앙 워터마크를 포함하는지의 시각 확인과 최종 sample set 재측정은 Stage 3 범위로 남긴다.
+
+## 다음 단계 영향
+
+Stage 3에서는 다음을 확인한다.
+
+1. `복학원서.hwp` studio reference PNG의 좌상단 로고와 중앙 BehindText 워터마크 포함 여부.
+2. overlay-positive sample의 `captureMode=webViewSnapshot`, `overlayIncluded=true` 유지 여부.
+3. `tac-img-02.hwp` 같은 `overlayCount=0` sample의 `canvasDataURL` 유지 여부.
+4. 기존 v0.1.4 image sample set에서 snapshot path 전환이 visual diff summary 해석에 미치는 영향.
+
+## 승인 요청
+
+Stage 2는 overlay-aware snapshot 선택 보강과 smoke 검증을 완료했다. Stage 3 sample set smoke와 visual diff 재측정으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m014_293_stage3.md
+++ b/mydocs/working/task_m014_293_stage3.md
@@ -1,0 +1,165 @@
+# Task M014 #293 Stage 3 보고서 - overlay snapshot smoke 재측정
+
+## 단계 목적
+
+보정 후 `rhwp-studio` overlay-positive sample과 v0.1.4 image sample set의 capture metadata와 visual diff metric을 다시 생성했다.
+
+Stage 3 중 `WKWebView.takeSnapshot` 결과가 실제 page content가 아니라 단색 `#f0f0f0` PNG로 나오는 것을 확인해, overlay-positive reference는 WebKit bitmap snapshot 대신 WebView DOM의 same-origin canvas/image drawable을 JavaScript에서 합성하는 `domComposite` 경로로 회복했다.
+
+## 산출물
+
+| 구분 | 경로 | 요약 |
+|------|------|------|
+| source | `scripts/preview_visual_diff_harness.swift` | overlay-positive 문서에서 DOM composite PNG export 경로 추가 |
+| Stage 보고서 | `mydocs/working/task_m014_293_stage3.md` | visual check, sample metric, 잔여 위험 정리 |
+| overlay summary | `build.noindex/task293-stage3-overlay/summary.md` | `복학원서.hwp` 최종 overlay-positive smoke |
+| sample summary | `build.noindex/task293-stage3-samples/summary.md` | v0.1.4 sample set 최종 smoke |
+
+`build.noindex/`, `Frameworks/`, `RustBridge/target/`는 로컬 검증 산출물이며 커밋하지 않는다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- `StudioReferenceRenderer.capture`에서 overlay-positive 문서는 `exportCompositePNG`를 사용하도록 변경했다.
+- `exportCanvasPNG`와 composite export가 같은 PNG decode helper를 공유하도록 정리했다.
+- `compositeDataURLScript`를 추가해 같은 page rect 안의 canvas와 image overlay를 DOM order/z-index 기준으로 offscreen canvas에 그린다.
+- renderer/compositor production path, wrapper script, bundled `rhwp-studio` asset은 수정하지 않았다.
+
+최종 capture decision:
+
+```swift
+let hasOverlayDOM = pageState.overlayCount > 0 || pageState.usedOverlayUnion
+if hasOverlayDOM {
+    png = try exportCompositePNG(pageNumber: pageNumber)
+    captureMode = "domComposite"
+    overlayIncluded = true
+} else if pageState.canvasSampleNonWhitePixels <= 0 {
+    png = try captureSnapshotPNG(rect: snapshotRectMetadata.cgRect)
+    captureMode = "webViewSnapshot"
+} else {
+    png = try exportCanvasPNG(pageNumber: pageNumber)
+}
+```
+
+## 검증 결과
+
+### 중간 실패와 회복
+
+Stage 2의 `webViewSnapshot` 경로로 Stage 3 visual check를 수행했을 때 `복학원서.hwp` studio PNG는 문서 내용 없이 전체가 단색 `#f0f0f0`이었다. window를 화면 안쪽으로 옮겨도 동일했다.
+
+#280 Stage 2에서도 `WKWebView.takeSnapshot`이 page canvas 영역의 배경만 캡처하고 canvas backing store를 누락한다는 관찰이 있었으므로, 이번 Stage 3에서는 overlay-positive reference를 `domComposite`로 회복했다.
+
+### Swift compile
+
+명령:
+
+```bash
+swiftc -parse-as-library \
+  -module-cache-path build.noindex/task293-stage3-swift-module-cache \
+  -Xcc -fmodules-cache-path=build.noindex/task293-stage3-clang-module-cache \
+  -I Frameworks/modulemap \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  Sources/RhwpCoreBridge/RenderTree.swift \
+  Sources/RhwpCoreBridge/FontFallback.swift \
+  Sources/RhwpCoreBridge/FontResourceRegistry.swift \
+  Sources/RhwpCoreBridge/CGTreeRenderer.swift \
+  Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/preview_visual_diff_harness.swift \
+  Frameworks/universal/librhwp.a \
+  -framework AppKit -framework CoreGraphics -framework CoreText \
+  -framework Foundation -framework ImageIO -framework UniformTypeIdentifiers \
+  -framework Security -framework CoreFoundation -framework WebKit \
+  -lc++ -liconv -lz \
+  -o build.noindex/task293-stage3-syntax-check
+```
+
+결과: 성공.
+
+### overlay-positive smoke
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage3-overlay --page 1 \
+  samples/복학원서.hwp
+```
+
+summary 결과:
+
+| File | Status | StudioSize | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture |
+|------|--------|------------|---------------|----------------|--------------|-------------|---------------|
+| `복학원서.hwp` | OK | `1587x2245` | `1140387/3562815` | `32.0080%` | `37.8073` | `255` | `domComposite` |
+
+metadata:
+
+| 항목 | Stage 1 | Stage 3 최종 |
+|------|---------|--------------|
+| `captureMode` | `canvasDataURL` | `domComposite` |
+| `overlayIncluded` | `false` | `true` |
+| `overlayCount` | `5` | `5` |
+| `usedOverlayUnion` | `true` | `true` |
+| PNG size | `1587x2245` | `1587x2245` |
+
+시각 확인:
+
+- 좌상단 고려대학교 로고가 포함됨.
+- 중앙 BehindText 워터마크가 포함됨.
+- 하단 우측 붉은 도장 overlay가 포함됨.
+
+### v0.1.4 sample set smoke
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage3-samples --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp
+```
+
+summary 결과:
+
+| File | Status | StudioSize | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture |
+|------|--------|------------|---------------|----------------|--------------|-------------|---------------|
+| `request.hwp` | OK | `1133x1587` | `321031/1798071` | `17.8542%` | `11.0716` | `255` | `domComposite` |
+| `hwpx-01.hwpx` | OK | `1587x2245` | `535436/3562815` | `15.0285%` | `15.2088` | `255` | `domComposite` |
+| `tac-img-02.hwp` | OK | `1587x2245` | `146622/3562815` | `4.1153%` | `3.6698` | `255` | `canvasDataURL` |
+| `tac-img-02.hwpx` | OK | `1587x2245` | `146622/3562815` | `4.1153%` | `3.6698` | `255` | `domComposite` |
+| `hwp-img-001.hwp` | OK | `1587x2245` | `278887/3562815` | `7.8277%` | `8.1872` | `255` | `domComposite` |
+
+metadata 확인:
+
+- `복학원서.hwp`: `captureMode=domComposite`, `overlayIncluded=true`, `overlayCount=5`, `usedOverlayUnion=true`
+- `tac-img-02.hwp`: `captureMode=canvasDataURL`, `overlayIncluded=false`, `overlayCount=0`, `usedOverlayUnion=false`
+- 나머지 sample은 현행 detector 기준 `overlayCount=1`이라 `domComposite`로 전환됨.
+
+### PNG 속성 확인
+
+```text
+복학원서.hwp stage3 studio PNG: 1587x2245, hasAlpha=yes, bitsPerSample=8
+```
+
+### diff check
+
+```text
+git diff --check
+```
+
+통과했다.
+
+## 잔여 위험
+
+- `domComposite`는 canvas와 `img` element를 DOM order/z-index 기준으로 합성한다. CSS transform, background-image, SVG element, blend mode 같은 더 복잡한 DOM paint feature는 아직 일반화하지 않았다.
+- `request.hwp`처럼 일반 sample도 detector 기준 `overlayCount=1`로 잡힌다. 이번 이슈 목표상 overlay 후보가 있으면 composite를 선택하지만, 향후 detector 과검출을 줄이는 후속 작업이 필요할 수 있다.
+- `captureMode`는 최종적으로 `webViewSnapshot`이 아니라 `domComposite`다. WebKit snapshot은 이 harness 환경에서 blank capture가 재현되어 실제 캡처 방식과 metadata 일치를 위해 별도 mode로 기록했다.
+- 이번 작업은 reference capture를 보정한 것이며 native renderer/compositor 자체의 watermark opacity, image effect, z-order는 수정하지 않았다.
+
+## 다음 단계 영향
+
+Stage 4에서는 다음을 최종 보고서에 정리한다.
+
+1. #282/#116 handoff: `복학원서.hwp` reference capture는 `domComposite`, overlay included 기준으로 사용한다.
+2. sample set metric: `tac-img-02.hwp`만 canvas-only path 유지, 나머지 overlay-detected sample은 composite path로 해석한다.
+3. WebKit snapshot blank 한계: 향후 WebKit snapshot 재시도보다 DOM drawable composite 보강이 현실적인 후속 방향이다.
+
+## 승인 요청
+
+Stage 3은 overlay 포함 reference PNG와 sample set 재측정을 완료했다. Stage 4 #282/#116 handoff와 최종 보고 정리로 진행해도 되는지 승인 요청한다.

--- a/scripts/preview_visual_diff_harness.swift
+++ b/scripts/preview_visual_diff_harness.swift
@@ -586,18 +586,20 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         var overlayIncluded = false
         var snapshotSampleNonWhitePixels = 0
         var snapshotSamplePixels = 0
-        if pageState.canvasSampleNonWhitePixels > 0 {
+        let hasOverlayDOM = pageState.overlayCount > 0 || pageState.usedOverlayUnion
+        let shouldCaptureSnapshot = hasOverlayDOM || pageState.canvasSampleNonWhitePixels <= 0
+        if shouldCaptureSnapshot {
+            png = try captureSnapshotPNG(rect: snapshotRectMetadata.cgRect)
+            captureMode = "webViewSnapshot"
+            overlayIncluded = hasOverlayDOM
+            snapshotSampleNonWhitePixels = png.sampleNonWhitePixels
+            snapshotSamplePixels = png.samplePixels
+        } else {
             png = try exportCanvasPNG(pageNumber: pageNumber)
             if let snapshotPNG = try? captureSnapshotPNG(rect: snapshotRectMetadata.cgRect) {
                 snapshotSampleNonWhitePixels = snapshotPNG.sampleNonWhitePixels
                 snapshotSamplePixels = snapshotPNG.samplePixels
             }
-        } else {
-            png = try captureSnapshotPNG(rect: snapshotRectMetadata.cgRect)
-            captureMode = "webViewSnapshot"
-            overlayIncluded = true
-            snapshotSampleNonWhitePixels = png.sampleNonWhitePixels
-            snapshotSamplePixels = png.samplePixels
         }
         try png.data.write(to: pngURL, options: .atomic)
 

--- a/scripts/preview_visual_diff_harness.swift
+++ b/scripts/preview_visual_diff_harness.swift
@@ -587,11 +587,15 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         var snapshotSampleNonWhitePixels = 0
         var snapshotSamplePixels = 0
         let hasOverlayDOM = pageState.overlayCount > 0 || pageState.usedOverlayUnion
-        let shouldCaptureSnapshot = hasOverlayDOM || pageState.canvasSampleNonWhitePixels <= 0
-        if shouldCaptureSnapshot {
+        if hasOverlayDOM {
+            png = try exportCompositePNG(pageNumber: pageNumber)
+            captureMode = "domComposite"
+            overlayIncluded = true
+            snapshotSampleNonWhitePixels = png.sampleNonWhitePixels
+            snapshotSamplePixels = png.samplePixels
+        } else if pageState.canvasSampleNonWhitePixels <= 0 {
             png = try captureSnapshotPNG(rect: snapshotRectMetadata.cgRect)
             captureMode = "webViewSnapshot"
-            overlayIncluded = hasOverlayDOM
             snapshotSampleNonWhitePixels = png.sampleNonWhitePixels
             snapshotSamplePixels = png.samplePixels
         } else {
@@ -934,13 +938,22 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
 
     private func exportCanvasPNG(pageNumber: Int) throws -> PNGOutput {
         let value = try evaluateJavaScript(canvasDataURLScript(pageNumber: pageNumber), timeout: 10, phase: .canvasExport)
+        return try pngOutput(fromCanvasExportValue: value, phase: .canvasExport)
+    }
+
+    private func exportCompositePNG(pageNumber: Int) throws -> PNGOutput {
+        let value = try evaluateJavaScript(compositeDataURLScript(pageNumber: pageNumber), timeout: 10, phase: .canvasExport)
+        return try pngOutput(fromCanvasExportValue: value, phase: .canvasExport)
+    }
+
+    private func pngOutput(fromCanvasExportValue value: Any?, phase: PreviewHarnessPhase) throws -> PNGOutput {
         guard let json = value as? String,
               let data = json.data(using: .utf8),
               let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any],
               let dataURL = dictionary["dataURL"] as? String
         else {
             throw PreviewHarnessPhaseError(
-                phase: .canvasExport,
+                phase: phase,
                 detail: "unexpected canvas export result: \(describeJavaScriptValue(value))"
             )
         }
@@ -1196,6 +1209,132 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
               exportContext.drawImage(target, 0, 0);
               return exportCanvas.toDataURL('image/png');
             })()
+          };
+        })());
+        """
+    }
+
+    // WKWebView snapshots can omit the canvas backing store in this harness, so
+    // overlay-positive references are composited from same-origin DOM drawables.
+    private func compositeDataURLScript(pageNumber: Int) -> String {
+        """
+        JSON.stringify((() => {
+          const pageNumber = \(pageNumber);
+          const content = document.querySelector('#scroll-content');
+          const canvases = content
+            ? Array.from(content.querySelectorAll('canvas')).filter((canvas) => {
+                const rect = canvas.getBoundingClientRect();
+                return rect.width > 0 && rect.height > 0 && canvas.width > 0 && canvas.height > 0;
+              })
+            : [];
+          const target = canvases[pageNumber - 1] || null;
+          if (!target) {
+            throw new Error(`page canvas not found for page ${pageNumber}`);
+          }
+
+          const targetRect = target.getBoundingClientRect();
+          let unionLeft = targetRect.left;
+          let unionTop = targetRect.top;
+          let unionRight = targetRect.right;
+          let unionBottom = targetRect.bottom;
+          const drawables = [];
+          let order = 0;
+          const addDrawable = (element, role) => {
+            const tag = element.tagName.toLowerCase();
+            if (tag !== 'canvas' && tag !== 'img') {
+              return;
+            }
+            const style = window.getComputedStyle(element);
+            if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) {
+              return;
+            }
+            if (tag === 'img' && (!element.complete || element.naturalWidth <= 0 || element.naturalHeight <= 0)) {
+              return;
+            }
+            const rect = element.getBoundingClientRect();
+            if (rect.width <= 0 || rect.height <= 0) {
+              return;
+            }
+            const intersectsVertical = rect.bottom >= targetRect.top - 1 && rect.top <= targetRect.bottom + 1;
+            const intersectsHorizontal = rect.right >= targetRect.left - 1 && rect.left <= targetRect.right + 1;
+            if (!intersectsVertical || !intersectsHorizontal) {
+              return;
+            }
+            unionLeft = Math.min(unionLeft, rect.left);
+            unionTop = Math.min(unionTop, rect.top);
+            unionRight = Math.max(unionRight, rect.right);
+            unionBottom = Math.max(unionBottom, rect.bottom);
+            const z = Number.parseFloat(style.zIndex);
+            const opacity = Number.parseFloat(style.opacity);
+            drawables.push({
+              element,
+              role,
+              tag,
+              order: order++,
+              zIndex: Number.isFinite(z) ? z : 0,
+              opacity: Number.isFinite(opacity) ? opacity : 1,
+              rect
+            });
+          };
+
+          addDrawable(target, 'pageCanvas');
+          for (const element of Array.from(content.querySelectorAll('*'))) {
+            if (element === target) {
+              continue;
+            }
+            addDrawable(element, 'overlay');
+          }
+          drawables.sort((a, b) => (a.zIndex - b.zIndex) || (a.order - b.order));
+
+          const dpr = Number(window.devicePixelRatio) || 1;
+          const cssWidth = Math.max(1, unionRight - unionLeft);
+          const cssHeight = Math.max(1, unionBottom - unionTop);
+          const exportCanvas = document.createElement('canvas');
+          exportCanvas.width = Math.max(1, Math.round(cssWidth * dpr));
+          exportCanvas.height = Math.max(1, Math.round(cssHeight * dpr));
+          const exportContext = exportCanvas.getContext('2d');
+          exportContext.fillStyle = '#ffffff';
+          exportContext.fillRect(0, 0, exportCanvas.width, exportCanvas.height);
+          exportContext.setTransform(dpr, 0, 0, dpr, -unionLeft * dpr, -unionTop * dpr);
+
+          for (const item of drawables) {
+            exportContext.save();
+            exportContext.globalAlpha = Math.max(0, Math.min(1, item.opacity));
+            exportContext.drawImage(
+              item.element,
+              item.rect.left,
+              item.rect.top,
+              item.rect.width,
+              item.rect.height
+            );
+            exportContext.restore();
+          }
+
+          exportContext.setTransform(1, 0, 0, 1, 0, 0);
+          const imageData = exportContext.getImageData(0, 0, exportCanvas.width, exportCanvas.height).data;
+          const step = Math.max(1, Math.floor(Math.min(exportCanvas.width, exportCanvas.height) / 160));
+          let canvasSampleNonWhitePixels = 0;
+          let canvasSamplePixels = 0;
+          for (let y = 0; y < exportCanvas.height; y += step) {
+            for (let x = 0; x < exportCanvas.width; x += step) {
+              const index = (y * exportCanvas.width + x) * 4;
+              const r = imageData[index];
+              const g = imageData[index + 1];
+              const b = imageData[index + 2];
+              const a = imageData[index + 3];
+              canvasSamplePixels += 1;
+              if (a > 0 && (r < 245 || g < 245 || b < 245)) {
+                canvasSampleNonWhitePixels += 1;
+              }
+            }
+          }
+
+          return {
+            width: exportCanvas.width,
+            height: exportCanvas.height,
+            canvasSampleNonWhitePixels,
+            canvasSamplePixels,
+            dataURL: exportCanvas.toDataURL('image/png')
           };
         })());
         """


### PR DESCRIPTION
## 요약

- 대상 타스크: #293
- 왜: `rhwp-studio` 화면에는 보이는 DOM overlay가 visual diff harness의 studio reference PNG에서 누락되어 native renderer 비교 기준이 흔들렸다.
- 무엇: overlay-positive page는 same-origin DOM drawable을 오프스크린 canvas로 합성한 `domComposite` PNG로 저장하고, overlay 없는 canvas-only 문서는 기존 `canvasDataURL` 경로를 유지한다.
- 리뷰 포인트: `scripts/preview_visual_diff_harness.swift`의 capture decision, `compositeDataURLScript`, `captureMode`/`overlayIncluded` metadata 기록.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/2f5a998862590e544fa916aa9c13cdaec67bdc1b/mydocs/working/task_m014_293_stage1.md)** ([e177e6c](https://github.com/postmelee/alhangeul-macos/commit/e177e6cf2581885ff0aedc88f740f9c9f67f7446)): `복학원서.hwp`에서 `overlayCount=5`인데 `captureMode=canvasDataURL`, `overlayIncluded=false`로 저장되는 문제를 재현했다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/2f5a998862590e544fa916aa9c13cdaec67bdc1b/mydocs/working/task_m014_293_stage2.md)** ([db77c30](https://github.com/postmelee/alhangeul-macos/commit/db77c30a455694502f61b9f15c71196cb5b3d765)): overlay-positive capture를 `webViewSnapshot` 우선으로 보강했지만 WebKit snapshot blank 위험을 확인했다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/2f5a998862590e544fa916aa9c13cdaec67bdc1b/mydocs/working/task_m014_293_stage3.md)** ([8ccac7a](https://github.com/postmelee/alhangeul-macos/commit/8ccac7ad3baf5013378346274aafeb3f855e1484)): `domComposite` capture로 overlay 포함 reference를 생성하고 smoke sample을 재측정했다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/2f5a998862590e544fa916aa9c13cdaec67bdc1b/mydocs/report/task_m014_293_report.md)** ([2f5a998](https://github.com/postmelee/alhangeul-macos/commit/2f5a998862590e544fa916aa9c13cdaec67bdc1b)): 최종 보고서와 오늘할일 완료 상태를 정리했다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `scripts/preview_visual_diff_harness.swift` | overlay-positive 문서에서 canvas-only export 대신 DOM composite PNG를 생성 | `canvas`/`img` 기반 DOM order 및 z-index 정렬 범위 |
| `scripts/preview_visual_diff_harness.swift` | `captureMode=domComposite`, `overlayIncluded=true` metadata 기록 | #282/#116에서 baseline 해석 시 capture mode 확인 필요 |
| `mydocs/working`, `mydocs/report`, `mydocs/orders` | 재현, 구현 경과, 검증, 최종 handoff 문서화 | Stage 2 `webViewSnapshot` 시도는 Stage 3에서 supersede됨 |

- 수행 계획서: [task_m014_293.md](https://github.com/postmelee/alhangeul-macos/blob/2f5a998862590e544fa916aa9c13cdaec67bdc1b/mydocs/plans/task_m014_293.md)
- 구현 계획서: [task_m014_293_impl.md](https://github.com/postmelee/alhangeul-macos/blob/2f5a998862590e544fa916aa9c13cdaec67bdc1b/mydocs/plans/task_m014_293_impl.md)
- 최종 보고서: [task_m014_293_report.md](https://github.com/postmelee/alhangeul-macos/blob/2f5a998862590e544fa916aa9c13cdaec67bdc1b/mydocs/report/task_m014_293_report.md)

## 핵심 리뷰 포인트

- `overlayCount > 0 || usedOverlayUnion`일 때만 `domComposite`를 선택하고, overlay 없는 `tac-img-02.hwp`는 기존 `canvasDataURL` 경로를 유지한다.
- `WKWebView.takeSnapshot`은 harness 환경에서 blank PNG가 나올 수 있어 overlay-positive 최종 기준으로 쓰지 않는다.
- `domComposite`는 현재 same-origin `canvas`와 `img` drawable을 대상으로 한다.

## 검증

- `./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage3-overlay --page 1 samples/복학원서.hwp`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task293-stage3-samples --page 1 samples/request.hwp samples/hwpx-01.hwpx samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp`
- `복학원서.hwp` 최종 studio PNG 수동 확인: 좌상단 고려대학교 로고, 중앙 BehindText 워터마크, 하단 우측 붉은 도장 포함.
- `복학원서.hwp`: `captureMode=domComposite`, `overlayIncluded=true`, `ChangedPercent=32.0080%`, `MeanRGBDelta=37.8073`.
- `tac-img-02.hwp`: `captureMode=canvasDataURL`, `overlayIncluded=false`, `ChangedPercent=4.1153%`, `MeanRGBDelta=3.6698`.
- `rg -n "#293|overlay|captureMode|overlayIncluded|webViewSnapshot|canvasDataURL|#282|#116|ChangedPixels|MeanRGBDelta" mydocs/report/task_m014_293_report.md mydocs/orders/20260529.md`
- `git diff --check`

## 스크린샷

`복학원서.hwp` 1페이지 기준입니다. GitHub PR 편집 화면에서 아래 placeholder를 각 PNG 드래그앤드롭 결과로 교체하면 됩니다.

| Before: `canvasDataURL` | After: `domComposite` |
|-------------------------|-----------------------|
|<img width="1587" height="2245" alt="01-before-canvasDataURL-missing-overlay" src="https://github.com/user-attachments/assets/6c644270-4765-4d38-8984-208d93c58713" />|<img width="1587" height="2245" alt="02-after-domComposite-overlay-included" src="https://github.com/user-attachments/assets/bf69918d-025a-4371-908c-47bebfbd7b3b" />|

| Native vs Studio Diff |
|-----------------------|
| <img width="1587" height="2245" alt="03-after-native-vs-studio-diff" src="https://github.com/user-attachments/assets/68af4b4f-38b2-4318-bd67-6b327e886bb2" /> |

## 관련 이슈

- #282: 후속 native renderer/compositor parity 측정에서 `복학원서.hwp` studio reference는 `domComposite` 기준으로 해석해야 한다.
- #116: watermark parity 작업에서 중앙 BehindText watermark는 이제 studio reference에 포함된다.

## 후속 이슈 제안

- overlay detector가 일부 일반 sample에서 `overlayCount=1`을 기록하므로, 실제 image overlay와 wrapper/DOM artifact를 구분하는 정밀화가 필요하면 별도 이슈로 분리한다.
- CSS `background-image`, SVG, blend mode, transform까지 DOM composite 대상이 넓어지는 문서가 발견되면 capture script 확장 이슈로 분리한다.

## 남은 리스크

- `domComposite`는 현재 `canvas`와 `img` element를 대상으로 하며 CSS 배경, SVG, 복잡한 transform, blend mode를 완전하게 재현하지 않는다.
- `webViewSnapshot` 경로는 blank snapshot 위험이 있어 blank-canvas fallback 용도로만 남겼다.
- `request.hwp`처럼 현행 detector가 `overlayCount=1`로 잡는 sample은 metric 해석 시 `captureMode`를 함께 확인해야 한다.
