### PR TITLE
Task #282: Quick Look/Thumbnail native compositor 보강

### DIFF
--- a/Alhangeul.xcodeproj/project.pbxproj
+++ b/Alhangeul.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		364457423D706CF1C778334C /* ExtensionStatusModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8E524F7A95D1616AB85E3F2 /* ExtensionStatusModel.swift */; };
 		37B400334D28A4A06AC40307 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4457E7F57DA695C2D4A7757 /* CoreServices.framework */; };
 		39EB4CA94F5944239BDB869F /* FontResourceRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2D57719DF9672E7C311D7 /* FontResourceRegistry.swift */; };
+		3BA210E4DB4D1BF2C8E03893 /* HwpNativePageCompositor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541160BFAFD7D51040244110 /* HwpNativePageCompositor.swift */; };
 		41C5D25E1060BEF211833C8A /* HwpPreviewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F373DBDDC753FC79292E2D /* HwpPreviewProvider.swift */; };
 		44CDAB1946DFA27A7CADCF6D /* RecentDocumentThumbnailRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4915E7318DD22D9A61F584 /* RecentDocumentThumbnailRefresher.swift */; };
 		4603821692664AB0F6480AD4 /* FontFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF11065A3E3439B4C5B8DD7 /* FontFallback.swift */; };
@@ -77,8 +78,10 @@
 		9BFD17415060EB3D21AA11BB /* RhwpStudioPrintController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A0E726A1E03A5D6891045C8 /* RhwpStudioPrintController.swift */; };
 		9E7FC8AC6078A6BD9975CD4E /* RhwpProvenance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2953DECE3F38280938C3CE2B /* RhwpProvenance.swift */; };
 		A155D58D6F716FCFDAC1675C /* DocumentOpenRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F4546426B7A9CF2CC1B9D5 /* DocumentOpenRouter.swift */; };
+		A15CE462970FB420A669581E /* HwpNativePageCompositor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541160BFAFD7D51040244110 /* HwpNativePageCompositor.swift */; };
 		A37A870989D1BA673D744596 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D03050B560F60198F4CBBB0 /* Metal.framework */; };
 		A6B358FD54D1069D3C08BF76 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B49CA0DEC91C628C9B92B7A1 /* CoreFoundation.framework */; };
+		A9D512641E80997A3D087945 /* HwpNativePageCompositor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541160BFAFD7D51040244110 /* HwpNativePageCompositor.swift */; };
 		ACA5EC231EB0D299AC1CD286 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D60B1C83682555AB978A8F1C /* InfoPlist.strings */; };
 		B15B6B22B2AF932D35690B5C /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B1F8E64A61A87C41A3680C56 /* Sparkle */; };
 		B20E66185823D980E1A1DC3B /* DocumentFileActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC5D4F52776B873F6AB20372 /* DocumentFileActions.swift */; };
@@ -192,6 +195,7 @@
 		423B5D870B909D2D5D87F3D6 /* RhwpDocument.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RhwpDocument.swift; sourceTree = "<group>"; };
 		4B5C316C5FBCECA08C309CF9 /* HwpPageImageRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HwpPageImageRenderer.swift; sourceTree = "<group>"; };
 		4D19355F771E9D7C6E9E068F /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateController.swift; sourceTree = "<group>"; };
+		541160BFAFD7D51040244110 /* HwpNativePageCompositor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HwpNativePageCompositor.swift; sourceTree = "<group>"; };
 		5D6D965AEFE52537281289A1 /* RhwpStudioResourceSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RhwpStudioResourceSchemeHandler.swift; sourceTree = "<group>"; };
 		5E97EA87050B083B9FA29249 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		612627C44A23C2ADDA48A054 /* ThumbnailExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = ThumbnailExtension.entitlements; sourceTree = "<group>"; };
@@ -348,6 +352,7 @@
 			isa = PBXGroup;
 			children = (
 				317B028E5037D11892BC394D /* HwpDocumentInputValidator.swift */,
+				541160BFAFD7D51040244110 /* HwpNativePageCompositor.swift */,
 				4B5C316C5FBCECA08C309CF9 /* HwpPageImageRenderer.swift */,
 				2512041CBA5B9CE5521537DC /* HwpPreviewPDFRenderer.swift */,
 			);
@@ -679,6 +684,7 @@
 				58FEED15D7979CC23FADA9D9 /* FontResourceRegistry.swift in Sources */,
 				14EA0DCDA1ED018ADDA22F01 /* HostApp.swift in Sources */,
 				C2FE57F60D5817A705C6B411 /* HwpDocumentInputValidator.swift in Sources */,
+				A15CE462970FB420A669581E /* HwpNativePageCompositor.swift in Sources */,
 				7BF16A0B1E4314FB46041152 /* HwpPageImageRenderer.swift in Sources */,
 				02E1371B73A762F8E64ED8EF /* HwpPreviewPDFRenderer.swift in Sources */,
 				55993B1F9BBFFBBA62397829 /* LaunchMaintenanceService.swift in Sources */,
@@ -709,6 +715,7 @@
 				B98567E2BF18CDD24BB51F5B /* FontFallback.swift in Sources */,
 				39EB4CA94F5944239BDB869F /* FontResourceRegistry.swift in Sources */,
 				9499CFEE20DAD2F23BF05520 /* HwpDocumentInputValidator.swift in Sources */,
+				A9D512641E80997A3D087945 /* HwpNativePageCompositor.swift in Sources */,
 				C898F0CA6BE3F209145CAC28 /* HwpPageImageRenderer.swift in Sources */,
 				D6ECD4A743DEDC3A090EEEF4 /* HwpPreviewPDFRenderer.swift in Sources */,
 				8348EA8DD0B313DC71B3E9C7 /* HwpThumbnailProvider.swift in Sources */,
@@ -727,6 +734,7 @@
 				4603821692664AB0F6480AD4 /* FontFallback.swift in Sources */,
 				187BD036B336DB87EB4EC8C0 /* FontResourceRegistry.swift in Sources */,
 				ECED3AEFEF7467CA44F2A001 /* HwpDocumentInputValidator.swift in Sources */,
+				3BA210E4DB4D1BF2C8E03893 /* HwpNativePageCompositor.swift in Sources */,
 				DBD45292114D646A364B0B87 /* HwpPageImageRenderer.swift in Sources */,
 				D9E0E7DB88B12FDF40623328 /* HwpPreviewPDFRenderer.swift in Sources */,
 				41C5D25E1060BEF211833C8A /* HwpPreviewProvider.swift in Sources */,

--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -98,6 +98,26 @@ class CGTreeRenderer {
         imageCache.removeAll()
     }
 
