### PR TITLE
Task #116: baked watermark 중복 보정 방지

### DIFF
--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -764,7 +764,12 @@ class CGTreeRenderer {
         ctx.saveGState()
         applyTransform(node.transform, bbox: image.bbox, in: ctx)
 
-        let drawImage = preparedImage(for: cgImage, node: node)
+        let appliesAdjustments = !(image.bakedWatermark && image.source.data != nil)
+        let drawImage = preparedImage(
+            for: cgImage,
+            node: node,
+            applyingAdjustments: appliesAdjustments
+        )
         let rect = cgRect(image.bbox)
         let drawRect = imageDestinationRect(for: node, size: rect.size)
         ctx.saveGState()
@@ -1289,8 +1294,13 @@ class CGTreeRenderer {
         }
     }
 
-    private func preparedImage(for image: CGImage, node: ImageNode) -> CGImage {
+    private func preparedImage(
+        for image: CGImage,
+        node: ImageNode,
+        applyingAdjustments: Bool = true
+    ) -> CGImage {
         let cropped = croppedImage(for: image, crop: node.crop)
+        guard applyingAdjustments else { return cropped }
         return adjustedImage(for: cropped, node: node)
     }
 

--- a/mydocs/orders/20260530.md
+++ b/mydocs/orders/20260530.md
@@ -11,5 +11,5 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 완료 | PR #297 merge 완료, #116 선행 작업 |
-| #116 | 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 | 진행중 | M014, Stage 4 visual diff 완료, 최종 보고 대기 |
+| #116 | 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 | 완료 | M014, 완료: 14:58 |
 | #296 | upstream rhwp #1016 resolved watermark payload 반영 시 Swift fallback 중복 적용 방지 | 보류 | upstream rhwp #1016 release 포함 시 처리 |

--- a/mydocs/orders/20260530.md
+++ b/mydocs/orders/20260530.md
@@ -11,5 +11,5 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 완료 | PR #297 merge 완료, #116 선행 작업 |
-| #116 | 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 | 진행중 | M014, Stage 1 baseline 완료, bakedWatermark gate 설계 승인 대기 |
+| #116 | 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 | 진행중 | M014, Stage 2 설계 완료, baked overlay adjustment skip 구현 대기 |
 | #296 | upstream rhwp #1016 resolved watermark payload 반영 시 Swift fallback 중복 적용 방지 | 보류 | upstream rhwp #1016 release 포함 시 처리 |

--- a/mydocs/orders/20260530.md
+++ b/mydocs/orders/20260530.md
@@ -5,11 +5,11 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #79 | 메인테이너용 public release 실행 runbook 작성 | 완료 | M040, 최종 보고 완료: 13:51 |
+
 ## M014 — v0.1.4 Native Preview/Viewer Parity
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 완료 | 최종 보고와 handoff 완료: 13:19 |
-| #116 | native preview watermark/effect parity 보강 | 예정 | #282 후속, `복학원서.hwp` 중앙 watermark fallback 범위부터 정리 |
+| #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 완료 | PR #297 merge 완료, #116 선행 작업 |
+| #116 | 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
 | #296 | upstream rhwp #1016 resolved watermark payload 반영 시 Swift fallback 중복 적용 방지 | 보류 | upstream rhwp #1016 release 포함 시 처리 |
-

--- a/mydocs/orders/20260530.md
+++ b/mydocs/orders/20260530.md
@@ -11,5 +11,5 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 완료 | PR #297 merge 완료, #116 선행 작업 |
-| #116 | 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 | 진행중 | M014, Stage 3 구현 완료, Stage 4 visual diff 검증 대기 |
+| #116 | 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 | 진행중 | M014, Stage 4 visual diff 완료, 최종 보고 대기 |
 | #296 | upstream rhwp #1016 resolved watermark payload 반영 시 Swift fallback 중복 적용 방지 | 보류 | upstream rhwp #1016 release 포함 시 처리 |

--- a/mydocs/orders/20260530.md
+++ b/mydocs/orders/20260530.md
@@ -11,5 +11,5 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 완료 | PR #297 merge 완료, #116 선행 작업 |
-| #116 | 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 | 진행중 | M014, Stage 2 설계 완료, baked overlay adjustment skip 구현 대기 |
+| #116 | 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 | 진행중 | M014, Stage 3 구현 완료, Stage 4 visual diff 검증 대기 |
 | #296 | upstream rhwp #1016 resolved watermark payload 반영 시 Swift fallback 중복 적용 방지 | 보류 | upstream rhwp #1016 release 포함 시 처리 |

--- a/mydocs/orders/20260530.md
+++ b/mydocs/orders/20260530.md
@@ -11,5 +11,5 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 완료 | PR #297 merge 완료, #116 선행 작업 |
-| #116 | 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+| #116 | 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 | 진행중 | M014, Stage 1 baseline 완료, bakedWatermark gate 설계 승인 대기 |
 | #296 | upstream rhwp #1016 resolved watermark payload 반영 시 Swift fallback 중복 적용 방지 | 보류 | upstream rhwp #1016 release 포함 시 처리 |

--- a/mydocs/plans/task_m014_116.md
+++ b/mydocs/plans/task_m014_116.md
@@ -1,0 +1,132 @@
+# Task M014 #116 수행계획서
+
+## 목적
+
+`samples/복학원서.hwp` 첫 페이지 중앙 JPEG 워터마크가 native preview에서 rhwp-studio 기준보다 너무 진하게 보이고 gray rectangle이 남는 문제를 줄인다. 목표는 Quick Look preview, Finder thumbnail, HostApp native preview가 같은 CoreGraphics renderer 결과를 사용하면서 중앙 워터마크를 옅은 회색 watermark처럼 표시하고, 일반 JPEG 사진이나 다른 이미지에는 과도한 투명화 휴리스틱을 적용하지 않는 것이다.
+
+## 배경
+
+#282에서 Quick Look/Thumbnail native CoreGraphics compositor가 page content와 overlay image pass를 명시적으로 합성하도록 정리됐다. #293 이후 visual diff harness는 rhwp-studio overlay DOM을 `domComposite`로 캡처한다. 이 조합으로 `복학원서.hwp`가 BehindText positive fixture임을 확인했다.
+
+Stage 4 관찰값:
+
+| 항목 | 값 |
+|------|----|
+| `복학원서.hwp` visual diff | 32.0086% |
+| overlay metadata | `overlay=2`, `behind=2`, `front=0`, `renderable=2`, `binLinked=2` |
+| studio capture | `captureMode=domComposite`, `overlayIncluded=true` |
+| 중앙 watermark payload | `mime=image/jpeg`, `effect=grayScale`, `brightness=-50`, `contrast=70`, `watermarkPreset=custom`, `bakedWatermark=false` |
+
+native output도 중앙 watermark image를 그리지만, JPEG가 alpha 없이 들어오고 brightness/contrast 보정이 흰색 배경까지 회색으로 낮추면서 image extent가 사각형 배경처럼 보인다. 이 문제는 #282의 compositor pass presence 문제가 아니라 image effect, alpha mask, watermark payload 해석 문제다.
+
+현재 upstream rhwp #1016/#1017 계열에서 resolved/baked watermark payload가 논의되고 있으므로, 이번 작업은 현 릴리즈 기준 Swift fallback을 신중하게 좁혀 적용하고, 향후 upstream release에서 중복 적용하지 않도록 #296과 연결한다.
+
+## 범위
+
+포함:
+
+- `복학원서.hwp` 중앙 JPEG BehindText watermark의 현재 Swift/CoreGraphics 처리 경로 조사
+- `effect=grayScale`, `brightness`, `contrast`, `watermarkPreset`, `bakedWatermark` 조합의 native 적용 정책 정의
+- JPEG alpha가 없는 watermark-like image에 대해 제한된 background transparency 또는 alpha mask fallback 적용
+- 일반 JPEG 사진/그림에서 흰색 배경이 임의로 사라지지 않도록 조건을 좁힌 회귀 검증
+- `복학원서.hwp`와 기존 v0.1.4 sample set visual diff 재측정
+- #296 handoff 기준 문서화
+
+제외:
+
+- upstream rhwp 수정 자체
+- upstream unreleased commit pin 적용
+- upstream #1016/#1017 resolved baked payload 소비 정책 구현
+- InFrontOfText positive fixture 신규 제작
+- image fill/tile/placement parity(#122)
+- RawSvg/OLE/chart(#121), Placeholder/FormObject(#110), text/layout parity 수정
+
+## 설계 방향
+
+구현은 일반 이미지 렌더링에 영향을 주지 않도록 보수적으로 좁힌다.
+
+1. 우선 현재 렌더 경로를 inventory한다.
+   - `CGTreeRenderer.renderImage`와 Stage #282의 `renderOverlayImages`가 같은 image decode/effect path를 통과하는지 확인한다.
+   - render tree `ImageNode`와 #281/#282 overlay metadata 중 watermark 판단에 사용할 수 있는 필드를 정리한다.
+2. fallback 적용 조건을 좁힌다.
+   - JPEG처럼 alpha가 없는 이미지
+   - `BehindText` 또는 overlay metadata의 behind layer
+   - `watermarkPreset`이 있거나, `effect=grayScale`과 watermark-like brightness/contrast 조합이 있는 경우
+   - page-centered 또는 large watermark 형태처럼 문서 watermark로 볼 수 있는 경우
+3. alpha 처리 정책을 분리한다.
+   - 흰색 또는 near-white 배경 픽셀은 투명하게 만들고, 어두운 도형/문양은 낮은 alpha의 회색으로 남긴다.
+   - 밝기/대비 보정 순서가 사각형 배경을 만들지 않도록 alpha mask 생성과 color adjustment 순서를 비교한다.
+4. upstream compatibility를 남긴다.
+   - `bakedWatermark=true` 또는 resolved PNG payload가 내려오면 Swift fallback을 적용하지 않는 조건은 #296에서 처리한다.
+   - 이번 작업에서는 현 v0.7.13 payload의 `bakedWatermark=false` 기준으로만 fallback을 좁힌다.
+
+## 예상 변경 파일
+
+| 파일 | 예상 변경 |
+|------|-----------|
+| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | watermark-like JPEG alpha/effect fallback, image adjustment 순서 보강 |
+| `Sources/RhwpCoreBridge/RenderTree.swift` | 필요 시 watermark/effect 관련 모델 필드 확인 또는 accessor 보강 |
+| `Sources/Shared/HwpNativePageCompositor.swift` | overlay metadata의 watermark context 전달이 필요할 경우 제한적 수정 |
+| `scripts/preview-visual-diff-harness.sh` | 필요 시 #116 smoke preset 또는 sample list 보강 |
+| `mydocs/working/task_m014_116_stage*.md` | 단계별 측정 결과와 판단 기록 |
+| `mydocs/report/task_m014_116_report.md` | 최종 결과와 #296 handoff 정리 |
+
+## 잠정 단계
+
+1. Stage 1: `복학원서.hwp` watermark baseline 재현과 current path inventory
+   - #282 PR #297 merge 또는 equivalent base 반영 후 시작한다.
+   - visual diff, overlay metadata, native PNG 시각 확인을 기준선으로 고정한다.
+2. Stage 2: watermark-like JPEG fallback 조건 설계
+   - false positive 위험이 큰 조건을 제외하고, 적용 조건과 제외 조건을 문서화한다.
+3. Stage 3: CoreGraphics image adjustment 구현
+   - alpha mask 또는 transparency key fallback을 최소 범위로 구현한다.
+4. Stage 4: visual diff와 회귀 smoke
+   - `복학원서.hwp` 개선 수치와 기존 image sample 회귀 여부를 확인한다.
+5. Stage 5: 최종 보고와 PR 게시
+   - #296, #122, #121, #110과의 handoff를 정리한다.
+
+## 검증 계획
+
+기본 검증:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-baseline --page 1 \
+  samples/복학원서.hwp
+
+./scripts/overlay-metadata-smoke.sh build.noindex/task116-overlay-metadata --page 1 \
+  samples/복학원서.hwp
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-regression --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task116 CODE_SIGNING_ALLOWED=NO build
+
+git diff --check
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+수용 기준:
+
+- `복학원서.hwp` 중앙 watermark의 gray rectangle이 줄거나 사라진다.
+- 중앙 watermark는 rhwp-studio처럼 옅은 회색으로 보이고 본문 텍스트 가독성을 해치지 않는다.
+- 좌상단 로고와 하단 우측 도장 image가 회귀하지 않는다.
+- 기존 image sample에서 일반 JPEG/PNG 이미지의 배경이 임의로 투명화되지 않는다.
+- Quick Look/Thumbnail/HostApp native CoreGraphics path가 같은 결과를 사용한다.
+
+## 리스크
+
+- white/near-white transparency 휴리스틱은 일반 사진 이미지에서 false positive를 만들 수 있다.
+- brightness/contrast 수치 해석이 Hancom/rhwp-studio와 다르면 gray rectangle은 줄어도 watermark tone이 맞지 않을 수 있다.
+- #282 PR #297이 merge되기 전 구현을 시작하면 compositor/harness 기준이 어긋날 수 있다.
+- upstream rhwp #1016/#1017이 resolved/baked payload를 release하면 이번 Swift fallback과 중복될 수 있다. 이 경우 #296에서 gate를 추가해야 한다.
+- JPEG color space와 alpha mask 생성 순서에 따라 visual diff 수치가 환경별로 달라질 수 있다.
+
+## 승인 요청 사항
+
+1. #116 구현은 #282 PR #297이 merge된 devel 기준으로 진행한다.
+2. 현 v0.7.13 payload의 `bakedWatermark=false` 조건에 한정해 Swift/CoreGraphics fallback을 구현한다.
+3. upstream rhwp #1016/#1017 release 반영 시 중복 적용 방지는 #296에서 별도 처리한다.
+

--- a/mydocs/plans/task_m014_116_impl.md
+++ b/mydocs/plans/task_m014_116_impl.md
@@ -1,0 +1,87 @@
+# Task M014 #116 구현계획서
+
+## 기준
+
+- 이슈: #116
+- 브랜치: `local/task116`
+- 기준 브랜치: `origin/devel` `2b852af`
+- 선행 작업: #282 PR #297 merge 완료
+- core 기준: rhwp `v0.7.13`, resolved commit `b3e16ef212af81ef37d973ddb86d6816d3804642`
+
+## 구현 목표
+
+`samples/복학원서.hwp` 중앙 BehindText watermark가 native CoreGraphics preview에서 rhwp-studio보다 과하게 진하고 gray rectangle이 보이는 문제를 줄인다. 다만 Stage 1 기준에서 중앙 watermark payload가 이미 `bakedWatermark=true`인 PNG로 내려오는 것이 확인됐으므로, 구현은 기존 계획의 "JPEG white background transparency fallback"보다 "baked watermark에 기존 effect/brightness/contrast를 중복 적용하지 않는 gate"를 먼저 검증한다.
+
+## Stage 구성
+
+| Stage | 목표 | 산출물 |
+|-------|------|--------|
+| Stage 1 | baseline 재현과 current path inventory | `task_m014_116_stage1.md` |
+| Stage 2 | baked watermark 중복 보정 방지 설계 | `task_m014_116_stage2.md` |
+| Stage 3 | 최소 구현 | `CGTreeRenderer.swift` 중심 변경 |
+| Stage 4 | visual diff와 회귀 smoke | `task_m014_116_stage4.md` |
+| Stage 5 | 최종 보고와 PR 게시 | `task_m014_116_report.md` |
+
+## Stage 1 결과에 따른 설계 전환
+
+수행계획서 작성 당시의 전제:
+
+- 중앙 watermark는 JPEG 원본에 alpha가 없어 Swift에서 white/near-white transparency fallback이 필요할 수 있다.
+- upstream resolved/baked payload는 미래 release에서 내려올 것으로 보고 #296에서 중복 적용 방지를 처리한다.
+
+Stage 1에서 확인한 현재 기준:
+
+- 중앙 watermark overlay metadata는 `mime=image/png`, `bakedWatermark=true`다.
+- 같은 image에는 여전히 `effect=grayScale`, `brightness=-50`, `contrast=70`, `watermarkPreset=custom`도 함께 남아 있다.
+- `CGTreeRenderer.renderOverlayImage`는 `bakedWatermark`를 `ImageNode`로 전달하지 않고, 기존 `preparedImage` -> `adjustedImage` 경로에서 effect/brightness/contrast를 다시 적용한다.
+
+따라서 Stage 2 설계 우선순위는 다음과 같다.
+
+1. `RhwpPageOverlayImage.bakedWatermark == true`인 overlay image에는 Swift image adjustment를 다시 적용하지 않는 gate를 둔다.
+2. `bakedWatermark == false`인 legacy/current fallback payload만 기존 effect/brightness/contrast 또는 제한된 transparency fallback 후보로 남긴다.
+3. render tree fallback path에는 `bakedWatermark` 정보가 없으므로 기존 동작을 유지한다.
+4. #296은 향후 upstream payload shape가 다시 바뀌거나 core dependency update가 들어올 때의 compatibility follow-up으로 남기되, 현재 v0.7.13 기준의 duplicate adjustment gate는 #116에 포함할지 승인받는다.
+
+## 예상 코드 방향
+
+1. `CGTreeRenderer.renderOverlayImage`에서 overlay-specific image preparation context를 분리한다.
+2. `bakedWatermark=true`이면 `effect`, `brightness`, `contrast`를 무시하거나 `preparedImage`에 skip adjustment option을 전달한다.
+3. crop, transform, fill/destination rect는 기존과 동일하게 유지한다.
+4. 일반 render tree image path와 non-baked overlay path에는 기존 adjustment를 유지한다.
+
+## 검증 계획
+
+Stage 3 이후 최소 검증:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-after-baked-gate --page 1 \
+  samples/복학원서.hwp
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-regression --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+
+./scripts/overlay-metadata-smoke.sh build.noindex/task116-overlay-metadata --page 1 \
+  samples/복학원서.hwp
+
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task116 CODE_SIGNING_ALLOWED=NO build
+
+git diff --check
+```
+
+해석 기준:
+
+- `복학원서.hwp`의 `ChangedPercent`, `MeanRGBDelta`, native PNG 시각 결과가 개선되는지 확인한다.
+- 기존 image sample에서 일반 image의 ChangedPercent가 의미 있게 악화되지 않아야 한다.
+- `bakedWatermark=false`인 overlay가 생길 경우 기존 adjustment path가 유지되는지 별도 fixture가 필요하다.
+
+## 승인 필요 사항
+
+Stage 2로 넘어가기 전 다음 방향을 승인받는다.
+
+1. #116의 첫 구현을 `bakedWatermark=true` overlay에 대한 중복 effect/brightness/contrast 적용 방지로 좁힌다.
+2. white/near-white transparency fallback은 `bakedWatermark=false` fixture가 다시 확인될 때까지 보류한다.
+3. #296은 upstream release/update compatibility 후속으로 유지하되, 현재 v0.7.13 payload의 duplicate adjustment gate는 #116에서 처리한다.
+

--- a/mydocs/report/task_m014_116_report.md
+++ b/mydocs/report/task_m014_116_report.md
@@ -1,0 +1,165 @@
+# Task M014 #116 최종 결과보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#116](https://github.com/postmelee/alhangeul-macos/issues/116) 복학원서.hwp JPEG 워터마크 효과/투명키 렌더링 보강 |
+| 마일스톤 | M014 — v0.1.4 Native Preview/Viewer Parity |
+| 브랜치 | `local/task116` |
+| 기준 브랜치 | `origin/devel` `2b852af` |
+| core 기준 | rhwp `v0.7.13`, resolved commit `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| 단계 수 | 5단계 |
+
+이번 작업은 `samples/복학원서.hwp` 중앙 BehindText watermark가 native CoreGraphics preview에서 rhwp-studio보다 과하게 어둡고 gray rectangle이 더 드러나는 문제를 줄였다. 초기 이슈 본문은 `JPEG + bakedWatermark=false` 전제였지만, 최신 `v0.7.13` 기준 smoke에서 실제 payload가 `image/png + bakedWatermark=true`로 확인되어 구현 방향을 바꿨다.
+
+최종 구현은 `bakedWatermark=true`이고 overlay JSON에 resolved bytes가 실제로 포함된 image에 한해 Swift/CoreGraphics `effect/brightness/contrast` 후처리를 생략한다. 일반 render tree image path, `bakedWatermark=false` overlay, binData fallback path는 기존 동작을 유지한다.
+
+결과적으로 `복학원서.hwp` visual diff는 `32.0188%`에서 `7.8441%`로 줄었고, regression sample set 6개는 Stage 1 baseline과 동일한 수치를 유지했다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | overlay image drawing path에서 resolved baked watermark bytes에는 image adjustment를 중복 적용하지 않도록 `preparedImage(..., applyingAdjustments:)` gate를 추가했다. |
+| `mydocs/plans/task_m014_116.md` | 최초 수행계획서. 현재 일부 전제는 Stage 1에서 최신 정보로 갱신됐다. |
+| `mydocs/plans/task_m014_116_impl.md` | Stage 1 결과에 따라 구현 목표를 JPEG transparency fallback에서 baked watermark 중복 보정 방지로 전환했다. |
+| `mydocs/working/task_m014_116_stage1.md` | 최신 baseline, overlay metadata, native renderer path inventory를 기록했다. |
+| `mydocs/working/task_m014_116_stage2.md` | 관련 이슈 재점검과 `image.source.data != nil` 조건을 포함한 skip 설계를 기록했다. |
+| `mydocs/working/task_m014_116_stage3.md` | 최소 구현과 HostApp Debug build 결과를 기록했다. |
+| `mydocs/working/task_m014_116_stage4.md` | visual diff 개선 수치, regression smoke, overlay metadata smoke를 기록했다. |
+| `mydocs/report/task_m014_116_report.md` | 최종 결과와 handoff를 정리했다. |
+| `mydocs/orders/20260530.md` | 오늘할일 진행 상태와 완료 시간을 기록했다. |
+
+## 단계별 결과
+
+| Stage | 커밋 | 결과 |
+|-------|------|------|
+| 계획 | `d24d48a` | 수행계획서와 구현계획서를 작성하고 오늘할일에 #116을 등록 |
+| Stage 1 | `24b8740` | 최신 `v0.7.13` baseline에서 중앙 watermark가 `image/png`, `bakedWatermark=true`임을 확인 |
+| Stage 2 | `08cff0a` | #116/#296 본문 전제 갱신 코멘트 작성, resolved baked overlay adjustment skip 조건 설계 |
+| Stage 3 | `52c8e81` | `CGTreeRenderer` overlay path에 `applyingAdjustments` gate 구현, HostApp Debug build 통과 |
+| Stage 4 | `673c43f` | target visual diff와 regression sample set smoke 완료 |
+| Stage 5 | 현재 | 최종 보고서와 PR 게시 |
+
+## 변경 전·후 정량 비교
+
+### `복학원서.hwp` visual diff
+
+| Metric | Stage 1 baseline | Stage 4 after gate | 변화 |
+|--------|-----------------:|-------------------:|-----:|
+| ChangedPixels | 1140771/3562815 | 279470/3562815 | -861301 |
+| ChangedPercent | 32.0188% | 7.8441% | -24.1747%p |
+| MeanRGBDelta | 18.2116 | 6.9643 | -11.2473 |
+| NativeMs | 1168.1 | 1038.8 | -129.3ms |
+
+해석:
+
+- ChangedPercent 기준 약 75.5%의 changed pixel 감소가 있었다.
+- MeanRGBDelta도 크게 줄어 중앙 watermark 중복 보정 제거가 실제 rhwp-studio reference parity에 유효했다.
+- NativeMs 변화는 단일 smoke 관찰값이므로 성능 개선 결론으로 보지 않는다.
+
+### Regression sample set
+
+| Sample | Stage 1 ChangedPercent | Stage 4 ChangedPercent | Stage 1 MeanRGBDelta | Stage 4 MeanRGBDelta | 판단 |
+|--------|-----------------------:|-----------------------:|---------------------:|---------------------:|------|
+| `request.hwp` | 17.8542% | 17.8542% | 11.0716 | 11.0716 | 변화 없음 |
+| `hwpx-01.hwpx` | 15.0285% | 15.0285% | 15.2088 | 15.2088 | 변화 없음 |
+| `tac-img-02.hwp` | 4.1153% | 4.1153% | 3.6698 | 3.6698 | 변화 없음 |
+| `tac-img-02.hwpx` | 4.1153% | 4.1153% | 3.6698 | 3.6698 | 변화 없음 |
+| `hwp-img-001.hwp` | 7.8277% | 7.8277% | 8.1872 | 8.1872 | 변화 없음 |
+| `img-start-001.hwp` | 13.9805% | 13.9805% | 13.9111 | 13.9111 | 변화 없음 |
+
+해석:
+
+- 변경이 target baked overlay path에만 적용되고 일반 image path에는 영향을 주지 않았다는 설계 의도와 일치한다.
+
+## 최신 판단과 이슈 정리
+
+작업 중 #116과 #296의 오래된 전제를 갱신하는 코멘트를 남겼다.
+
+| 이슈 | 코멘트 | 판단 |
+|------|--------|------|
+| #116 | https://github.com/postmelee/alhangeul-macos/issues/116#issuecomment-4581800700 | `JPEG + bakedWatermark=false` 전제는 현재 `v0.7.13` 기준에서 맞지 않으며, 즉시 구현 범위는 baked payload 중복 보정 방지 |
+| #296 | https://github.com/postmelee/alhangeul-macos/issues/296#issuecomment-4581800594 | 향후 core update compatibility follow-up으로 유지하되, 현재 duplicate adjustment gate는 #116에서 처리 |
+
+관련 upstream 상태:
+
+| 항목 | 판단 |
+|------|------|
+| edwardkim/rhwp#976 | closed. 현재 baked PNG payload 관찰의 직접 배경 |
+| edwardkim/rhwp#1016 | open. resolved visual payload 일반화 이슈이나 현재 target fixture는 이미 baked PNG로 관찰됨 |
+| edwardkim/rhwp#1017 | open. z-order/replay policy 축이며 이번 중복 보정 gate와 분리 |
+| edwardkim/rhwp#421/#516/#535 | closed. 과거 blocker였지만 현재 직접 blocker로 보지 않음 |
+
+## 검증 결과
+
+| 수용 기준 | 결과 | 근거 |
+|-----------|------|------|
+| `복학원서.hwp` 중앙 watermark gray rectangle 감소 | OK | `ChangedPercent 32.0188% -> 7.8441%`, native PNG 시각 확인 |
+| watermark tone이 rhwp-studio에 가까워짐 | OK | Stage 4 native/studio PNG 직접 확인 |
+| 좌상단 로고와 하단 우측 도장 회귀 없음 | OK | target native PNG에서 양쪽 image 표시 확인 |
+| 기존 image sample 회귀 없음 | OK | 6개 regression sample 수치가 Stage 1과 동일 |
+| Quick Look/Thumbnail/HostApp native CoreGraphics path 공유 | OK | 변경이 shared `CGTreeRenderer` overlay path에 적용됨 |
+| HostApp Debug build | OK | `** BUILD SUCCEEDED ** [11.865 sec]` |
+| extension registration hygiene | OK | `Issues: none`, `Development registrations: none` |
+| whitespace 검증 | OK | `git diff --check` 통과 |
+
+실행한 주요 명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-after-baked-gate --page 1 \
+  samples/복학원서.hwp
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-regression --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+
+./scripts/overlay-metadata-smoke.sh build.noindex/task116-overlay-metadata --page 1 \
+  samples/복학원서.hwp
+
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task116-stage3 CODE_SIGNING_ALLOWED=NO build
+
+./scripts/check-extension-registration-hygiene.sh --check-only
+git diff --check
+```
+
+Stage 4 artifact:
+
+| Artifact | 경로 |
+|----------|------|
+| Studio PNG | `build.noindex/task116-after-baked-gate/studio/복학원서.hwp-page1-studio.png` |
+| Native PNG | `build.noindex/task116-after-baked-gate/native/복학원서.hwp-page1-native.png` |
+| Diff PNG | `build.noindex/task116-after-baked-gate/diff/복학원서.hwp-page1-diff.png` |
+
+## 잔여 위험과 후속 작업
+
+| 항목 | 내용 |
+|------|------|
+| render tree fallback | `bakedWatermark` 의미가 없으므로 기존 image adjustment를 유지한다. overlay metadata path가 없는 문서에서는 같은 개선이 적용되지 않을 수 있다. |
+| binData fallback | overlay JSON bytes가 없고 `binDataId`로 원본 리소스를 읽는 경우는 baked resolved bytes라고 보장할 수 없어 기존 보정을 유지한다. |
+| legacy JPEG watermark | `bakedWatermark=false`인 legacy JPEG watermark transparency fallback은 구현하지 않았다. 양성 fixture 확보 후 별도 설계가 필요하다. |
+| text/font/layout parity | `복학원서.hwp` 하단 overflow, 일부 glyph fallback, text/font/layout 차이는 여전히 남아 있으며 #116 범위가 아니다. |
+| upstream replay policy | edwardkim/rhwp#1017의 장기 z-order/replay policy 공통화는 별도 축이다. |
+
+## Handoff
+
+다음 순서:
+
+1. #116 PR을 게시하고 review/merge한다.
+2. #296은 향후 rhwp core update 시 `bakedWatermark`, MIME, resolved payload shape, z-order contract가 다시 바뀌는지 확인하는 compatibility follow-up으로 유지한다.
+3. #122에서 image fill/tile/placement parity를 이어간다.
+4. #121/#110은 RawSvg/OLE/chart, Placeholder/FormObject 등 남은 native renderer parity 영역으로 별도 진행한다.
+
+이번 작업에서 알게 된 점:
+
+- `v0.7.13` 현재 release에서도 #116/#296 작성 당시의 `JPEG + bakedWatermark=false` 전제는 이미 바뀌어 있었다.
+- downstream Swift renderer는 upstream payload가 이미 visual projection을 끝낸 경우 후처리를 반복하지 않는 gate가 필요하다.
+- `bakedWatermark=true`만 보지 않고 실제 resolved bytes 존재 여부까지 조건에 넣어야 binData fallback의 오탐 skip을 피할 수 있다.
+- 수치 비교상 중앙 watermark 문제는 opacity/alpha heuristic보다 중복 effect/brightness/contrast 적용 문제가 컸다.
+
+## 작업지시자 승인 요청
+
+최종 보고서 작성과 오늘할일 완료 처리를 끝낸 뒤 `publish/task116` 원격 브랜치를 만들고 `devel` 대상 Open PR로 게시한다. PR merge 후에는 `pr-merge-cleanup` 절차로 이슈 close와 브랜치/worktree 정리를 진행한다.

--- a/mydocs/working/task_m014_116_stage1.md
+++ b/mydocs/working/task_m014_116_stage1.md
@@ -1,0 +1,213 @@
+# Task M014 #116 Stage 1 보고서
+
+## 단계 목적
+
+`복학원서.hwp` 중앙 watermark 문제를 수정하기 전에 최신 `devel` 기준 baseline, overlay metadata, native renderer path를 다시 고정한다. #282 PR #297이 merge된 뒤의 compositor 기준에서 #116 구현 방향이 여전히 유효한지도 확인했다.
+
+## 기준 정렬
+
+- 작업 브랜치: `local/task116`
+- rebase 기준: `origin/devel` `2b852af`
+- 선행 merge:
+  - #297: #282 native compositor 보강
+  - #298: #79 release runbook
+- rebase 중 `mydocs/orders/20260530.md` add/add 충돌이 발생했고, #79/#282/#116/#296 행을 모두 보존해 해결했다.
+- Rust bridge artifact는 새 worktree에 없어서 `./scripts/build-rust-macos.sh`로 생성했다.
+
+## Baseline smoke 결과
+
+### `복학원서.hwp` visual diff
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-stage1-visual --page 1 \
+  samples/복학원서.hwp
+```
+
+조건:
+
+- NativePolicy: `coreGraphicsOnly`
+- StudioReleaseTag: `v0.7.13`
+- StudioResolvedCommit: `b3e16ef212af81ef37d973ddb86d6816d3804642`
+- Viewport: `1400x1800`
+- SettleMs: `120`
+- DiffPixelThreshold: `12`
+
+| File | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | StudioCapture | NativeBackend | NativeMs |
+|------|--------------:|---------------:|-------------:|------------:|------------|---------------|---------------|---------:|
+| `복학원서.hwp` | 1140771/3562815 | 32.0188% | 18.2116 | 255 | 83,45 1436x2155 | `domComposite` | `coreGraphics` | 1168.1 |
+
+관찰:
+
+- native output에는 중앙 watermark의 gray rectangle이 뚜렷하게 보인다.
+- studio reference는 watermark가 훨씬 옅고 rectangle이 덜 드러난다.
+- Stage 4 #282 수치 32.0086%와 거의 같은 수준이므로 #282 merge 이후에도 문제는 유지된다.
+- `MeanRGBDelta`는 Stage 4 보고값과 달라졌으므로 같은 branch/run 기준에서 비교해야 한다.
+
+### Overlay metadata
+
+명령:
+
+```bash
+./scripts/overlay-metadata-smoke.sh build.noindex/task116-stage1-overlay-metadata --page 1 \
+  samples/복학원서.hwp
+```
+
+| PageCount | UpstreamImages | Overlay | Behind | Front | Renderable | BinLinked | TreeImages | TreeEmbeddedAvailable | Wraps |
+|----------:|---------------:|--------:|-------:|------:|-----------:|----------:|-----------:|-----------------------|-------|
+| 1 | 2 | 2 | 2 | 0 | 2 | 2 | 2 | 2/2 | BehindText:2 |
+
+중앙 watermark payload:
+
+| binDataId | mime | effect | brightness | contrast | watermarkPreset | bakedWatermark | byteCount | bbox |
+|----------:|------|--------|-----------:|---------:|-----------------|----------------|----------:|------|
+| 2 | image/png | grayScale | -50 | 70 | custom | true | 253602 | 137.707,270.24 495.04x495.733 |
+
+좌상단 로고 payload:
+
+| binDataId | mime | effect | brightness | contrast | bakedWatermark | byteCount | bbox |
+|----------:|------|--------|-----------:|---------:|----------------|----------:|------|
+| 1 | image/png | realPic | 0 | 0 | false | 44860 | 65.493,49.013 77.013x87.893 |
+
+핵심 발견:
+
+- 수행계획서 작성 당시의 전제였던 `mime=image/jpeg`, `bakedWatermark=false`가 최신 `devel` Stage 1 기준에서는 맞지 않는다.
+- 현재 중앙 watermark는 이미 `image/png`, `bakedWatermark=true`다.
+- 그런데 `effect=grayScale`, `brightness=-50`, `contrast=70` 값도 같이 남아 있다.
+
+### Native render debug
+
+명령:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task116-stage1-render-debug --page 1 \
+  samples/복학원서.hwp
+```
+
+결과:
+
+| 항목 | 값 |
+|------|----|
+| PageSizePt | 793.7x1122.5 |
+| NativePNGSize | 794x1123 |
+| NativeNonWhitePixels | 277497 |
+| TextRuns | 102 |
+| HangulRuns | 25 |
+| HangulScalars | 143 |
+| MissingHangulGlyphs | 0 |
+| DiffDifferentPixels | 342189 |
+| DiffDifferentPixelRatio | 0.383765 |
+| DiffMaxChannelDelta | 255 |
+
+Render tree image node for `bin_data_id=2`:
+
+```json
+{
+  "bin_data_id": 2,
+  "effect": "GrayScale",
+  "brightness": -50,
+  "contrast": 70,
+  "text_wrap": "BehindText",
+  "crop": [0, 0, 54600, 54660]
+}
+```
+
+## 기존 sample set 회귀 baseline
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-stage1-regression-baseline --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+| Sample | ChangedPercent | MeanRGBDelta | StudioCapture | NativeBackend | NativeMs |
+|--------|---------------:|-------------:|---------------|---------------|---------:|
+| `request.hwp` | 17.8542% | 11.0716 | domComposite | coreGraphics | 959.5 |
+| `hwpx-01.hwpx` | 15.0285% | 15.2088 | domComposite | coreGraphics | 34.4 |
+| `tac-img-02.hwp` | 4.1153% | 3.6698 | canvasDataURL | coreGraphics | 7.6 |
+| `tac-img-02.hwpx` | 4.1153% | 3.6698 | domComposite | coreGraphics | 3.9 |
+| `hwp-img-001.hwp` | 7.8277% | 8.1872 | domComposite | coreGraphics | 15.1 |
+| `img-start-001.hwp` | 13.9805% | 13.9111 | domComposite | coreGraphics | 28.4 |
+
+## Current renderer path inventory
+
+현재 path:
+
+1. `HwpNativePageCompositor.render`가 `overlays.behind`를 `renderOverlayLayer(.behindText, ...)`로 전달한다.
+2. `HwpNativePageCompositor.renderOverlayLayer`는 `hasRenderableData` overlay를 골라 `CGTreeRenderer.renderOverlayImages`를 호출한다.
+3. `CGTreeRenderer.renderOverlayImage`는 `RhwpPageOverlayImage`를 `ImageNode`로 다시 구성한다.
+4. 이때 `bakedWatermark`는 `ImageNode`에 전달되지 않는다.
+5. `preparedImage(for:node:)` -> `adjustedImage(for:node:)`는 `effect`, `brightness`, `contrast`를 적용한다.
+
+문제 가능성이 높은 지점:
+
+- 중앙 watermark는 이미 `bakedWatermark=true` PNG인데, Swift renderer가 같은 `effect/brightness/contrast`를 다시 적용할 수 있다.
+- `bakedWatermark`를 무시하는 구조 때문에 resolved/baked payload의 의도가 render path에 반영되지 않는다.
+- render tree fallback에는 `bakedWatermark` 정보가 없으므로 metadata overlay path에서만 gate를 둘 수 있다.
+
+## 설계 결론
+
+Stage 2의 첫 후보는 JPEG white background transparency fallback이 아니라 `bakedWatermark=true` overlay의 duplicate adjustment 방지다.
+
+권장 방향:
+
+1. `RhwpPageOverlayImage.bakedWatermark == true`이면 `effect`, `brightness`, `contrast`를 Swift에서 다시 적용하지 않는다.
+2. crop, transform, destination rect는 기존대로 유지한다.
+3. `bakedWatermark == false`인 overlay나 일반 render tree image는 기존 adjustment path를 유지한다.
+4. white/near-white transparency fallback은 현재 positive fixture가 없으므로 보류한다.
+
+#296과의 관계:
+
+- #296은 "upstream release 이후 compatibility"로 만든 이슈였지만, 현재 `v0.7.13` 기준으로 이미 `bakedWatermark=true` payload가 관찰된다.
+- 따라서 현재 release의 duplicate adjustment gate는 #116에 포함하는 편이 자연스럽다.
+- #296은 이후 upstream payload shape 변경 또는 core update 시 중복 적용 방지 회귀 이슈로 남길 수 있다.
+
+## 검증
+
+실행:
+
+```bash
+./scripts/build-rust-macos.sh
+./scripts/overlay-metadata-smoke.sh build.noindex/task116-stage1-overlay-metadata --page 1 samples/복학원서.hwp
+./scripts/render-debug-compare.sh build.noindex/task116-stage1-render-debug --page 1 samples/복학원서.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-stage1-visual --page 1 samples/복학원서.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-stage1-regression-baseline --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task116-stage1 CODE_SIGNING_ALLOWED=NO build
+```
+
+결과:
+
+- Rust bridge artifacts 생성 성공
+- overlay metadata smoke 성공
+- render debug smoke 성공
+- visual diff harness 성공
+- HostApp Debug build 성공: `** BUILD SUCCEEDED ** [11.537 sec]`
+
+registration hygiene:
+
+```bash
+./scripts/check-extension-registration-hygiene.sh --check-only
+./scripts/check-extension-registration-hygiene.sh --cleanup-dev-registrations
+```
+
+- `xcodebuild`가 `build.noindex/DerivedData-task116-stage1/.../Alhangeul.app`을 LaunchServices에 등록했다.
+- cleanup script가 `pluginkit -r`, `lsregister -u`, `qlmanage -r cache`를 수행했지만 LaunchServices stale registration이 남았다.
+- 생성된 Debug app bundle은 삭제했으나 stale registration은 계속 보고됐다.
+- 이 문제는 #116 renderer 구현과 직접 관련은 없고 로컬 LaunchServices 상태 문제로 보인다. 다음 smoke 전에 별도 hygiene 정리가 필요할 수 있다.
+
+## 다음 단계 승인 요청
+
+Stage 2에서는 기존 계획을 수정해 다음 방향으로 진행하고자 한다.
+
+1. `bakedWatermark=true` overlay image에는 Swift `effect/brightness/contrast`를 중복 적용하지 않는 gate를 설계한다.
+2. JPEG white background transparency fallback은 현재 positive fixture가 없으므로 보류한다.
+3. #296은 future upstream/core update compatibility follow-up으로 유지한다.
+

--- a/mydocs/working/task_m014_116_stage2.md
+++ b/mydocs/working/task_m014_116_stage2.md
@@ -1,0 +1,117 @@
+# Task M014 #116 Stage 2 보고서
+
+## 단계 목적
+
+Stage 1에서 확인한 최신 `v0.7.13` overlay metadata를 기준으로 `복학원서.hwp` 중앙 watermark의 Swift/CoreGraphics 보정 경로를 설계했다. 기존 이슈 본문은 `JPEG + bakedWatermark=false` 전제였지만, 현재 payload는 `image/png + bakedWatermark=true`이므로 구현 범위를 중복 image adjustment 방지로 좁혔다.
+
+## 최신 이슈 정리
+
+작업 전 관련 이슈를 다시 점검했고, 오래된 전제와 현재 관찰값이 충돌하는 내용을 이슈 코멘트로 남겼다.
+
+- #116: https://github.com/postmelee/alhangeul-macos/issues/116#issuecomment-4581800700
+- #296: https://github.com/postmelee/alhangeul-macos/issues/296#issuecomment-4581800594
+
+관련 이슈 판단:
+
+| 이슈 | 상태 | #116 영향 |
+|------|------|-----------|
+| #296 | open | 향후 core update compatibility follow-up으로 유지. 현재 `v0.7.13` duplicate adjustment gate는 #116에서 처리 |
+| #122 | open | 다음 image fill/tile/placement parity. #116 blocker 아님 |
+| #121, #110 | open | renderer parity 후속. 현재 watermark 후처리와 별도 |
+| edwardkim/rhwp#976 | closed | 현재 baked PNG payload의 upstream 배경 |
+| edwardkim/rhwp#1016 | open | resolved payload 일반화 이슈. 현재 대상 fixture는 이미 baked PNG로 관찰됨 |
+| edwardkim/rhwp#1017 | open | z-order/replay policy 축. 이번 중복 보정 gate와 분리 |
+| edwardkim/rhwp#421/#516/#535 | closed | 과거 blocker였지만 현재 직접 blocker로 보지 않음 |
+
+## 경로 확인
+
+현재 Swift/CoreGraphics path:
+
+1. `HwpNativePageCompositor`가 `RhwpPageOverlayImageSet.behind`를 `CGTreeRenderer.renderOverlayImages`로 전달한다.
+2. `CGTreeRenderer.renderOverlayImage`는 `RhwpPageOverlayImage`를 임시 `ImageNode`로 변환한다.
+3. `RhwpPageOverlayImage.bakedWatermark`는 `ImageNode`에 전달되지 않는다.
+4. `preparedImage(for:node:)`는 crop 적용 후 항상 `adjustedImage(for:node:)`를 호출한다.
+5. `adjustedImage`는 `effect=grayScale`, `brightness=-50`, `contrast=70`을 다시 적용한다.
+
+따라서 `bakedWatermark=true`인 resolved PNG가 Swift에서 한 번 더 어두워질 수 있다.
+
+## 설계 결정
+
+Stage 3 구현은 `CGTreeRenderer`의 overlay path에 한정한다.
+
+1. `preparedImage(for:node:)`에 adjustment 적용 여부를 전달할 수 있는 인자를 추가한다.
+2. 일반 render tree image path는 기본값으로 기존 동작을 유지한다.
+3. overlay path에서는 `image.bakedWatermark && image.source.data != nil`일 때만 adjustment를 생략한다.
+4. crop, transform, destination rect, fill mode 계산은 기존과 동일하게 유지한다.
+5. `ImageNode` 모델에 `bakedWatermark`를 추가하지 않는다. render tree JSON에는 해당 의미가 없고, 이번 결정은 compact overlay resolved payload contract에만 의존하기 때문이다.
+
+`image.source.data != nil` 조건을 추가한 이유:
+
+- 현재 `복학원서.hwp` 중앙 watermark는 overlay JSON에 실제 resolved PNG bytes가 포함되어 있고 `byteCount=253602`이다.
+- 그러나 overlay JSON이 없거나 base64 decode가 실패하면 `decodedOverlayImage`는 `binDataId`로 원본 문서 리소스를 다시 읽을 수 있다.
+- 이 fallback 입력이 이미 baked된 bytes라는 보장이 없으므로, 이 경우에는 기존 effect/brightness/contrast 보정을 유지하는 편이 안전하다.
+
+## 보류 결정
+
+JPEG white/near-white transparency fallback은 이번 Stage 3에 넣지 않는다.
+
+이유:
+
+- 현재 target fixture가 더 이상 `JPEG + bakedWatermark=false`가 아니다.
+- 일반 JPEG 사진이나 흰 배경 그림에 오탐 적용될 위험이 있다.
+- `bakedWatermark=false` 양성 fixture가 확보된 뒤 별도 조건과 threshold를 설계하는 편이 안전하다.
+
+## Stage 3 구현 계획
+
+예상 변경:
+
+```swift
+private func preparedImage(
+    for image: CGImage,
+    node: ImageNode,
+    applyingAdjustments: Bool = true
+) -> CGImage {
+    let cropped = croppedImage(for: image, crop: node.crop)
+    guard applyingAdjustments else { return cropped }
+    return adjustedImage(for: cropped, node: node)
+}
+```
+
+overlay path:
+
+```swift
+let appliesAdjustments = !(image.bakedWatermark && image.source.data != nil)
+let drawImage = preparedImage(for: cgImage, node: node, applyingAdjustments: appliesAdjustments)
+```
+
+## 검증 계획
+
+Stage 3 구현 후 실행한다.
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-after-baked-gate --page 1 \
+  samples/복학원서.hwp
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-regression --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+
+./scripts/overlay-metadata-smoke.sh build.noindex/task116-overlay-metadata --page 1 \
+  samples/복학원서.hwp
+
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task116 CODE_SIGNING_ALLOWED=NO build
+
+git diff --check
+```
+
+비교 기준:
+
+- `복학원서.hwp` native output의 중앙 watermark가 Stage 1보다 덜 어둡고 rhwp-studio reference에 가까워지는지 확인한다.
+- `ChangedPercent`, `MeanRGBDelta`를 Stage 1 baseline과 비교한다.
+- 기존 image sample set에서 일반 image effect/crop/fill 경로가 회귀하지 않는지 확인한다.
+
+## 다음 단계
+
+Stage 3에서는 위 설계대로 최소 구현을 진행한다.

--- a/mydocs/working/task_m014_116_stage3.md
+++ b/mydocs/working/task_m014_116_stage3.md
@@ -1,0 +1,101 @@
+# Task M014 #116 Stage 3 보고서
+
+## 단계 목적
+
+Stage 2에서 정한 설계대로 `bakedWatermark=true` resolved overlay image에 Swift/CoreGraphics image adjustment가 중복 적용되지 않게 최소 구현했다. 이번 단계는 코드 변경과 기본 빌드 검증까지 수행하고, visual diff 수치 비교는 Stage 4에서 별도로 진행한다.
+
+## 변경 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | overlay image drawing path에서 baked resolved payload의 `effect/brightness/contrast` 후처리 생략 |
+| `mydocs/orders/20260530.md` | #116 진행 상태를 Stage 3 구현 완료 기준으로 갱신 |
+
+## 구현 내용
+
+`preparedImage(for:node:)`에 adjustment 적용 여부를 제어하는 기본 인자를 추가했다.
+
+```swift
+private func preparedImage(
+    for image: CGImage,
+    node: ImageNode,
+    applyingAdjustments: Bool = true
+) -> CGImage {
+    let cropped = croppedImage(for: image, crop: node.crop)
+    guard applyingAdjustments else { return cropped }
+    return adjustedImage(for: cropped, node: node)
+}
+```
+
+일반 render tree image path는 호출부를 바꾸지 않아 기본값 `true`로 기존 동작을 유지한다.
+
+overlay image path에서는 다음 조건일 때만 adjustment를 생략한다.
+
+```swift
+let appliesAdjustments = !(image.bakedWatermark && image.source.data != nil)
+```
+
+의미:
+
+- `bakedWatermark=true`: core가 워터마크 visual projection을 끝낸 payload라는 신호
+- `image.source.data != nil`: overlay JSON에 실제 resolved image bytes가 포함되어 Swift가 그 bytes를 직접 그리고 있다는 신호
+
+이 두 조건이 모두 참이면 Swift/CoreGraphics는 crop만 적용하고 `effect/brightness/contrast`를 다시 적용하지 않는다.
+
+## 의도적으로 유지한 동작
+
+- `bakedWatermark=false` overlay는 기존 adjustment path를 유지한다.
+- overlay JSON bytes가 없어서 `binDataId` fallback으로 원본 문서 리소스를 읽는 경우도 기존 adjustment path를 유지한다.
+- render tree fallback path에는 `bakedWatermark` contract가 없으므로 기존 동작을 유지한다.
+- JPEG white/near-white transparency fallback은 구현하지 않았다.
+- crop, transform, destination rect, fill mode 계산은 변경하지 않았다.
+
+## 검증
+
+### diff check
+
+```bash
+git diff --check
+```
+
+결과: 통과.
+
+### HostApp Debug build
+
+처음 실행한 sandbox 내부 빌드는 `DerivedData/.../SourcePackages`와 `Logs` 생성 권한 문제로 실패했다. 같은 명령을 sandbox 밖에서 재실행해 실제 컴파일을 확인했다.
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task116-stage3 CODE_SIGNING_ALLOWED=NO build
+```
+
+결과:
+
+```text
+** BUILD SUCCEEDED ** [11.865 sec]
+```
+
+### registration hygiene
+
+```bash
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+결과:
+
+- Issues: none
+- Development registrations: none
+- Warning: `build.noindex/DerivedData-task116-stage3/.../Alhangeul.app` 개발 bundle은 존재하지만 등록 문제는 없음
+
+## 남은 검증
+
+Stage 4에서 다음을 수행해야 한다.
+
+1. `samples/복학원서.hwp` visual diff 전후 수치 비교
+2. 기존 image sample set regression visual diff
+3. overlay metadata smoke 재확인
+4. 필요 시 native/studio PNG를 직접 열어 중앙 watermark 톤과 gray rectangle 변화를 확인
+
+## Stage 3 결론
+
+코드 변경은 의도한 범위로 제한됐고 HostApp 빌드를 통과했다. 다음 단계에서는 이번 변경이 실제로 `복학원서.hwp` native output을 rhwp-studio reference에 가깝게 만드는지 수치와 PNG artifact로 확인한다.

--- a/mydocs/working/task_m014_116_stage4.md
+++ b/mydocs/working/task_m014_116_stage4.md
@@ -1,0 +1,135 @@
+# Task M014 #116 Stage 4 보고서
+
+## 단계 목적
+
+Stage 3의 `bakedWatermark=true` resolved overlay adjustment skip이 실제로 `복학원서.hwp` native preview를 rhwp-studio 기준에 가깝게 만드는지 수치와 PNG artifact로 확인했다. 또한 기존 image sample set의 visual diff가 변하지 않는지 회귀 smoke를 수행했다.
+
+## 검증 기준
+
+- 기준 core: rhwp `v0.7.13`
+- NativePolicy: `coreGraphicsOnly`
+- StudioReleaseTag: `v0.7.13`
+- StudioResolvedCommit: `b3e16ef212af81ef37d973ddb86d6816d3804642`
+- Viewport: `1400x1800`
+- SettleMs: `120`
+- DiffPixelThreshold: `12`
+
+## `복학원서.hwp` visual diff
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-after-baked-gate --page 1 \
+  samples/복학원서.hwp
+```
+
+결과:
+
+| File | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | StudioCapture | NativeBackend | NativeMs |
+|------|--------------:|---------------:|-------------:|------------:|------------|---------------|---------------|---------:|
+| `복학원서.hwp` | 279470/3562815 | 7.8441% | 6.9643 | 255 | 83,45 1436x2155 | `domComposite` | `coreGraphics` | 1038.8 |
+
+Stage 1 baseline 대비:
+
+| Metric | Stage 1 baseline | Stage 4 after gate | 변화 |
+|--------|-----------------:|-------------------:|-----:|
+| ChangedPixels | 1140771/3562815 | 279470/3562815 | -861301 |
+| ChangedPercent | 32.0188% | 7.8441% | -24.1747%p |
+| MeanRGBDelta | 18.2116 | 6.9643 | -11.2473 |
+| NativeMs | 1168.1 | 1038.8 | -129.3ms |
+
+해석:
+
+- ChangedPercent가 32.0188%에서 7.8441%로 줄어 약 75.5%의 changed pixel 감소가 있었다.
+- MeanRGBDelta도 18.2116에서 6.9643으로 줄어 watermark 중복 보정 제거가 실제 reference parity를 크게 개선했다.
+- NativeMs 감소는 단일 smoke 관찰값이며 성능 개선 결론으로 보지 않는다.
+
+Artifact:
+
+- Studio PNG: `build.noindex/task116-after-baked-gate/studio/복학원서.hwp-page1-studio.png`
+- Native PNG: `build.noindex/task116-after-baked-gate/native/복학원서.hwp-page1-native.png`
+- Diff PNG: `build.noindex/task116-after-baked-gate/diff/복학원서.hwp-page1-diff.png`
+
+시각 관찰:
+
+- Stage 1 native output에서 두드러졌던 중앙 watermark의 과도한 어두움과 회색 사각형 노출이 크게 줄었다.
+- Stage 4 native output은 rhwp-studio reference의 watermark 톤에 훨씬 가까워졌다.
+- 남은 차이는 주로 native text/font/layout, 일부 glyph fallback, 하단 clipping/overflow 등 기존 renderer parity 문제로 보인다.
+
+## Regression visual diff
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task116-regression --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/tac-img-02.hwp samples/tac-img-02.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp
+```
+
+결과:
+
+| Sample | ChangedPercent | MeanRGBDelta | StudioCapture | NativeBackend | NativeMs |
+|--------|---------------:|-------------:|---------------|---------------|---------:|
+| `request.hwp` | 17.8542% | 11.0716 | domComposite | coreGraphics | 985.3 |
+| `hwpx-01.hwpx` | 15.0285% | 15.2088 | domComposite | coreGraphics | 35.6 |
+| `tac-img-02.hwp` | 4.1153% | 3.6698 | canvasDataURL | coreGraphics | 7.9 |
+| `tac-img-02.hwpx` | 4.1153% | 3.6698 | domComposite | coreGraphics | 4.2 |
+| `hwp-img-001.hwp` | 7.8277% | 8.1872 | domComposite | coreGraphics | 15.0 |
+| `img-start-001.hwp` | 13.9805% | 13.9111 | domComposite | coreGraphics | 28.3 |
+
+Stage 1 regression baseline과 비교:
+
+| Sample | Stage 1 ChangedPercent | Stage 4 ChangedPercent | Stage 1 MeanRGBDelta | Stage 4 MeanRGBDelta | 판단 |
+|--------|-----------------------:|-----------------------:|---------------------:|---------------------:|------|
+| `request.hwp` | 17.8542% | 17.8542% | 11.0716 | 11.0716 | 변화 없음 |
+| `hwpx-01.hwpx` | 15.0285% | 15.0285% | 15.2088 | 15.2088 | 변화 없음 |
+| `tac-img-02.hwp` | 4.1153% | 4.1153% | 3.6698 | 3.6698 | 변화 없음 |
+| `tac-img-02.hwpx` | 4.1153% | 4.1153% | 3.6698 | 3.6698 | 변화 없음 |
+| `hwp-img-001.hwp` | 7.8277% | 7.8277% | 8.1872 | 8.1872 | 변화 없음 |
+| `img-start-001.hwp` | 13.9805% | 13.9805% | 13.9111 | 13.9111 | 변화 없음 |
+
+해석:
+
+- 기존 sample set 수치가 Stage 1과 동일하다.
+- 이번 변경이 일반 render tree image path나 non-baked image path에 영향을 주지 않았다는 설계 의도와 일치한다.
+
+## Overlay metadata smoke
+
+명령:
+
+```bash
+./scripts/overlay-metadata-smoke.sh build.noindex/task116-overlay-metadata --page 1 \
+  samples/복학원서.hwp
+```
+
+결과:
+
+| PageCount | UpstreamImages | Overlay | Behind | Front | Renderable | BinLinked | TreeImages | TreeEmbeddedAvailable | Wraps |
+|----------:|---------------:|--------:|-------:|------:|-----------:|----------:|-----------:|-----------------------|-------|
+| 1 | 2 | 2 | 2 | 0 | 2 | 2 | 2 | 2/2 | BehindText:2 |
+
+중앙 watermark payload:
+
+| binDataId | mime | effect | brightness | contrast | watermarkPreset | bakedWatermark | byteCount | bbox |
+|----------:|------|--------|-----------:|---------:|-----------------|----------------|----------:|------|
+| 2 | image/png | grayScale | -50 | 70 | custom | true | 253602 | 137.707,270.24 495.04x495.733 |
+
+해석:
+
+- Stage 3 code change는 metadata contract를 바꾸지 않았다.
+- target overlay는 여전히 resolved PNG bytes와 `bakedWatermark=true`를 제공한다.
+
+## 한계
+
+- 이번 수정은 `RhwpPageOverlayImage` metadata path에서 resolved bytes가 있는 baked watermark만 다룬다.
+- render tree fallback path에는 `bakedWatermark` 의미가 없으므로 기존 image adjustment를 유지한다.
+- `bakedWatermark=false`인 legacy JPEG watermark에 대한 white/near-white transparency fallback은 구현하지 않았다.
+- `복학원서.hwp`의 하단 overflow, 일부 glyph fallback, text/font/layout 차이는 여전히 남아 있으며 #116의 현재 범위가 아니다.
+- upstream rhwp #1017의 장기 z-order/replay policy 공통화는 별도 축이다.
+
+## Stage 4 결론
+
+`bakedWatermark=true` resolved overlay bytes에서 Swift/CoreGraphics 후처리를 생략하는 변경은 target fixture에서 명확한 개선을 보였다. `복학원서.hwp` visual diff는 `32.0188% -> 7.8441%`로 크게 감소했고, regression sample set 수치는 Stage 1과 동일하게 유지됐다.
+
+따라서 Stage 3 구현은 #116의 현재 목표인 "현재 v0.7.13 기준 baked watermark 중복 보정 제거"에 유효하다. 다음 단계에서는 최종 보고서와 PR 설명에 이 수치, 한계, #296과의 관계를 반영한다.


### PR DESCRIPTION
## 요약

- 대상 타스크: #116 `복학원서.hwp` 중앙 BehindText watermark의 native CoreGraphics preview parity 개선
- 왜: 현재 rhwp `v0.7.13` payload는 이미 `image/png + bakedWatermark=true`인데 Swift/CoreGraphics가 `effect/brightness/contrast`를 다시 적용해 watermark가 과하게 어둡게 보였음
- 무엇: resolved baked overlay bytes가 실제로 있을 때만 image adjustment를 생략하고, 일반 image/render tree/binData fallback 경로는 기존 동작 유지
- 리뷰 포인트: `복학원서.hwp` visual diff가 `32.0188% -> 7.8441%`로 줄었고 regression sample set 6개 수치는 Stage 1과 동일함

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/ee3691e9a123aeeefc3ae9ccd5deb85b878df408/mydocs/working/task_m014_116_stage1.md)** ([24b8740](https://github.com/postmelee/alhangeul-macos/commit/24b8740)): 최신 baseline에서 target watermark가 `image/png`, `bakedWatermark=true`임을 확인하고 기존 이슈 전제가 오래됐음을 분리
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/ee3691e9a123aeeefc3ae9ccd5deb85b878df408/mydocs/working/task_m014_116_stage2.md)** ([08cff0a](https://github.com/postmelee/alhangeul-macos/commit/08cff0a)): #116/#296 최신 판단 코멘트와 resolved bytes 기준 adjustment skip 설계
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/ee3691e9a123aeeefc3ae9ccd5deb85b878df408/mydocs/working/task_m014_116_stage3.md)** ([52c8e81](https://github.com/postmelee/alhangeul-macos/commit/52c8e81)): `CGTreeRenderer` overlay path에 `preparedImage(..., applyingAdjustments:)` gate 구현
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/ee3691e9a123aeeefc3ae9ccd5deb85b878df408/mydocs/working/task_m014_116_stage4.md)** ([673c43f](https://github.com/postmelee/alhangeul-macos/commit/673c43f)): target visual diff, regression sample set, overlay metadata smoke 검증
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/ee3691e9a123aeeefc3ae9ccd5deb85b878df408/mydocs/report/task_m014_116_report.md)** ([ee3691e](https://github.com/postmelee/alhangeul-macos/commit/ee3691e)): 최종 보고서와 오늘할일 완료 처리

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | overlay resolved baked watermark bytes는 crop만 적용하고 image adjustment 생략 | `image.bakedWatermark && image.source.data != nil` 조건이 의도대로 좁은지 확인 |
| 일반 image path | `preparedImage` 기본값으로 기존 adjustment 유지 | render tree image, non-baked overlay, binData fallback 회귀 없음 |
| 문서 | Stage별 관찰, 이슈 전제 갱신, 수치 비교, 한계 기록 | #296과의 역할 분리가 맞는지 확인 |

- 수행 계획서: [task_m014_116.md](https://github.com/postmelee/alhangeul-macos/blob/ee3691e9a123aeeefc3ae9ccd5deb85b878df408/mydocs/plans/task_m014_116.md)
- 구현 계획서: [task_m014_116_impl.md](https://github.com/postmelee/alhangeul-macos/blob/ee3691e9a123aeeefc3ae9ccd5deb85b878df408/mydocs/plans/task_m014_116_impl.md)
- 최종 보고서: [task_m014_116_report.md](https://github.com/postmelee/alhangeul-macos/blob/ee3691e9a123aeeefc3ae9ccd5deb85b878df408/mydocs/report/task_m014_116_report.md)

## 핵심 리뷰 포인트

- `bakedWatermark=true`만으로 skip하지 않고 `image.source.data != nil`까지 요구한다. overlay JSON resolved bytes가 없고 `binDataId` fallback으로 원본 리소스를 읽는 경우는 기존 보정을 유지한다.
- `ImageNode`에 `bakedWatermark`를 추가하지 않았다. 이번 contract는 compact overlay resolved payload에만 존재하고 render tree fallback에는 같은 의미가 없기 때문이다.
- JPEG white/near-white transparency heuristic은 구현하지 않았다. 현재 target fixture가 이미 baked PNG이고, false positive 위험이 있어 별도 양성 fixture 확보 전까지 보류한다.

## 검증

- `./scripts/preview-visual-diff-harness.sh build.noindex/task116-after-baked-gate --page 1 samples/복학원서.hwp`
  - `ChangedPercent: 32.0188% -> 7.8441%`
  - `MeanRGBDelta: 18.2116 -> 6.9643`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task116-regression --page 1 samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/tac-img-02.hwp samples/tac-img-02.hwpx samples/hwp-img-001.hwp samples/img-start-001.hwp`
  - 6개 sample 모두 Stage 1 baseline과 동일 수치
- `./scripts/overlay-metadata-smoke.sh build.noindex/task116-overlay-metadata --page 1 samples/복학원서.hwp`
  - `overlay=2`, `behind=2`, `front=0`, `Renderable=2`, `BinLinked=2`, `bakedWatermark=true` 중앙 PNG 확인
- `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task116-stage3 CODE_SIGNING_ALLOWED=NO build`
  - `** BUILD SUCCEEDED ** [11.865 sec]`
- `./scripts/check-extension-registration-hygiene.sh --check-only`
  - Issues 없음, development registrations 없음
- `git diff --check`
  - 통과

## 관련 이슈

- #282: native compositor와 overlay image pass 선행 작업
- #293: visual diff harness의 `domComposite` reference capture 보강
- #296: 향후 rhwp core update compatibility follow-up
- #122: image fill/tile/placement parity 후속
- #121, #110: RawSvg/OLE/chart, Placeholder/FormObject native renderer parity 후속
- edwardkim/rhwp#976: upstream watermark baked PNG 처리
- edwardkim/rhwp#1016, edwardkim/rhwp#1017: resolved payload와 z-order/replay policy 관련 upstream 추적

## 후속 이슈 제안

- 새 이슈는 만들지 않음. #296, #122, #121, #110으로 후속 범위가 이미 분리되어 있음.

## 남은 리스크

- overlay metadata path에 resolved bytes가 없으면 이번 개선이 적용되지 않는다.
- `bakedWatermark=false` legacy JPEG watermark transparency fallback은 구현하지 않았다.
- `복학원서.hwp`의 하단 overflow, 일부 glyph fallback, text/font/layout 차이는 여전히 남아 있으며 이번 PR 범위가 아니다.
