### PR TITLE
Task #259: Skia readiness gate 정리

### DIFF
--- a/Sources/QLExtension/HwpPreviewProvider.swift
+++ b/Sources/QLExtension/HwpPreviewProvider.swift
@@ -44,7 +44,7 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
         let page = try HwpPageImageRenderer.renderPage(
             document: documentContext.document,
             pageIndex: 0,
-            policy: .skiaOptIn
+            policy: .coreGraphicsOnly
         )
         logRenderedPageDiagnostics(page, replyType: "PNG", filename: filename)
         let data = try HwpPageImageRenderer.encodePNG(page.image)
@@ -76,7 +76,7 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
         let contentSize = documentContext.contentSize
         let result = try HwpPreviewPDFRenderer.render(
             context: documentContext,
-            policy: .skiaOptIn,
+            policy: .coreGraphicsOnly,
             collectDiagnostics: true
         )
         let data = result.data

--- a/mydocs/orders/20260530.md
+++ b/mydocs/orders/20260530.md
@@ -5,6 +5,13 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #79 | 메인테이너용 public release 실행 runbook 작성 | 완료 | M040, 최종 보고 완료: 13:51 |
+
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #259 | Skia backend visual/performance/package regression gate 정리 | 진행중 | 수행계획서 작성 후 승인 대기 |
+
 ## M014 — v0.1.4 Native Preview/Viewer Parity
 
 | Issue | 타스크 | 상태 | 비고 |
@@ -12,4 +19,3 @@
 | #282 | Quick Look/Thumbnail native compositor를 rhwp-studio flow·overlay 구조로 보강 | 완료 | 최종 보고와 handoff 완료: 13:19 |
 | #116 | native preview watermark/effect parity 보강 | 예정 | #282 후속, `복학원서.hwp` 중앙 watermark fallback 범위부터 정리 |
 | #296 | upstream rhwp #1016 resolved watermark payload 반영 시 Swift fallback 중복 적용 방지 | 보류 | upstream rhwp #1016 release 포함 시 처리 |
-

--- a/mydocs/orders/20260530.md
+++ b/mydocs/orders/20260530.md
@@ -10,7 +10,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #259 | Skia backend visual/performance/package regression gate 정리 | 진행중 | 수행계획서 작성 후 승인 대기 |
+| #259 | Skia backend visual/performance/package regression gate 정리 | 완료 | 완료: 15:06, CoreGraphics default 복귀 |
 
 ## M014 — v0.1.4 Native Preview/Viewer Parity
 

