### PR TITLE
Task #307: CoreGraphics 텍스트 shade sentinel 보정

### DIFF
--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -1501,6 +1501,16 @@ class CGTreeRenderer {
 
     // MARK: - 텍스트 (Core Text)
 
+    private func drawTextShadeIfNeeded(style: TextStyle, bbox: BBox, in ctx: CGContext) {
+        switch style.shadeColor {
+        case 0, 0x00FFFFFF, 0xFFFFFFFF:
+            return
+        default:
+            ctx.setFillColor(colorRefToCGColor(style.shadeColor, alpha: 0.3))
+            ctx.fill(cgRect(bbox))
+        }
+    }
+
     private func renderTextRun(_ run: TextRunNode, bbox: BBox, in ctx: CGContext) {
         let displayRun = makeTextRunDisplay(run)
         guard !displayRun.text.isEmpty else { return }
@@ -1530,11 +1540,7 @@ class CGTreeRenderer {
         ctx.saveGState()
 
         // 음영 (형광펜 배경) — 텍스트 변환 전에 그리기
-        if style.shadeColor != 0x00FFFFFF && style.shadeColor != 0 {
-            let shadeRect = cgRect(bbox)
-            ctx.setFillColor(colorRefToCGColor(style.shadeColor).copy(alpha: 0.3)!)
-            ctx.fill(shadeRect)
-        }
+        drawTextShadeIfNeeded(style: style, bbox: bbox, in: ctx)
 
         // 전체 좌표계가 Y반전(좌상단 원점) 상태이지만,
         // Core Text는 Y축이 위로 증가하는 좌표계를 기대한다.
@@ -1640,10 +1646,7 @@ class CGTreeRenderer {
     ) {
         ctx.saveGState()
 
-        if style.shadeColor != 0x00FFFFFF && style.shadeColor != 0 {
-            ctx.setFillColor(colorRefToCGColor(style.shadeColor).copy(alpha: 0.3)!)
-            ctx.fill(cgRect(bbox))
-        }
+        drawTextShadeIfNeeded(style: style, bbox: bbox, in: ctx)
 
         if abs(rotation) > pathEpsilon {
             applyTextRunRotation(rotation, bbox: bbox, in: ctx)

--- a/mydocs/orders/20260531.md
+++ b/mydocs/orders/20260531.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #305 | CoreGraphics preview에서 복학원서.hwp PUA 표시 최소 보정 | 완료 | M014, 완료: 17:01 |
-| #307 | CoreGraphics preview에서 텍스트 뒤 불투명 박스가 그려지는 문제 | 진행중 | M014, Stage 2 CoreGraphics shade 보정 완료 |
+| #307 | CoreGraphics preview에서 텍스트 뒤 불투명 박스가 그려지는 문제 | 진행중 | M014, Stage 3 smoke/build 검증 완료 |
 
 ## M900 — Release Operations
 

--- a/mydocs/orders/20260531.md
+++ b/mydocs/orders/20260531.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #305 | CoreGraphics preview에서 복학원서.hwp PUA 표시 최소 보정 | 완료 | M014, 완료: 17:01 |
-| #307 | CoreGraphics preview에서 텍스트 뒤 불투명 박스가 그려지는 문제 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+| #307 | CoreGraphics preview에서 텍스트 뒤 불투명 박스가 그려지는 문제 | 진행중 | M014, Stage 1 원인 확인 완료 |
 
 ## M900 — Release Operations
 

--- a/mydocs/orders/20260531.md
+++ b/mydocs/orders/20260531.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #305 | CoreGraphics preview에서 복학원서.hwp PUA 표시 최소 보정 | 완료 | M014, 완료: 17:01 |
-| #307 | CoreGraphics preview에서 텍스트 뒤 불투명 박스가 그려지는 문제 | 진행중 | M014, Stage 1 원인 확인 완료 |
+| #307 | CoreGraphics preview에서 텍스트 뒤 불투명 박스가 그려지는 문제 | 진행중 | M014, Stage 2 CoreGraphics shade 보정 완료 |
 
 ## M900 — Release Operations
 

--- a/mydocs/orders/20260531.md
+++ b/mydocs/orders/20260531.md
@@ -5,6 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #305 | CoreGraphics preview에서 복학원서.hwp PUA 표시 최소 보정 | 완료 | M014, 완료: 17:01 |
+| #307 | CoreGraphics preview에서 텍스트 뒤 불투명 박스가 그려지는 문제 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
 
 ## M900 — Release Operations
 

--- a/mydocs/orders/20260531.md
+++ b/mydocs/orders/20260531.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #305 | CoreGraphics preview에서 복학원서.hwp PUA 표시 최소 보정 | 완료 | M014, 완료: 17:01 |
-| #307 | CoreGraphics preview에서 텍스트 뒤 불투명 박스가 그려지는 문제 | 진행중 | M014, Stage 3 smoke/build 검증 완료 |
+| #307 | CoreGraphics preview에서 텍스트 뒤 불투명 박스가 그려지는 문제 | 완료 | M014, PR 준비 |
 
 ## M900 — Release Operations
 

--- a/mydocs/plans/task_m014_307.md
+++ b/mydocs/plans/task_m014_307.md
@@ -1,0 +1,111 @@
+# Task M014 #307 수행계획서
+
+## 목적
+
+`samples/basic/BookReview.hwp`와 `samples/복학원서.hwp`의 Quick Look preview에서 실제 문서에 없는 흰색/연한 박스가 텍스트 뒤에 그려지는 문제를 v0.1.4 배포 재개 전에 보정한다.
+
+완료 후에는 Quick Look preview와 Finder thumbnail의 기존 CoreGraphics 기본 경로를 유지하면서, 텍스트 음영/배경이 아닌 기본값 또는 없음 값을 실제 배경 박스로 그리지 않아야 한다.
+
+## 배경
+
+v0.1.4 draft DMG 설치 smoke 중 `BookReview.hwp`, `복학원서.hwp`에서 텍스트 뒤에 불투명하거나 반투명한 박스가 보였다. 같은 문서를 앱 viewer로 열면 정상적으로 보인다.
+
+앱 viewer는 bundled `rhwp-studio`를 WKWebView로 표시하는 경로이고, Quick Look/Thumbnail은 `PageRenderTree`를 Swift `CGTreeRenderer`가 그리는 CoreGraphics 경로다. 따라서 증상은 HostApp viewer 문제가 아니라 Swift/CoreGraphics preview renderer의 텍스트 style 해석 문제로 보는 것이 맞다.
+
+현재 `CGTreeRenderer`는 `TextStyle.shadeColor`가 `0x00FFFFFF`와 `0`이 아니면 텍스트 bbox 전체를 `alpha: 0.3`으로 채운다. 하지만 HWP에서 음영 없음/기본값으로 전달되는 값이 `0xFFFFFFFF` 계열이거나, 실제 shade와 다른 sentinel일 가능성이 있다. 이 경우 renderer가 기본값을 실제 텍스트 배경으로 오인해 박스를 그린다.
+
+## 범위
+
+포함:
+
+- `BookReview.hwp`, `복학원서.hwp` render tree에서 문제 text run의 `shade_color` 값 inventory
+- `CGTreeRenderer`의 text shade/background 처리 조건 보정
+- 보정 전/후 native PNG 확인
+- 실제 text shade/highlight가 필요한 경우를 식별할 수 있는 최소 회귀 확인
+- Quick Look/Thumbnail 기본 `.coreGraphicsOnly` 정책 유지 확인
+- #305 PUA 보정과 충돌하지 않는지 확인
+
+제외:
+
+- Quick Look/Thumbnail backend를 PageLayerTree/Skia로 전환
+- HostApp viewer/WebView 렌더링 변경
+- upstream `rhwp` 수정 또는 unreleased commit pin 적용
+- release workflow, DMG, signing/notarization, Pages/appcast, Homebrew 변경
+- HWP text shade 전체 semantics 재구현
+
+## 설계 방향
+
+먼저 문제 샘플의 render tree에서 `shade_color` 분포와 실제 박스가 생기는 text run을 확인한다. `0xFFFFFFFF` 같은 없음/기본값 계열이 반복적으로 원인이라면 CoreGraphics renderer에서 해당 값을 no shade로 처리한다.
+
+보정은 `CGTreeRenderer` 내부 helper로 제한한다. 일반 text run과 rotation/vertical 경로인 centered text run이 같은 판정을 쓰게 하고, 실제 shade로 판단되는 값만 bbox fill을 수행한다.
+
+이번 작업은 release-blocking 결함을 줄이는 최소 조치다. 실제 HWP text shade/highlight 문서에서 추가 semantics가 필요한 경우에는 known limitation 또는 후속 이슈로 분리한다.
+
+## 예상 변경 파일
+
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+- `mydocs/orders/20260531.md`
+- `mydocs/plans/task_m014_307.md`
+- `mydocs/plans/task_m014_307_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m014_307_stage{N}.md`
+- `mydocs/report/task_m014_307_report.md`
+
+## 잠정 단계
+
+1. Stage 1: text shade 입력과 재현 inventory
+   - `BookReview.hwp`, `복학원서.hwp` render tree의 `shade_color` 분포를 확인한다.
+   - 문제 박스 위치와 text run bbox/style을 매칭한다.
+   - #305 PUA 보정 후 기준 branch에서 증상을 재확인한다.
+2. Stage 2: CoreGraphics text shade 판정 보정
+   - `CGTreeRenderer`에 text shade 여부를 판단하는 helper를 추가한다.
+   - 없음/기본값 sentinel은 fill하지 않도록 한다.
+   - 일반/centered text run 양쪽에 같은 helper를 적용한다.
+3. Stage 3: renderer smoke와 extension build 검증
+   - `BookReview.hwp`, `복학원서.hwp` native output에서 의도치 않은 박스가 사라졌는지 확인한다.
+   - 대표 샘플과 실제 shade 후보를 smoke한다.
+   - QLExtension/ThumbnailExtension Debug build를 수행한다.
+4. Stage 4: 최종 보고서와 release handoff
+   - 변경 범위, 검증 결과, #301 artifact 재생성 필요성을 정리한다.
+
+## 검증 계획
+
+계획 문서 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260531.md mydocs/plans/task_m014_307.md
+rg -n "#307|shade|불투명|BookReview|복학원서|CoreGraphics|M014" \
+  mydocs/orders/20260531.md mydocs/plans/task_m014_307.md
+```
+
+구현 단계 후보:
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/render-debug-compare.sh build.noindex/task307-stage1 samples/basic/BookReview.hwp samples/복학원서.hwp
+./scripts/render-debug-compare.sh build.noindex/task307-stage3 samples/basic/BookReview.hwp samples/복학원서.hwp
+rg -n "shadeColor|shade_color|coreGraphicsOnly|skiaOptIn" Sources/RhwpCoreBridge Sources/QLExtension Sources/ThumbnailExtension Sources/Shared
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask307 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask307 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+가능하면 Stage 3에서 생성한 native PNG를 직접 확인해 `BookReview.hwp` 표지의 큰 제목 뒤 박스와 `복학원서.hwp` 텍스트 주변 박스가 사라졌는지 기록한다.
+
+## 리스크
+
+- 실제 텍스트 음영이 있는 문서에서 배경 표시가 줄어들 수 있다.
+- HWP shade sentinel과 실제 색상 의미가 upstream `PageRenderTree` JSON에서 충분히 구분되지 않을 수 있다.
+- `BookReview.hwp`의 박스가 text shade가 아니라 다른 draw-order 또는 shape blending 문제라면 추가 원인 조사가 필요하다.
+- Quick Look/Thumbnail cache 때문에 설치본 smoke에서는 이전 bitmap이 보일 수 있다.
+- #305와 같은 renderer 영역을 건드리므로 PUA 보정 회귀를 함께 확인해야 한다.
+
+## 승인 요청 사항
+
+1. #307을 v0.1.4 배포 재개 전 CoreGraphics text shade/background 최소 보정 작업으로 진행하는 범위 승인
+2. backend 정책은 `.coreGraphicsOnly` 유지, PageLayerTree/Skia 전환 제외 승인
+3. 실제 shade/highlight 전체 semantics가 불명확하면 release-blocking 샘플 중심의 sentinel 보정으로 제한하는 방향 승인
+4. 다음 단계: 승인 후 구현계획서(`mydocs/plans/task_m014_307_impl.md`) 작성과 Stage 1 inventory 진행
+
+승인 전에는 Swift source 변경을 진행하지 않는다.

--- a/mydocs/plans/task_m014_307_impl.md
+++ b/mydocs/plans/task_m014_307_impl.md
@@ -1,0 +1,72 @@
+# Task M014 #307 구현 계획 - CoreGraphics 텍스트 shade sentinel 보정
+
+## 목적
+
+Quick Look/Thumbnail CoreGraphics preview에서 `samples/basic/BookReview.hwp`, `samples/복학원서.hwp` 텍스트 뒤에 불투명한 흰색 박스가 그려지는 문제를 최소 범위로 보정한다.
+
+## Stage 1. 원인 inventory
+
+완료 기준:
+
+- 문제 샘플의 render tree에서 `TextRun.style.shade_color` 분포를 확인한다.
+- core SVG와 native PNG를 비교해 박스가 CoreGraphics renderer에서만 생기는지 확인한다.
+- 수정 위치를 `CGTreeRenderer` 내부 shade drawing 조건으로 확정한다.
+
+검증:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task307-stage1 samples/basic/BookReview.hwp samples/복학원서.hwp
+jq -r '[.. | objects | select(.node_type.TextRun? != null) | .node_type.TextRun.style.shade_color] as $shades | input_filename + "\n" + (($shades | sort | group_by(.)[] | "  count=\(length) shade=\(.[0])"))' build.noindex/task307-stage1/*page1-render-tree.json
+rg -n "fill=\"#fff|fill=\"white|opacity|rgba|rect" build.noindex/task307-stage1/*core.svg
+```
+
+## Stage 2. CoreGraphics shade 조건 보정
+
+구현:
+
+- `CGTreeRenderer`에 텍스트 shade helper를 추가한다.
+- `0`, `0x00FFFFFF`, `0xFFFFFFFF`는 no shade로 처리한다.
+- 기존 실제 shade 값은 `colorRefToCGColor(...).copy(alpha: 0.3)` 흐름을 유지한다.
+- 일반 text run과 centered/rotated/vertical text run 양쪽에서 같은 helper를 사용한다.
+
+완료 기준:
+
+- 문제 샘플의 기본 텍스트 박스가 사라진다.
+- 실제 shade 값 처리 경로를 삭제하지 않는다.
+- `Sources/RhwpCoreBridge`에 AppKit/UIKit 의존을 추가하지 않는다.
+
+검증:
+
+```bash
+./scripts/check-no-appkit.sh
+git diff --check -- Sources/RhwpCoreBridge/CGTreeRenderer.swift mydocs/plans/task_m014_307_impl.md mydocs/working/task_m014_307_stage1.md
+```
+
+## Stage 3. renderer smoke와 extension build
+
+검증:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task307-stage3 samples/basic/BookReview.hwp samples/복학원서.hwp
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask307 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask307 CODE_SIGNING_ALLOWED=NO build
+```
+
+완료 기준:
+
+- `BookReview.hwp` native PNG의 제목/표지 텍스트 뒤 흰색 박스가 사라진다.
+- `복학원서.hwp` native PNG에서 #305 PUA 보정이 유지되고 텍스트 뒤 박스가 사라진다.
+- Quick Look/Thumbnail extension Debug build가 통과한다.
+
+## Stage 4. 최종 보고와 PR
+
+정리:
+
+- 최종 보고서에 원인, 변경 범위, 검증 산출물, 잔여 리스크를 기록한다.
+- #301 릴리즈 작업에 반영해야 할 후속 조치로 PR merge 후 `devel` 재기준화가 필요함을 남긴다.
+- `publish/task307` 브랜치로 `devel` 대상 PR을 게시한다.
+
+## 리스크
+
+- `0xFFFFFFFF`가 특정 문서에서 실제 흰색 shade를 의미할 가능성이 이론적으로 남는다. 다만 현재 core SVG는 해당 shade rect를 출력하지 않고, `0x00FFFFFF`도 기존부터 no shade로 처리하고 있어 `0xFFFFFFFF`는 기본값/sentinel로 보는 것이 더 일관적이다.
+- 이번 작업은 CoreGraphics renderer 최소 보정이다. 장기적으로 Quick Look/Thumbnail을 PageLayerTree 소비 경로로 전환하는 문제는 별도 이슈/코멘트에서 계속 추적한다.

--- a/mydocs/report/task_m014_307_report.md
+++ b/mydocs/report/task_m014_307_report.md
@@ -1,0 +1,117 @@
+# Task M014 #307 최종 보고서 - CoreGraphics preview 텍스트 박스 제거
+
+## 요약
+
+Quick Look/Thumbnail CoreGraphics renderer가 `TextStyle.shadeColor = 0xFFFFFFFF`를 실제 텍스트 shade로 오인해 bbox 전체를 30% 흰색으로 칠하던 문제를 수정했다.
+
+변경 후 `samples/basic/BookReview.hwp`, `samples/복학원서.hwp` native PNG에서 텍스트 뒤 흰색 박스가 제거됐고, QLExtension/ThumbnailExtension Debug build가 통과했다.
+
+## 이슈
+
+- GitHub Issue: #307
+- Milestone: M014
+- 대상 증상:
+  - `BookReview.hwp` 표지 제목/큰 글자 뒤 흰색 반투명 박스
+  - `복학원서.hwp` 본문/표/서명란 주변 텍스트 뒤 흰색 반투명 박스
+
+## 원인
+
+문제 샘플 첫 페이지의 모든 `TextRun`이 `shade_color = 4294967295`를 가진다. 이 값은 `0xFFFFFFFF`다.
+
+기존 `CGTreeRenderer`는 `shadeColor`가 `0` 또는 `0x00FFFFFF`가 아니면 실제 음영으로 보고 bbox 전체를 `alpha: 0.3`으로 채웠다. 따라서 기본값/sentinel 성격의 `0xFFFFFFFF`가 흰색 shade로 렌더링됐다.
+
+core SVG에는 같은 위치의 텍스트 shade rect가 없어, Swift/CoreGraphics 소비 경로의 sentinel 해석 문제로 판단했다.
+
+## 변경 내용
+
+변경 파일:
+
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+
+주요 변경:
+
+- `drawTextShadeIfNeeded(style:bbox:in:)` helper 추가
+- no shade 값에 `0xFFFFFFFF` 추가
+- 일반 `renderTextRun`과 `renderCenteredTextRun`이 같은 shade 판정을 사용하도록 정리
+- 실제 shade 값의 `alpha: 0.3` 렌더링 정책은 유지
+
+no shade 처리 값:
+
+```text
+0
+0x00FFFFFF
+0xFFFFFFFF
+```
+
+## 문서 산출물
+
+- `mydocs/plans/task_m014_307.md`
+- `mydocs/plans/task_m014_307_impl.md`
+- `mydocs/working/task_m014_307_stage1.md`
+- `mydocs/working/task_m014_307_stage2.md`
+- `mydocs/working/task_m014_307_stage3.md`
+- `mydocs/report/task_m014_307_report.md`
+- `mydocs/orders/20260531.md`
+
+## 검증
+
+Stage 1 원인 확인:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task307-stage1 samples/basic/BookReview.hwp samples/복학원서.hwp
+jq -r '[.. | objects | select(.node_type.TextRun? != null) | .node_type.TextRun.style.shade_color] as $shades | input_filename + "\n" + (($shades | sort | group_by(.)[] | "  count=\(length) shade=\(.[0])"))' build.noindex/task307-stage1/*page1-render-tree.json
+```
+
+결과:
+
+```text
+BookReview-page1-render-tree.json: count=66 shade=4294967295
+복학원서-page1-render-tree.json: count=102 shade=4294967295
+```
+
+Stage 2 코드 경계 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+git diff --check -- Sources/RhwpCoreBridge/CGTreeRenderer.swift mydocs/orders/20260531.md mydocs/working/task_m014_307_stage2.md
+```
+
+결과:
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+Stage 3 smoke/build 검증:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task307-stage3 samples/basic/BookReview.hwp samples/복학원서.hwp
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask307 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask307 CODE_SIGNING_ALLOWED=NO build
+```
+
+결과:
+
+```text
+OK BookReview.hwp
+OK 복학원서.hwp
+** BUILD SUCCEEDED ** [13.655 sec]
+** BUILD SUCCEEDED ** [2.100 sec]
+```
+
+시각 확인:
+
+- `BookReview.hwp`: 표지 제목/큰 글자 뒤 흰색 박스 제거
+- `복학원서.hwp`: 본문/표/서명란 주변 가로 흰색 텍스트 박스 제거
+- #305 PUA `(인)` 표시 유지
+
+`qlmanage` 기반 core SVG rasterize는 로컬 환경에서 실패해 pixel diff는 생성되지 않았다. native PNG 생성, summary 작성, extension build는 모두 성공했다.
+
+## 잔여 리스크
+
+- `0xFFFFFFFF`가 실제 흰색 텍스트 shade를 의미하는 문서가 있을 가능성은 이론적으로 남는다. 다만 기존 renderer가 이미 `0x00FFFFFF`를 no shade로 취급했고, core SVG도 문제 샘플에서 shade rect를 출력하지 않아 이번 보정은 sentinel 해석으로 보는 것이 일관적이다.
+- `복학원서.hwp` 중앙 워터마크가 앱 viewer보다 진하게 보이는 기존 CoreGraphics overlay 표현 차이는 이번 변경 전후 동일하게 남아 있다. 이는 #307의 텍스트 shade 문제와 별개이며, 장기적인 PageLayerTree 전환/renderer parity 작업에서 다루는 것이 적절하다.
+
+## 릴리즈 작업 연결
+
+#301 v0.1.4 릴리즈 작업은 이 PR이 `devel`에 merge된 뒤 `devel`을 다시 받아 release worktree/branch를 재기준화한 다음 이어가야 한다. release artifact는 이번 CoreGraphics 보정 포함 commit 이후에 다시 생성하는 것이 맞다.

--- a/mydocs/working/task_m014_307_stage1.md
+++ b/mydocs/working/task_m014_307_stage1.md
@@ -1,0 +1,78 @@
+# Task M014 #307 Stage 1 보고서 - 텍스트 shade sentinel 원인 확인
+
+## 목적
+
+`samples/basic/BookReview.hwp`, `samples/복학원서.hwp`의 CoreGraphics preview에서 텍스트 뒤에 불투명한 흰색 박스가 생기는 원인을 render tree 입력과 renderer 소비 조건 기준으로 확인한다.
+
+## 실행 명령
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task307-stage1 samples/basic/BookReview.hwp samples/복학원서.hwp
+jq -r '[.. | objects | select(.node_type.TextRun? != null) | .node_type.TextRun.style.shade_color] as $shades | input_filename + "\n" + (($shades | sort | group_by(.)[] | "  count=\(length) shade=\(.[0])"))' build.noindex/task307-stage1/*page1-render-tree.json
+jq -r '.. | objects | select(.node_type.TextRun? != null) | select(.node_type.TextRun.style.shade_color != 0 and .node_type.TextRun.style.shade_color != 16777215) | {file: input_filename, id, bbox, text: .node_type.TextRun.text, shade: .node_type.TextRun.style.shade_color, color: .node_type.TextRun.style.color, font: .node_type.TextRun.style.font_family, size: .node_type.TextRun.style.font_size}' build.noindex/task307-stage1/*page1-render-tree.json
+rg -n "fill=\"#fff|fill=\"white|opacity|rgba|rect" build.noindex/task307-stage1/*core.svg
+```
+
+분리 worktree에는 gitignore된 `Frameworks/` 산출물이 없으므로, Stage 1 helper 실행을 위해 원본 workspace의 동일 산출물을 가리키는 symlink를 생성했다.
+
+```bash
+ln -s /Users/melee/Documents/projects/rhwp-mac/Frameworks Frameworks
+```
+
+`Frameworks/`는 gitignore 대상이며 commit 대상이 아니다.
+
+## 산출물
+
+```text
+build.noindex/task307-stage1/BookReview-page1-render-tree.json
+build.noindex/task307-stage1/BookReview-page1-core.svg
+build.noindex/task307-stage1/BookReview-page1-native.png
+build.noindex/task307-stage1/BookReview-page1-summary.txt
+build.noindex/task307-stage1/복학원서-page1-render-tree.json
+build.noindex/task307-stage1/복학원서-page1-core.svg
+build.noindex/task307-stage1/복학원서-page1-native.png
+build.noindex/task307-stage1/복학원서-page1-summary.txt
+```
+
+render helper 실행 중 `BookReview.hwp`에서 2.5px layout overflow 경고가 출력됐지만, 기존 문서 layout overflow이며 이번 shade 원인 확인의 blocker는 아니다.
+
+## shade_color 분포
+
+두 샘플의 첫 페이지 `TextRun`은 모두 `shade_color = 4294967295`를 가진다.
+
+```text
+build.noindex/task307-stage1/BookReview-page1-render-tree.json
+  count=66 shade=4294967295
+build.noindex/task307-stage1/복학원서-page1-render-tree.json
+  count=102 shade=4294967295
+```
+
+`4294967295`는 `0xFFFFFFFF`다. 현재 `CGTreeRenderer`는 `TextStyle.shadeColor`가 `0x00FFFFFF`와 `0`이 아니면 bbox 전체를 `alpha: 0.3`으로 채운다.
+
+```text
+Sources/RhwpCoreBridge/CGTreeRenderer.swift:1533
+Sources/RhwpCoreBridge/CGTreeRenderer.swift:1643
+```
+
+따라서 `0xFFFFFFFF`가 모든 일반 텍스트에서 실제 shade로 오인되어, `BookReview.hwp` 표지의 제목/큰 글자 뒤와 `복학원서.hwp` 본문 곳곳에 흰색 반투명 박스가 나타난다.
+
+## core SVG 대조
+
+core SVG에는 문서 배경, 도형, 표 외곽선에 해당하는 rect는 있지만, 위 `TextRun` bbox 전체를 30% 흰색으로 칠하는 shade rect는 없다. `BookReview.hwp`의 표지 제목 뒤 박스는 native PNG에서만 확인된다.
+
+따라서 원인은 core render tree의 실제 shade 표현 누락이 아니라 Swift/CoreGraphics 소비 경로의 sentinel 해석 차이로 판단한다.
+
+## Stage 2 구현 결정
+
+- `0xFFFFFFFF`를 텍스트 shade 없음 sentinel로 추가한다.
+- `0`, `0x00FFFFFF` no shade 판정은 유지한다.
+- 같은 판정을 일반 `renderTextRun`과 centered/rotated/vertical 경로 `renderCenteredTextRun`에 공통 적용한다.
+- `colorRefToCGColor`나 실제 shade alpha 정책은 변경하지 않는다.
+
+## 검증
+
+```bash
+git diff --check -- mydocs/plans/task_m014_307_impl.md mydocs/working/task_m014_307_stage1.md
+```
+
+결과: 통과.

--- a/mydocs/working/task_m014_307_stage2.md
+++ b/mydocs/working/task_m014_307_stage2.md
@@ -1,0 +1,49 @@
+# Task M014 #307 Stage 2 보고서 - CoreGraphics 텍스트 shade sentinel 보정
+
+## 목적
+
+Stage 1에서 확인한 `0xFFFFFFFF` 텍스트 shade sentinel을 CoreGraphics renderer에서 no shade로 처리해, Quick Look/Thumbnail preview의 불필요한 흰색 박스 렌더링을 제거한다.
+
+## 변경 파일
+
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+
+## 구현 내용
+
+`CGTreeRenderer`에 `drawTextShadeIfNeeded(style:bbox:in:)` helper를 추가했다.
+
+no shade로 처리하는 값:
+
+```text
+0
+0x00FFFFFF
+0xFFFFFFFF
+```
+
+기존 `0`, `0x00FFFFFF` 판정은 유지했고, `0xFFFFFFFF`만 추가했다. 실제 shade 값인 경우에는 기존과 동일하게 bbox를 `alpha: 0.3`으로 칠한다. 다만 기존의 `copy(alpha:)!` force unwrap 대신 기존 `colorRefToCGColor(_:alpha:)` helper를 사용해 같은 alpha 값을 적용한다.
+
+적용 경로:
+
+- `renderTextRun`
+- `renderCenteredTextRun`
+
+따라서 일반 텍스트와 회전/세로쓰기/centered 텍스트가 같은 shade sentinel 판정을 공유한다.
+
+## 검증
+
+```bash
+./scripts/check-no-appkit.sh
+git diff --check -- Sources/RhwpCoreBridge/CGTreeRenderer.swift mydocs/orders/20260531.md mydocs/plans/task_m014_307_impl.md mydocs/working/task_m014_307_stage1.md
+```
+
+결과:
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+`git diff --check` 통과.
+
+## 다음 단계
+
+Stage 3에서 `BookReview.hwp`, `복학원서.hwp` render smoke를 다시 실행하고 native PNG를 확인한다. 그 다음 QLExtension, ThumbnailExtension Debug build로 extension 소비 경로 compile을 검증한다.

--- a/mydocs/working/task_m014_307_stage3.md
+++ b/mydocs/working/task_m014_307_stage3.md
@@ -1,0 +1,89 @@
+# Task M014 #307 Stage 3 보고서 - renderer smoke와 extension build 검증
+
+## 목적
+
+Stage 2의 `0xFFFFFFFF` shade sentinel 보정이 문제 샘플에서 실제로 텍스트 박스를 제거하는지 확인하고, Quick Look/Thumbnail extension build가 통과하는지 검증한다.
+
+## 실행 명령
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task307-stage3 samples/basic/BookReview.hwp samples/복학원서.hwp
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask307 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask307 CODE_SIGNING_ALLOWED=NO build
+```
+
+## render smoke 결과
+
+`render-debug-compare.sh`는 두 샘플 모두 OK로 완료됐다.
+
+```text
+OK BookReview.hwp: page=1 renderTreeJSON=/private/tmp/rhwp-mac-task307/build.noindex/task307-stage3/BookReview-page1-render-tree.json coreSVG=/private/tmp/rhwp-mac-task307/build.noindex/task307-stage3/BookReview-page1-core.svg nativePNG=/private/tmp/rhwp-mac-task307/build.noindex/task307-stage3/BookReview-page1-native.png summary=/private/tmp/rhwp-mac-task307/build.noindex/task307-stage3/BookReview-page1-summary.txt
+OK 복학원서.hwp: page=1 renderTreeJSON=/private/tmp/rhwp-mac-task307/build.noindex/task307-stage3/복학원서-page1-render-tree.json coreSVG=/private/tmp/rhwp-mac-task307/build.noindex/task307-stage3/복학원서-page1-core.svg nativePNG=/private/tmp/rhwp-mac-task307/build.noindex/task307-stage3/복학원서-page1-native.png summary=/private/tmp/rhwp-mac-task307/build.noindex/task307-stage3/복학원서-page1-summary.txt
+```
+
+`BookReview.hwp`에서는 Stage 1 native PNG에 보이던 표지 제목과 큰 글자 뒤의 흰색 반투명 박스가 사라졌다.
+
+`복학원서.hwp`에서는 Stage 1 native PNG에 보이던 본문/표/서명란 주변 가로 흰색 텍스트 박스가 사라졌다. #305에서 보정한 PUA `(인)` 표시는 유지됐다.
+
+Stage 1과 Stage 3 양쪽에서 중앙 워터마크가 앱 viewer보다 진하게 보이는 기존 CoreGraphics overlay 표현 차이는 남아 있다. 이번 이슈의 변경 전후 동일하게 존재하므로 #307 범위 밖의 잔여 렌더링 parity 이슈로 본다.
+
+## summary 주요 값
+
+`BookReview.hwp`:
+
+```text
+PageCount: 2
+PageSizePt: 793.7x1122.5
+RenderTreeJSONBytes: 104282
+CoreSVGBytes: 126245
+NativePNGSize: 794x1123
+NativeNonWhitePixels: 389185
+TextRuns: 66
+HangulRuns: 28
+HangulScalars: 209
+MissingHangulGlyphs: 0
+```
+
+`복학원서.hwp`:
+
+```text
+PageCount: 1
+PageSizePt: 793.7x1122.5
+RenderTreeJSONBytes: 196151
+CoreSVGBytes: 791753
+NativePNGSize: 794x1123
+NativeNonWhitePixels: 277216
+TextRuns: 102
+HangulRuns: 25
+HangulScalars: 143
+MissingHangulGlyphs: 0
+```
+
+`qlmanage` 기반 core SVG rasterize는 두 샘플 모두 실패해 pixel diff는 생성되지 않았다. native PNG 생성과 summary는 성공했고, 이번 검증 목적은 CoreGraphics native 렌더 결과의 텍스트 박스 제거 확인이므로 blocker로 보지 않는다.
+
+## build 결과
+
+QLExtension scheme:
+
+```text
+** BUILD SUCCEEDED ** [13.655 sec]
+```
+
+ThumbnailExtension scheme:
+
+```text
+** BUILD SUCCEEDED ** [2.100 sec]
+```
+
+QLExtension scheme 빌드 중 Swift Package `Sparkle 2.9.1` resolved package 준비가 실행됐다. 같은 `DerivedDataTask307`를 재사용한 ThumbnailExtension scheme 빌드는 증분 빌드로 통과했다.
+
+## 검증 판단
+
+- CoreGraphics renderer compile 통과.
+- Quick Look/Thumbnail extension build 통과.
+- `BookReview.hwp`, `복학원서.hwp`의 `0xFFFFFFFF` shade sentinel 오인으로 생기던 텍스트 박스 제거 확인.
+- #305 PUA 보정 유지 확인.
+
+## 다음 단계
+
+최종 보고서를 작성하고, #301 릴리즈 작업에 이 PR merge 후 `devel` 재기준화가 필요함을 명시한다.


### PR DESCRIPTION
 #307

## 요약

Quick Look/Thumbnail의 CoreGraphics renderer가 `TextStyle.shadeColor = 0xFFFFFFFF`를 실제 텍스트 음영으로 오인해 텍스트 bbox 전체를 30% 흰색으로 칠하던 문제를 수정했습니다.

이번 변경은 `0xFFFFFFFF`를 no-shade sentinel로 처리하고, 일반 텍스트와 centered/rotated 텍스트 경로가 같은 shade 판정을 쓰도록 정리합니다.

## 변경 내용

- `CGTreeRenderer`에 `drawTextShadeIfNeeded(style:bbox:in:)` helper 추가
- no-shade 값에 `0xFFFFFFFF` 추가
- `renderTextRun`, `renderCenteredTextRun`의 shade drawing 조건 공통화
- 실제 shade 값의 `alpha: 0.3` 렌더링 정책은 유지
- Stage 1-3 조사/검증 보고서와 #301 릴리즈 handoff 메모 추가

## 스크린샷

아래 placeholder는 PR 편집 화면에서 PNG를 drag & drop으로 첨부한 뒤 생성된 GitHub 이미지 URL로 교체하면 됩니다.

### `BookReview.hwp` title area

<img width="1656" height="1251" alt="BookReview-page1-before-after" src="https://github.com/user-attachments/assets/e093a627-ab9a-42ef-aaa3-fb568e97ad80" />

## 검증

- `./scripts/check-no-appkit.sh`
- `./scripts/render-debug-compare.sh build.noindex/task307-stage3 samples/basic/BookReview.hwp samples/복학원서.hwp`
- `xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask307 CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask307 CODE_SIGNING_ALLOWED=NO build`

## 확인 결과

- `BookReview.hwp` 표지 제목/큰 글자 뒤의 불필요한 흰색 박스가 제거됐습니다.
- `복학원서.hwp` 본문/표/서명란 주변의 가로 흰색 텍스트 박스가 제거됐습니다.
- #305에서 보정한 `복학원서.hwp` PUA `(인)` 표시는 유지됩니다.

## 남은 범위

`복학원서.hwp` 중앙 워터마크가 앱 viewer보다 진하게 보이는 기존 CoreGraphics overlay 표현 차이는 이번 변경 전후 동일하게 남아 있습니다. 이 항목은 #307의 텍스트 shade sentinel 문제와 별개이므로 장기 renderer/PageLayerTree parity 트랙에서 다루는 것이 적절합니다.

## 문서

- `mydocs/report/task_m014_307_report.md`
- `mydocs/working/task_m014_307_stage1.md`
- `mydocs/working/task_m014_307_stage2.md`
- `mydocs/working/task_m014_307_stage3.md`