+    @discardableResult
+    func renderOverlayImages(
+        _ images: [RhwpPageOverlayImage],
+        in context: CGContext,
+        document: RhwpDocument
+    ) -> Int {
+        if !isRenderingSameDocument(document) {
+            clearCache()
+        }
+        self.document = document
+
+        var drawnCount = 0
+        for image in images {
+            if renderOverlayImage(image, in: context, document: document) {
+                drawnCount += 1
+            }
+        }
+        return drawnCount
+    }
+
     private func isRenderingSameDocument(_ document: RhwpDocument?) -> Bool {
         guard let currentDocument = self.document else {
             return document == nil
@@ -716,6 +736,68 @@ class CGTreeRenderer {
         ctx.restoreGState()
 
         ctx.restoreGState()
+    }
+
+    private func renderOverlayImage(
+        _ image: RhwpPageOverlayImage,
+        in ctx: CGContext,
+        document: RhwpDocument
+    ) -> Bool {
+        guard let cgImage = decodedOverlayImage(image, document: document) else { return false }
+
+        let node = ImageNode(
+            binDataId: image.source.binDataId ?? 0,
+            sectionIndex: nil,
+            paraIndex: nil,
+            controlIndex: nil,
+            fillMode: image.fillMode,
+            originalSize: image.originalSize,
+            originalSizeHU: image.originalSizeHU,
+            effect: image.effect,
+            brightness: image.brightness,
+            contrast: image.contrast,
+            textWrap: image.wrap,
+            transform: ShapeTransform(image.transform),
+            crop: image.crop
+        )
+
+        ctx.saveGState()
+        applyTransform(node.transform, bbox: image.bbox, in: ctx)
+
+        let drawImage = preparedImage(for: cgImage, node: node)
+        let rect = cgRect(image.bbox)
+        let drawRect = imageDestinationRect(for: node, size: rect.size)
+        ctx.saveGState()
+        ctx.translateBy(x: rect.minX, y: rect.minY + rect.height)
+        ctx.scaleBy(x: 1, y: -1)
+        ctx.draw(drawImage, in: drawRect)
+        ctx.restoreGState()
+
+        ctx.restoreGState()
+        return true
+    }
+
+    private func decodedOverlayImage(
+        _ image: RhwpPageOverlayImage,
+        document: RhwpDocument
+    ) -> CGImage? {
+        if let data = image.source.data,
+           let decoded = decodeImage(data) {
+            return decoded
+        }
+
+        guard let binDataId = image.source.binDataId, binDataId > 0 else {
+            return nil
+        }
+        if let cached = imageCache[binDataId] {
+            return cached
+        }
+        guard let data = document.imageData(binDataId: binDataId),
+              let decoded = decodeImage(data) else {
+            return nil
+        }
+        imageCache[binDataId] = decoded
+        return decoded
     }
 
     private func decodeImage(_ data: Data) -> CGImage? {
@@ -3621,5 +3703,15 @@ private final class EquationSVGFragmentParser: NSObject, XMLParserDelegate {
         default:
             return false
         }
+    }
+}
+
+private extension ShapeTransform {
+    init(_ transform: RhwpPageOverlayTransform) {
+        self.init(
+            rotation: transform.rotation,
+            horzFlip: transform.horzFlip,
+            vertFlip: transform.vertFlip
+        )
     }
 }

--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -7,6 +7,37 @@ import CoreText
 import Foundation
 import ImageIO
 
+enum CGTreeOverlayLayer {
+    case behindText
+    case inFrontOfText
+
+    init?(textWrap: String?) {
+        guard let normalized = textWrap?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "_", with: "")
+            .lowercased() else {
+            return nil
+        }
+
+        switch normalized {
+        case "behindtext":
+            self = .behindText
+        case "infrontoftext":
+            self = .inFrontOfText
+        default:
+            return nil
+        }
+    }
+}
+
+enum CGTreeRenderMode {
+    case complete
+    case pageBackground
+    case flowExcludingPageOverlays([CGTreeOverlayLayer])
+    case pageOverlay(CGTreeOverlayLayer)
+}
+
 class CGTreeRenderer {
     private let imageCropUnitsPerPixel = 75.0
     private let tableCellClipRightSlack = 4.0
@@ -20,6 +51,7 @@ class CGTreeRenderer {
 
     private var pageBounds: BBox?
     private var pageHeight: Double = 0
+    private var renderMode: CGTreeRenderMode = .complete
 
     private struct BuiltPath {
         let path: CGPath
@@ -34,7 +66,13 @@ class CGTreeRenderer {
         case curve(CGPoint, CGPoint, CGPoint)
     }
 
-    func render(tree: RenderNode, in context: CGContext, pageHeight: Double, document: RhwpDocument?) {
+    func render(
+        tree: RenderNode,
+        in context: CGContext,
+        pageHeight: Double,
+        document: RhwpDocument?,
+        mode: CGTreeRenderMode = .complete
+    ) {
         HwpBundledFontRegistry.ensureRegistered()
 
         // 이미지 binDataId는 문서 내부 식별자이므로 문서가 바뀌면 캐시를 이어 쓰면 안 된다.
@@ -48,6 +86,11 @@ class CGTreeRenderer {
         // 렌더 트리의 좌표(좌상단 원점)를 그대로 사용할 수 있다.
         // 단, Core Text와 CGImage는 원본 CG 좌표계(좌하단)를 기대하므로
         // 해당 요소에서만 국소적으로 좌표를 조정한다.
+        let previousMode = renderMode
+        renderMode = mode
+        defer {
+            renderMode = previousMode
+        }
         renderNode(tree, in: context)
     }
 
@@ -75,7 +118,9 @@ class CGTreeRenderer {
             renderPage(node, in: ctx)
 
         case .pageBackground(let bg):
-            renderPageBackground(bg, bbox: node.bbox, in: ctx)
+            if shouldRenderPageBackground {
+                renderPageBackground(bg, bbox: node.bbox, in: ctx)
+            }
 
         case .body(let body):
             renderBody(body, node: node, in: ctx)
@@ -87,40 +132,56 @@ class CGTreeRenderer {
             renderTableCell(cell, node: node, in: ctx)
 
         case .rectangle(let rect):
-            renderRectangle(rect, bbox: node.bbox, in: ctx)
+            if shouldRenderFlowContent {
+                renderRectangle(rect, bbox: node.bbox, in: ctx)
+            }
             renderChildren(node, in: ctx)
 
         case .line(let line):
-            renderLine(line, bbox: node.bbox, in: ctx)
+            if shouldRenderFlowContent {
+                renderLine(line, bbox: node.bbox, in: ctx)
+            }
             renderChildren(node, in: ctx)
 
         case .ellipse(let ell):
-            renderEllipse(ell, bbox: node.bbox, in: ctx)
+            if shouldRenderFlowContent {
+                renderEllipse(ell, bbox: node.bbox, in: ctx)
+            }
             renderChildren(node, in: ctx)
 
         case .path(let path):
-            renderPath(path, bbox: node.bbox, in: ctx)
+            if shouldRenderFlowContent {
+                renderPath(path, bbox: node.bbox, in: ctx)
+            }
             renderChildren(node, in: ctx)
 
         case .image(let img):
-            renderImage(img, bbox: node.bbox, in: ctx)
+            if shouldRenderImage(img) {
+                renderImage(img, bbox: node.bbox, in: ctx)
+            }
             renderChildren(node, in: ctx)
 
         case .group:
             renderGroup(node, in: ctx)
 
         case .textRun(let run):
-            renderTextRun(run, bbox: node.bbox, in: ctx)
+            if shouldRenderFlowContent {
+                renderTextRun(run, bbox: node.bbox, in: ctx)
+            }
 
         case .equation(let equation):
-            renderEquation(equation, bbox: node.bbox, in: ctx)
+            if shouldRenderFlowContent {
+                renderEquation(equation, bbox: node.bbox, in: ctx)
+            }
 
         case .formObject:
             // 양식 개체는 M3 이후
             break
 
         case .footnoteMarker(let marker):
-            renderFootnoteMarker(marker, bbox: node.bbox, in: ctx)
+            if shouldRenderFlowContent {
+                renderFootnoteMarker(marker, bbox: node.bbox, in: ctx)
+            }
 
         default:
             // 구조 노드(header, footer, column 등): 자식만 순회
@@ -156,13 +217,29 @@ class CGTreeRenderer {
     }
 
     private func renderPage(_ node: RenderNode, in ctx: CGContext) {
-        // 페이지 기본 배경.
-        ctx.setFillColor(red: 1, green: 1, blue: 1, alpha: 1)
-        ctx.fill(cgRect(node.bbox))
+        switch renderMode {
+        case .complete:
+            renderCompletePage(node, in: ctx)
+        case .pageBackground:
+            renderPageBaseAndBackground(node, in: ctx)
+        case .flowExcludingPageOverlays(let layers):
+            renderPageForegroundFlowChildren(node, excluding: layers, in: ctx)
+        case .pageOverlay:
+            renderChildren(node, in: ctx)
+        }
+    }
 
-        renderPageBackgroundChildren(node, in: ctx)
+    private func renderCompletePage(_ node: RenderNode, in ctx: CGContext) {
+        // 페이지 기본 배경.
+        renderPageBaseAndBackground(node, in: ctx)
         renderPageBehindTextImages(node, in: ctx)
         renderPageForegroundChildren(node, in: ctx)
+    }
+
+    private func renderPageBaseAndBackground(_ node: RenderNode, in ctx: CGContext) {
+        ctx.setFillColor(red: 1, green: 1, blue: 1, alpha: 1)
+        ctx.fill(cgRect(node.bbox))
+        renderPageBackgroundChildren(node, in: ctx)
     }
 
     private func renderPageBackgroundChildren(_ node: RenderNode, in ctx: CGContext) {
@@ -186,6 +263,19 @@ class CGTreeRenderer {
         }
     }
 
+    private func renderPageForegroundFlowChildren(
+        _ node: RenderNode,
+        excluding layers: [CGTreeOverlayLayer],
+        in ctx: CGContext
+    ) {
+        for child in node.children {
+            guard !isPageBackgroundNode(child), !isPageOverlayImage(child, in: layers) else {
+                continue
+            }
+            renderNode(child, in: ctx)
+        }
+    }
+
     private func renderColumn(_ node: RenderNode, in ctx: CGContext) {
         for child in node.children where isBehindTextImage(child) {
             renderNode(child, in: ctx)
@@ -203,16 +293,56 @@ class CGTreeRenderer {
     }
 
     private func isBehindTextImage(_ node: RenderNode) -> Bool {
+        isPageOverlayImage(node, layer: .behindText)
+    }
+
+    private func isPageOverlayImage(_ node: RenderNode, layer: CGTreeOverlayLayer) -> Bool {
         guard case .image(let image) = node.nodeType else {
             return false
         }
-        return isBehindTextWrap(image.textWrap)
+        return CGTreeOverlayLayer(textWrap: image.textWrap) == layer
     }
 
-    private func isBehindTextWrap(_ value: String?) -> Bool {
-        value?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .caseInsensitiveCompare("BehindText") == .orderedSame
+    private func isPageOverlayImage(_ node: RenderNode, in layers: [CGTreeOverlayLayer]) -> Bool {
+        guard case .image(let image) = node.nodeType,
+              let layer = CGTreeOverlayLayer(textWrap: image.textWrap) else {
+            return false
+        }
+        return layers.contains(layer)
+    }
+
+    private var shouldRenderPageBackground: Bool {
+        switch renderMode {
+        case .complete, .pageBackground:
+            return true
+        case .flowExcludingPageOverlays, .pageOverlay:
+            return false
+        }
+    }
+
+    private var shouldRenderFlowContent: Bool {
+        switch renderMode {
+        case .complete, .flowExcludingPageOverlays:
+            return true
+        case .pageBackground, .pageOverlay:
+            return false
+        }
+    }
+
+    private func shouldRenderImage(_ image: ImageNode) -> Bool {
+        switch renderMode {
+        case .complete:
+            return true
+        case .pageBackground:
+            return false
+        case .flowExcludingPageOverlays(let layers):
+            guard let layer = CGTreeOverlayLayer(textWrap: image.textWrap) else {
+                return true
+            }
+            return !layers.contains(layer)
+        case .pageOverlay(let layer):
+            return CGTreeOverlayLayer(textWrap: image.textWrap) == layer
+        }
     }
 
     private func renderBody(_ body: BodyNode, node: RenderNode, in ctx: CGContext) {

--- a/Sources/Shared/HwpNativePageCompositor.swift
+++ b/Sources/Shared/HwpNativePageCompositor.swift
@@ -1,0 +1,90 @@
+import CoreGraphics
+
+enum HwpNativePageCompositor {
+    static func render(
+        tree: RenderNode,
+        overlays: RhwpPageOverlayImageSet?,
+        in context: CGContext,
+        pageHeight: Double,
+        document: RhwpDocument
+    ) {
+        let renderer = CGTreeRenderer()
+        let overlayLayers = renderTreeOverlayLayers(from: overlays, tree: tree)
+
+        renderer.render(
+            tree: tree,
+            in: context,
+            pageHeight: pageHeight,
+            document: document,
+            mode: .pageBackground
+        )
+
+        if overlayLayers.contains(.behindText) {
+            renderer.render(
+                tree: tree,
+                in: context,
+                pageHeight: pageHeight,
+                document: document,
+                mode: .pageOverlay(.behindText)
+            )
+        }
+
+        renderer.render(
+            tree: tree,
+            in: context,
+            pageHeight: pageHeight,
+            document: document,
+            mode: .flowExcludingPageOverlays(overlayLayers)
+        )
+
+        if overlayLayers.contains(.inFrontOfText) {
+            renderer.render(
+                tree: tree,
+                in: context,
+                pageHeight: pageHeight,
+                document: document,
+                mode: .pageOverlay(.inFrontOfText)
+            )
+        }
+    }
+
+    private static func renderTreeOverlayLayers(
+        from overlays: RhwpPageOverlayImageSet?,
+        tree: RenderNode
+    ) -> [CGTreeOverlayLayer] {
+        let treeLayers = overlayLayers(in: tree)
+        guard let overlays else {
+            return treeLayers
+        }
+
+        var layers = treeLayers
+        if !overlays.behind.isEmpty && !layers.contains(.behindText) {
+            layers.append(.behindText)
+        }
+        if !overlays.front.isEmpty && !layers.contains(.inFrontOfText) {
+            layers.append(.inFrontOfText)
+        }
+        return layers
+    }
+
+    private static func overlayLayers(in node: RenderNode) -> [CGTreeOverlayLayer] {
+        var layers: [CGTreeOverlayLayer] = []
+        collectOverlayLayers(in: node, into: &layers)
+        return layers
+    }
+
+    private static func collectOverlayLayers(
+        in node: RenderNode,
+        into layers: inout [CGTreeOverlayLayer]
+    ) {
+        if case .image(let image) = node.nodeType,
+           let layer = CGTreeOverlayLayer(textWrap: image.textWrap),
+           !layers.contains(layer) {
+            layers.append(layer)
+        }
+
+        for child in node.children {
+            collectOverlayLayers(in: child, into: &layers)
+        }
+    }
+}

--- a/Sources/Shared/HwpNativePageCompositor.swift
+++ b/Sources/Shared/HwpNativePageCompositor.swift
@@ -20,12 +20,14 @@ enum HwpNativePageCompositor {
         )
 
         if overlayLayers.contains(.behindText) {
-            renderer.render(
+            renderOverlayLayer(
+                .behindText,
                 tree: tree,
-                in: context,
+                overlays: overlays?.behind ?? [],
+                renderer: renderer,
+                context: context,
                 pageHeight: pageHeight,
-                document: document,
-                mode: .pageOverlay(.behindText)
+                document: document
             )
         }
 
@@ -38,13 +40,47 @@ enum HwpNativePageCompositor {
         )
 
         if overlayLayers.contains(.inFrontOfText) {
+            renderOverlayLayer(
+                .inFrontOfText,
+                tree: tree,
+                overlays: overlays?.front ?? [],
+                renderer: renderer,
+                context: context,
+                pageHeight: pageHeight,
+                document: document
+            )
+        }
+    }
+
+    private static func renderOverlayLayer(
+        _ layer: CGTreeOverlayLayer,
+        tree: RenderNode,
+        overlays: [RhwpPageOverlayImage],
+        renderer: CGTreeRenderer,
+        context: CGContext,
+        pageHeight: Double,
+        document: RhwpDocument
+    ) {
+        let renderableOverlays = overlays.filter(\.hasRenderableData)
+        if renderableOverlays.isEmpty {
             renderer.render(
                 tree: tree,
                 in: context,
                 pageHeight: pageHeight,
                 document: document,
-                mode: .pageOverlay(.inFrontOfText)
+                mode: .pageOverlay(layer)
             )
+        } else {
+            let drawnCount = renderer.renderOverlayImages(renderableOverlays, in: context, document: document)
+            if drawnCount == 0 {
+                renderer.render(
+                    tree: tree,
+                    in: context,
+                    pageHeight: pageHeight,
+                    document: document,
+                    mode: .pageOverlay(layer)
+                )
+            }
         }
     }
 

--- a/Sources/Shared/HwpPageImageRenderer.swift
+++ b/Sources/Shared/HwpPageImageRenderer.swift
@@ -398,6 +398,7 @@ enum HwpPageImageRenderer {
         guard let tree = document.renderPageTree(at: pageIndex) else {
             throw HwpRenderError.renderTreeUnavailable
         }
+        let overlays = document.pageOverlayImages(at: pageIndex, renderTree: tree)
 
         let width = Int(pixelSize.width)
         let height = Int(pixelSize.height)
@@ -419,8 +420,13 @@ enum HwpPageImageRenderer {
         context.translateBy(x: 0, y: CGFloat(height))
         context.scaleBy(x: scale, y: -scale)
 
-        let renderer = CGTreeRenderer()
-        renderer.render(tree: tree, in: context, pageHeight: pageSize.height, document: document)
+        HwpNativePageCompositor.render(
+            tree: tree,
+            overlays: overlays,
+            in: context,
+            pageHeight: pageSize.height,
+            document: document
+        )
 
         guard let image = context.makeImage() else {
             throw HwpRenderError.imageUnavailable

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -5,6 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 완료 | M014, 완료: 15:37, PR 준비 |
+| #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
 | #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, #286 visual diff 재측정 보강: 14:30, PR 갱신 |
 | #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |
 

--- a/mydocs/orders/20260527.md
+++ b/mydocs/orders/20260527.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #281 | PageLayerTree overlay image metadata를 Swift preview 입력으로 연결 | 완료 | M014, 완료: 15:37, PR 준비 |
-| #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+| #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 완료 | M014, 완료: 13:19, 최종 보고와 PR 게시 준비 |
 | #283 | rhwp-studio 문서 열기 normalization·external image parity 영향 조사 | 완료 | M014, #286 visual diff 재측정 보강: 14:30, PR 갱신 |
 | #286 | rhwp-studio preview visual diff harness readiness 안정화 | 완료 | M014, 완료: 14:02, PR 준비 |
 

--- a/mydocs/orders/20260530.md
+++ b/mydocs/orders/20260530.md
@@ -1,0 +1,10 @@
+# 오늘 할일 - 2026년 5월 30일
+
+## M014 — v0.1.4 Native Preview/Viewer Parity
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 완료 | 최종 보고와 handoff 완료: 13:19 |
+| #116 | native preview watermark/effect parity 보강 | 예정 | #282 후속, `복학원서.hwp` 중앙 watermark fallback 범위부터 정리 |
+| #296 | upstream rhwp #1016 resolved watermark payload 반영 시 Swift fallback 중복 적용 방지 | 보류 | upstream rhwp #1016 release 포함 시 처리 |
+

--- a/mydocs/plans/task_m014_282.md
+++ b/mydocs/plans/task_m014_282.md
@@ -1,0 +1,149 @@
+# Task M014 #282 수행계획서
+
+## 목적
+
+Quick Look preview와 Finder thumbnail이 공유할 수 있는 native compositor policy를 보강해 `rhwp-studio` 기본 렌더의 flow/overlay 합성 순서에 더 가깝게 맞춘다.
+
+완료 후 작업자는 #281에서 준비한 `RhwpDocument.pageOverlayImages(at:renderTree:)` 입력을 사용해 `background -> BehindText overlay -> flow -> InFrontOfText overlay` 순서의 합성 경로를 Swift/CoreGraphics fallback에 적용하고, #280/#286 visual diff harness로 전후 차이를 기록할 수 있어야 한다.
+
+## 배경
+
+#280은 `rhwp-studio` 기준 visual diff harness를 마련했고, #286은 readiness polling과 output stem 문제를 안정화했다. #283은 `rhwp-studio` open pipeline 차이를 조사해 filename/base directory/external linked image는 별도 upstream/downstream 작업으로 분리하는 것이 맞다고 정리했다. #281은 PageLayerTree/overlay image metadata를 Swift 입력 모델로 연결했고, render tree를 이미 가진 호출자가 중복 decode를 피할 수 있는 overload까지 준비했다.
+
+현재 Quick Look 단일 페이지 PNG와 다중 페이지 PDF, Finder thumbnail은 `Sources/Shared/HwpPageImageRenderer.swift`와 `Sources/Shared/HwpPreviewPDFRenderer.swift`를 공유한다. CoreGraphics fallback은 `renderPageTree(at:)` 결과를 `CGTreeRenderer`로 한 번에 그리며, Skia opt-in이 성공하면 Skia PNG를 그대로 사용한다. 이 구조만으로는 `rhwp-studio`의 별도 overlay layer 순서, 특히 BehindText/InFrontOfText 이미지의 앞뒤 관계와 watermark/effect 적용 위치가 달라질 수 있다.
+
+이번 작업은 release tag 기반 현재 core pin 위에서 downstream compositor policy를 정리한다. upstream rhwp 수정, unreleased commit pin, 전체 PageLayerTree PaintOp renderer 재작성은 하지 않는다.
+
+## 범위
+
+포함:
+
+- Quick Look preview와 Finder thumbnail이 공유하는 native compositor entry point 조사
+- #281 `RhwpPageOverlayImageSet` 입력을 CoreGraphics fallback 렌더 경로에 연결
+- background, BehindText overlay, flow, InFrontOfText overlay pass 순서 정의
+- flow rendering에서 overlay 후보가 중복 렌더링되지 않도록 하는 renderer policy 설계
+- overlay image source 선택 순서 정의: compact payload bytes 우선, embedded `binDataId` fallback
+- watermark multiply blend, opacity, grayscale/blackWhite/brightness/contrast 적용 가능 범위 확인
+- 단일 페이지 PNG, 다중 페이지 PDF, thumbnail scale 경로가 같은 policy를 사용하도록 정리
+- #280/#286 visual diff harness와 #281 metadata smoke를 사용한 before/after 수치 기록
+- positive fixture가 부족한 경우 관찰 한계와 후속 fixture 확보 조건 문서화
+
+제외:
+
+- upstream `edwardkim/rhwp` 수정
+- upstream rhwp unreleased commit pin 또는 core dependency update
+- 전체 PageLayerTree PaintOp renderer 재작성
+- Finder preview 기본 출력에 rhwp-studio margin guide/editor chrome 포함
+- HostApp 편집 overlay, ruler, caret, selection, IME 구현
+- filename field, base directory, external linked image discovery/injection 구현
+- RawSvg/OLE/chart, Placeholder/FormObject 정적 객체 보강
+- signing, notarization, Homebrew 배포 작업
+
+## 설계 방향
+
+먼저 현재 renderer ownership을 확인한다. `HwpPageImageRenderer.renderPage`가 Quick Look PNG, Preview PDF, Thumbnail cache의 공통 진입점이므로, 가능한 한 이 계층에 compositor policy를 두고 extension별 분기 없이 공유한다. Skia opt-in은 성공 시 기존처럼 Skia PNG를 사용하고, CoreGraphics fallback에서만 native compositor를 적용하는 방향을 우선 검토한다.
+
+CoreGraphics fallback은 한 번의 `CGTreeRenderer.render(tree:)` 호출을 그대로 유지하면 overlay pass를 분리하기 어렵다. Stage 1에서 `CGTreeRenderer`에 render policy 또는 node filter를 추가할지, 별도 `HwpNativePageCompositor`를 두어 tree traversal과 overlay drawing을 조합할지 결정한다. 중복 decode를 피하기 위해 `renderPageTree(at:)`로 얻은 `RenderNode`를 #281의 `pageOverlayImages(at:renderTree:)`에 전달한다.
+
+합성 순서는 다음 방향으로 둔다.
+
+1. page background
+2. BehindText overlay images
+3. normal flow content
+4. InFrontOfText overlay images
+
+overlay image rendering은 #282에서 최소한 실제 bytes를 그릴 수 있는 경로를 확보한다. 이미지 effect와 watermark parity는 이번 이슈에서 적용 가능한 범위까지 구현하되, #116/#122의 세부 품질 보정과 충돌하지 않도록 남은 차이는 수치와 함께 후속으로 넘긴다.
+
+## 예상 변경 파일
+
+- `mydocs/orders/20260527.md`
+- `mydocs/plans/task_m014_282.md`
+- `mydocs/plans/task_m014_282_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m014_282_stage{N}.md`
+- `mydocs/report/task_m014_282_report.md`
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/Shared/HwpPreviewPDFRenderer.swift`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+- `Sources/RhwpCoreBridge/PageOverlayImages.swift`
+- 필요 시 `Sources/RhwpCoreBridge/RenderTree.swift`
+- 필요 시 `Sources/Shared/HwpNativePageCompositor.swift`
+- 필요 시 `scripts/preview_visual_diff_harness.swift`
+- 필요 시 smoke 결과 산출물 경로 문서
+
+## 잠정 단계
+
+1. Stage 1: renderer/compositor 구조 inventory와 구현계획 확정
+   - Quick Look PNG, Preview PDF, Thumbnail cache가 공유하는 render entry point를 확인한다.
+   - `CGTreeRenderer`의 background/image/textWrap 처리와 #281 overlay metadata를 비교한다.
+   - flow/overlay pass 분리 방식과 before baseline sample set을 구현계획서에 확정한다.
+2. Stage 2: native compositor policy와 pass 분리 구현
+   - CoreGraphics fallback에서 render tree와 overlay metadata를 한 번만 수집한다.
+   - background, BehindText, flow, InFrontOfText pass 순서를 코드로 표현한다.
+   - overlay 후보의 중복 렌더링을 방지하는 filter 또는 renderer policy를 추가한다.
+3. Stage 3: overlay image drawing, effect/watermark 최소 parity 보강
+   - overlay image source bytes를 선택하고, 기존 image decode/cache 경로와 최대한 공유한다.
+   - watermark/effect는 현재 codebase에서 안전하게 적용 가능한 범위까지 반영한다.
+   - #116/#122로 넘길 품질 잔여 범위를 분리한다.
+4. Stage 4: Quick Look/Thumbnail 통합 smoke와 visual diff 측정
+   - 단일 페이지 PNG, 다중 페이지 PDF, thumbnail scale 경로에서 같은 compositor policy가 사용되는지 확인한다.
+   - #280/#286 harness로 before/after 수치를 남긴다.
+   - positive fixture가 부족하면 그 사실을 결과와 한계에 명확히 기록한다.
+5. Stage 5: 최종 handoff와 후속 이슈 정리
+   - #116, #122, #121, #110에 영향을 주는 발견 사항을 정리한다.
+   - WebView fallback, Skia opt-in, CoreGraphics fallback의 역할과 한계를 최종 보고서에 남긴다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+rg -n "#282|native compositor|overlay|BehindText|InFrontOfText" \
+  mydocs/orders/20260527.md mydocs/plans/task_m014_282.md
+git diff --check -- mydocs/orders/20260527.md mydocs/plans/task_m014_282.md
+git status --short --branch
+```
+
+구현 단계 후보:
+
+```bash
+rg -n "renderPage\\(|renderCoreGraphicsPage|CGTreeRenderer|pageOverlayImages|textWrap|BehindText|InFrontOfText" \
+  Sources/Shared Sources/RhwpCoreBridge Sources/QLExtension Sources/ThumbnailExtension
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/overlay-metadata-smoke.sh build.noindex/task282-overlay-metadata
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-before-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-after-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-after-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task282 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+git status --short --branch
+```
+
+Quick Look/Thumbnail smoke가 필요한 경우에는 표준 smoke helper를 사용하고, 종료 시 개발 산출물 등록 해제와 registration hygiene 확인을 수행한다.
+
+## 리스크
+
+- #281 smoke에서 현재 sample set은 `BehindText`/`InFrontOfText` positive fixture를 확보하지 못했다. #282에서 합성 순서를 구현해도 visual diff 개선을 증명할 fixture가 부족할 수 있다.
+- Skia opt-in이 성공하는 경로는 core가 만든 PNG를 사용하므로 CoreGraphics compositor 변경이 적용되지 않는다. PR에서는 Skia, CoreGraphics fallback, WebView fallback의 적용 범위를 명확히 기록해야 한다.
+- `CGTreeRenderer`가 현재 image/text/background를 한 pass에서 처리한다면 pass 분리를 위해 renderer policy가 필요하고, 잘못 분리하면 기존 flow content가 누락될 수 있다.
+- overlay image effect와 watermark blending은 #116/#122의 세부 parity 작업과 겹친다. 이번 작업에서 과도하게 구현하면 후속 이슈의 책임 경계가 흐려질 수 있다.
+- Thumbnail은 maximum pixel size와 embedded thumbnail fallback이 있어 Quick Look preview와 관찰 조건이 다를 수 있다.
+- Visual diff harness는 `rhwp-studio` DOM capture와 native output의 scale 차이를 함께 다루므로, 수치 해석에 주의가 필요하다.
+- Quick Look/Thumbnail extension smoke는 LaunchServices/PlugInKit 등록 상태에 영향을 줄 수 있으므로 표준 cleanup 없이 임의 등록을 하지 않는다.
+
+## 승인 요청 사항
+
+1. #282를 Quick Look/Thumbnail 공유 native compositor policy 보강 작업으로 진행하는 범위 승인
+2. Skia opt-in 성공 경로는 기존 Skia PNG를 유지하고, CoreGraphics fallback을 우선 보강하는 방향 승인
+3. `background -> BehindText overlay -> flow -> InFrontOfText overlay` pass 구조를 코드상 명시하는 방향 승인
+4. watermark/effect/fill/tile 세부 parity는 이번 작업에서 가능한 최소 범위만 반영하고, 잔여 차이는 #116/#122로 넘기는 방향 승인
+5. positive fixture가 부족하면 visual diff 개선 수치보다 관찰 한계와 후속 fixture 확보 조건을 명확히 남기는 방향 승인
+6. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m014_282_impl.md`) 작성과 Stage 1 renderer/compositor inventory 진행
+
+승인 전에는 Swift source, project, script, renderer 동작 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m014_282_impl.md
+++ b/mydocs/plans/task_m014_282_impl.md
@@ -1,0 +1,293 @@
+# Task M014 #282 구현 계획서
+
+수행계획서: `mydocs/plans/task_m014_282.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #282 Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강
+- 마일스톤: M014 (`v0.1.4 Native Preview/Viewer Parity`)
+- 브랜치: `local/task282`
+- 작업 위치: `/Users/melee/Documents/projects/rhwp-mac-task282`
+- 기준 브랜치: `devel`
+- 현재 앱 core lock: `rhwp-core.lock` `v0.7.12` (`1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5`)
+- 목표: CoreGraphics fallback renderer가 #281 overlay metadata를 사용해 `background -> BehindText overlay -> flow -> InFrontOfText overlay` 순서를 명시적으로 합성하게 만든다.
+
+## 구현 원칙
+
+- #282의 1차 대상은 Swift/CoreGraphics fallback compositor다.
+- Quick Look `skiaOptIn` 성공 경로는 기존 Skia PNG를 유지하고, Skia 실패 또는 `coreGraphicsOnly` 경로에서 native compositor를 적용한다.
+- Finder Thumbnail은 현재 `coreGraphicsOnly` 경로를 사용하므로 #282 변경이 직접 적용된다.
+- `RhwpDocument.renderPageTree(at:)` 결과를 한 번만 얻고, #281의 `pageOverlayImages(at:renderTree:)` overload로 overlay metadata를 보충한다.
+- 기존 `CGTreeRenderer`의 도형/텍스트/이미지 decode/crop/effect/transform 로직을 재사용한다.
+- overlay 후보는 flow pass에서 중복 렌더링하지 않는다.
+- `Sources/RhwpCoreBridge`에는 AppKit/UIKit/WebKit 의존을 추가하지 않는다.
+- upstream rhwp 수정, unreleased commit pin, core dependency update는 하지 않는다.
+- watermark/effect/fill/tile 세부 parity는 안전하게 적용 가능한 최소 범위만 반영하고, 잔여 차이는 #116/#122로 넘긴다.
+
+## 현재 기준 관찰
+
+| 영역 | 현재 관찰 | 구현 판단 |
+|------|-----------|-----------|
+| Quick Look PNG | `HwpPreviewProvider.pngReply`가 `HwpPageImageRenderer.renderPage(..., policy: .skiaOptIn)` 호출 | Skia 성공 시 compositor를 우회한다. CoreGraphics fallback을 보강하고 PR에서 범위를 명시한다. |
+| Quick Look PDF | `HwpPreviewPDFRenderer.render`가 page별 `HwpPageImageRenderer.renderPage`를 호출 | 단일 page render path를 고치면 다중 페이지 PDF에도 같은 fallback policy가 적용된다. |
+| Thumbnail | `HwpThumbnailRenderCache`가 `renderFirstPage(..., embeddedThumbnailPolicy: .never)` 호출, 기본 policy는 `.coreGraphicsOnly` | Thumbnail은 #282 CoreGraphics compositor 변경의 직접 수혜 경로다. |
+| CoreGraphics fallback | `renderCoreGraphicsPage`가 `renderPageTree(at:)` 후 `CGTreeRenderer.render(tree:)` 1회 호출 | 이 지점에서 render tree와 overlay metadata를 한 번만 수집해 compositor에 넘긴다. |
+| `CGTreeRenderer` page pass | page background -> direct page `BehindText` image -> foreground children | direct page child 중심이며 `InFrontOfText` pass가 없다. |
+| `CGTreeRenderer` column pass | column direct child `BehindText` image -> non-behind children | nested tree 전체의 overlay 후보를 전역 pass로 분리하지 않는다. |
+| image rendering | `renderImage`가 `imageData`, decode, crop, effect, transform, fill destination을 처리 | overlay drawing은 이 로직을 재사용하도록 `CGTreeRenderer` 내부 API를 확장한다. |
+| #281 overlay provider | compact overlay JSON + render tree supplement merge 제공 | `pageOverlayImages(at:renderTree:)`로 중복 decode 없이 compositor 입력을 만든다. |
+| sample fixture | 기본 6개 sample의 `BehindText`/`InFrontOfText` overlay count는 모두 0 | 합성 구조 검증은 가능하지만 positive overlay visual improvement는 별도 fixture가 필요하다. |
+| harness compile list | `preview-visual-diff-harness.sh`가 아직 `PageOverlayImages.swift`를 compile list에 포함하지 않음 | #282에서 `HwpPageImageRenderer`가 overlay type을 참조하면 harness script도 함께 수정해야 한다. |
+
+## 산출물 구조
+
+| 파일 | 역할 |
+|------|------|
+| `mydocs/plans/task_m014_282_impl.md` | 단계별 구현 범위, 검증, 완료 기준 |
+| `mydocs/working/task_m014_282_stage1.md` | renderer/compositor inventory와 구현 경로 결정 |
+| `mydocs/working/task_m014_282_stage2.md` | compositor pass 분리 구현 보고 |
+| `mydocs/working/task_m014_282_stage3.md` | overlay image drawing/effect 최소 parity 구현 보고 |
+| `mydocs/working/task_m014_282_stage4.md` | Quick Look/Thumbnail smoke와 visual diff 측정 보고 |
+| `mydocs/working/task_m014_282_stage5.md` | 후속 이슈 handoff 보고 |
+| `mydocs/report/task_m014_282_report.md` | 최종 결과와 한계, 후속 작업 정리 |
+| `build.noindex/task282-*` | 검증 산출물. 커밋하지 않는다. |
+
+## Stage 1. renderer/compositor 구조 inventory와 구현 경로 확정
+
+### 목표
+
+Quick Look PNG, Quick Look PDF, Finder Thumbnail이 공유하는 render entry point와 `CGTreeRenderer`의 현재 pass 구조를 확인하고, #282 구현 경로와 before baseline을 확정한다.
+
+### 작업
+
+- Quick Look/Thumbnail render entry point를 확인한다.
+- `HwpPageImageRenderer.renderCoreGraphicsPage`의 tree decode와 renderer 호출 지점을 확인한다.
+- `CGTreeRenderer`의 page background, `BehindText`, normal flow, image effect 처리 현황을 확인한다.
+- #281 overlay metadata smoke를 현재 `devel` 기준으로 다시 실행한다.
+- #282 before visual diff baseline을 생성한다.
+- Stage 2 이후 변경해야 할 compile script 목록을 확인한다.
+
+### 산출물
+
+- `mydocs/plans/task_m014_282_impl.md`
+- `mydocs/working/task_m014_282_stage1.md`
+- `build.noindex/task282-stage1-overlay-metadata/`
+- `build.noindex/task282-stage1-before-basic/`
+- `build.noindex/task282-stage1-before-images/`
+
+### 검증
+
+```bash
+rg -n "renderPage\\(|renderCoreGraphicsPage|CGTreeRenderer|pageOverlayImages|textWrap|BehindText|InFrontOfText" \
+  Sources/Shared Sources/RhwpCoreBridge Sources/QLExtension Sources/ThumbnailExtension scripts
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/overlay-metadata-smoke.sh build.noindex/task282-stage1-overlay-metadata
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage1-before-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage1-before-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+git diff --check
+```
+
+### 완료 기준
+
+- Quick Look/Thumbnail 공통 render entry point와 policy 차이가 문서화된다.
+- `CGTreeRenderer` pass 분리 한계가 문서화된다.
+- before visual diff baseline과 overlay metadata baseline이 생성된다.
+- Stage 2 구현 경로가 확정된다.
+- production source는 변경하지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #282 Stage 1: native compositor inventory 정리
+```
+
+## Stage 2. native compositor policy와 pass 분리 구현
+
+### 목표
+
+CoreGraphics fallback에서 render tree를 한 번만 decode하고, page background와 flow pass를 명시적으로 분리할 수 있는 renderer/compositor 구조를 추가한다.
+
+### 작업
+
+- `HwpPageImageRenderer.renderCoreGraphicsPage`에서 `tree`와 `overlays`를 함께 수집한다.
+- 필요 시 `HwpNativePageCompositor` 또는 `CGTreeRenderer` render mode를 추가한다.
+- `CGTreeRenderer`에 pass/filter policy를 추가한다.
+  - page background only
+  - flow excluding overlay images
+  - 기존 all render fallback
+- `RhwpPageOverlayLayer(textWrap:)`와 같은 normalization을 사용해 `BehindText`/`InFrontOfText` 후보를 flow pass에서 제외한다.
+- 기존 `render(tree:)` 호출자는 backward-compatible하게 유지한다.
+- harness compile list에 `PageOverlayImages.swift`와 신규 compositor file을 포함한다.
+
+### 산출물
+
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+- 필요 시 `Sources/Shared/HwpNativePageCompositor.swift`
+- 필요 시 `scripts/preview-visual-diff-harness.sh`
+- 필요 시 `scripts/smoke-quicklook-skia-policy.sh`, `scripts/compare-quicklook-pdf-renderers.sh`
+- `mydocs/working/task_m014_282_stage2.md`
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/overlay-metadata-smoke.sh build.noindex/task282-stage2-overlay-metadata
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage2-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task282-stage2 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+### 완료 기준
+
+- CoreGraphics fallback이 compositor 구조를 통해 page를 렌더한다.
+- overlay 후보가 flow pass에서 중복 렌더링되지 않는다.
+- 기존 `CGTreeRenderer.render(tree:)` 사용자는 깨지지 않는다.
+- Quick Look/Thumbnail target build가 통과한다.
+
+### 커밋 메시지
+
+```text
+Task #282 Stage 2: native compositor pass 분리
+```
+
+## Stage 3. overlay image drawing과 effect/watermark 최소 parity 보강
+
+### 목표
+
+#281 overlay image metadata를 실제 CGContext overlay pass에서 그릴 수 있게 하고, 기존 image decode/crop/effect/transform 로직을 재사용한다.
+
+### 작업
+
+- `RhwpPageOverlayImage` drawing path를 추가한다.
+- image source 선택 순서를 구현한다.
+  - `source.data` 우선
+  - `source.binDataId` fallback
+  - bytes가 없으면 skip
+- overlay bbox, transform, crop/fill destination을 기존 image rendering과 맞춘다.
+- grayscale/blackWhite/brightness/contrast는 기존 image adjustment와 같은 기준을 사용한다.
+- `bakedWatermark == true`인 경우 중복 watermark 처리를 피한다.
+- watermark multiply/opacity가 현재 core payload에서 관찰되지 않으면 구현 범위를 문서화하고 #116으로 넘긴다.
+
+### 산출물
+
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+- 필요 시 `Sources/Shared/HwpNativePageCompositor.swift`
+- 필요 시 `Sources/RhwpCoreBridge/PageOverlayImages.swift`
+- `mydocs/working/task_m014_282_stage3.md`
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/overlay-metadata-smoke.sh build.noindex/task282-stage3-overlay-metadata
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage3-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+git diff --check
+```
+
+### 완료 기준
+
+- overlay metadata가 있을 때 behind/front pass에서 draw 시도할 수 있다.
+- 기존 sample에서 regression 없이 visual diff harness가 통과한다.
+- positive fixture 부재로 개선을 증명할 수 없는 경우 한계가 stage report에 기록된다.
+
+### 커밋 메시지
+
+```text
+Task #282 Stage 3: overlay image drawing 연결
+```
+
+## Stage 4. Quick Look/Thumbnail 통합 smoke와 visual diff 측정
+
+### 목표
+
+Quick Look PNG/PDF와 Finder Thumbnail 경로가 같은 CoreGraphics compositor policy를 공유하는지 확인하고, before/after visual diff를 정리한다.
+
+### 작업
+
+- Stage 1 baseline과 같은 sample set으로 after visual diff를 생성한다.
+- Thumbnail maximum pixel size 경로에서 compositor output이 생성되는지 확인한다.
+- Quick Look PDF page loop에서 같은 `HwpPageImageRenderer` 경로가 쓰이는지 확인한다.
+- Skia opt-in 성공 경로와 CoreGraphics fallback 적용 범위를 문서화한다.
+- 필요 시 registration hygiene는 표준 smoke helper 범위 안에서만 수행한다.
+
+### 산출물
+
+- `build.noindex/task282-stage4-*`
+- `mydocs/working/task_m014_282_stage4.md`
+
+### 검증
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task282-stage4-skia-policy \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task282-stage4 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+### 완료 기준
+
+- before/after visual diff가 같은 sample set으로 기록된다.
+- Quick Look/Thumbnail 공유 policy와 Skia/CoreGraphics 적용 범위가 명확히 정리된다.
+- 개발 산출물 registration 상태가 보고서에 남는다.
+
+### 커밋 메시지
+
+```text
+Task #282 Stage 4: compositor smoke와 visual diff 정리
+```
+
+## Stage 5. 최종 handoff와 후속 이슈 정리
+
+### 목표
+
+#282의 결과와 한계를 정리하고, #116/#122/#121/#110에 영향을 주는 발견 사항을 다음 작업자가 바로 사용할 수 있게 남긴다.
+
+### 작업
+
+- Stage 2-4 결과를 통합해 최종 보고서 초안을 작성한다.
+- #116 watermark/effect, #122 fill/tile/placement, #121 resource object, #110 Placeholder/FormObject에 넘길 내용을 정리한다.
+- positive overlay fixture가 여전히 없으면 fixture 확보 후속을 명시한다.
+- 오늘할일 #282 상태를 단계 완료/최종 보고 대기 상태로 갱신한다.
+
+### 산출물
+
+- `mydocs/working/task_m014_282_stage5.md`
+- `mydocs/report/task_m014_282_report.md`
+- `mydocs/orders/20260527.md`
+
+### 검증
+
+```bash
+rg -n "#116|#122|#121|#110|#282|Skia|CoreGraphics|overlay|ChangedPercent" \
+  mydocs/working/task_m014_282_stage*.md mydocs/report/task_m014_282_report.md
+git diff --check
+git status --short --branch
+```
+
+### 완료 기준
+
+- 후속 작업의 입력/한계가 최종 보고서에 정리된다.
+- PR 생성 전 필요한 검증과 잔여 위험이 명확하다.
+
+### 커밋 메시지
+
+```text
+Task #282 Stage 5: compositor handoff 정리
+```

--- a/mydocs/plans/task_m014_282_impl.md
+++ b/mydocs/plans/task_m014_282_impl.md
@@ -236,6 +236,13 @@ Quick Look PNG/PDF와 Finder Thumbnail 경로가 같은 CoreGraphics compositor 
 ./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-images --page 1 \
   samples/tac-img-02.hwp samples/tac-img-02.hwpx \
   samples/hwp-img-001.hwp samples/img-start-001.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-overlay-positive --page 1 \
+  samples/복학원서.hwp
+./scripts/overlay-metadata-smoke.sh build.noindex/task282-stage4-overlay-metadata --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp \
+  samples/복학원서.hwp
 ./scripts/smoke-quicklook-skia-policy.sh build.noindex/task282-stage4-skia-policy \
   samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
 xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
@@ -265,7 +272,7 @@ Task #282 Stage 4: compositor smoke와 visual diff 정리
 
 - Stage 2-4 결과를 통합해 최종 보고서 초안을 작성한다.
 - #116 watermark/effect, #122 fill/tile/placement, #121 resource object, #110 Placeholder/FormObject에 넘길 내용을 정리한다.
-- positive overlay fixture가 여전히 없으면 fixture 확보 후속을 명시한다.
+- positive overlay fixture로 확인한 `samples/복학원서.hwp` 결과와 #116/#1016 handoff를 명시한다.
 - 오늘할일 #282 상태를 단계 완료/최종 보고 대기 상태로 갱신한다.
 
 ### 산출물

--- a/mydocs/plans/task_m014_282_impl.md
+++ b/mydocs/plans/task_m014_282_impl.md
@@ -11,7 +11,7 @@
 - 브랜치: `local/task282`
 - 작업 위치: `/Users/melee/Documents/projects/rhwp-mac-task282`
 - 기준 브랜치: `devel`
-- 현재 앱 core lock: `rhwp-core.lock` `v0.7.12` (`1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5`)
+- 현재 앱 core lock: `rhwp-core.lock` `v0.7.13` (`b3e16ef212af81ef37d973ddb86d6816d3804642`)
 - 목표: CoreGraphics fallback renderer가 #281 overlay metadata를 사용해 `background -> BehindText overlay -> flow -> InFrontOfText overlay` 순서를 명시적으로 합성하게 만든다.
 
 ## 구현 원칙
@@ -22,6 +22,7 @@
 - `RhwpDocument.renderPageTree(at:)` 결과를 한 번만 얻고, #281의 `pageOverlayImages(at:renderTree:)` overload로 overlay metadata를 보충한다.
 - 기존 `CGTreeRenderer`의 도형/텍스트/이미지 decode/crop/effect/transform 로직을 재사용한다.
 - overlay 후보는 flow pass에서 중복 렌더링하지 않는다.
+- #278 이후 `v0.7.13` 기준에서는 compact overlay metadata뿐 아니라 PageLayerTree/render tree image node의 `resolved` payload, embedded bytes availability, `bakedWatermark` 상태를 같이 고려한다.
 - `Sources/RhwpCoreBridge`에는 AppKit/UIKit/WebKit 의존을 추가하지 않는다.
 - upstream rhwp 수정, unreleased commit pin, core dependency update는 하지 않는다.
 - watermark/effect/fill/tile 세부 parity는 안전하게 적용 가능한 최소 범위만 반영하고, 잔여 차이는 #116/#122로 넘긴다.
@@ -169,12 +170,13 @@ Task #282 Stage 2: native compositor pass 분리
 
 - `RhwpPageOverlayImage` drawing path를 추가한다.
 - image source 선택 순서를 구현한다.
-  - `source.data` 우선
-  - `source.binDataId` fallback
+  - compact/resolved `source.data` 우선
+  - render tree supplement의 `source.binDataId` fallback
   - bytes가 없으면 skip
 - overlay bbox, transform, crop/fill destination을 기존 image rendering과 맞춘다.
 - grayscale/blackWhite/brightness/contrast는 기존 image adjustment와 같은 기준을 사용한다.
 - `bakedWatermark == true`인 경우 중복 watermark 처리를 피한다.
+- `bakedWatermark == true` payload는 image bytes가 이미 watermark 처리를 포함한다고 보고 별도 watermark pass를 추가하지 않는다.
 - watermark multiply/opacity가 현재 core payload에서 관찰되지 않으면 구현 범위를 문서화하고 #116으로 넘긴다.
 
 ### 산출물

--- a/mydocs/report/task_m014_282_report.md
+++ b/mydocs/report/task_m014_282_report.md
@@ -1,0 +1,238 @@
+# Task M014 #282 최종 결과보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#282](https://github.com/postmelee/alhangeul-macos/issues/282) Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 |
+| 마일스톤 | M014 — v0.1.4 Native Preview/Viewer Parity |
+| 브랜치 | `local/task282` |
+| 단계 수 | 5단계 |
+| 최종 기준 | rhwp v0.7.13 기준, CoreGraphics compositor는 overlay image pass를 page content 이후에 합성 |
+
+이번 작업은 Quick Look/Thumbnail native CoreGraphics preview가 rhwp-studio와 같은 overlay image 구조를 더 잘 반영하도록 compositor path를 보강했다. 기존에는 render tree drawing과 page image rendering이 서로 다른 위치에서 수행되어 overlay image를 별도 pass로 다루기 어려웠다. 이제 `HwpNativePageCompositor`가 page content pass와 overlay image pass를 명시적으로 합성하고, `CGTreeRenderer`는 upstream metadata overlay 또는 기존 tree image fallback을 그릴 수 있다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | `renderOverlayImages` 경로를 추가해 metadata overlay image의 transform, alpha, embedded/bin data decoding을 CoreGraphics에 그리도록 보강했다. |
+| `Sources/Shared/HwpNativePageCompositor.swift` | page content와 overlay image pass를 합성하는 compositor를 추가했다. renderable metadata overlay가 없으면 기존 render tree image fallback을 사용한다. |
+| `Sources/Shared/HwpPageImageRenderer.swift` | Quick Look/Thumbnail native page rendering이 compositor를 통해 CoreGraphics output을 만들도록 연결했다. |
+| `Alhangeul.xcodeproj/project.pbxproj` | 새 shared compositor source를 HostApp/QLExtension/ThumbnailExtension build target에 포함했다. |
+| `scripts/preview-visual-diff-harness.sh` | Stage smoke에서 `RHWP_SWIFT_RENDERER_BACKEND=coreGraphicsOnly` 환경을 명시했다. |
+| `scripts/smoke-quicklook-skia-policy.sh` | Quick Look Skia/CoreGraphics policy 비교 smoke에서 explicit renderer policy를 사용하도록 정리했다. |
+| `scripts/compare-quicklook-pdf-renderers.sh` | PDF renderer 비교 smoke의 backend policy 전달을 정리했다. |
+| `mydocs/plans/task_m014_282.md` | 수행계획서. |
+| `mydocs/plans/task_m014_282_impl.md` | 구현계획서. |
+| `mydocs/working/task_m014_282_stage1.md` | baseline 측정과 코드 inventory. |
+| `mydocs/working/task_m014_282_stage2.md` | compositor pass 분리. |
+| `mydocs/working/task_m014_282_stage3.md` | overlay image drawing 연결. |
+| `mydocs/working/task_m014_282_stage4.md` | harness 보정 후 통합 smoke와 visual diff 측정. |
+| `mydocs/working/task_m014_282_stage5.md` | 최종 handoff 정리. |
+| `mydocs/orders/20260527.md`, `mydocs/orders/20260530.md` | 오늘할일 상태와 다음 실행 순서 기록. |
+
+## 단계별 결과
+
+### Stage 1. 기준 조사와 baseline 측정
+
+Stage 1에서는 native preview path, render tree image drawing, Quick Look/Thumbnail renderer policy, visual diff harness를 확인했다. 당시 기준은 rhwp-studio v0.7.12와 기존 harness였다.
+
+| Sample | ChangedPercent | MeanRGBDelta | 비고 |
+|--------|----------------:|-------------:|------|
+| `request.hwp` | 18.1021% | 11.2164 | basic HWP |
+| `hwpx-01.hwpx` | 15.1839% | 15.2202 | basic HWPX |
+| `tac-img-02.hwp` | 4.1375% | 3.7200 | image sample |
+| `tac-img-02.hwpx` | 3.6427% | 3.1392 | image sample |
+| `hwp-img-001.hwp` | 7.8448% | 8.3580 | image sample |
+| `img-start-001.hwp` | 14.4365% | 18.6470 | image sample |
+
+Stage 1의 중요한 발견은 기존 sample set에 BehindText/InFrontOfText overlay 양성 케이스가 없었다는 점이다. 따라서 overlay pass가 실제 양성 케이스에서 동작하는지 검증하려면 별도 fixture가 필요했다.
+
+### Stage 2. Native compositor pass 분리
+
+Stage 2에서는 `HwpNativePageCompositor`를 추가해 page content rendering과 overlay pass를 분리했다. 이 단계는 rendering order를 명확하게 만들기 위한 구조 작업이다. 아직 metadata overlay image drawing은 연결하지 않았고, 기존 render tree image fallback을 보존했다.
+
+검증 결과:
+
+- HostApp/QLExtension/ThumbnailExtension Debug build 성공
+- extension registration hygiene 문제 없음
+- `git diff --check` 통과
+
+### Stage 3. Overlay image drawing 연결
+
+Stage 3에서는 metadata overlay image drawing path를 `CGTreeRenderer.renderOverlayImages`로 연결했다. 우선순위는 다음과 같다.
+
+1. upstream metadata overlay의 embedded `source.data`
+2. metadata overlay의 `binDataId`
+3. renderable metadata overlay가 없을 때 기존 render tree image fallback
+
+이 단계에서 기존 sample set의 image smoke는 정상 종료했다. 다만 당시 visual diff harness는 `복학원서.hwp` 같은 overlay DOM을 studio reference에 포함하지 못해 positive overlay 판단에는 한계가 있었다.
+
+Stage 3 image set 결과:
+
+| Sample | ChangedPercent | MeanRGBDelta | StudioCapture |
+|--------|----------------:|-------------:|---------------|
+| `tac-img-02.hwp` | 4.1335% | 3.7157 | `canvasDataURL` |
+| `tac-img-02.hwpx` | 4.2178% | 3.6095 | `domComposite` |
+| `hwp-img-001.hwp` | 7.9015% | 8.3980 | `domComposite` |
+| `img-start-001.hwp` | 18.0119% | 22.1834 | `domComposite` |
+
+### Stage 4. Harness 보정 후 통합 smoke
+
+#293에서 visual diff harness가 overlay DOM을 `domComposite`로 캡처하도록 수정된 뒤 Stage 4를 재측정했다. `복학원서.hwp`는 BehindText overlay positive fixture로 확인됐다.
+
+Common condition:
+
+- Page: 1
+- Native policy: `coreGraphicsOnly`
+- Studio release: `v0.7.13`
+- Studio resolved commit: `b3e16ef212af81ef37d973ddb86d6816d3804642`
+- Viewport: `1400x1800`
+- Settle: `120ms`
+- Diff pixel threshold: `12`
+
+Basic/image sample set:
+
+| Sample | Stage 1 | Stage 4 | 변화 | StudioCapture |
+|--------|--------:|--------:|-----:|---------------|
+| `request.hwp` | 18.1021% | 18.0172% | -0.0849pp | `domComposite` |
+| `hwpx-01.hwpx` | 15.1839% | 15.0285% | -0.1554pp | `domComposite` |
+| `tac-img-02.hwp` | 4.1375% | 4.1335% | -0.0040pp | `canvasDataURL` |
+| `tac-img-02.hwpx` | 3.6427% | 4.2178% | +0.5751pp | `domComposite` |
+| `hwp-img-001.hwp` | 7.8448% | 7.9015% | +0.0567pp | `domComposite` |
+| `img-start-001.hwp` | 14.4365% | 18.0119% | +3.5754pp | `domComposite` |
+
+Positive overlay fixture:
+
+| Sample | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend | NativeMs |
+|--------|--------------:|---------------:|-------------:|------------:|---------------|---------------|---------:|
+| `복학원서.hwp` | 1140407/3562815 | 32.0086% | 37.8181 | 255 | `domComposite` | `coreGraphics` | 1105.5 |
+
+Overlay metadata smoke:
+
+| Sample | UpstreamImages | Overlay | Behind | Front | Renderable | BinLinked | Wraps |
+|--------|---------------:|--------:|-------:|------:|-----------:|----------:|-------|
+| `복학원서.hwp` | 2 | 2 | 2 | 0 | 2 | 2 | BehindText:2 |
+
+관찰:
+
+- `복학원서.hwp`는 `BehindText` 두 이미지를 가진 positive fixture다.
+- `front=0`이므로 InFrontOfText positive fixture는 아직 없다.
+- studio reference는 `captureMode=domComposite`, `overlayCount=5`, `usedOverlayUnion=true`, `overlayIncluded=true`로 기록됐다.
+- native output도 좌상단 로고와 중앙 워터마크를 그린다.
+- 중앙 워터마크는 native에서 너무 진하고 gray rectangle이 남는다. 이 차이는 compositor pass보다는 watermark effect parity 문제다.
+
+Quick Look Skia policy smoke:
+
+| Sample | Reply | Pages | CGBackend | CGFallback | CGSeconds | SkiaBackend | SkiaFallback | SkiaSeconds |
+|--------|------|------:|-----------|-----------:|----------:|-------------|-------------:|------------:|
+| `request.hwp` | png | 1 | skia:0,cg:1,embedded:0 | 0 | 0.981999 | skia:1,cg:0,embedded:0 | 0 | 3.577944 |
+| `hwpx-01.hwpx` | pdf | 9 | skia:0,cg:9,embedded:0 | 0 | 0.367728 | skia:9,cg:0,embedded:0 | 0 | 0.641190 |
+
+해석:
+
+- CoreGraphics-only policy는 Quick Look PNG/PDF path에서 CG renderer를 사용한다.
+- Skia opt-in policy는 두 sample 모두 Skia backend를 사용했고 fallback은 0건이다.
+- 따라서 #282 변경은 Thumbnail 기본 경로와 Quick Look CoreGraphics fallback/coreGraphicsOnly 측정에 직접 적용된다. Skia 성공 경로는 #282 compositor를 우회한다.
+
+### Stage 5. 최종 보고와 handoff
+
+Stage 5에서는 관찰, 수치 비교, 결론, 한계, 다음 작업 순서를 최종 보고서에 정리했다. 별도 compatibility follow-up으로 #296을 생성해 upstream rhwp #1016 release 반영 시 Swift fallback 중복 적용을 막는 작업을 추적하도록 했다.
+
+## 결론
+
+#282의 목표였던 native CoreGraphics compositor 구조 보강과 overlay image drawing 연결은 완료됐다. `복학원서.hwp` 기준으로 metadata overlay image가 native path에서 실제로 그려지는 것을 확인했으므로, 기존의 "overlay image pass가 없는 구조" 문제는 해소됐다.
+
+남은 큰 visual gap은 compositor 순서 문제가 아니라 watermark/effect payload 처리 문제다. 특히 중앙 워터마크 payload는 `mime=image/jpeg`, `effect=grayScale`, `brightness=-50`, `contrast=70`, `watermarkPreset=custom`, `bakedWatermark=false`로 내려오며, native renderer는 rhwp-studio처럼 보정된 결과를 만들지 못한다. 이 부분은 #116에서 다루는 것이 맞다.
+
+## 관찰과 얻은 교훈
+
+- visual diff 숫자는 reference capture 방식에 매우 민감하다. #293 전에는 studio web 화면에는 보이는 overlay가 reference PNG에는 빠질 수 있었다.
+- sample set에 양성 케이스가 없으면 구현 성공 여부를 수치만으로 판단하기 어렵다. `복학원서.hwp`가 BehindText positive fixture 역할을 하면서 #282의 실제 효과를 확인할 수 있었다.
+- `overlayIncluded=true`와 `captureMode=domComposite` 같은 metadata를 함께 기록해야 visual diff 수치를 해석할 수 있다.
+- Quick Look/Thumbnail preview parity 작업은 Skia 성공 경로와 CoreGraphics fallback 경로를 나눠 봐야 한다. #282는 CoreGraphics path의 의미 있는 작업이며, Skia path parity는 upstream renderer 진척과 별도로 추적해야 한다.
+- upstream resolved payload가 release로 내려올 가능성이 있는 영역은 Swift fallback을 먼저 추가하더라도 compatibility gate를 별도로 남겨야 한다.
+
+## 한계와 잔여 위험
+
+- #282는 watermark grayscale/brightness/contrast를 구현하지 않았다.
+- #282는 upstream #1016/#1017 resolved baked watermark payload를 소비하지 않는다.
+- #282는 InFrontOfText positive fixture를 추가하지 않았다.
+- partial overlay success에서 일부 overlay만 실패하는 경우 per-image fallback은 아직 없다. 현재 fallback은 renderable overlay가 없거나 attempted draw가 0건인 경우에 초점이 있다.
+- `domComposite` reference는 canvas/img 중심의 harness 합성이다. CSS transform, blend mode, SVG, background-image까지 일반화한 browser paint capture는 아니다.
+- fill/tile/placement residual diff는 #122, text/layout residual diff는 #121/#110 후속 영역으로 남는다.
+
+## 검증 결과
+
+Stage 4까지 수행한 주요 검증:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-overlay-positive --page 1 \
+  samples/복학원서.hwp
+
+./scripts/overlay-metadata-smoke.sh build.noindex/task282-stage4-overlay-metadata --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp \
+  samples/복학원서.hwp
+
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task282-stage4-skia-policy \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task282-stage4 CODE_SIGNING_ALLOWED=NO build
+
+git diff --check
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+결과:
+
+- `xcodebuild`: `** BUILD SUCCEEDED ** [11.918 sec]`
+- visual diff harness: 대상 sample 모두 OK
+- overlay metadata smoke: 대상 sample 모두 OK
+- Quick Look Skia policy smoke: CG/Skia policy 분기 확인, fallback 0
+- `git diff --check`: 통과
+- extension registration hygiene: Issues 없음
+
+Stage 5 문서 검증:
+
+```bash
+rg -n "#116|#122|#121|#110|#282|#296|Skia|CoreGraphics|overlay|ChangedPercent" \
+  mydocs/working/task_m014_282_stage*.md mydocs/report/task_m014_282_report.md
+git diff --check
+git status --short --branch
+```
+
+## Handoff
+
+다음 순서:
+
+1. #282 PR을 게시하고 review/merge한다.
+2. #116에서 `복학원서.hwp` 중앙 watermark/effect parity를 진행한다.
+3. #296은 upstream rhwp #1016 release가 내려온 뒤 Swift fallback 중복 적용 방지로 처리한다.
+4. #122/#121/#110은 watermark parity 이후 남는 diff를 기준으로 분리한다.
+
+#116에서 바로 확인할 기준:
+
+- `복학원서.hwp` studio reference는 `captureMode=domComposite`, `overlayIncluded=true`여야 한다.
+- native output의 중앙 watermark가 너무 진하고 gray rectangle이 남는 현상을 먼저 줄인다.
+- 현재 upstream payload가 `bakedWatermark=false`이므로 Swift fallback bake를 적용하더라도, #296에서 향후 `bakedWatermark=true` 또는 resolved PNG payload가 내려올 때 중복 적용하지 않도록 해야 한다.
+
+## PR 반영 메모
+
+PR 본문에는 다음을 반드시 포함한다.
+
+- Stage 4 smoke 측정값과 결론
+- `복학원서.hwp`가 BehindText positive fixture이며 InFrontOfText positive fixture는 아직 없다는 점
+- Quick Look Skia policy smoke에서 Skia 성공 경로가 #282 compositor를 우회한다는 점
+- #116, #296, #122, #121, #110 handoff
+

--- a/mydocs/working/task_m014_282_stage1.md
+++ b/mydocs/working/task_m014_282_stage1.md
@@ -1,0 +1,169 @@
+# Task M014 #282 Stage 1 보고서 - native compositor inventory 정리
+
+## 단계 목적
+
+- 이슈: #282 Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강
+- 단계: Stage 1. renderer/compositor 구조 inventory와 구현 경로 확정
+- 목표: Quick Look PNG, Quick Look PDF, Finder Thumbnail이 공유하는 render entry point와 `CGTreeRenderer`의 현재 pass 구조를 확인하고, #282 구현 경로와 before baseline을 확정한다.
+
+이번 단계는 조사, baseline 생성, 구현계획 문서화만 수행했다. Swift production source, Xcode project, RustBridge source는 수정하지 않았다.
+
+## 산출물
+
+| 파일/경로 | 내용 |
+|-----------|------|
+| `mydocs/plans/task_m014_282_impl.md` | 293 lines. Stage 1-5 구현계획, 검증, 완료 기준 작성 |
+| `mydocs/working/task_m014_282_stage1.md` | Stage 1 inventory, baseline, 구현 결정 정리 |
+| `build.noindex/task282-stage1-overlay-metadata/` | #281 overlay metadata smoke 산출물 |
+| `build.noindex/task282-stage1-before-basic/` | 기본 sample visual diff baseline |
+| `build.noindex/task282-stage1-before-images/` | image-heavy sample visual diff baseline |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- production Swift/Rust source 변경 없음.
+- `mydocs/plans/task_m014_282_impl.md` 신규 추가만 수행.
+- `build.noindex/` 산출물은 검증용이며 커밋하지 않는다.
+
+## renderer entry point inventory
+
+| 경로 | 현재 호출 | #282 영향 |
+|------|-----------|-----------|
+| Quick Look 단일 페이지 PNG | `HwpPreviewProvider.pngReply` -> `HwpPageImageRenderer.renderPage(..., policy: .skiaOptIn)` | Skia 성공 시 Swift compositor를 우회한다. CoreGraphics fallback 보강 범위를 PR에 명시해야 한다. |
+| Quick Look 다중 페이지 PDF | `HwpPreviewPDFRenderer.render` -> page별 `HwpPageImageRenderer.renderPage(..., policy: .skiaOptIn)` | page renderer를 고치면 PDF loop도 같은 fallback policy를 사용한다. |
+| Finder Thumbnail | `HwpThumbnailRenderCache.renderedPage` -> `HwpPageImageRenderer.renderFirstPage(...)` 기본 policy `.coreGraphicsOnly` | Thumbnail은 #282 CoreGraphics compositor 변경이 직접 적용되는 경로다. |
+| visual diff harness | `NativePreviewRenderer.render` -> `HwpPageImageRenderer.renderPage(..., policy: coreGraphicsOnly)` | before/after 측정은 CoreGraphics compositor 효과를 직접 본다. |
+
+## CGTreeRenderer inventory
+
+| 항목 | 현재 상태 | 구현 판단 |
+|------|-----------|-----------|
+| page pass | white fill -> page background child -> direct page `BehindText` image -> foreground children | 이미 일부 behind ordering을 한다. 하지만 direct page child 중심이며 전역 overlay pass는 아니다. |
+| column pass | direct column `BehindText` image -> non-behind children | column 내부에 한정된 ordering이다. nested tree 전체의 overlay 후보를 flow에서 제외하지 않는다. |
+| InFrontOfText | 별도 pass 없음 | #282에서 flow 이후 pass를 명시해야 한다. |
+| wrap normalization | `isBehindTextWrap`은 case-insensitive exact `BehindText`만 처리 | #281 `RhwpPageOverlayLayer(textWrap:)`의 normalization과 통일하는 편이 안전하다. |
+| image drawing | `renderImage`가 `imageData`, decode, crop, effect, transform, destination rect를 처리 | overlay drawing은 이 로직을 재사용하도록 `CGTreeRenderer` 내부 API를 확장한다. |
+| image effects | grayscale/blackWhite/brightness/contrast가 이미 구현됨 | overlay image도 같은 adjustment를 사용한다. blackWhite는 현재 grayscale에 가깝다는 한계가 있다. |
+| watermark | `RhwpPageOverlayImage`에는 `watermarkPreset`, `bakedWatermark`가 있으나 renderer 구현 없음 | #116과 경계를 맞춰 최소 처리 또는 명시적 handoff가 필요하다. |
+
+## 구현 경로 결정
+
+Stage 2 구현 경로는 `HwpPageImageRenderer`의 CoreGraphics fallback 내부에서 compositor를 호출하는 방식으로 고정한다.
+
+1. `renderCoreGraphicsPage`에서 `document.renderPageTree(at:)`를 한 번만 호출한다.
+2. 같은 `tree`를 `document.pageOverlayImages(at:renderTree:)`에 전달해 #281 overlay metadata를 얻는다.
+3. `CGTreeRenderer`에 pass/filter policy를 추가하거나, 얇은 `HwpNativePageCompositor`를 두어 다음 순서로 그린다.
+   - background
+   - BehindText overlay
+   - flow excluding overlay images
+   - InFrontOfText overlay
+4. overlay image drawing은 `CGTreeRenderer`의 기존 image decode/crop/effect/transform 로직을 재사용한다.
+5. Skia opt-in 성공 경로는 그대로 둔다. #282 결과는 CoreGraphics fallback과 Thumbnail path에 직접 적용되고, Quick Look에서는 Skia 실패 fallback 또는 `coreGraphicsOnly` 측정에서 관찰된다.
+6. `preview-visual-diff-harness.sh` 등 `HwpPageImageRenderer.swift`를 직접 compile하는 script에는 `PageOverlayImages.swift`와 신규 compositor file을 compile list에 포함한다.
+
+## overlay metadata baseline
+
+실행:
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/overlay-metadata-smoke.sh build.noindex/task282-stage1-overlay-metadata
+```
+
+처음에는 새 분리 worktree에 gitignored `Frameworks/universal/librhwp.a`가 없어 smoke가 실패했다. `build-rust-macos.sh --verify-lock`로 framework 산출물을 생성한 뒤 다시 실행해 통과했다. lock 변경은 발생하지 않았다.
+
+| sample | UpstreamImages | Overlay | Behind | Front | TreeImages | EmbeddedAvailable | Wraps |
+|--------|----------------|---------|--------|-------|------------|-------------------|-------|
+| `request.hwp` | `1` | `0` | `0` | `0` | `1` | `1/1` | `TopAndBottom:1` |
+| `hwpx-01.hwpx` | `2` | `0` | `0` | `0` | `2` | `2/2` | `TopAndBottom:2` |
+| `tac-img-02.hwp` | `1` | `0` | `0` | `0` | `1` | `1/1` | `TopAndBottom:1` |
+| `tac-img-02.hwpx` | `1` | `0` | `0` | `0` | `1` | `1/1` | `TopAndBottom:1` |
+| `hwp-img-001.hwp` | `4` | `0` | `0` | `0` | `4` | `4/4` | `Square:1, TopAndBottom:3` |
+| `img-start-001.hwp` | `0` | `0` | `0` | `0` | `0` | `0/0` | `-` |
+
+해석:
+
+- 현재 default sample set은 #281과 동일하게 `BehindText`/`InFrontOfText` positive fixture가 아니다.
+- Stage 2-3에서 compositor 구조와 중복 렌더 방지는 검증할 수 있지만, overlay visual improvement는 positive fixture 없이는 증명하기 어렵다.
+
+## visual diff baseline
+
+공통 조건:
+
+- Page: 1
+- NativePolicy: `coreGraphicsOnly`
+- Studio release: `v0.7.12`
+- Studio resolved commit: `1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5`
+- Viewport: `1400x1800`
+- Settle: `120ms`
+- Diff pixel threshold: `12`
+
+실행:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage1-before-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage1-before-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+결과:
+
+| sample | Status | StudioSize | NativeSize | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | NativeBackend | NativeMs |
+|--------|--------|------------|------------|---------------|----------------|--------------|-------------|---------------|----------|
+| `request.hwp` | OK | `1133x1587` | `567x794` | `325488/1798071` | `18.1021%` | `11.5796` | `255` | `coreGraphics` | `1118.3` |
+| `hwpx-01.hwpx` | OK | `1587x2245` | `794x1123` | `540973/3562815` | `15.1839%` | `15.6722` | `255` | `coreGraphics` | `40.7` |
+| `tac-img-02.hwp` | OK | `1587x2245` | `794x1123` | `147412/3562815` | `4.1375%` | `3.7228` | `255` | `coreGraphics` | `1065.3` |
+| `tac-img-02.hwpx` | OK | `1587x2245` | `794x1123` | `129783/3562815` | `3.6427%` | `3.3924` | `255` | `coreGraphics` | `7.3` |
+| `hwp-img-001.hwp` | OK | `1587x2245` | `794x1123` | `279494/3562815` | `7.8448%` | `8.2731` | `255` | `coreGraphics` | `18.6` |
+| `img-start-001.hwp` | OK | `1587x2244` | `794x1123` | `514115/3561228` | `14.4365%` | `15.4773` | `255` | `coreGraphics` | `34.0` |
+
+수치는 #281 Stage 4 handoff와 같은 baseline이다. Stage 2-4 이후에도 같은 sample set으로 after를 측정해 regression 여부를 확인한다.
+
+## 검증 결과
+
+실행:
+
+```bash
+rg -n "renderPage\\(|renderCoreGraphicsPage|CGTreeRenderer|pageOverlayImages|textWrap|BehindText|InFrontOfText" \
+  Sources/Shared Sources/RhwpCoreBridge Sources/QLExtension Sources/ThumbnailExtension scripts
+rg -n "BehindText|InFrontOfText|behindText|inFrontOfText|behind_text|in_front" samples
+rg -n "PageOverlayImages\\.swift|RhwpPageOverlay|pageOverlayImages" .github project.yml scripts Sources mydocs
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/overlay-metadata-smoke.sh build.noindex/task282-stage1-overlay-metadata
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage1-before-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage1-before-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+결과:
+
+- renderer entry point와 `CGTreeRenderer` pass 구조를 확인했다.
+- `samples/` text search에서 `BehindText`/`InFrontOfText` 문자열은 찾지 못했다. binary HWP와 compressed HWPX 특성상 이것만으로 fixture 부재를 확정하지는 않지만, overlay metadata smoke도 positive case를 찾지 못했다.
+- `build-rust-macos.sh --verify-lock`: 통과. 새 worktree framework 산출물 생성, lock 검증 완료.
+- overlay metadata smoke: 6개 sample 모두 OK.
+- visual diff harness: 6개 sample 모두 OK.
+
+## 잔여 위험
+
+- positive overlay fixture가 없어 Stage 2-3의 실제 overlay ordering 개선을 수치로 증명하기 어렵다.
+- Quick Look은 `.skiaOptIn`을 사용하므로 Skia 성공 시 CoreGraphics compositor 변경을 우회한다. Thumbnail과 harness는 CoreGraphics path를 직접 탄다.
+- `CGTreeRenderer` 내부 image rendering 함수가 private이라 overlay drawing 재사용을 위해 신중한 API 정리가 필요하다.
+- `preview-visual-diff-harness.sh`는 현재 `PageOverlayImages.swift`를 compile list에 포함하지 않는다. Stage 2에서 `HwpPageImageRenderer`가 overlay model을 직접 참조하면 script 업데이트가 필요하다.
+- watermark multiply/opacity는 현재 code path에서 구현되어 있지 않다. #116과 책임 경계를 다시 확인해야 한다.
+
+## 다음 단계 영향
+
+Stage 2는 다음 순서로 진행한다.
+
+1. `renderCoreGraphicsPage`에서 tree와 overlay metadata를 한 번만 수집한다.
+2. `CGTreeRenderer`에 render pass/filter policy를 추가한다.
+3. flow pass에서 `BehindText`/`InFrontOfText` overlay 후보를 제외한다.
+4. background/flow pass 분리까지만 먼저 안정화하고, 실제 overlay image drawing은 Stage 3에서 구현한다.
+5. `preview-visual-diff-harness.sh`와 관련 smoke compile list를 함께 갱신한다.
+
+## 승인 요청
+
+Stage 1 결과를 기준으로 Stage 2 `native compositor policy와 pass 분리 구현` 진입 승인을 요청한다.

--- a/mydocs/working/task_m014_282_stage2.md
+++ b/mydocs/working/task_m014_282_stage2.md
@@ -1,0 +1,112 @@
+# Task #282 Stage 2 보고서
+
+## 단계 목적
+
+Quick Look/Thumbnail native CoreGraphics 렌더러가 rhwp-studio의 flow/overlay 구조로 갈 수 있도록 기존 단일 pass 렌더 경로를 background, behind overlay, flow, front overlay pass로 분리했다.
+
+이번 단계는 실제 compact overlay image bytes를 별도 주입해 그리는 완성 단계가 아니라, pass 경계와 순서 보존을 먼저 만든 준비 단계다.
+
+## 산출물
+
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+  - `CGTreeOverlayLayer`, `CGTreeRenderMode`를 추가했다.
+  - `complete`, `pageBackground`, `flowExcludingPageOverlays`, `pageOverlay` 모드로 같은 render tree를 여러 pass에서 재사용할 수 있게 했다.
+  - `BehindText`, `InFrontOfText` textWrap 정규화를 `-`, `_`, 대소문자 차이에 견디도록 처리했다.
+- `Sources/Shared/HwpNativePageCompositor.swift`
+  - native page compositor를 새로 추가했다.
+  - render tree의 image textWrap과 #281 overlay metadata를 함께 보고 필요한 overlay pass를 결정한다.
+  - overlay metadata가 비어 있어도 render tree에 overlay textWrap이 있으면 기존 layer 순서를 잃지 않도록 했다.
+- `Sources/Shared/HwpPageImageRenderer.swift`
+  - CoreGraphics fallback 렌더 경로에서 render tree decode 후 `pageOverlayImages` metadata를 조회하고 compositor로 위임하도록 변경했다.
+- `scripts/preview-visual-diff-harness.sh`, `scripts/smoke-quicklook-skia-policy.sh`, `scripts/compare-quicklook-pdf-renderers.sh`
+  - standalone Swift compile 대상에 `PageOverlayImages.swift`, `HwpNativePageCompositor.swift`를 추가했다.
+- `Alhangeul.xcodeproj/project.pbxproj`
+  - `xcodegen generate`로 `HwpNativePageCompositor.swift`를 HostApp, QLExtension, ThumbnailExtension source phase에 반영했다.
+
+## 본문 변경 / 무손실
+
+문서 파싱 결과나 문서 본문 데이터는 변경하지 않았다. 변경 범위는 native CoreGraphics 렌더링 순서와 빌드/검증 스크립트 compile list에 한정된다.
+
+현재 샘플의 visual diff 수치는 Stage 1 baseline과 동일하게 유지됐다. 즉, overlay 양성 fixture가 없는 현 샘플군에서는 pass 분리가 기존 출력 픽셀을 바꾸지 않았다.
+
+## 검증 결과
+
+`./scripts/check-no-appkit.sh`
+
+- 결과: OK
+- 공유 Swift 코드에 AppKit/UIKit 직접 의존 없음.
+
+`./scripts/verify-rhwp-studio-assets.sh`
+
+- 결과: OK
+- bundled rhwp-studio asset 경로: `Sources/HostApp/Resources/rhwp-studio`
+
+`./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage2-basic --page 1 samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx`
+
+| File | Status | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | NativeBackend | NativeMs |
+| --- | --- | ---: | ---: | ---: | ---: | --- | ---: |
+| `request.hwp` | OK | 325488/1798071 | 18.1021% | 11.5796 | 255 | coreGraphics | 1063.2 |
+| `hwpx-01.hwpx` | OK | 540973/3562815 | 15.1839% | 15.6722 | 255 | coreGraphics | 35.0 |
+
+Stage 1 baseline과 비교하면 `ChangedPercent`는 두 샘플 모두 동일하다. `NativeMs`는 `request.hwp`가 1010.4ms에서 1063.2ms로, `hwpx-01.hwpx`가 42.5ms에서 35.0ms로 관찰됐다. 단일 smoke 측정이라 성능 판단 근거로 보지는 않고, pass 분리가 현재 샘플 출력 픽셀을 바꾸지 않았다는 확인 용도로만 사용한다.
+
+실행 중 `request.hwp`에서 기존 layout overflow 경고가 반복 관찰됐다.
+
+- `Table` overflow 4.0px
+- Stage 2 변경으로 새로 생긴 실패는 아니며, visual diff 결과는 OK다.
+
+`./scripts/overlay-metadata-smoke.sh build.noindex/task282-stage2-overlay-metadata`
+
+| File | Status | PageCount | UpstreamImages | Overlay | Behind | Front | TreeImages | TreeEmbeddedAvailable | Wraps |
+| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
+| `request.hwp` | OK | 1 | 1 | 0 | 0 | 0 | 1 | 1/1 | TopAndBottom:1 |
+| `hwpx-01.hwpx` | OK | 9 | 2 | 0 | 0 | 0 | 2 | 2/2 | TopAndBottom:2 |
+| `tac-img-02.hwp` | OK | 66 | 1 | 0 | 0 | 0 | 1 | 1/1 | TopAndBottom:1 |
+| `tac-img-02.hwpx` | OK | 69 | 1 | 0 | 0 | 0 | 1 | 1/1 | TopAndBottom:1 |
+| `hwp-img-001.hwp` | OK | 1 | 4 | 0 | 0 | 0 | 4 | 4/4 | Square:1, TopAndBottom:3 |
+| `img-start-001.hwp` | OK | 3 | 0 | 0 | 0 | 0 | 0 | 0/0 | - |
+
+현 기본 샘플에는 `BehindText`/`InFrontOfText` 양성 overlay가 없다. 따라서 이번 단계에서 검증한 것은 pass 분리 후 기존 샘플 출력 보존과 metadata 조회 경로 정상 동작이다.
+
+`xcodegen generate`
+
+- 결과: OK
+- `project.yml` 원본 기준으로 Xcode project를 재생성했다.
+
+`xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task282-stage2 CODE_SIGNING_ALLOWED=NO build`
+
+- 결과: `** BUILD SUCCEEDED ** [3.343 sec]`
+- `HwpNativePageCompositor.swift`가 QLExtension, ThumbnailExtension, HostApp에서 컴파일되는 것을 확인했다.
+
+`./scripts/check-extension-registration-hygiene.sh --cleanup-dev-registrations`
+
+- 최초 결과: FAIL
+- 원인: Debug app 자체의 provider 등록은 `/Applications/Alhangeul.app`만 보였지만, Stage 2 빌드 산출물 내부 Sparkle `Updater.app` 경로가 LaunchServices dump에 남아 `Alhangeul.app` 개발 등록으로 추출됐다.
+- 조치: 현재 작업 산출물의 nested `Updater.app`만 `lsregister -u`로 해제했다.
+- 재확인: `./scripts/check-extension-registration-hygiene.sh --check-only` OK
+- 남은 warning: `build.noindex/DerivedData-task282-stage2/.../Alhangeul.app` 번들은 파일시스템에 남아 있다. 등록은 남아 있지 않다.
+
+`git diff --check`
+
+- 결과: OK
+
+## 결론
+
+Stage 2는 native CoreGraphics fallback을 rhwp-studio와 유사한 pass 구조로 나눌 수 있는 최소 구조를 만들었다. 현재 샘플군에서는 기존 visual diff 수치를 유지했고, HostApp/Quick Look/Thumbnail target 빌드도 통과했다.
+
+이번 단계에서 얻은 중요한 관찰은 overlay pass 활성화 조건을 #281 metadata에만 의존하면 안 된다는 점이다. metadata가 비어 있어도 render tree의 `textWrap`에 overlay layer가 있으면 기존 순서 보존을 위해 pass를 켜야 한다. 그래서 compositor는 metadata와 render tree를 모두 사용하도록 구현했다.
+
+## 한계
+
+- 기본 smoke 샘플에는 `BehindText`/`InFrontOfText` 양성 fixture가 없어 실제 overlay pass의 픽셀 개선을 아직 수치로 증명하지 못했다.
+- compact overlay image bytes를 직접 그리는 경로는 아직 없다. Stage 3에서 #281 metadata의 renderable image bytes를 실제 pass에 주입해야 한다.
+- Quick Look PNG/PDF 경로에서 Skia가 성공하면 CoreGraphics compositor는 fallback으로만 사용된다. Thumbnail은 기본적으로 CoreGraphics 경로를 타므로 이번 변경 영향이 더 직접적이다.
+- `check-extension-registration-hygiene.sh --cleanup-dev-registrations`는 nested Sparkle `Updater.app` 등록까지 직접 해제하지는 않았다. 이번 단계에서는 수동 unregister로 정리했지만, 필요하면 별도 hygiene 개선 이슈로 분리하는 것이 좋다.
+
+## 다음 단계
+
+Stage 3에서는 `RhwpPageOverlayImageSet`의 behind/front renderable image bytes를 compositor pass에 실제로 주입하는 경로를 구현한다. 그 뒤 overlay 양성 fixture가 없다는 한계가 계속 남으면 synthetic 또는 신규 샘플 확보 여부를 판단해야 한다.
+
+## 승인 요청
+
+Stage 2 구현과 검증을 완료했다. 작업지시자가 승인하면 Stage 3로 진행한다.

--- a/mydocs/working/task_m014_282_stage3.md
+++ b/mydocs/working/task_m014_282_stage3.md
@@ -1,0 +1,114 @@
+# Task #282 Stage 3 완료 보고서
+
+## 작업 개요
+
+- 이슈: #282
+- 브랜치: `local/task282`
+- 기준 브랜치: `origin/devel`
+- Stage 3 목표: overlay metadata에 renderable image bytes가 들어오는 경우 CoreGraphics fallback renderer가 해당 이미지를 `BehindText`/`InFrontOfText` pass에서 직접 그릴 수 있게 한다.
+
+## 기준 정렬
+
+- #278 병합 후 `local/task282`를 `origin/devel` 위로 rebase했다.
+- rebase 후 기준 merge commit은 `b9365ff`이며, 작업 브랜치는 `origin/devel` 대비 3개 커밋 ahead 상태에서 Stage 3를 시작했다.
+- 현재 core/studio 기준은 `rhwp-core.lock`의 `v0.7.13` / `b3e16ef212af81ef37d973ddb86d6816d3804642`이다.
+- 계획서의 기존 `v0.7.12` 표기를 `v0.7.13` 기준으로 갱신하고, #278 이후 관찰 가능한 `resolved` payload, embedded bytes availability, `bakedWatermark` 상태를 Stage 3 구현 원칙에 반영했다.
+
+## 구현 내용
+
+- `HwpNativePageCompositor`에 overlay layer 전용 render helper를 추가했다.
+- 각 overlay layer는 먼저 `RhwpPageOverlayImage.hasRenderableData`가 있는 metadata image를 찾는다.
+- renderable metadata가 없으면 Stage 2의 기존 render tree overlay fallback pass를 그대로 사용한다.
+- renderable metadata가 있으면 `CGTreeRenderer.renderOverlayImages`로 overlay 이미지를 직접 그린다.
+- metadata image가 하나도 그려지지 못한 경우에는 render tree overlay fallback pass를 다시 수행한다.
+- image bytes 해석 순서는 다음과 같다.
+  - `source.data` 우선 사용
+  - `source.binDataId`가 있으면 `RhwpDocument.imageData(binDataId:)` fallback
+  - 둘 다 decode할 수 없으면 해당 overlay image skip
+- overlay image drawing은 기존 image path와 같은 decode/crop/effect/brightness/contrast/transform/destination 계산을 재사용한다.
+- `bakedWatermark == true` payload는 bytes 자체가 이미 watermark 처리를 포함한다고 보고 별도 watermark pass를 추가하지 않는다.
+
+## 검증 결과
+
+### 정적/빌드 검증
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-studio-assets.sh
+git diff --check
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task282-stage3 CODE_SIGNING_ALLOWED=NO build
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+- `check-no-appkit.sh`: 통과
+- `verify-rhwp-studio-assets.sh`: 통과
+- `git diff --check`: 통과
+- `xcodegen generate`: 통과
+- `xcodebuild`: `** BUILD SUCCEEDED ** [13.754 sec]`
+- extension registration hygiene: Issues 없음
+  - 개발 빌드 app bundle은 `build.noindex/DerivedData-task282-stage3` 아래에 존재하지만 등록되지는 않았다.
+  - PlugInKit provider path 미보고 경고는 기존 hygiene check의 관찰 항목이며 이번 Stage 3 변경으로 새로 생긴 등록 오염은 없다.
+
+### Overlay metadata smoke
+
+명령:
+
+```bash
+./scripts/overlay-metadata-smoke.sh build.noindex/task282-stage3-overlay-metadata
+```
+
+결과:
+
+| File | Status | UpstreamImages | Overlay | Behind | Front | Renderable | TreeImages | TreeEmbeddedAvailable | Wraps |
+|---|---|---:|---:|---:|---:|---:|---:|---|---|
+| `request.hwp` | OK | 1 | 0 | 0 | 0 | 0 | 1 | 1/1 | TopAndBottom:1 |
+| `hwpx-01.hwpx` | OK | 2 | 0 | 0 | 0 | 0 | 2 | 2/2 | TopAndBottom:2 |
+| `tac-img-02.hwp` | OK | 1 | 0 | 0 | 0 | 0 | 1 | 1/1 | TopAndBottom:1 |
+| `tac-img-02.hwpx` | OK | 1 | 0 | 0 | 0 | 0 | 1 | 1/1 | TopAndBottom:1 |
+| `hwp-img-001.hwp` | OK | 4 | 0 | 0 | 0 | 0 | 4 | 4/4 | Square:1, TopAndBottom:3 |
+| `img-start-001.hwp` | OK | 0 | 0 | 0 | 0 | 0 | 0 | 0/0 | - |
+
+관찰:
+
+- 현재 smoke sample set에는 `BehindText`/`InFrontOfText` overlay image 양성 케이스가 없다.
+- 대신 render tree image의 embedded bytes availability는 `request.hwp`, `hwpx-01.hwpx`, `tac-img-02.hwp`, `tac-img-02.hwpx`, `hwp-img-001.hwp`에서 모두 확인됐다.
+- Stage 3 코드는 metadata overlay가 renderable할 때 사용할 drawing path를 연결했지만, 현재 sample set만으로는 실제 overlay image pass의 픽셀 개선을 증명할 수 없다.
+
+### Preview visual diff smoke
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage3-images --page 1 samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+결과:
+
+| File | Status | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | NativeBackend | NativeMs |
+|---|---|---:|---:|---:|---:|---|---:|
+| `tac-img-02.hwp` | OK | 147270/3562815 | 4.1335% | 3.7157 | 255 | coreGraphics | 1051.3 |
+| `tac-img-02.hwpx` | OK | 150272/3562815 | 4.2178% | 3.6095 | 255 | coreGraphics | 7.4 |
+| `hwp-img-001.hwp` | OK | 281516/3562815 | 7.9015% | 8.3980 | 255 | coreGraphics | 22.2 |
+| `img-start-001.hwp` | OK | 641445/3561228 | 18.0119% | 22.1834 | 255 | coreGraphics | 36.4 |
+
+관찰:
+
+- `StudioReleaseTag`와 `StudioResolvedCommit`은 각각 `v0.7.13`, `b3e16ef212af81ef37d973ddb86d6816d3804642`로 기록됐다.
+- `tac-img-02.hwpx`에서 기존과 같은 paragraph layout overflow warning이 관찰됐다.
+- overlay 양성 케이스가 없으므로 위 수치는 Stage 3의 overlay image path 개선 수치가 아니라, v0.7.13 기준의 기존 image sample smoke 기준선으로 봐야 한다.
+
+## 결론
+
+- Stage 3의 코드 목표였던 `source.data`/`binDataId` 기반 overlay image drawing path 연결은 완료했다.
+- 기존 render tree overlay fallback은 유지했고, renderable metadata가 없거나 metadata image draw가 전부 실패하는 경우 fallback pass가 동작하도록 했다.
+- 현재 fixture에서는 overlay metadata가 0건이라 실제 `BehindText`/`InFrontOfText` image overlay 픽셀 개선은 아직 측정할 수 없다.
+- 따라서 Stage 3 완료 판정은 "렌더 경로 연결 + 기존 sample regression 없음 + fallback 유지" 기준으로 한다.
+
+## 한계와 handoff
+
+- overlay 양성 fixture가 필요하다. 현재 smoke sample만으로는 `BehindText`/`InFrontOfText` image가 실제로 metadata path에서 그려지는지 pixel diff로 증명할 수 없다.
+- metadata image가 여러 개이고 일부만 draw에 성공하는 경우, 현재 구현은 성공한 image는 그리고 실패한 image만 개별적으로 render tree fallback하지 않는다. 전체 draw count가 0일 때만 fallback한다.
+- watermark multiply/opacity parity는 현재 core payload에서 독립 구현할 근거가 부족하므로 #116/#122 범위로 남긴다.
+- image destination은 기존 `CGTreeRenderer`의 `imageDestinationRect`와 같은 제한을 공유한다. 현재는 fit/stretch 계열 외 fill mode 차이를 적극적으로 해석하지 않는다.
+- 다음 단계에서는 overlay 양성 fixture 또는 upstream metadata payload가 준비되는 즉시 Stage 3 path의 실제 픽셀 개선을 측정해야 한다.

--- a/mydocs/working/task_m014_282_stage4.md
+++ b/mydocs/working/task_m014_282_stage4.md
@@ -1,0 +1,179 @@
+# Task #282 Stage 4 완료 보고서
+
+## 작업 개요
+
+- 이슈: #282
+- 브랜치: `local/task282`
+- 단계: Stage 4. Quick Look/Thumbnail 통합 smoke와 visual diff 측정
+- 목표: #293 visual diff harness 수정이 반영된 상태에서 CoreGraphics compositor 결과, Quick Look Skia/CoreGraphics policy, overlay 양성 fixture 결과를 다시 측정한다.
+
+## 기준 정렬
+
+- #293 완료 후 `local/task282`가 `origin/devel` 대비 18커밋 behind 상태였다.
+- 작업 트리가 clean인 상태에서 `git rebase origin/devel`을 수행했고 충돌 없이 완료했다.
+- Stage 4 시작 기준 `origin/devel`은 `5966bd7`이며, #293 merge commit `fa75296`과 #292 merge commit `5966bd7`이 포함됐다.
+- rebase 후 #282 커밋은 `origin/devel` 대비 4개 ahead 상태다.
+
+## Stage 4 측정 범위
+
+- Stage 1 baseline과 같은 basic/image sample set을 다시 측정했다.
+- #293에서 수정된 harness가 overlay DOM을 포함하는지 확인하기 위해 `samples/복학원서.hwp`를 positive overlay fixture로 추가했다.
+- Quick Look PNG/PDF smoke에서 CoreGraphics-only와 Skia opt-in policy를 비교했다.
+- HostApp/QLExtension/ThumbnailExtension Debug build와 extension registration hygiene를 확인했다.
+
+## Visual Diff 결과
+
+공통 조건:
+
+- Page: 1
+- NativePolicy: `coreGraphicsOnly`
+- Studio release: `v0.7.13`
+- Studio resolved commit: `b3e16ef212af81ef37d973ddb86d6816d3804642`
+- Viewport: `1400x1800`
+- Settle: `120ms`
+- Diff pixel threshold: `12`
+
+### Basic sample set
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+| File | Status | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend | NativeMs |
+|---|---|---:|---:|---:|---:|---|---|---:|
+| `request.hwp` | OK | 323962/1798071 | 18.0172% | 11.1875 | 255 | domComposite | coreGraphics | 1054.2 |
+| `hwpx-01.hwpx` | OK | 535436/3562815 | 15.0285% | 15.2088 | 255 | domComposite | coreGraphics | 35.4 |
+
+관찰:
+
+- Stage 1 baseline은 `v0.7.12` / 기존 harness 기준이라 Stage 4 수치와 완전히 같은 조건은 아니다.
+- 같은 sample set 기준으로 `request.hwp`는 18.1021%에서 18.0172%, `hwpx-01.hwpx`는 15.1839%에서 15.0285%로 소폭 낮아졌다.
+- `request.hwp`에서 기존 Table layout overflow 4.0px 경고가 관찰됐다.
+
+### Image sample set
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-images --page 1 \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+| File | Status | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend | NativeMs |
+|---|---|---:|---:|---:|---:|---|---|---:|
+| `tac-img-02.hwp` | OK | 147270/3562815 | 4.1335% | 3.7157 | 255 | canvasDataURL | coreGraphics | 941.4 |
+| `tac-img-02.hwpx` | OK | 150272/3562815 | 4.2178% | 3.6095 | 255 | domComposite | coreGraphics | 8.0 |
+| `hwp-img-001.hwp` | OK | 281516/3562815 | 7.9015% | 8.3980 | 255 | domComposite | coreGraphics | 17.9 |
+| `img-start-001.hwp` | OK | 641445/3561228 | 18.0119% | 22.1834 | 255 | domComposite | coreGraphics | 36.9 |
+
+관찰:
+
+- Stage 3의 image set 수치와 같은 값을 유지했다.
+- `tac-img-02.hwp`만 canvas-only capture를 유지했고, 나머지는 #293 이후 DOM composite capture로 기록됐다.
+- `tac-img-02.hwpx`에서 기존 FullParagraph layout overflow 2.4px 경고가 관찰됐다.
+
+### Positive overlay fixture
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-overlay-positive --page 1 \
+  samples/복학원서.hwp
+```
+
+| File | Status | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend | NativeMs |
+|---|---|---:|---:|---:|---:|---|---|---:|
+| `복학원서.hwp` | OK | 1140407/3562815 | 32.0086% | 37.8181 | 255 | domComposite | coreGraphics | 1105.5 |
+
+관찰:
+
+- #293 이후 studio reference metadata는 `captureMode=domComposite`, `overlayCount=5`, `usedOverlayUnion=true`, `overlayIncluded=true`로 기록됐다.
+- studio reference PNG에는 좌상단 로고와 중앙 BehindText 워터마크가 포함된다.
+- native PNG도 두 이미지를 그리지만, 중앙 워터마크가 rhwp-studio보다 훨씬 진하고 gray rectangle이 남는다.
+- 현재 v0.7.13 overlay payload는 중앙 워터마크를 `mime=image/jpeg`, `effect=grayScale`, `brightness=-50`, `contrast=70`, `watermarkPreset=custom`, `bakedWatermark=false`로 제공한다.
+- 이 차이는 #282 compositor 순서보다는 #116 watermark/effect parity와 upstream #1016 resolved baked watermark payload 범위에 가깝다.
+
+## Overlay Metadata Smoke
+
+명령:
+
+```bash
+./scripts/overlay-metadata-smoke.sh build.noindex/task282-stage4-overlay-metadata --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp \
+  samples/복학원서.hwp
+```
+
+| File | Status | UpstreamImages | Overlay | Behind | Front | Renderable | BinLinked | TreeImages | TreeEmbeddedAvailable | Wraps |
+|---|---|---:|---:|---:|---:|---:|---:|---:|---|---|
+| `request.hwp` | OK | 1 | 0 | 0 | 0 | 0 | 0 | 1 | 1/1 | TopAndBottom:1 |
+| `hwpx-01.hwpx` | OK | 2 | 0 | 0 | 0 | 0 | 0 | 2 | 2/2 | TopAndBottom:2 |
+| `tac-img-02.hwp` | OK | 1 | 0 | 0 | 0 | 0 | 0 | 1 | 1/1 | TopAndBottom:1 |
+| `tac-img-02.hwpx` | OK | 1 | 0 | 0 | 0 | 0 | 0 | 1 | 1/1 | TopAndBottom:1 |
+| `hwp-img-001.hwp` | OK | 4 | 0 | 0 | 0 | 0 | 0 | 4 | 4/4 | Square:1, TopAndBottom:3 |
+| `img-start-001.hwp` | OK | 0 | 0 | 0 | 0 | 0 | 0 | 0 | 0/0 | - |
+| `복학원서.hwp` | OK | 2 | 2 | 2 | 0 | 2 | 2 | 2 | 2/2 | BehindText:2 |
+
+결론:
+
+- 기존 6개 sample은 여전히 BehindText/InFrontOfText positive fixture가 아니다.
+- `복학원서.hwp`는 #282의 positive BehindText fixture로 사용할 수 있다.
+- `front=0`이므로 InFrontOfText 양성 fixture는 아직 없다.
+
+## Quick Look Skia Policy Smoke
+
+명령:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task282-stage4-skia-policy \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+| File | Reply | Pages | CGBackend | CGFallback | CGSeconds | SkiaBackend | SkiaFallback | SkiaSeconds |
+|---|---|---:|---|---:|---:|---|---:|---:|
+| `request.hwp` | png | 1 | skia:0,cg:1,embedded:0 | 0 | 0.981999 | skia:1,cg:0,embedded:0 | 0 | 3.577944 |
+| `hwpx-01.hwpx` | pdf | 9 | skia:0,cg:9,embedded:0 | 0 | 0.367728 | skia:9,cg:0,embedded:0 | 0 | 0.641190 |
+
+해석:
+
+- CoreGraphics-only policy는 Quick Look PNG/PDF 경로에서 CG renderer를 사용한다.
+- Skia opt-in policy는 두 sample 모두 Skia backend를 사용했고 fallback은 0건이다.
+- 따라서 #282 CoreGraphics compositor 변경은 Thumbnail 기본 경로와 Quick Look CoreGraphics fallback/coreGraphicsOnly 측정에 직접 적용된다. Skia 성공 경로는 #282 compositor를 우회한다.
+
+## 빌드와 위생 검증
+
+명령:
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task282-stage4 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+결과:
+
+- `xcodebuild`: `** BUILD SUCCEEDED ** [11.918 sec]`
+- `git diff --check`: 통과
+- registration hygiene: Issues 없음
+  - 개발 app bundle은 `build.noindex/DerivedData-task282-stage3`와 `build.noindex/DerivedData-task282-stage4` 아래에 남아 있지만 등록되지는 않았다.
+  - Quick Look/Thumbnail provider path 미보고 warning은 기존 check output과 같은 형태다.
+
+## 결론
+
+- #293 반영 후 harness는 overlay DOM이 있는 rhwp-studio reference를 `domComposite`로 캡처하고, `복학원서.hwp`의 overlay를 포함한다.
+- #282 Stage 3에서 연결한 metadata overlay image drawing path는 `복학원서.hwp`의 `BehindText` 두 이미지를 실제로 그리는 경로를 탄다.
+- Stage 4 smoke에서 CoreGraphics compositor, Quick Look policy, HostApp/QLExtension/ThumbnailExtension build는 모두 통과했다.
+- 남은 큰 visual gap은 compositor 순서가 아니라 watermark/effect payload 처리다. 현재 core payload가 `bakedWatermark=false`이므로 #116에서 Swift fallback bake 또는 #1016 release 반영 후 resolved payload 소비 정책을 결정해야 한다.
+
+## Handoff
+
+- #116: `복학원서.hwp` 중앙 JPEG 워터마크의 tone/gray rectangle 차이를 처리해야 한다. 현재 native는 원본 JPEG에 기존 effect/brightness/contrast를 적용해 rhwp-studio보다 훨씬 진하게 보인다.
+- #1016 upstream: 향후 `bakedWatermark=true` / resolved PNG payload가 release로 내려오면 Swift renderer는 해당 payload에 effect/brightness/contrast를 중복 적용하지 않아야 한다.
+- #122: fill/tile/placement는 Stage 4 image set 수치에서 계속 잔여 diff로 남는다.
+- #282 Stage 5: positive fixture 부재 한계는 해소됐다. 최종 보고서에는 `복학원서.hwp`를 BehindText positive fixture로 명시하고, InFrontOfText fixture는 여전히 부재하다고 정리한다.

--- a/mydocs/working/task_m014_282_stage5.md
+++ b/mydocs/working/task_m014_282_stage5.md
@@ -1,0 +1,72 @@
+# Task #282 Stage 5 완료 보고서
+
+## 작업 개요
+
+- 이슈: #282
+- 브랜치: `local/task282`
+- 단계: Stage 5. 최종 보고와 후속 작업 handoff 정리
+- 목표: Stage 1-4의 구현, smoke 측정, 관찰, 한계, 후속 작업 관계를 최종 보고서와 PR 본문에 넣을 수 있는 형태로 정리한다.
+
+## Stage 5에서 정리한 항목
+
+| 항목 | 내용 |
+|------|------|
+| 최종 보고서 | `mydocs/report/task_m014_282_report.md` 생성 |
+| 오늘할일 | `mydocs/orders/20260527.md`의 #282 상태를 완료로 갱신 |
+| 오늘할일 | `mydocs/orders/20260530.md` 생성, #282/#116/#296 실행 순서 기록 |
+| compatibility follow-up | #296을 upstream rhwp #1016 release 반영 시 처리할 후속 이슈로 연결 |
+
+## 최종 결론
+
+#282의 구현 범위는 Quick Look/Thumbnail native CoreGraphics compositor가 rhwp-studio flow에 더 가까운 순서로 page content와 overlay image pass를 합성하도록 만드는 것이다. Stage 3에서 overlay image drawing path를 연결했고, Stage 4에서 `복학원서.hwp`를 BehindText positive fixture로 사용해 실제 overlay image 2개가 native path에서 그려지는 것을 확인했다.
+
+Stage 4 기준 `복학원서.hwp` visual diff는 32.0086%로 여전히 크다. 그러나 smoke와 metadata를 함께 보면 남은 차이의 핵심은 compositor pass 연결 자체가 아니라 중앙 워터마크의 effect/brightness/contrast 처리와 upstream resolved watermark payload 여부다. 따라서 #282는 compositor 구조 보강으로 마무리하고, watermark parity는 #116에서 이어가는 것이 맞다.
+
+## 핵심 수치
+
+| Sample | Stage 1 기준 | Stage 4 결과 | 해석 |
+|--------|-------------:|-------------:|------|
+| `request.hwp` | 18.1021% | 18.0172% | harness/core 기준 변경 후 소폭 개선 |
+| `hwpx-01.hwpx` | 15.1839% | 15.0285% | harness/core 기준 변경 후 소폭 개선 |
+| `tac-img-02.hwp` | 4.1375% | 4.1335% | 거의 동일 |
+| `tac-img-02.hwpx` | 3.6427% | 4.2178% | capture mode가 `domComposite`로 바뀌며 기준이 달라짐 |
+| `hwp-img-001.hwp` | 7.8448% | 7.9015% | 거의 동일 |
+| `img-start-001.hwp` | 14.4365% | 18.0119% | studio/core 기준 변경 영향이 큼 |
+| `복학원서.hwp` | 해당 없음 | 32.0086% | BehindText positive fixture, watermark effect 차이 큼 |
+
+## 관찰과 얻은 점
+
+- 기존 sample set에는 BehindText/InFrontOfText overlay 양성 케이스가 없었다.
+- `복학원서.hwp`는 `overlay=2`, `behind=2`, `front=0`, `renderable=2`, `binLinked=2`로 기록되므로 BehindText positive fixture로 쓸 수 있다.
+- InFrontOfText positive fixture는 아직 없다. 이후 front overlay 회귀 검증에는 별도 fixture가 필요하다.
+- #293 이후 visual diff harness는 overlay DOM이 있는 studio reference를 `domComposite`로 캡처한다. 이 변경 덕분에 `복학원서.hwp`의 좌상단 로고와 중앙 워터마크가 reference에 포함됐다.
+- `복학원서.hwp` native output은 두 overlay image를 그리지만 중앙 워터마크가 rhwp-studio보다 훨씬 진하고 gray rectangle이 남는다.
+- 현재 v0.7.13 payload는 중앙 워터마크를 `mime=image/jpeg`, `effect=grayScale`, `brightness=-50`, `contrast=70`, `watermarkPreset=custom`, `bakedWatermark=false`로 제공한다.
+- Quick Look Skia opt-in 성공 경로는 #282의 CoreGraphics compositor를 우회한다. #282 변경은 Thumbnail 기본 경로와 Quick Look CoreGraphics fallback/coreGraphicsOnly policy에 직접 적용된다.
+
+## 한계
+
+- watermark/effect parity는 #282 범위를 넘긴다. #116에서 brightness/contrast/grayscale fallback을 다뤄야 한다.
+- upstream rhwp #1016/#1017이 resolved baked watermark payload를 release하면 Swift fallback을 중복 적용하지 않도록 #296에서 compatibility gate를 넣어야 한다.
+- fill/tile/placement 차이는 #122 영역으로 남는다.
+- text/layout residual diff는 #121/#110 계열로 분리해서 봐야 한다.
+- #282는 InFrontOfText positive fixture를 새로 만들지 않았다.
+
+## 후속 순서
+
+1. #282 PR을 게시하고 review/merge 대상으로 넘긴다.
+2. #116에서 `복학원서.hwp` 중앙 watermark effect parity를 먼저 진행한다.
+3. #296은 upstream rhwp #1016 release가 내려온 시점에 Swift fallback 중복 적용 방지로 처리한다.
+4. #122/#121/#110은 watermark parity 이후 남는 diff를 분리해 진행한다.
+
+## 검증 계획
+
+Stage 5는 문서 정리 단계이므로 다음 검증을 수행한다.
+
+```bash
+rg -n "#116|#122|#121|#110|#282|#296|Skia|CoreGraphics|overlay|ChangedPercent" \
+  mydocs/working/task_m014_282_stage*.md mydocs/report/task_m014_282_report.md
+git diff --check
+git status --short --branch
+```
+

--- a/scripts/compare-quicklook-pdf-renderers.sh
+++ b/scripts/compare-quicklook-pdf-renderers.sh
@@ -53,10 +53,12 @@ swiftc -parse-as-library \
   -I "$MODULEMAP_DIR" \
   "$ROOT/Sources/RhwpCoreBridge/RhwpDocument.swift" \
   "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/PageOverlayImages.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontFallback.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontResourceRegistry.swift" \
   "$ROOT/Sources/RhwpCoreBridge/CGTreeRenderer.swift" \
   "$ROOT/Sources/Shared/HwpPageImageRenderer.swift" \
+  "$ROOT/Sources/Shared/HwpNativePageCompositor.swift" \
   "$ROOT/Sources/Shared/HwpPreviewPDFRenderer.swift" \
   "$ROOT/scripts/quicklook_pdf_renderer_compare.swift" \
   "$LIB" \

--- a/scripts/preview-visual-diff-harness.sh
+++ b/scripts/preview-visual-diff-harness.sh
@@ -158,10 +158,12 @@ swiftc -parse-as-library \
   -I "$MODULEMAP_DIR" \
   "$ROOT/Sources/RhwpCoreBridge/RhwpDocument.swift" \
   "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/PageOverlayImages.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontFallback.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontResourceRegistry.swift" \
   "$ROOT/Sources/RhwpCoreBridge/CGTreeRenderer.swift" \
   "$ROOT/Sources/Shared/HwpPageImageRenderer.swift" \
+  "$ROOT/Sources/Shared/HwpNativePageCompositor.swift" \
   "$ROOT/scripts/preview_visual_diff_harness.swift" \
   "$LIB" \
   -framework AppKit \

--- a/scripts/render-debug-compare.sh
+++ b/scripts/render-debug-compare.sh
@@ -88,6 +88,7 @@ swiftc -parse-as-library \
   -I "$MODULEMAP_DIR" \
   "$ROOT/Sources/RhwpCoreBridge/RhwpDocument.swift" \
   "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/PageOverlayImages.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontFallback.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontResourceRegistry.swift" \
   "$ROOT/Sources/RhwpCoreBridge/CGTreeRenderer.swift" \

--- a/scripts/smoke-quicklook-skia-policy.sh
+++ b/scripts/smoke-quicklook-skia-policy.sh
@@ -54,10 +54,12 @@ swiftc -parse-as-library \
   -I "$MODULEMAP_DIR" \
   "$ROOT/Sources/RhwpCoreBridge/RhwpDocument.swift" \
   "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/PageOverlayImages.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontFallback.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontResourceRegistry.swift" \
   "$ROOT/Sources/RhwpCoreBridge/CGTreeRenderer.swift" \
   "$ROOT/Sources/Shared/HwpPageImageRenderer.swift" \
+  "$ROOT/Sources/Shared/HwpNativePageCompositor.swift" \
   "$ROOT/Sources/Shared/HwpPreviewPDFRenderer.swift" \
   "$ROOT/scripts/quicklook_skia_policy_smoke.swift" \
   "$LIB" \

--- a/scripts/validate-stage3-render.sh
+++ b/scripts/validate-stage3-render.sh
@@ -70,6 +70,7 @@ swiftc -parse-as-library \
   -I "$MODULEMAP_DIR" \
   "$ROOT/Sources/RhwpCoreBridge/RhwpDocument.swift" \
   "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/PageOverlayImages.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontFallback.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontResourceRegistry.swift" \
   "$ROOT/Sources/RhwpCoreBridge/CGTreeRenderer.swift" \


### PR DESCRIPTION
## 요약

Closes #282.

Quick Look/Thumbnail native CoreGraphics preview에 명시적인 compositor 경로를 추가했습니다.

- page content rendering과 overlay image rendering을 별도 pass로 분리
- `pageOverlayImages` metadata overlay image를 `CGTreeRenderer.renderOverlayImages`에서 그림
- renderable metadata overlay가 없을 때 기존 render tree image fallback 유지
- Quick Look/Thumbnail smoke script에서 CoreGraphics/Skia 측정 policy를 명시적으로 전달

이번 PR의 범위는 CoreGraphics fallback/default path입니다. Skia가 성공하는 경로는 여전히 이 Swift compositor를 우회합니다.

## Smoke 측정 결과

공통 visual diff 조건:

- page: 1
- native policy: `coreGraphicsOnly`
- rhwp-studio release: `v0.7.13`
- rhwp-studio resolved commit: `b3e16ef212af81ef37d973ddb86d6816d3804642`
- viewport: `1400x1800`
- settle: `120ms`
- diff pixel threshold: `12`

### Stage 1 baseline 대비 Stage 4 결과

| Sample | Stage 1 ChangedPercent | Stage 4 ChangedPercent | Delta | Stage 4 capture |
|--------|-----------------------:|-----------------------:|------:|-----------------|
| `request.hwp` | 18.1021% | 18.0172% | -0.0849pp | `domComposite` |
| `hwpx-01.hwpx` | 15.1839% | 15.0285% | -0.1554pp | `domComposite` |
| `tac-img-02.hwp` | 4.1375% | 4.1335% | -0.0040pp | `canvasDataURL` |
| `tac-img-02.hwpx` | 3.6427% | 4.2178% | +0.5751pp | `domComposite` |
| `hwp-img-001.hwp` | 7.8448% | 7.9015% | +0.0567pp | `domComposite` |
| `img-start-001.hwp` | 14.4365% | 18.0119% | +3.5754pp | `domComposite` |

### BehindText overlay 양성 fixture

#293에서 studio reference capture path가 보정된 뒤, `samples/복학원서.hwp`를 BehindText 양성 fixture로 사용했습니다.

| Sample | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | StudioCapture | NativeBackend | NativeMs |
|--------|--------------:|---------------:|-------------:|------------:|---------------|---------------|---------:|
| `복학원서.hwp` | 1140407/3562815 | 32.0086% | 37.8181 | 255 | `domComposite` | `coreGraphics` | 1105.5 |

`복학원서.hwp` overlay metadata smoke:

| UpstreamImages | Overlay | Behind | Front | Renderable | BinLinked | Wraps |
|---------------:|--------:|-------:|------:|-----------:|----------:|-------|
| 2 | 2 | 2 | 0 | 2 | 2 | BehindText:2 |

관찰:

- studio reference에는 좌상단 로고와 중앙 BehindText watermark가 포함됩니다.
- native output도 두 overlay image를 그립니다.
- 중앙 watermark는 여전히 rhwp-studio보다 훨씬 진하고 gray rectangle이 남습니다.
- 현재 v0.7.13 payload는 중앙 watermark를 `mime=image/jpeg`, `effect=grayScale`, `brightness=-50`, `contrast=70`, `watermarkPreset=custom`, `bakedWatermark=false`로 제공합니다.

결론:

- `복학원서.hwp`의 남은 큰 diff는 compositor ordering 문제가 아닙니다.
- 핵심은 watermark/effect parity와 resolved watermark payload 처리입니다.

### Quick Look Skia policy smoke

| Sample | Reply | Pages | CGBackend | CGFallback | CGSeconds | SkiaBackend | SkiaFallback | SkiaSeconds |
|--------|------|------:|-----------|-----------:|----------:|-------------|-------------:|------------:|
| `request.hwp` | png | 1 | skia:0,cg:1,embedded:0 | 0 | 0.981999 | skia:1,cg:0,embedded:0 | 0 | 3.577944 |
| `hwpx-01.hwpx` | pdf | 9 | skia:0,cg:9,embedded:0 | 0 | 0.367728 | skia:9,cg:0,embedded:0 | 0 | 0.641190 |

해석:

- `coreGraphicsOnly`는 Quick Look PNG/PDF path에서 CoreGraphics renderer를 사용합니다.
- Skia opt-in은 두 sample 모두 Skia backend를 사용했고 fallback은 0건입니다.
- 이번 PR은 Thumbnail과 Quick Look CoreGraphics fallback/coreGraphicsOnly 측정에 직접 적용됩니다.
- Skia preview가 성공하는 경로는 이 Swift compositor를 우회합니다.

## 결론

- native CoreGraphics path에 page content와 overlay image pass를 합성하는 명확한 compositor 경계가 생겼습니다.
- metadata overlay drawing path가 실제로 동작합니다. `복학원서.hwp`는 `overlay=2`, `behind=2`, `renderable=2`이며 native output도 해당 이미지를 그립니다.
- 기존 sample set에 BehindText 양성 케이스가 없던 한계는 `복학원서.hwp`로 해소했습니다.
- InFrontOfText 양성 fixture는 아직 없습니다.
- 남은 가장 큰 시각 차이는 overlay pass 부재가 아니라 watermark effect parity입니다.

## 관찰과 얻은 교훈

- visual diff metric은 reference capture 방식에 크게 의존합니다. #293 전에는 rhwp-studio browser 화면에는 overlay가 보이지만 reference PNG에는 빠질 수 있었습니다.
- `ChangedPercent`는 `captureMode`, `overlayIncluded` metadata와 함께 봐야 합니다. 그렇지 않으면 renderer 변화와 reference capture 변화가 섞여 해석됩니다.
- preview parity 작업은 Skia 성공 경로와 CoreGraphics fallback/default 경로를 분리해서 봐야 합니다. 두 경로는 소유 범위와 migration risk가 다릅니다.
- upstream에서 resolved/baked image payload를 추후 제공할 가능성이 있는 영역은 Swift fallback을 추가하더라도 compatibility gate를 별도로 남겨야 합니다.

## 한계

- 이번 PR은 watermark grayscale/brightness/contrast parity를 구현하지 않습니다.
- 이번 PR은 향후 upstream #1016/#1017 resolved baked watermark payload를 소비하지 않습니다.
- 이번 PR은 InFrontOfText 양성 fixture를 추가하지 않습니다.
- partial overlay draw failure에 대한 per-image fallback은 아직 제한적입니다. 현재 fallback은 "renderable overlay 없음" 또는 "attempted overlay draw count가 0"인 경우에 초점이 있습니다.
- visual diff harness의 `domComposite` reference는 canvas/img DOM composite이며, 모든 CSS feature를 포함하는 완전한 browser paint capture는 아닙니다.
- fill/tile/placement residual difference는 후속 preview parity 작업으로 남습니다.
- text/layout residual difference는 이번 compositor 작업과 별개로 추적해야 합니다.

## Handoff

### 업스트림 업데이트 없이 진행 가능

1. #116: `복학원서.hwp` 중앙 watermark/effect parity 처리
   - 현재 rhwp v0.7.13 payload의 `bakedWatermark=false` 기준으로 Swift/CoreGraphics fallback을 좁게 적용합니다.
   - `captureMode=domComposite`, `overlayIncluded=true` 기준 fixture를 사용합니다.
   - 먼저 줄여야 할 native 문제는 중앙 watermark가 너무 진하고 gray rectangle이 남는 현상입니다.

2. #122: watermark parity 이후 남는 fill/tile/placement residual difference 처리
   - #116 결과 이후에도 남는 image placement 계열 diff를 분리해서 봅니다.

3. #121/#110: 나머지 text/layout 및 정적 객체 차이 처리
   - 현재 payload로 재현 가능한 native renderer 차이를 별도 이슈에서 진행합니다.

### 업스트림 특정 PR이 release에 포함된 뒤 진행

1. #296: upstream rhwp #1016/#1017 계열 resolved/baked watermark payload 반영
   - upstream release/tag에 `bakedWatermark=true` 또는 resolved PNG payload가 포함된 뒤 처리합니다.
   - Swift fallback이 이미 baked된 watermark에 중복 적용되지 않도록 gate를 추가합니다.
   - core dependency update와 함께 smoke를 다시 측정합니다.

## 검증

Stage 4에서 실행:

```bash
./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-basic --page 1 \
  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx

./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-images --page 1 \
  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
  samples/hwp-img-001.hwp samples/img-start-001.hwp

./scripts/preview-visual-diff-harness.sh build.noindex/task282-stage4-overlay-positive --page 1 \
  samples/복학원서.hwp

./scripts/overlay-metadata-smoke.sh build.noindex/task282-stage4-overlay-metadata --page 1 \
  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
  samples/hwp-img-001.hwp samples/img-start-001.hwp \
  samples/복학원서.hwp

./scripts/smoke-quicklook-skia-policy.sh build.noindex/task282-stage4-skia-policy \
  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx

xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
  -derivedDataPath build.noindex/DerivedData-task282-stage4 CODE_SIGNING_ALLOWED=NO build

git diff --check
./scripts/check-extension-registration-hygiene.sh --check-only
```

결과:

- `xcodebuild`: `** BUILD SUCCEEDED ** [11.918 sec]`
- visual diff harness: 대상 sample 모두 OK
- overlay metadata smoke: 대상 sample 모두 OK
- Quick Look Skia policy smoke: CoreGraphics/Skia policy 분기 확인, fallback 0
- `git diff --check`: 통과
- extension registration hygiene: issues 없음

Stage 5에서 실행:

```bash
rg -n "#116|#122|#121|#110|#282|#296|Skia|CoreGraphics|overlay|ChangedPercent" \
  mydocs/working/task_m014_282_stage*.md mydocs/report/task_m014_282_report.md
git diff --check
git status --short --branch
```