--- a/mydocs/plans/task_m020_259.md
+++ b/mydocs/plans/task_m020_259.md
@@ -1,0 +1,131 @@
+# Task M020 #259 수행계획서
+
+## 목적
+
+Skia backend를 Quick Look/Thumbnail release 후보에 어느 수준으로 포함할지 판단하는 release readiness gate를 정리한다.
+
+이번 작업의 핵심은 #258을 진행하기 전에 현재 `devel` 상태의 Quick Look Skia 기본 적용이 배포 후보로 충분한지 먼저 판정하는 것이다. 필요하면 Quick Look 기본 backend를 `coreGraphicsOnly`로 되돌리고, Skia는 opt-in/diagnostic 경로로 유지하는 결론까지 이 작업 안에서 다룬다.
+
+## 배경
+
+#255에서 RustBridge `native-skia` PNG FFI와 provenance gate가 추가됐고, #256에서 Shared renderer의 `skiaOptIn` + CoreGraphics fallback contract가 생겼다. #257은 Quick Look 단일 PNG와 다중 PDF preview에 `skiaOptIn`을 연결했다. #278은 upstream `rhwp v0.7.13` 반영 후 Quick Look Skia smoke와 visual diff를 재측정했다.
+
+현재 #258 Finder thumbnail Skia 적용은 아직 열려 있다. 원래 #259는 #258까지 받은 뒤 마지막 gate로 설계됐지만, 최신 코드에서는 Quick Look 기본 경로가 이미 Skia 우선 정책을 사용한다. 따라서 thumbnail으로 적용 범위를 넓히기 전에 Quick Look 기본 정책, visual diff, latency, package size, release note 조건을 먼저 고정해야 한다.
+
+## 범위
+
+포함:
+
+- #255, #256, #257, #278 산출물에서 ABI, fallback contract, Quick Look smoke, visual diff, package size 증가 기록을 수집한다.
+- 현재 코드 기준 Quick Look 단일 PNG/다중 PDF의 실제 render policy와 Finder thumbnail의 policy 차이를 확인한다.
+- 대표 HWP/HWPX 샘플의 Skia vs CoreGraphics visual/performance 측정 기준을 확정하고 필요한 smoke를 실행한다.
+- `rhwp v0.7.13` 기준 package/staticlib size와 release artifact 영향 기록을 정리한다.
+- Skia 기본 유지, Quick Look 기본 CoreGraphics 복귀, Skia opt-in 유지, #258 진행/보류 중 어떤 결론이 맞는지 판단한다.
+- release note/known limitations 초안을 작성한다.
+- #258을 계속 진행할지, 범위를 바꿀지, 다음 release 이후로 넘길지 handoff를 남긴다.
+
+제외:
+
+- upstream `rhwp` Skia renderer 수정
+- Finder thumbnail Skia 구현 자체
+- Skia visual parity 결함의 renderer-level 수정
+- signed/notarized public release 실행
+- Homebrew Cask 반영
+- unrelated native viewer/editor parity 작업
+
+## 설계 방향
+
+이 작업은 구현 확장보다 release gate 판정에 초점을 둔다. 먼저 현재 `devel`의 실제 정책을 코드와 smoke로 확인하고, 이미 남아 있는 #257/#278 수치가 release default를 지지하는지 검토한다.
+
+판정 기준은 보수적으로 둔다. Skia가 일부 샘플에서 visual diff를 낮추더라도 latency, memory, package size, fallback 관측성, Quick Look/Thumbnail 간 정책 불일치가 배포 위험으로 크면 기본 backend는 CoreGraphics/native path로 두고 Skia는 opt-in/diagnostic 경로로 유지한다.
+
+만약 Quick Look 기본 정책을 바꿔야 한다는 결론이 나오면, 그 변경은 release gate의 산출물로 최소 범위에서 수행한다. Finder thumbnail 쪽은 #258에서 별도 구현하게 하고, #259에서는 진행 조건과 cache/render signature 요구사항만 고정한다.
+
+## 예상 변경 파일
+
+- `mydocs/plans/task_m020_259.md`
+- `mydocs/plans/task_m020_259_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m020_259_stage{N}.md`
+- `mydocs/report/task_m020_259_report.md`
+- `mydocs/orders/20260530.md`
+- 필요 시 `Sources/QLExtension/HwpPreviewProvider.swift`
+- 필요 시 `Sources/Shared/HwpPageImageRenderer.swift`
+- 필요 시 `scripts/smoke-quicklook-skia-policy.sh` 또는 관련 smoke helper 문서/출력 경로
+
+읽기 대상:
+
+- `mydocs/report/task_m020_255_report.md`
+- `mydocs/report/task_m020_256_report.md`
+- `mydocs/report/task_m020_257_report.md`
+- `mydocs/report/task_m020_278_report.md`
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `mydocs/manual/release_distribution_guide.md`
+
+## 잠정 단계
+
+1. Stage 1: 입력 산출물과 현재 backend 정책 inventory
+   - #255/#256/#257/#278 보고서에서 readiness 입력을 추출한다.
+   - Quick Look과 Finder thumbnail의 현재 render policy를 코드 기준으로 확인한다.
+   - #258 미완료 상태에서 #259를 선행하는 판단 근거를 구현계획서에 고정한다.
+2. Stage 2: visual/performance/package gate 측정
+   - 대표 샘플로 Skia/CoreGraphics Quick Look policy smoke와 visual diff를 실행한다.
+   - `rhwp v0.7.13` 기준 staticlib/Rhwp.xcframework/package 영향과 latency 결과를 정리한다.
+3. Stage 3: release policy 판정과 필요 시 최소 보정
+   - Quick Look 기본 backend 유지/복귀 여부를 결정한다.
+   - 필요하면 Quick Look 기본 policy를 `coreGraphicsOnly`로 되돌리고 smoke로 확인한다.
+   - #258 진행 조건과 cache/render signature 요구사항을 정리한다.
+4. Stage 4: readiness checklist와 release note 초안 정리
+   - Skia optional backend release readiness checklist를 작성한다.
+   - known limitations, release note 문구, #258 handoff를 최종 보고서에 정리한다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260530.md mydocs/plans/task_m020_259.md
+rg -n "#259|Skia|Quick Look|Thumbnail|CoreGraphics|release|readiness|#258" \
+  mydocs/orders/20260530.md mydocs/plans/task_m020_259.md
+```
+
+구현 단계 후보:
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task259-skia-policy \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/복학원서.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task259-visual-basic --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/복학원서.hwp
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+필요 시 추가:
+
+```bash
+du -sh Frameworks/universal/librhwp.a Frameworks/Rhwp.xcframework
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+## 리스크
+
+- #258이 아직 완료되지 않아 thumbnail memory/cache smoke 입력이 부족하다. 이 경우 #259는 #258 진행 조건을 고정하고, 최종 default 판단은 Quick Look 범위로 제한해야 한다.
+- Skia와 CoreGraphics 결과 차이는 문서별로 방향이 다르다. 단일 changed percent만으로 default 전환을 판단하면 안 된다.
+- Skia first-call latency, PNG decode/re-encode 비용, staticlib/package size 증가가 release 품질에 영향을 줄 수 있다.
+- Quick Look Debug/helper smoke는 설치본 LaunchServices/PlugInKit 상태와 다를 수 있다. release 실행 단계 smoke와 구분해서 기록해야 한다.
+- Quick Look 기본을 CoreGraphics로 되돌릴 경우 #257의 기존 결론과 차이가 생긴다. 보고서에서 정책 변경 사유를 명확히 남겨야 한다.
+
+## 승인 요청 사항
+
+1. #259를 #258보다 먼저 진행해 Skia default/release gate 판단을 수행하는 범위 승인
+2. 기준 브랜치는 `devel`, 작업 브랜치는 `local/task259`로 진행 승인
+3. Stage 1에서 #255/#256/#257/#278 산출물과 현재 코드 정책을 먼저 inventory하는 방향 승인
+4. 측정 결과 Skia 기본 유지 근거가 부족하면 Quick Look 기본 policy를 CoreGraphics/native path로 되돌리는 최소 보정까지 #259 범위에 포함하는 것 승인
+5. 승인 전에는 구현계획서 작성과 Swift source 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m020_259_impl.md
+++ b/mydocs/plans/task_m020_259_impl.md
@@ -1,0 +1,229 @@
+# Task M020 #259 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_259.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #259 Skia backend visual/performance/package regression gate 정리
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 브랜치: `local/task259`
+- 작업 위치: `/Users/melee/Documents/projects/rhwp-mac`
+- 기준 브랜치: `devel`
+- 선행 상태: #255/#256/#257/#278은 완료됐고, #258 Finder thumbnail Skia 적용은 아직 열려 있다.
+- 목표: 현재 Quick Look Skia 기본 적용이 release 후보로 충분한지 판단하고, 필요하면 Quick Look 기본 backend를 CoreGraphics/native path로 되돌린 뒤 Skia를 opt-in/diagnostic 경로로 유지하는 결론을 남긴다.
+
+## 구현 원칙
+
+- #259는 구현 확장보다 release gate 판정 작업이다.
+- #258 미완료 상태를 명시적으로 인정하고, thumbnail 적용 확장은 이 작업에서 수행하지 않는다.
+- 판단 근거는 기존 보고서 수치, 현재 코드 정책, 추가 smoke 결과를 함께 사용한다.
+- Skia 기본 유지 여부는 visual diff만이 아니라 latency, fallback 관측성, staticlib/package size, Quick Look/Thumbnail 정책 일관성까지 함께 본다.
+- Skia 기본 유지 근거가 부족하면 Quick Look provider의 기본 정책을 CoreGraphics/native path로 되돌리는 최소 보정까지 수행한다.
+- `Sources/RhwpCoreBridge`에는 AppKit/UIKit 의존을 추가하지 않는다.
+- public release 실행, tag 생성, signing/notarization, Homebrew 반영은 하지 않는다.
+
+## 판정 기준
+
+| 항목 | Skia 기본 유지 쪽 근거 | CoreGraphics 기본 복귀 쪽 근거 |
+|---|---|---|
+| Visual diff | 대표 샘플 다수에서 rhwp-studio/reference 대비 의미 있게 개선 | 개선 폭이 작거나 문서별로 방향이 갈림 |
+| Latency | 단일/다중 Quick Look path에서 CoreGraphics와 동등하거나 빠름 | first-call 또는 대표 문서에서 큰 지연 발생 |
+| Fallback | 실패 시 CoreGraphics fallback이 관측 가능하고 안정적 | fallback 원인/횟수/성능을 release에서 해석하기 어려움 |
+| Package size | native-skia 크기 증가가 release 가치에 비례 | staticlib/package 증가 대비 사용자-facing 개선 근거 부족 |
+| Surface 일관성 | Quick Look과 Thumbnail 모두 같은 정책으로 갈 준비가 됨 | Quick Look은 Skia, Thumbnail은 CoreGraphics로 갈라져 release 설명이 복잡함 |
+| Known limitations | 제한이 명확하고 사용자 영향이 작음 | 알려진 시각/성능 이슈를 기본 경로로 배포하기 부담스러움 |
+
+최종 결론은 `default 유지`, `default 복귀 + opt-in 유지`, `#258 선행 필요`, `추가 upstream 대기` 중 하나로 고정한다.
+
+## Stage 1. 입력 산출물과 현재 backend 정책 inventory
+
+### 목표
+
+#255/#256/#257/#278 산출물과 현재 코드 정책을 수집해 #259가 #258보다 먼저 진행되는 이유와 판단 입력을 고정한다.
+
+### 작업
+
+1. #255 보고서에서 native-skia ABI, staticlib size 증가, symbol/header 변경을 추출한다.
+2. #256 보고서에서 `HwpPageImageRenderer` policy, fallback taxonomy, diagnostics contract를 추출한다.
+3. #257 보고서에서 Quick Look 단일/다중 page Skia smoke와 known limitations를 추출한다.
+4. #278 보고서에서 `rhwp v0.7.13` 기준 Quick Look policy smoke, visual diff, Skia latency 결과를 추출한다.
+5. 현재 `Sources/QLExtension/HwpPreviewProvider.swift`, `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`, `Sources/Shared/HwpPageImageRenderer.swift`의 backend policy를 확인한다.
+6. #258 미완료 상태에서 #259를 먼저 진행하는 판단 근거를 Stage 1 보고서에 기록한다.
+
+### 산출물
+
+- `mydocs/plans/task_m020_259_impl.md`
+- `mydocs/working/task_m020_259_stage1.md`
+
+### 검증
+
+```bash
+rg -n "#255|#256|#257|#258|#259|#278|skiaOptIn|coreGraphicsOnly|backendUsed|fallbackReason|staticlib|visual diff" \
+  mydocs/plans/task_m020_259_impl.md mydocs/working/task_m020_259_stage1.md \
+  mydocs/report/task_m020_255_report.md mydocs/report/task_m020_256_report.md \
+  mydocs/report/task_m020_257_report.md mydocs/report/task_m020_278_report.md
+rg -n "skiaOptIn|coreGraphicsOnly|HwpPageRenderPolicy|renderFirstPage|renderPage" \
+  Sources/QLExtension Sources/ThumbnailExtension Sources/Shared --glob '!**/Resources/**'
+git diff --check
+```
+
+### 완료 기준
+
+- 현재 Quick Look은 Skia 우선, Finder thumbnail은 CoreGraphics 기본이라는 정책 차이가 문서화된다.
+- Stage 2 측정 대상과 Stage 3 판정 기준이 확정된다.
+- Swift source는 아직 변경하지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #259 Stage 1: Skia readiness 입력과 정책 inventory 정리
+```
+
+## Stage 2. visual/performance/package gate 측정
+
+### 목표
+
+`rhwp v0.7.13` 기준으로 Skia/CoreGraphics Quick Look 결과를 재측정하고 release 판단에 필요한 visual, latency, package size 입력을 확보한다.
+
+### 작업
+
+1. Rust lock과 bundled `rhwp-studio` provenance를 검증한다.
+2. 대표 샘플을 최소 3개 이상 사용한다.
+   - `samples/basic/request.hwp`
+   - `samples/hwpx/hwpx-01.hwpx`
+   - `samples/복학원서.hwp`
+   - 필요 시 `samples/basic/KTX.hwp`, `samples/hwp-multi-001.hwp`
+3. `smoke-quicklook-skia-policy.sh`로 CoreGraphics/Skia reply shape, backend, fallback, latency를 비교한다.
+4. `preview-visual-diff-harness.sh`로 reference 대비 CoreGraphics/Skia visual diff를 비교한다.
+5. staticlib/Rhwp.xcframework size와 #255/#278 기록 대비 변화를 정리한다.
+6. Stage 2 보고서에 수치와 해석을 기록한다.
+
+### 산출물
+
+- `mydocs/working/task_m020_259_stage2.md`
+- `build.noindex/task259-*` 측정 산출물
+
+### 검증
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task259-skia-policy \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/복학원서.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task259-visual-cg --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/복학원서.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task259-visual-skia --page 1 --policy skiaOptIn \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/복학원서.hwp
+du -sh Frameworks/universal/librhwp.a Frameworks/Rhwp.xcframework
+git diff --check
+```
+
+### 완료 기준
+
+- 대표 샘플별 Skia/CoreGraphics backend, fallback, latency, visual diff 수치가 보고서에 있다.
+- size/package 영향이 release gate 판단 입력으로 정리되어 있다.
+- Stage 3에서 default 유지/복귀를 판단할 수 있다.
+
+### 커밋 메시지
+
+```text
+Task #259 Stage 2: Skia visual/performance gate 측정
+```
+
+## Stage 3. release policy 판정과 필요 시 최소 보정
+
+### 목표
+
+Stage 1-2 입력을 바탕으로 Quick Look 기본 backend 정책을 확정하고, 필요 시 최소 source 보정을 수행한다.
+
+### 작업
+
+1. 판정 기준표에 따라 `Skia default 유지` 또는 `CoreGraphics default 복귀 + Skia opt-in 유지`를 결정한다.
+2. CoreGraphics default 복귀가 필요하면 `HwpPreviewProvider`의 단일 PNG와 다중 PDF policy를 `coreGraphicsOnly`로 조정한다.
+3. Skia opt-in smoke helper와 Shared renderer contract는 유지한다.
+4. QLExtension/HostApp/ThumbnailExtension build 영향 범위를 확인한다.
+5. #258 진행 조건을 정리한다.
+   - default 복귀 시 #258은 release 전 필수에서 제외하거나 diagnostic/cache 설계 이슈로 재범위화한다.
+   - default 유지 시 #258에서 cache key/backend signature/memory smoke를 release 전 필수로 둔다.
+6. Stage 3 보고서에 정책 결정과 근거를 기록한다.
+
+### 산출물
+
+- 필요 시 `Sources/QLExtension/HwpPreviewProvider.swift`
+- 필요 시 `Sources/Shared/HwpPreviewPDFRenderer.swift`
+- `mydocs/working/task_m020_259_stage3.md`
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "skiaOptIn|coreGraphicsOnly|HwpPageRenderPolicy|Preview selected|Preview rendering" \
+  Sources/QLExtension Sources/Shared Sources/ThumbnailExtension --glob '!**/Resources/**'
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task259-after-policy \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+git diff --check
+```
+
+### 완료 기준
+
+- Quick Look 기본 backend 정책이 source 또는 명시적 보고서 결론으로 고정된다.
+- 필요한 source 보정이 있었다면 build와 smoke가 통과한다.
+- #258 진행/보류/재범위화 조건이 명확하다.
+
+### 커밋 메시지
+
+```text
+Task #259 Stage 3: Skia release policy 판정
+```
+
+## Stage 4. readiness checklist와 release note 초안 정리
+
+### 목표
+
+Skia optional backend의 release readiness checklist, known limitations, release note 초안, #258 handoff를 최종 산출물로 정리한다.
+
+### 작업
+
+1. Stage 1-3 결과를 종합해 readiness checklist를 작성한다.
+2. release note/known limitations 후보 문구를 작성한다.
+3. #258에 넘길 조건을 정리한다.
+4. #259 최종 보고서를 작성한다.
+5. 오늘할일을 완료 처리한다.
+6. PR 본문에 포함할 summary와 검증 결과를 정리한다.
+
+### 산출물
+
+- `mydocs/report/task_m020_259_report.md`
+- `mydocs/orders/20260530.md`
+- 필요 시 `mydocs/working/task_m020_259_stage4.md`
+
+### 검증
+
+```bash
+rg -n "#259|#258|Skia|CoreGraphics|Quick Look|Thumbnail|release note|known limitation|readiness|default" \
+  mydocs/report/task_m020_259_report.md mydocs/orders/20260530.md
+git diff --check
+git status --short --branch
+```
+
+### 완료 기준
+
+- Skia backend release readiness 판단이 근거와 함께 최종 보고서에 남아 있다.
+- release note/known limitations 초안이 있다.
+- #258을 계속할지, 보류할지, 범위를 바꿀지 명확히 남아 있다.
+- PR 게시 준비가 가능하다.
+
+### 커밋 메시지
+
+```text
+Task #259 Stage 4 + 최종 보고서: Skia readiness gate 정리
+```

--- a/mydocs/report/task_m020_259_report.md
+++ b/mydocs/report/task_m020_259_report.md
@@ -1,0 +1,204 @@
+# Task M020 #259 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|---|---|
+| 이슈 | #259 Skia backend visual/performance/package regression gate 정리 |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 기준 브랜치 | `devel` |
+| 작업 브랜치 | `local/task259` |
+| 기준 core | `rhwp v0.7.13` |
+| resolved commit | `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+
+결론:
+
+- Quick Look 기본 backend는 CoreGraphics/native path로 복귀했다.
+- Skia backend는 제거하지 않고 `.skiaOptIn` opt-in 경로, CoreGraphics fallback, diagnostics, smoke helper를 유지했다.
+- Finder Thumbnail은 이미 CoreGraphics 기본이므로 이번 release 기본 surface는 Quick Look/Thumbnail 모두 CoreGraphics 기준으로 다시 일관된다.
+- #258은 이번 release 전 필수 작업에서 제외하고, 후속 Skia thumbnail opt-in/cache diagnostic 설계 이슈로 재범위화하는 것이 맞다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|---|---|
+| `Sources/QLExtension/HwpPreviewProvider.swift` | Quick Look 단일 PNG와 다중 PDF preview 호출부의 policy를 `.skiaOptIn`에서 `.coreGraphicsOnly`로 변경 |
+| `mydocs/plans/task_m020_259.md` | 수행계획서 작성 |
+| `mydocs/plans/task_m020_259_impl.md` | 단계별 구현계획서 작성 |
+| `mydocs/working/task_m020_259_stage1.md` | 선행 산출물과 현재 backend 정책 inventory |
+| `mydocs/working/task_m020_259_stage2.md` | visual/performance/package gate 측정 결과 |
+| `mydocs/working/task_m020_259_stage3.md` | release policy 판정과 source 보정 결과 |
+| `mydocs/orders/20260530.md` | #259 완료 처리 |
+| `mydocs/report/task_m020_259_report.md` | 최종 보고서 |
+
+Source 변경은 Quick Look provider의 policy 2곳으로 제한했다. `Sources/RhwpCoreBridge`는 변경하지 않았다.
+
+## 단계별 결과
+
+| Stage | 커밋 | 결과 |
+|---|---|---|
+| 계획 | `198adba` | 수행계획서와 오늘할일 등록 |
+| 구현계획 | `7b54634` | Stage 1-4 계획과 판정 기준 작성 |
+| Stage 1 | `c5bfc9e` | #255/#256/#257/#278 입력과 현재 backend 정책 inventory |
+| Stage 2 | `c019850` | Quick Look policy smoke, visual diff, package size 측정 |
+| Stage 3 | `63d11e8` | Quick Look 기본을 CoreGraphics로 복귀, Skia opt-in 유지 |
+| Stage 4 | 현재 | 최종 보고서와 오늘할일 완료 처리 |
+
+## Stage 1 inventory 결론
+
+현재 코드와 선행 산출물 기준으로 확인한 정책은 다음과 같았다.
+
+| Surface | Stage 1 당시 정책 | 의미 |
+|---|---|---|
+| Quick Look 단일 PNG | `.skiaOptIn` | Skia 우선 |
+| Quick Look 다중 PDF | `.skiaOptIn` | page별 Skia 우선 |
+| Finder Thumbnail | `renderFirstPage` 기본값 | CoreGraphics 기본 |
+| Shared renderer | 기본값 `.coreGraphicsOnly`, 명시 opt-in `.skiaOptIn` | default와 opt-in 분리 가능 |
+
+이 상태에서는 Quick Look과 Thumbnail의 기본 backend가 갈라진다. 따라서 #258로 Thumbnail까지 Skia를 확장하기 전에 #259에서 release gate를 먼저 판정해야 한다고 정리했다.
+
+## Stage 2 측정 결과
+
+### Package size
+
+| 기준 | `librhwp.a` size | 변화 |
+|---|---:|---:|
+| #255 이전 | 108,417,040 bytes | - |
+| #255 native-skia 반영 | 190,410,384 bytes | +81,993,344 bytes |
+| #278 v0.7.13 반영 후 현재 | 203,436,808 bytes | #255 이전 대비 +95,019,768 bytes |
+
+현재 `du -sh` 기준 `Frameworks/universal/librhwp.a`와 `Frameworks/Rhwp.xcframework`는 모두 `194M`이다.
+
+### Quick Look policy smoke
+
+| File | Reply | Pages | CG sec | Skia sec | Skia fallback |
+|---|---|---:|---:|---:|---:|
+| `request.hwp` | png | 1 | 1.073779 | 0.069324 | 0 |
+| `hwpx-01.hwpx` | pdf | 9 | 0.376997 | 0.617429 | 0 |
+| `복학원서.hwp` | png | 1 | 0.160401 | 0.065900 | 0 |
+| `KTX.hwp` | png | 1 | 0.069717 | 0.071174 | 0 |
+| `hwp-multi-001.hwp` | pdf | 10 | 0.390930 | 0.666077 | 0 |
+
+fallback은 0으로 안정적이었다. 그러나 다중 PDF 샘플 2개에서는 Skia가 CoreGraphics보다 느렸다.
+
+### Visual diff
+
+| File | CG changed | Skia changed | Delta pp | CG mean RGB | Skia mean RGB | CG ms | Skia ms |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| `request.hwp` | 17.8542% | 12.8683% | -4.9859 | 11.0716 | 10.1453 | 1016.7 | 5460.6 |
+| `hwpx-01.hwpx` | 15.0285% | 14.6452% | -0.3833 | 15.2088 | 16.0791 | 33.8 | 69.2 |
+| `복학원서.hwp` | 32.0188% | 6.4738% | -25.5450 | 18.2116 | 7.2558 | 157.6 | 61.1 |
+| `KTX.hwp` | 31.1362% | 47.1389% | +16.0027 | 13.6308 | 22.5798 | 52.3 | 65.3 |
+| `hwp-multi-001.hwp` | 14.8327% | 14.3340% | -0.4987 | 14.8651 | 15.7946 | 29.2 | 66.3 |
+
+Skia는 `복학원서.hwp`에서 큰 개선을 보였지만, `KTX.hwp`에서는 크게 악화됐다. `request.hwp`는 visual diff가 개선됐지만 Skia native render time이 5초대로 측정됐다.
+
+## 최종 backend 정책
+
+| Surface | 최종 정책 | 설명 |
+|---|---|---|
+| Quick Look 단일 PNG | `.coreGraphicsOnly` | release 기본 preview는 CoreGraphics/native renderer 사용 |
+| Quick Look 다중 PDF | `.coreGraphicsOnly` | 다중 page bitmap PDF도 CoreGraphics/native renderer 사용 |
+| Finder Thumbnail | `.coreGraphicsOnly` 기본값 유지 | 기존 default 유지 |
+| Skia backend | `.skiaOptIn` 유지 | helper, diagnostic, 후속 실험에서 명시 opt-in |
+
+변경 후 Quick Look provider는 source에서 `.coreGraphicsOnly`를 명시한다. Shared renderer는 여전히 Skia opt-in과 fallback contract를 제공한다.
+
+## Readiness checklist
+
+| 항목 | 상태 | 근거 |
+|---|---|---|
+| Skia ABI 포함 | 준비됨 | `rhwp_render_page_png`와 status/fallback contract 유지 |
+| Skia opt-in smoke | 준비됨 | `smoke-quicklook-skia-policy.sh` 유지, Stage 3 smoke fallback 0 |
+| Quick Look default Skia | 보류 | visual/latency/package gate가 default 기준을 만족하지 못함 |
+| Quick Look default CoreGraphics | 준비됨 | Stage 3에서 source 보정, QLExtension build 통과 |
+| Thumbnail default Skia | 보류 | #258 재범위화 필요 |
+| Release package size 해석 | 주의 필요 | native-skia 포함으로 staticlib가 #255 이전 대비 약 95 MB 증가 |
+| 설치본 Quick Look UI smoke | 후속 package/release smoke | 이번 작업은 helper/build 중심 |
+
+Release 후보로는 `CoreGraphics default + Skia optional backend` 상태가 가장 깔끔하다.
+
+## release note 후보
+
+```text
+Quick Look preview 기본 렌더링 경로를 안정적인 CoreGraphics/native renderer로 유지했습니다.
+Skia 기반 native PNG renderer는 opt-in 진단 경로로 남겨 두었으며, fallback과 backend diagnostics를 통해 후속 품질/성능 개선을 계속 검증할 수 있습니다.
+```
+
+## known limitation 후보
+
+```text
+Skia renderer는 일부 문서에서 reference 대비 visual diff를 크게 줄이지만, 문서별 품질 편차와 다중 페이지 preview 성능 편차가 남아 있어 이번 release에서는 기본 경로로 사용하지 않습니다.
+Finder Thumbnail의 Skia 적용은 기본 release 범위에서 제외되며, 후속 cache key/backend signature 설계와 함께 재검토합니다.
+```
+
+## #258 handoff
+
+#258은 기존 "Finder thumbnail Skia 적용" 범위 그대로 release 전 필수로 진행하지 않는다. 후속으로 이어간다면 다음 범위로 재정의하는 것이 맞다.
+
+| 항목 | 권장 처리 |
+|---|---|
+| 목적 | Thumbnail Skia default 적용이 아니라 opt-in diagnostic/cache 설계 |
+| cache key | backend policy, pixel bucket, render option signature 포함 |
+| 성능 gate | first render latency와 repeated thumbnail cache hit/miss 분리 |
+| visual gate | `KTX.hwp` 악화 사례와 `복학원서.hwp` 개선 사례를 모두 포함 |
+| release 조건 | Quick Look default Skia 재검토 전까지 Thumbnail default Skia도 보류 |
+
+## PR summary 후보
+
+```text
+## Summary
+- Quick Look Skia readiness gate를 정리하고 visual/performance/package 측정 결과를 문서화했습니다.
+- Stage 2 결과에 따라 Quick Look 기본 backend를 CoreGraphics/native path로 되돌렸습니다.
+- Skia opt-in renderer, fallback diagnostics, policy smoke helper는 유지했습니다.
+- #258은 release 전 필수 default 전환 작업이 아니라 후속 thumbnail opt-in/cache diagnostic 설계로 재범위화하는 결론을 남겼습니다.
+
+## Verification
+- ./scripts/build-rust-macos.sh --verify-lock
+- ./scripts/verify-rhwp-studio-assets.sh
+- ./scripts/check-no-appkit.sh
+- ./scripts/smoke-quicklook-skia-policy.sh build.noindex/task259-skia-policy ...
+- ./scripts/preview-visual-diff-harness.sh build.noindex/task259-visual-cg ...
+- ./scripts/preview-visual-diff-harness.sh build.noindex/task259-visual-skia --policy skiaOptIn ...
+- xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
+- xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
+- xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
+- git diff --check
+```
+
+## 최종 검증
+
+Stage 2-3에서 실행한 검증:
+
+| 검증 | 결과 |
+|---|---|
+| `./scripts/build-rust-macos.sh --verify-lock` | 통과 |
+| `./scripts/verify-rhwp-studio-assets.sh` | 통과 |
+| `./scripts/check-no-appkit.sh` | 통과 |
+| Quick Look policy smoke | 통과, fallback 0 |
+| CoreGraphics visual diff harness | sandbox 밖 재실행 통과 |
+| Skia visual diff harness | sandbox 밖 재실행 통과 |
+| `xcodebuild ... QLExtension ... build` | 통과 |
+| `xcodebuild ... HostApp ... build` | 통과 |
+| `xcodebuild ... ThumbnailExtension ... build` | 통과 |
+| `git diff --check` | 통과 |
+
+검증 중 sandbox 제약:
+
+- `xcodebuild`는 sandbox 내부에서 Sparkle clone network 제한 또는 SwiftPM/clang cache 쓰기 제한으로 실패한 뒤 sandbox 밖에서 통과했다.
+- visual diff harness는 WKWebView/rhwp-studio readiness 단계에서 sandbox extension 오류가 나서 sandbox 밖에서 통과했다.
+
+## 잔여 위험
+
+| 항목 | 내용 |
+|---|---|
+| Skia package size | 기본 경로가 CoreGraphics여도 native-skia feature와 artifact size는 현재 포함되어 있다. 배포 package size는 release smoke에서 계속 확인해야 한다. |
+| Skia 품질 편차 | `복학원서.hwp` 개선과 `KTX.hwp` 악화가 공존한다. default 재검토 전 원인 분석이 필요하다. |
+| first/render cost | `request.hwp`에서 visual diff harness 기준 Skia 5초대 native render time이 남아 있다. |
+| 설치본 smoke | 이번 #259는 build/helper smoke 중심이다. 실제 배포 전 signed Release package smoke는 별도 release 절차에서 수행한다. |
+
+## 결론
+
+#259는 Skia backend를 release default로 둘지 판단하기 위한 gate 작업을 완료했다. 현재 측정 기준으로는 Skia를 Quick Look 기본 경로로 유지하기 어렵고, CoreGraphics/native renderer를 기본으로 두는 편이 release 후보로 더 깔끔하다.
+
+최종 상태는 `Quick Look/Thumbnail default = CoreGraphics`, `Skia = opt-in diagnostic backend`이다. 이 상태로 v0.2.x release 준비를 진행하고, #258은 후속 Skia thumbnail opt-in/cache diagnostic 설계로 재범위화하는 것을 권장한다.

