### PR TITLE
Task #301: Homebrew Cask v0.1.4 반영

### DIFF
--- a/Casks/alhangeul.rb
+++ b/Casks/alhangeul.rb
@@ -1,6 +1,6 @@
 cask "alhangeul" do
-  version "0.1.2"
-  sha256 "37a27321f03a84b8b28749b5f839ea5c5833975d20f2479e3b79ebd665811ead"
+  version "0.1.4"
+  sha256 "cf04cb23e9bd072d9852cc404d092824446c7177ffb23a9bf16d1d1438317c6b"
 
   url "https://github.com/postmelee/alhangeul-macos/releases/download/v#{version}/alhangeul-macos-#{version}.dmg"
   name "알한글"


### PR DESCRIPTION
## Summary
- Update repository Cask source to v0.1.4.
- Use public DMG SHA256 cf04cb23e9bd072d9852cc404d092824446c7177ffb23a9bf16d1d1438317c6b.
- Mirrors postmelee/homebrew-tap commit 5c3d4ee.

## Validation
- ./scripts/update-cask-sha256.sh --dry-run 0.1.4 build.noindex/release/public-v0.1.4/alhangeul-macos-0.1.4.dmg.sha256
- brew style --cask alhangeul
- brew audit --cask alhangeul
- brew audit --cask --new alhangeul
- brew install --cask postmelee/tap/alhangeul
- brew uninstall --cask alhangeul