### PR TITLE
Release v0.1.4 Homebrew Cask source sync

### DIFF
--- a/Casks/alhangeul.rb
+++ b/Casks/alhangeul.rb
@@ -1,6 +1,6 @@
 cask "alhangeul" do
-  version "0.1.2"
-  sha256 "37a27321f03a84b8b28749b5f839ea5c5833975d20f2479e3b79ebd665811ead"
+  version "0.1.4"
+  sha256 "cf04cb23e9bd072d9852cc404d092824446c7177ffb23a9bf16d1d1438317c6b"
 
   url "https://github.com/postmelee/alhangeul-macos/releases/download/v#{version}/alhangeul-macos-#{version}.dmg"
   name "알한글"


### PR DESCRIPTION
## Summary
- Sync repository Cask source to the published v0.1.4 Homebrew state.
- Includes PR #310 merged to devel.
- Matches postmelee/homebrew-tap commit 5c3d4ee.

## Validation
- PR #310 CI passed.
- postmelee/homebrew-tap Cask points to 0.1.4 and SHA256 cf04cb23e9bd072d9852cc404d092824446c7177ffb23a9bf16d1d1438317c6b.
- brew style/audit/install/uninstall smoke passed.