--- a/mydocs/working/task_m020_259_stage1.md
+++ b/mydocs/working/task_m020_259_stage1.md
@@ -1,0 +1,168 @@
+# Task M020 #259 Stage 1 보고서 - Skia readiness 입력과 backend 정책 inventory
+
+## 단계 개요
+
+- 이슈: #259 Skia backend visual/performance/package regression gate 정리
+- 단계: Stage 1. 입력 산출물과 현재 backend 정책 inventory
+- 기준 브랜치: `local/task259`
+- 목표: #255/#256/#257/#278 산출물과 현재 코드 정책을 수집해 #259가 #258보다 먼저 진행되는 이유와 Stage 2 측정 대상을 고정한다.
+
+Stage 1에서는 Swift source를 변경하지 않는다. 현재 제품 surface가 실제로 어느 backend를 기본으로 사용하는지와, release gate 판단에 필요한 입력이 어디까지 확보됐는지를 문서화한다.
+
+## 선행 산출물 inventory
+
+### #255 native-skia ABI와 package 입력
+
+| 항목 | 확인 내용 | #259 영향 |
+|---|---|---|
+| 새 ABI | `rhwp_render_page_png` 추가 | Skia PNG backend는 RustBridge C ABI로 호출 가능하다. |
+| render status | `RhwpRenderStatus` 6개 값 추가 | #256 fallback taxonomy 입력이 된다. |
+| FFI symbol 수 | 10개에서 11개로 증가 | ABI surface가 확장됐다. |
+| generated header | 1,349 bytes에서 1,978 bytes로 증가 | Swift wrapper가 새 ABI를 소비할 수 있다. |
+| staticlib size | 108,417,040 bytes에서 190,410,384 bytes로 증가 | `native-skia` 포함만으로 81,993,344 bytes 증가했다. |
+| `du -sh` | `librhwp.a` / `Rhwp.xcframework` 모두 `182M` | release package size gate에서 반드시 해석해야 한다. |
+| 제품 동작 | Quick Look/Thumbnail 제품 동작 변경 없음 | #255는 backend capability 추가이지 default 전환 근거가 아니다. |
+
+판단: #255는 Skia를 호출할 수 있게 만든 작업이지만, package size 증가는 크다. 따라서 사용자-facing 개선이 충분하지 않으면 Quick Look 기본 backend로 배포하기 어렵다.
+
+### #256 Shared renderer contract
+
+| 항목 | 확인 내용 | #259 영향 |
+|---|---|---|
+| 정책 | `HwpPageRenderPolicy.coreGraphicsOnly`, `.skiaOptIn` | default와 opt-in을 분리할 수 있다. |
+| 기본값 | `renderPage`, `renderFirstPage` 기본값은 `.coreGraphicsOnly` | Shared renderer 자체는 Skia 기본 전환을 하지 않았다. |
+| Skia 동작 | `.skiaOptIn`에서 Skia PNG render를 먼저 시도 | 호출부가 명시한 경우에만 Skia 우선이다. |
+| fallback | status failure, empty bytes, PNG decode failure 시 CoreGraphics fallback | Quick Look에서 Skia 실패가 곧바로 text fallback으로 내려가지는 않는다. |
+| diagnostics | `backendUsed`, `fallbackReason`, `pageSize`, `pixelSize`, `pngBytes`, `durationMs` | Stage 2 smoke와 Stage 3 정책 판단의 관측 필드다. |
+| embedded thumbnail | `.embeddedThumbnail` backend로 분리 | Finder thumbnail smoke에서 CoreGraphics render와 혼동하지 않게 됐다. |
+
+판단: #256은 Skia를 안전하게 실험할 수 있는 contract를 제공했다. 다만 #256 보고서 자체도 visual diff, latency, memory, package size를 보지 않았으므로 default 전환 결론은 내리지 않았다.
+
+### #257 Quick Look Skia 연결과 smoke
+
+| 항목 | 확인 내용 | #259 영향 |
+|---|---|---|
+| 단일 PNG reply | Quick Look PNG path가 `policy: .skiaOptIn` 사용 | 현재 Quick Look 단일 페이지 기본 렌더는 Skia 우선이다. |
+| 다중 PDF reply | Quick Look PDF path가 `policy: .skiaOptIn`, `collectDiagnostics: true` 사용 | 다중 페이지도 page별 Skia 우선으로 바뀌었다. |
+| smoke helper | `smoke-quicklook-skia-policy.sh` 추가 | Stage 2에서 같은 도구로 재측정한다. |
+| `request.hwp` | CG 1.081279s, Skia 0.095356s, fallback 0 | 당시에는 Skia가 빠르게 관측됐다. |
+| `KTX.hwp` | CG 0.067094s, Skia 0.073160s, fallback 0 | 단일 문서에서 큰 차이는 아니었다. |
+| `복학원서.hwp` | CG 0.412763s, Skia 0.062871s, fallback 0 | Skia가 빠르게 관측됐다. |
+| `hwp-multi-001.hwp` | CG 0.404578s, Skia 0.677783s, fallback 0 | 다중 PDF에서는 Skia가 느렸다. |
+| `hwpx-01.hwpx` | CG 0.353663s, Skia 0.623360s, fallback 0 | 다중 PDF에서는 Skia가 느렸다. |
+| Known limitation | 설치본 Quick Look UI smoke 없음, fallback 강제 fixture 없음, Skia PNG decode 후 재인코딩, 다중 PDF 성능 이슈 | release default 판단을 #259로 넘긴 이유다. |
+
+판단: #257은 Quick Look surface에 Skia를 실제 연결했다. 다만 일부 다중 문서에서 이미 성능 부담이 보였고, 설치본/package 관점 검증은 남아 있었다.
+
+### #278 rhwp v0.7.13 기준 회귀 입력
+
+| 항목 | 확인 내용 | #259 영향 |
+|---|---|---|
+| upstream | `rhwp v0.7.13`, resolved commit `b3e16ef212af81ef37d973ddb86d6816d3804642` | 현재 release 후보의 core 기준이다. |
+| staticlib size | 200,488,800 bytes에서 203,436,808 bytes로 증가 | v0.7.13 반영 후에도 package size가 추가 증가했다. |
+| ABI | FFI symbol/header 변경 없음, 12 symbols 유지 | #259에서 Swift ABI 보정은 필요 없어 보인다. |
+| `request.hwp` policy smoke | CG 0.990051s, Skia 12.158348s, fallback 0 | Skia first-call 또는 특정 문서 latency 리스크가 크다. |
+| `hwpx-01.hwpx` policy smoke | CG 0.358134s, Skia 0.617731s, fallback 0 | 다중 PDF에서 Skia가 계속 느렸다. |
+| `request.hwp` visual diff | CG changed 17.8542%, mean RGB 11.0716, 961.7ms / Skia changed 12.8683%, mean RGB 10.1453, 6240.1ms | changed pixel은 개선됐지만 latency 비용이 매우 크다. |
+| `hwpx-01.hwpx` visual diff | CG changed 15.0285%, mean RGB 15.2088, 29.8ms / Skia changed 14.6452%, mean RGB 16.0791, 64.4ms | changed pixel 개선 폭이 작고 mean RGB는 악화됐다. |
+| #278 결론 | Skia 기본 전환은 아직 이르다 | #259에서 default 유지/복귀를 판정해야 한다. |
+
+판단: v0.7.13 기준 Skia는 visual diff 일부 지표를 개선하지만, diff가 여전히 두 자릿수이고 latency가 문서별로 크게 흔들린다. 현재 입력만 보면 Quick Look 기본을 Skia로 유지하려면 추가 근거가 필요하다.
+
+## 현재 코드 backend 정책
+
+| Surface | 파일 | 현재 호출 | 해석 |
+|---|---|---|---|
+| Quick Look 단일 PNG | `Sources/QLExtension/HwpPreviewProvider.swift:40` | `HwpPageImageRenderer.renderPage(..., policy: .skiaOptIn)` | 현재 최신 코드 기준 단일 페이지 Quick Look 기본 렌더는 Skia 우선이다. |
+| Quick Look 다중 PDF | `Sources/QLExtension/HwpPreviewProvider.swift:73` | `HwpPreviewPDFRenderer.render(context:policy: .skiaOptIn, collectDiagnostics: true)` | 다중 페이지 Quick Look도 Skia 우선이다. |
+| PDF renderer public API | `Sources/Shared/HwpPreviewPDFRenderer.swift:52` | `policy: HwpPageRenderPolicy = .coreGraphicsOnly` | 일반 호출 기본값은 CoreGraphics이며, Quick Look provider가 명시적으로 Skia를 선택한다. |
+| Shared renderer policy | `Sources/Shared/HwpPageImageRenderer.swift:14` | `.coreGraphicsOnly`, `.skiaOptIn` | backend 정책은 명시 enum으로 분리되어 있다. |
+| Shared first page 기본값 | `Sources/Shared/HwpPageImageRenderer.swift:105` | `policy: HwpPageRenderPolicy = .coreGraphicsOnly` | 호출자가 생략하면 CoreGraphics만 사용한다. |
+| Shared page 기본값 | `Sources/Shared/HwpPageImageRenderer.swift:144` | `policy: HwpPageRenderPolicy = .coreGraphicsOnly` | 공용 렌더러의 default는 아직 native/CoreGraphics path다. |
+| Shared Skia fallback | `Sources/Shared/HwpPageImageRenderer.swift:166` | `.skiaOptIn`에서 Skia 성공 시 반환, 실패 시 CoreGraphics fallback | fallback contract는 유지된다. |
+| Finder thumbnail cache | `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift:88` | `renderFirstPage(... embeddedThumbnailPolicy: .never)` | policy 인자를 넘기지 않으므로 Thumbnail은 현재 CoreGraphics 기본이다. |
+
+현재 정책을 한 문장으로 정리하면 다음과 같다.
+
+- Quick Look preview: 단일 PNG와 다중 PDF 모두 Skia 우선이다.
+- Thumbnail extension: 아직 CoreGraphics 기본이다.
+- Shared renderer/PDF renderer API: 기본값은 CoreGraphics이고, Quick Look provider만 Skia를 명시 opt-in한다.
+
+이 상태는 release 설명 관점에서 애매하다. 사용자가 가장 먼저 접하는 Quick Look preview는 Skia를 기본으로 쓰지만, Finder thumbnail은 아직 CoreGraphics를 쓰므로 같은 문서에 대해 Finder surface별 rendering 특성이 달라질 수 있다.
+
+## #259를 #258보다 먼저 진행하는 이유
+
+#258은 Finder thumbnail에 Skia backend를 적용하는 작업이다. 그러나 현재 입력에서는 #258을 먼저 진행하면 Skia 기본 적용 범위가 더 넓어지기 전에 해결해야 할 release gate 질문이 남아 있다.
+
+1. Quick Look은 이미 Skia 우선이다. 따라서 지금 필요한 질문은 "Skia를 더 넓힐 것인가"보다 "이미 바뀐 기본 경로를 release에 실을 수 있는가"이다.
+2. #278의 `request.hwp` Skia latency는 Quick Look 기본 유지에 직접적인 위험 신호다. 이 상태에서 Thumbnail까지 Skia를 확장하면 cache key, memory, first-render latency 문제가 함께 커진다.
+3. #258의 cache key/backend signature 설계는 release policy에 의존한다. Skia를 기본으로 유지할지, opt-in diagnostic 경로로 낮출지 결정하지 않으면 #258의 cache key 범위와 smoke 기준이 흔들린다.
+4. package size 증가는 #255부터 이미 크고, v0.7.13에서 추가 증가했다. Thumbnail 적용은 사용자-facing 개선 근거가 package 비용을 정당화할 때 진행하는 편이 깔끔하다.
+5. #257 known limitation과 #278 결론 모두 default 판단을 #259로 넘겼다. 따라서 #259를 먼저 끝내야 #258을 release 필수 작업으로 둘지, 후속 diagnostic/cache 설계 작업으로 재범위화할지 결정할 수 있다.
+
+Stage 1 기준 잠정 판단은 `#259 선행`이다. #258은 Stage 2-3에서 Quick Look default 정책을 확정한 뒤 진행 여부와 범위를 다시 정하는 것이 맞다.
+
+## Stage 2 측정 대상
+
+Stage 2에서는 기존 보고서 수치를 그대로 믿고 끝내지 않고, 현재 `devel` 최신 코드와 `rhwp v0.7.13` 기준으로 같은 gate를 재측정한다.
+
+대표 샘플:
+
+| 샘플 | 이유 |
+|---|---|
+| `samples/basic/request.hwp` | #278에서 Skia latency가 크게 튄 단일 PNG 대표 리스크 |
+| `samples/hwpx/hwpx-01.hwpx` | 다중 PDF/HWPX 대표 샘플 |
+| `samples/복학원서.hwp` | #257에서 Skia가 빠르게 관측된 단일 문서, 한글 실사용 양식 |
+| `samples/basic/KTX.hwp` | #256/#257에서 CoreGraphics와 Skia 차이가 컸던 표/텍스트 문서 |
+| `samples/hwp-multi-001.hwp` | 다중 HWP PDF path 성능 확인 후보 |
+
+필수 측정:
+
+- `smoke-quicklook-skia-policy.sh`로 reply type, backend count, fallback count, bytes, latency 비교
+- `preview-visual-diff-harness.sh`로 CoreGraphics와 Skia의 reference 대비 visual diff 비교
+- `du -sh Frameworks/universal/librhwp.a Frameworks/Rhwp.xcframework`로 staticlib/xcframework 크기 확인
+- `build-rust-macos.sh --verify-lock`, `verify-rhwp-studio-assets.sh`, `check-no-appkit.sh`로 provenance와 shared dependency 규칙 확인
+
+Stage 2에서 특히 확인할 질문:
+
+1. #278의 `request.hwp` Skia 12.158348s가 재현되는가, first-call cost인가, 일시적 이상치인가.
+2. Skia visual diff 개선이 latency/package cost를 정당화할 정도로 반복되는가.
+3. 다중 PDF path에서 Skia가 CoreGraphics보다 느린 경향이 유지되는가.
+4. fallback이 0으로 유지될 때도 release default로 설명 가능한 품질과 성능인가.
+
+## Stage 3 판정에 넘길 기준
+
+Stage 2 결과가 다음 중 하나에 가까우면 Stage 3에서 Quick Look 기본 정책을 조정한다.
+
+| 조건 | Stage 3 방향 |
+|---|---|
+| Skia가 대표 샘플에서 visual diff를 의미 있게 개선하고 latency도 CoreGraphics와 동등하거나 빠름 | Quick Look Skia default 유지 검토 |
+| Skia visual 개선 폭이 작거나 문서별로 엇갈리고, latency가 느리거나 first-call 비용이 큼 | Quick Look 기본을 CoreGraphics로 복귀하고 Skia opt-in/diagnostic 유지 |
+| Thumbnail까지 같은 정책으로 묶어야 release 설명이 성립함 | #258을 release 전 필수로 유지 |
+| Quick Look 기본을 CoreGraphics로 복귀함 | #258은 release 전 필수에서 제외하거나 backend/cache diagnostic 작업으로 재범위화 |
+
+현재 Stage 1 입력만으로는 Skia default 유지 결론을 내리기 어렵다. 특히 `request.hwp` latency와 다중 PDF 성능은 Stage 2에서 재측정한 뒤 Stage 3에서 정책 보정 여부를 결정한다.
+
+## Stage 1 검증
+
+실행할 검증:
+
+```bash
+rg -n "#255|#256|#257|#258|#259|#278|skiaOptIn|coreGraphicsOnly|backendUsed|fallbackReason|staticlib|visual diff" \
+  mydocs/plans/task_m020_259_impl.md mydocs/working/task_m020_259_stage1.md \
+  mydocs/report/task_m020_255_report.md mydocs/report/task_m020_256_report.md \
+  mydocs/report/task_m020_257_report.md mydocs/report/task_m020_278_report.md
+rg -n "skiaOptIn|coreGraphicsOnly|HwpPageRenderPolicy|renderFirstPage|renderPage" \
+  Sources/QLExtension Sources/ThumbnailExtension Sources/Shared --glob '!**/Resources/**'
+git diff --check
+```
+
+기대 결과:
+
+- 선행 보고서와 Stage 1 보고서에 #259 판단 입력이 연결되어 있다.
+- 현재 Quick Look은 Skia 우선, Thumbnail은 CoreGraphics 기본이라는 정책 차이가 source 검색으로 확인된다.
+- Stage 1은 문서 추가만 수행했으므로 Swift source 변경은 없다.
+
+## 다음 단계 승인 요청
+
+Stage 2에서는 현재 코드 기준으로 Quick Look Skia/CoreGraphics visual, latency, fallback, package size gate를 재측정한다. Stage 2 완료 후 측정 보고서를 작성하고, Stage 3 정책 판정으로 넘어가기 전에 다시 승인을 요청한다.

--- a/mydocs/working/task_m020_259_stage2.md
+++ b/mydocs/working/task_m020_259_stage2.md
@@ -1,0 +1,178 @@
+# Task M020 #259 Stage 2 보고서 - Skia visual/performance/package gate 측정
+
+## 단계 개요
+
+- 이슈: #259 Skia backend visual/performance/package regression gate 정리
+- 단계: Stage 2. visual/performance/package gate 측정
+- 기준 브랜치: `local/task259`
+- 기준 core: `rhwp v0.7.13`, resolved commit `b3e16ef212af81ef37d973ddb86d6816d3804642`
+- 목표: 현재 최신 코드 기준 Quick Look Skia/CoreGraphics 결과를 재측정하고 Stage 3 release policy 판정 입력을 확보한다.
+
+Stage 2에서는 Swift source를 변경하지 않았다. 측정 산출물은 `build.noindex/task259-*` 아래에 생성했다.
+
+## 기준 산출물 검증
+
+| 항목 | 결과 | 비고 |
+|---|---|---|
+| Rust lock 검증 | 통과 | `./scripts/build-rust-macos.sh --verify-lock` |
+| FFI symbol set | 통과 | `rhwp_render_page_png`, `rhwp_page_overlay_images` 포함 12 symbols |
+| `rhwp-core.lock` | 통과 | `release-tag`, `v0.7.13`, commit `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| bundled `rhwp-studio` | 통과 | `./scripts/verify-rhwp-studio-assets.sh` |
+| Shared AppKit/UIKit 금지 | 통과 | `./scripts/check-no-appkit.sh` |
+
+`build-rust-macos.sh --verify-lock`는 sandbox 안에서 실행했기 때문에 `xcodebuild -create-xcframework` 중 CoreSimulator 관련 warning이 출력됐다. 그러나 xcframework 생성, symbol 출력, lock verification은 성공했다.
+
+## Package size
+
+| 항목 | 현재 값 |
+|---|---:|
+| `Frameworks/universal/librhwp.a` exact size | 203,436,808 bytes |
+| `Frameworks/generated_rhwp.h` exact size | 2,059 bytes |
+| `du -sh Frameworks/universal/librhwp.a` | `194M` |
+| `du -sh Frameworks/Rhwp.xcframework` | `194M` |
+| `du -sk Sources/HostApp/Resources/rhwp-studio` | `35736` KB |
+| `rhwp-studio` copied file count | 57 |
+| `rhwp-studio` copied total bytes | 36,462,802 bytes |
+
+비교 기준:
+
+| 기준 | `librhwp.a` size | 변화 |
+|---|---:|---:|
+| #255 이전 | 108,417,040 bytes | - |
+| #255 native-skia 반영 | 190,410,384 bytes | +81,993,344 bytes |
+| #278 v0.7.13 반영 후 현재 | 203,436,808 bytes | #255 대비 +13,026,424 bytes, #255 이전 대비 +95,019,768 bytes |
+
+판단 입력: Skia backend capability를 포함하면서 staticlib는 #255 이전 대비 약 95 MB 커졌다. Quick Look 기본 backend를 Skia로 유지하려면 visual/latency 개선이 이 비용을 정당화해야 한다.
+
+## Quick Look policy smoke
+
+실행:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task259-skia-policy \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/복학원서.hwp \
+  samples/basic/KTX.hwp samples/hwp-multi-001.hwp
+```
+
+결과:
+
+| File | Reply | Pages | CG backend | CG sec | Skia backend | Skia sec | Delta sec | Fallback |
+|---|---|---:|---|---:|---|---:|---:|---:|
+| `request.hwp` | png | 1 | `skia:0,cg:1,embedded:0` | 1.073779 | `skia:1,cg:0,embedded:0` | 0.069324 | -1.004455 | 0 |
+| `hwpx-01.hwpx` | pdf | 9 | `skia:0,cg:9,embedded:0` | 0.376997 | `skia:9,cg:0,embedded:0` | 0.617429 | +0.240432 | 0 |
+| `복학원서.hwp` | png | 1 | `skia:0,cg:1,embedded:0` | 0.160401 | `skia:1,cg:0,embedded:0` | 0.065900 | -0.094501 | 0 |
+| `KTX.hwp` | png | 1 | `skia:0,cg:1,embedded:0` | 0.069717 | `skia:1,cg:0,embedded:0` | 0.071174 | +0.001457 | 0 |
+| `hwp-multi-001.hwp` | pdf | 10 | `skia:0,cg:10,embedded:0` | 0.390930 | `skia:10,cg:0,embedded:0` | 0.666077 | +0.275147 | 0 |
+
+해석:
+
+- 5개 샘플 모두 Skia fallback은 0이었다.
+- 단일 PNG 샘플 중 `request.hwp`, `복학원서.hwp`는 Skia가 빨랐다.
+- `KTX.hwp` 단일 PNG는 거의 동률이었다.
+- 다중 PDF 샘플 2개는 Skia가 CoreGraphics보다 느렸다.
+- #278에서 관측한 `request.hwp` Quick Look Skia 12.158348s는 이번 policy smoke에서는 재현되지 않았다. 다만 아래 visual diff harness의 native render time에서는 `request.hwp` Skia가 여전히 5초대로 측정됐다.
+
+## Visual diff
+
+처음 sandbox 내부에서 `preview-visual-diff-harness.sh`를 실행했을 때 WKWebView/rhwp-studio readiness 단계가 실패했다.
+
+```text
+rhwp-studio page 1 readiness timed out: navigation=pending; events=[]; scheme={resourceRequests=0, documentRequests=0}
+Could not create a 'com.apple.gputools.service' sandbox extension
+Could not create a 'com.apple.coreservices.launchservicesd' sandbox extension
+```
+
+같은 명령을 sandbox 밖 권한으로 재실행해 완료했다.
+
+실행:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task259-visual-cg --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/복학원서.hwp \
+  samples/basic/KTX.hwp samples/hwp-multi-001.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task259-visual-skia --page 1 --policy skiaOptIn \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/복학원서.hwp \
+  samples/basic/KTX.hwp samples/hwp-multi-001.hwp
+```
+
+공통 조건:
+
+| 항목 | 값 |
+|---|---|
+| Reference | bundled `rhwp-studio` |
+| Studio release | `v0.7.13` |
+| Studio commit | `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| Page | 1 |
+| Viewport | `1400x1800` |
+| Settle | 120 ms |
+| Diff pixel threshold | 12 |
+
+결과:
+
+| File | CG changed | Skia changed | Delta pp | CG mean RGB | Skia mean RGB | Mean delta | CG native ms | Skia native ms | Ms delta |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| `request.hwp` | 17.8542% | 12.8683% | -4.9859 | 11.0716 | 10.1453 | -0.9263 | 1016.7 | 5460.6 | +4443.9 |
+| `hwpx-01.hwpx` | 15.0285% | 14.6452% | -0.3833 | 15.2088 | 16.0791 | +0.8703 | 33.8 | 69.2 | +35.4 |
+| `복학원서.hwp` | 32.0188% | 6.4738% | -25.5450 | 18.2116 | 7.2558 | -10.9558 | 157.6 | 61.1 | -96.5 |
+| `KTX.hwp` | 31.1362% | 47.1389% | +16.0027 | 13.6308 | 22.5798 | +8.9490 | 52.3 | 65.3 | +13.0 |
+| `hwp-multi-001.hwp` | 14.8327% | 14.3340% | -0.4987 | 14.8651 | 15.7946 | +0.9295 | 29.2 | 66.3 | +37.1 |
+
+해석:
+
+- Skia는 `복학원서.hwp`에서 visual diff를 크게 줄였다.
+- `request.hwp`도 changed pixel과 mean RGB가 개선됐지만, native render ms가 5초대로 매우 느리다.
+- `hwpx-01.hwpx`, `hwp-multi-001.hwp`는 changed pixel 개선 폭이 0.5pp 안팎이고 mean RGB는 오히려 나빠졌다.
+- `KTX.hwp`는 Skia가 changed pixel과 mean RGB 모두 크게 악화됐다.
+- visual 평균만 보면 Skia가 일부 개선되지만, 문서별 방향이 크게 갈려 release default의 안정 근거로 쓰기 어렵다.
+
+## Stage 3 판정 입력
+
+Stage 2 수치만 기준으로 보면 Stage 3에서 검토할 기본 방향은 `Quick Look 기본 CoreGraphics 복귀 + Skia opt-in/diagnostic 유지` 쪽이 더 강하다.
+
+근거:
+
+1. 다중 PDF Quick Look smoke에서 Skia가 계속 느리다.
+2. visual diff가 문서별로 갈린다. `복학원서.hwp`는 크게 개선되지만 `KTX.hwp`는 크게 악화된다.
+3. `request.hwp`는 Quick Look smoke에서 12초 지연이 재현되지는 않았지만 visual diff harness의 Skia native ms가 5초대로 남아 있다.
+4. staticlib size는 #255 이전 대비 약 95 MB 증가했다. 현재 개선 폭은 이 package cost를 기본 경로 전환 근거로 삼기 어렵다.
+5. Finder Thumbnail은 아직 CoreGraphics 기본이다. Quick Look만 Skia 기본으로 두면 release 설명과 회귀 대응 범위가 복잡하다.
+
+다만 Stage 2는 측정 단계이므로 source policy 변경은 하지 않았다. 최종 default 유지/복귀 결정과 필요 시 `HwpPreviewProvider` 보정은 Stage 3에서 수행한다.
+
+## Stage 2 검증
+
+실행한 검증:
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task259-skia-policy \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/복학원서.hwp \
+  samples/basic/KTX.hwp samples/hwp-multi-001.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task259-visual-cg --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/복학원서.hwp \
+  samples/basic/KTX.hwp samples/hwp-multi-001.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task259-visual-skia --page 1 --policy skiaOptIn \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/복학원서.hwp \
+  samples/basic/KTX.hwp samples/hwp-multi-001.hwp
+du -sh Frameworks/universal/librhwp.a Frameworks/Rhwp.xcframework
+git diff --check
+```
+
+결과:
+
+| 검증 | 결과 |
+|---|---|
+| Rust/core lock 검증 | 통과 |
+| `rhwp-studio` asset 검증 | 통과 |
+| Shared AppKit/UIKit 금지 | 통과 |
+| Quick Look policy smoke | 통과, fallback 0 |
+| Visual diff CoreGraphics | sandbox 밖 재실행 통과 |
+| Visual diff Skia | sandbox 밖 재실행 통과 |
+| Package size 확인 | 통과 |
+| `git diff --check` | 통과 |
+
+## 다음 단계 승인 요청
+
+Stage 3에서는 이 측정값을 기준으로 Quick Look 기본 backend 정책을 확정한다. CoreGraphics default 복귀가 필요하다고 판단하면 `Sources/QLExtension/HwpPreviewProvider.swift`의 단일 PNG와 다중 PDF policy를 최소 수정하고, Skia opt-in smoke/helper와 Shared renderer contract는 유지한다.

--- a/mydocs/working/task_m020_259_stage3.md
+++ b/mydocs/working/task_m020_259_stage3.md
@@ -1,0 +1,144 @@
+# Task M020 #259 Stage 3 보고서 - Skia release policy 판정
+
+## 단계 개요
+
+- 이슈: #259 Skia backend visual/performance/package regression gate 정리
+- 단계: Stage 3. release policy 판정과 최소 보정
+- 기준 브랜치: `local/task259`
+- 목표: Stage 1-2 입력을 바탕으로 Quick Look 기본 backend 정책을 확정하고, 필요한 source 보정을 수행한다.
+
+## 정책 결정
+
+결론: `Quick Look 기본 CoreGraphics/native path 복귀 + Skia opt-in/diagnostic 경로 유지`
+
+이 결정은 Skia 기능을 제거하는 것이 아니다. `HwpPageImageRenderer`의 `.skiaOptIn`, fallback contract, diagnostics, smoke helper는 유지한다. 다만 release 기본 경로에서는 Quick Look preview가 안정적인 CoreGraphics/native renderer를 먼저 사용하도록 되돌린다.
+
+## 판정 근거
+
+| Gate | Stage 2 결과 | 판정 |
+|---|---|---|
+| Visual diff | `복학원서.hwp`는 Skia가 크게 개선됐지만 `KTX.hwp`는 changed pixel 31.1362%에서 47.1389%로 악화 | 문서별 방향이 갈려 default 근거 부족 |
+| Latency | Quick Look smoke에서 단일 PNG 일부는 Skia가 빠르지만, 다중 PDF 2개는 Skia가 느림 | 다중 preview default로 부담 |
+| First/render cost | `request.hwp` visual diff harness에서 Skia native render가 5,460.6ms | release default로 위험 |
+| Fallback | 측정 샘플 fallback 0 | 실패 안정성은 좋지만 품질/성능 판단을 대체하지 못함 |
+| Package size | `librhwp.a`는 #255 이전 대비 +95,019,768 bytes | 기본 경로 개선 근거가 부족한 상태에서는 비용이 큼 |
+| Surface 일관성 | Quick Look은 Skia 우선, Thumbnail은 CoreGraphics 기본이던 상태 | CoreGraphics 기본으로 맞추는 편이 release 설명이 단순함 |
+
+Stage 2 수치만으로는 Skia를 기본 경로로 유지할 만큼 일관된 품질/성능 개선이 확인되지 않았다. 따라서 Stage 3에서는 Quick Look provider의 기본 정책만 CoreGraphics로 보정한다.
+
+## Source 변경
+
+변경 파일:
+
+| 파일 | 변경 |
+|---|---|
+| `Sources/QLExtension/HwpPreviewProvider.swift` | 단일 PNG reply의 `HwpPageImageRenderer.renderPage(... policy:)`를 `.skiaOptIn`에서 `.coreGraphicsOnly`로 변경 |
+| `Sources/QLExtension/HwpPreviewProvider.swift` | 다중 PDF reply의 `HwpPreviewPDFRenderer.render(... policy:)`를 `.skiaOptIn`에서 `.coreGraphicsOnly`로 변경 |
+
+변경하지 않은 것:
+
+| 범위 | 유지 이유 |
+|---|---|
+| `HwpPageRenderPolicy.skiaOptIn` | 후속 diagnostic/smoke와 opt-in 실험 경로로 필요 |
+| Skia fallback/diagnostics | `backendUsed`, `fallbackReason`, `pngBytes`, `durationMs` contract 유지 |
+| `HwpPreviewPDFRenderer` public API | 기본값이 이미 `.coreGraphicsOnly`이고 opt-in 호출을 계속 지원 |
+| Thumbnail extension | 현재도 CoreGraphics 기본이므로 Stage 3에서 추가 변경 없음 |
+| `smoke-quicklook-skia-policy.sh` | CoreGraphics/Skia 비교 gate로 계속 필요 |
+
+## 변경 후 backend 정책
+
+| Surface | 변경 후 정책 | 의미 |
+|---|---|---|
+| Quick Look 단일 PNG | `.coreGraphicsOnly` | release 기본 preview는 CoreGraphics/native renderer 사용 |
+| Quick Look 다중 PDF | `.coreGraphicsOnly` | PDF page bitmap도 CoreGraphics/native renderer 사용 |
+| Finder Thumbnail | `.coreGraphicsOnly` 기본값 유지 | `renderFirstPage` 기본 정책 그대로 사용 |
+| Shared renderer | `.coreGraphicsOnly`, `.skiaOptIn` 모두 유지 | Skia는 명시 opt-in일 때만 사용 |
+
+## #258 진행 조건
+
+이번 결정으로 #258은 release 전 필수 작업에서 제외하는 쪽이 맞다.
+
+정리:
+
+1. Quick Look 기본이 CoreGraphics로 복귀했으므로, release surface의 기본 preview/thumbnail backend는 다시 일관된다.
+2. #258을 지금 진행해 Thumbnail까지 Skia를 확장하면 Stage 2에서 확인한 visual/latency 리스크를 더 넓히게 된다.
+3. #258은 "Finder thumbnail Skia default 적용"보다는 후속 "Skia opt-in thumbnail diagnostic/cache 설계"로 재범위화하는 것이 안전하다.
+4. 나중에 #258을 진행한다면 cache key에는 backend 정책, pixel bucket, `maximumPixelSize`/`maxDimension` 변환 signature가 반드시 포함되어야 한다.
+5. Skia를 release default로 다시 검토하려면 KTX류 악화 사례와 `request.hwp` first/render cost를 먼저 줄여야 한다.
+
+## 검증 결과
+
+### Source/policy 검색
+
+```bash
+rg -n "skiaOptIn|coreGraphicsOnly|HwpPageRenderPolicy|Preview selected|Preview rendering" \
+  Sources/QLExtension Sources/Shared Sources/ThumbnailExtension --glob '!**/Resources/**'
+```
+
+결과:
+
+- `Sources/QLExtension/HwpPreviewProvider.swift`의 단일 PNG와 다중 PDF 호출부가 `.coreGraphicsOnly`를 명시한다.
+- Shared renderer와 smoke 관련 Skia opt-in 경로는 남아 있다.
+- Thumbnail은 여전히 `renderFirstPage` 기본값을 사용한다.
+
+### Build
+
+실행:
+
+```bash
+./scripts/check-no-appkit.sh
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
+```
+
+결과:
+
+| 명령 | 결과 | 비고 |
+|---|---|---|
+| `./scripts/check-no-appkit.sh` | 통과 | `OK: shared Swift code has no AppKit/UIKit dependencies` |
+| `xcodebuild ... QLExtension ... build` | 통과 | sandbox 안에서는 Sparkle clone network 제한으로 실패 후 sandbox 밖 재실행 통과, `** BUILD SUCCEEDED ** [12.360 sec]` |
+| `xcodebuild ... HostApp ... build` | 통과 | sandbox 안에서는 SwiftPM/clang cache 쓰기 제한으로 실패 후 sandbox 밖 재실행 통과, `** BUILD SUCCEEDED ** [1.368 sec]` |
+| `xcodebuild ... ThumbnailExtension ... build` | 통과 | sandbox 밖 실행, `** BUILD SUCCEEDED ** [0.590 sec]` |
+
+### Policy smoke
+
+실행:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task259-after-policy \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+결과:
+
+| File | Reply | Pages | CG backend | CG sec | Skia backend | Skia sec | Fallback |
+|---|---|---:|---|---:|---|---:|---:|
+| `request.hwp` | png | 1 | `skia:0,cg:1,embedded:0` | 1.079998 | `skia:1,cg:0,embedded:0` | 0.069319 | 0 |
+| `hwpx-01.hwpx` | pdf | 9 | `skia:0,cg:9,embedded:0` | 0.372840 | `skia:9,cg:0,embedded:0` | 0.615025 | 0 |
+
+이 smoke는 helper가 CoreGraphics와 Skia opt-in 정책을 직접 비교하는 검증이다. Stage 3 source 변경 후에도 opt-in Skia 경로와 fallback 관측이 유지됨을 확인했다.
+
+### Hygiene
+
+```bash
+git diff --check
+```
+
+결과: 통과.
+
+## 남은 작업
+
+Stage 4에서 다음을 최종 보고서로 정리한다.
+
+- release readiness checklist
+- release note/known limitation 초안
+- #258 handoff 문구
+- 오늘할일 완료 처리
+
+## 다음 단계 승인 요청
+
+Stage 4에서는 #259 최종 보고서를 작성하고, Quick Look 기본 CoreGraphics 복귀와 Skia opt-in 유지 결론을 release note 후보까지 정리한다.


### PR DESCRIPTION
## Summary
- Quick Look Skia readiness gate를 정리하고 visual/performance/package 측정 결과를 문서화했습니다.
- Stage 2 결과에 따라 Quick Look 기본 backend를 CoreGraphics/native path로 되돌렸습니다.
- Skia opt-in renderer, fallback diagnostics, policy smoke helper는 유지했습니다.
- #258은 release 전 필수 default 전환 작업이 아니라 후속 thumbnail opt-in/cache diagnostic 설계로 재범위화하는 결론을 남겼습니다.

## Verification
- ./scripts/build-rust-macos.sh --verify-lock
- ./scripts/verify-rhwp-studio-assets.sh
- ./scripts/check-no-appkit.sh
- ./scripts/smoke-quicklook-skia-policy.sh build.noindex/task259-skia-policy ...
- ./scripts/preview-visual-diff-harness.sh build.noindex/task259-visual-cg ...
- ./scripts/preview-visual-diff-harness.sh build.noindex/task259-visual-skia --policy skiaOptIn ...
- xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
- xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedData-task259 CODE_SIGNING_ALLOWED=NO build
- git diff --check

## Notes
- Visual diff harness와 일부 xcodebuild 검증은 sandbox 제한으로 인해 sandbox 밖 재실행에서 통과했습니다.
- 최종 정책은 Quick Look/Thumbnail default = CoreGraphics, Skia = opt-in diagnostic backend입니다.