### PR TITLE
Task #301: 이전 릴리즈 안내 자동화 main 반영

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -80,10 +80,17 @@ jobs:
           bash scripts/ci/check-rhwp-upstream-release.sh --help
           bash scripts/ci/detect-rhwp-studio-impact.sh --help
           bash scripts/ci/prepare-pages-artifact.sh --help
+          bash scripts/ci/update-release-version-notices.sh --help
           bash scripts/ci/write-rhwp-studio-sync-pr-body.sh --help
           bash scripts/ci/write-sparkle-appcast.sh --help
           bash scripts/sync-rhwp-studio.sh --help
           bash scripts/verify-rhwp-studio-assets.sh --help
+
+      - name: Check release note version notices
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check
 
       - name: Record classification summary
         shell: bash

--- a/docs/updates/v0.1.0.html
+++ b/docs/updates/v0.1.0.html
@@ -44,9 +44,9 @@
 
   <aside class="release-version-notice" aria-label="최신 릴리즈 안내">
     <div class="release-version-notice-inner">
-      <p><strong>이 문서는 이전 버전(v0.1.0)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.3에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
+      <p><strong>이 문서는 이전 버전(v0.1.0)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.4에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
       <div class="release-version-notice-actions">
-        <a class="notice-primary-link" href="./v0.1.3.html">최신 릴리즈 노트</a>
+        <a class="notice-primary-link" href="./v0.1.4.html">최신 릴리즈 노트</a>
         <a class="notice-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"
           rel="noreferrer">GitHub 최신 릴리즈</a>
       </div>

--- a/docs/updates/v0.1.1.html
+++ b/docs/updates/v0.1.1.html
@@ -44,9 +44,9 @@
 
   <aside class="release-version-notice" aria-label="최신 릴리즈 안내">
     <div class="release-version-notice-inner">
-      <p><strong>이 문서는 이전 버전(v0.1.1)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.3에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
+      <p><strong>이 문서는 이전 버전(v0.1.1)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.4에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
       <div class="release-version-notice-actions">
-        <a class="notice-primary-link" href="./v0.1.3.html">최신 릴리즈 노트</a>
+        <a class="notice-primary-link" href="./v0.1.4.html">최신 릴리즈 노트</a>
         <a class="notice-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"
           rel="noreferrer">GitHub 최신 릴리즈</a>
       </div>

--- a/docs/updates/v0.1.2.html
+++ b/docs/updates/v0.1.2.html
@@ -44,9 +44,9 @@
 
   <aside class="release-version-notice" aria-label="최신 릴리즈 안내">
     <div class="release-version-notice-inner">
-      <p><strong>이 문서는 이전 버전(v0.1.2)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.3에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
+      <p><strong>이 문서는 이전 버전(v0.1.2)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.4에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
       <div class="release-version-notice-actions">
-        <a class="notice-primary-link" href="./v0.1.3.html">최신 릴리즈 노트</a>
+        <a class="notice-primary-link" href="./v0.1.4.html">최신 릴리즈 노트</a>
         <a class="notice-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"
           rel="noreferrer">GitHub 최신 릴리즈</a>
       </div>

--- a/docs/updates/v0.1.3.html
+++ b/docs/updates/v0.1.3.html
@@ -42,6 +42,17 @@
     </div>
   </header>
 
+  <aside class="release-version-notice" aria-label="최신 릴리즈 안내">
+    <div class="release-version-notice-inner">
+      <p><strong>이 문서는 이전 버전(v0.1.3)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.4에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
+      <div class="release-version-notice-actions">
+        <a class="notice-primary-link" href="./v0.1.4.html">최신 릴리즈 노트</a>
+        <a class="notice-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"
+          rel="noreferrer">GitHub 최신 릴리즈</a>
+      </div>
+    </div>
+  </aside>
+
   <main id="main" class="updates-page">
     <section class="updates-hero" aria-labelledby="release-title">
       <h1 id="release-title">알한글 v0.1.3</h1>

--- a/mydocs/manual/ci_workflow_guide.md
+++ b/mydocs/manual/ci_workflow_guide.md
@@ -85,10 +85,12 @@ bash scripts/ci/classify-pr-changes.sh --help
 bash scripts/ci/check-rhwp-upstream-release.sh --help
 bash scripts/ci/detect-rhwp-studio-impact.sh --help
 bash scripts/ci/prepare-pages-artifact.sh --help
+bash scripts/ci/update-release-version-notices.sh --help
 bash scripts/ci/write-rhwp-studio-sync-pr-body.sh --help
 bash scripts/ci/write-sparkle-appcast.sh --help
 bash scripts/sync-rhwp-studio.sh --help
 bash scripts/verify-rhwp-studio-assets.sh --help
+scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check
 ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path); puts "Parsed #{path}" }'
 ```
 
@@ -132,6 +134,7 @@ release checks 재현:
 ./scripts/release.sh --help
 scripts/ci/write-release-notes.sh 0.1.1 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef build.noindex/release/release-notes-0.1.1.md
 scripts/ci/check-release-notes-template.sh build.noindex/release/release-notes-0.1.1.md
+scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check
 scripts/ci/verify-universal-macos-app.sh build.noindex/release/Alhangeul.app
 scripts/ci/write-release-delta-checklist.sh v0.1.0 HEAD build.noindex/release/delta-checklist-0.1.1.md
 scripts/ci/write-sparkle-appcast.sh \

--- a/mydocs/manual/public_release_runbook.md
+++ b/mydocs/manual/public_release_runbook.md
@@ -203,9 +203,18 @@ public publish는 release owner가 tag, version, candidate commit, workflow inpu
 
 - release candidate commit이 `main`에 반영되어 있다.
 - `v<version>` tag가 정확한 candidate commit을 가리킨다.
+- GitHub Release body, Pages 업데이트 문서, README 최신 요약, 내부 release record가 마지막 candidate commit 기준으로 다시 검토되어 있다.
+- draft signed/notarized DMG smoke 이후 추가 bugfix, tag 재지정, candidate commit 변경이 있었다면 사용자-facing 주요 변경 사항을 다시 작성했다.
 - `release` environment의 GitHub Actions variable/secret이 준비되어 있다.
 - `github-pages` environment가 release tag deployment를 허용한다.
 - `SPARKLE_ED_PRIVATE_KEY` secret이 stable appcast signing에 사용할 수 있게 등록되어 있다.
+
+사용자-facing release note 최종 확인:
+
+- `전체 요약`은 특정 샘플 문서명이나 issue 번호가 아니라 사용자가 보는 증상과 개선 결과로 일반화되어 있다.
+- `알한글 앱 변화`는 HostApp, Quick Look preview, Finder thumbnail, 설치, 업데이트처럼 앱 저장소가 소유한 사용자-visible 변화를 먼저 설명한다.
+- 구현 용어는 사용자 용어로 번역되어 있다. 예를 들어 PUA는 특수 문자/기호 표시, shade sentinel은 텍스트 배경/음영 표시처럼 설명한다.
+- workflow default, manifest, checksum, release record 정렬 같은 운영 정보는 주요 변경 요약이 아니라 metadata, 검증 결과, 내부 release record에 둔다.
 
 GitHub Actions 예시:
 

--- a/mydocs/manual/public_release_runbook.md
+++ b/mydocs/manual/public_release_runbook.md
@@ -290,6 +290,7 @@ official stable release일 때만 수행한다.
 - `Release Publish DMG` workflow의 `deploy-pages` job 성공
 - `page_url`이 `https://postmelee.github.io/alhangeul-macos/`를 가리킴
 - `https://postmelee.github.io/alhangeul-macos/updates/v<version>.html` 접근 가능
+- 최신 버전보다 낮은 `updates/v<previous>.html` 페이지에 최신 릴리즈 안내 banner가 보이고, banner가 `updates/v<version>.html`과 GitHub latest release로 연결됨
 - Pages 다운로드 버튼이 tag 고정 또는 latest 정책에 맞는 public DMG URL을 가리킴
 - `https://postmelee.github.io/alhangeul-macos/appcast.xml`이 새 stable item을 제공
 - appcast의 `sparkle:shortVersionString`이 `<version>`과 일치

--- a/mydocs/manual/release_distribution_guide.md
+++ b/mydocs/manual/release_distribution_guide.md
@@ -47,6 +47,7 @@
 - `scripts/ci/write-release-delta-checklist.sh`: 직전 public release 대비 영향 영역 checklist 초안 생성
 - `scripts/ci/write-sparkle-appcast.sh`: stable Sparkle appcast 생성
 - `scripts/ci/prepare-pages-artifact.sh`: `docs/` 정적 파일과 generated appcast를 Pages artifact로 조립
+- `scripts/ci/update-release-version-notices.sh`: `docs/updates/v*.html`의 이전 버전 안내 banner를 최신 release note 기준으로 삽입/갱신
 - `scripts/ci/classify-pr-changes.sh`: PR CI 변경 범위 flag 생성
 - `scripts/ci/detect-rhwp-studio-impact.sh`: upstream `rhwp` current..target diff에서 bundled studio/viewer 영향 path 감지
 - `scripts/ci/write-rhwp-studio-sync-pr-body.sh`: 자동 bundled `rhwp-studio` sync PR body 생성

--- a/mydocs/manual/release_github_pages_sparkle_guide.md
+++ b/mydocs/manual/release_github_pages_sparkle_guide.md
@@ -17,6 +17,8 @@
 - 릴리즈 상세 기록 `mydocs/release/v<version>.md`가 현재 release candidate 기준으로 갱신되었는가
 - 직전 public release 대비 delta checklist가 생성되고 release owner가 보정했는가
 - GitHub Release body의 `이번 버전의 주요 변경 사항`에 `전체 요약`, `포함된 rhwp 변화`, `알한글 앱 변화`가 실제 사용자-facing 내용으로 보정되었는가
+- 마지막 release candidate 변경, bugfix PR, draft signed/notarized DMG smoke 이후 GitHub Release body와 Pages 업데이트 문서를 다시 검토했는가
+- `전체 요약`과 `알한글 앱 변화`가 특정 검증 샘플명, issue 번호, 내부 구현 용어가 아니라 사용자가 보는 증상과 개선 결과 중심으로 쓰였는가
 - GitHub Release title이 기본형 `Alhangeul v<version>`을 쓰는가, 또는 upstream `rhwp` 반영 중심 release라서 `(rhwp vX.Y.Z)` 병기 조건을 충족하는가
 - `rhwp-core.lock`의 core repository와 commit이 release note에 기록되었는가
 - `rhwp-studio` manifest의 release tag와 commit이 release note에 기록되었는가
@@ -102,6 +104,14 @@ Release note에 포함할 내용:
 
 `## 이번 버전의 주요 변경 사항`은 release owner가 직전 public release 대비 실제 사용자-facing 변화를 보정해 작성한다. generated template이나 delta checklist 초안을 그대로 두지 않는다.
 
+작성 원칙:
+
+- 공개 릴리즈 노트의 top-level 요약은 "영향을 받는 문서/기능 영역", "사용자가 보던 증상", "이번 버전에서 달라진 결과" 순서로 일반화해 쓴다.
+- 검증 fixture, 샘플 파일명, issue 번호, PR 번호, stage 번호는 public Pages와 GitHub Release의 주요 변경 요약에 쓰지 않는다. 해당 정보는 내부 release record, 검증 결과, changelog provenance에 둔다.
+- `PUA`, `sentinel`, `render tree`, `CoreGraphics`처럼 일반 사용자가 바로 이해하기 어려운 구현 용어는 먼저 "특수 문자/기호 표시", "텍스트 배경/음영", "Quick Look 미리보기" 같은 사용자 용어로 설명하고, 필요할 때만 괄호나 metadata에서 기술 용어를 보충한다.
+- workflow default, README 정렬, manifest/checksum/provenance 같은 운영 변경은 사용자에게 직접 영향을 주는 설치, 업데이트, 보안 검증, 배포 경로 변화가 있을 때만 주요 변경에 넣는다. 그렇지 않으면 `Release metadata`, 내부 release record, 최종 보고서로 분리한다.
+- draft signed/notarized DMG smoke 이후 bugfix PR, tag 재지정, release candidate 변경이 있으면 publish 전에 주요 변경 사항을 최종 candidate 기준으로 다시 작성한다.
+
 필수 하위 구분:
 
 - `### 전체 요약`: 이번 릴리즈를 설치해야 하는 이유를 3~5개 bullet로 쓴다. `rhwp` 반영과 앱 자체 변경을 합쳐 사용자가 체감할 결과 중심으로 요약한다.
@@ -137,10 +147,13 @@ Pages는 사용자용 릴리즈 안내 표면이다. GitHub Release body의 긴 
 - `docs/updates/v<version>.html`이 현재 사이트의 header, hero, action button, content section, footer 구조를 유지하는가
 - `docs/updates/index.html`의 최신 항목과 latest DMG link가 최신 public release 파일명을 가리키는가
 - Pages 다운로드 버튼이 아키텍처 선택 UI 없이 단일 universal DMG latest URL을 직접 가리키는가
+- hero와 `전체 요약`이 내부 구현이나 upstream 버전명보다 이번 버전을 설치했을 때 사용자가 체감할 문서 열기, 미리보기, 설치, 업데이트 변화를 먼저 설명하는가
 - 사용자가 필요한 설치 방법, 첫 실행 안내, 업데이트 확인, 알려진 한계를 간결하게 확인할 수 있는가
 - Intel Mac과 Apple Silicon Mac이 같은 DMG를 사용한다는 안내가 최신 다운로드 주변 또는 FAQ/릴리즈 노트에 있는가
 - bundled `rhwp`를 안내해야 하는 release라면 `rhwp v<version>`과 upstream release 링크를 짧게 표시하고, commit/manifest/checksum 표는 GitHub Release body와 내부 release record로 연결하는가
 - 앱 자체 변화는 `주요 변경` 또는 필요 시 `알한글 앱 변화` section에서 짧게 구분하고, `rhwp` provenance와 한 목록에 과도하게 섞지 않는가
+- 특정 샘플 문서명이나 검증 fixture명 대신 "일부 HWP 양식 문서", "특수 문자/기호 표시", "텍스트 배경/음영"처럼 사용자가 이해할 수 있는 증상 단위로 일반화했는가
+- `알한글 앱 변화` section이 workflow, README, release record 정렬 같은 운영 항목보다 HostApp, Quick Look preview, Finder thumbnail, 설치/업데이트 경로의 사용자-visible 변화를 우선하는가
 - 실제 public DMG SHA256이 아직 확정되지 않은 문서는 release candidate 또는 #188 handoff 상태를 명확히 표시하는가
 
 Pages 다운로드 버튼은 사용자를 위한 latest DMG URL을 사용한다.

--- a/mydocs/manual/release_github_pages_sparkle_guide.md
+++ b/mydocs/manual/release_github_pages_sparkle_guide.md
@@ -150,6 +150,7 @@ Pages는 사용자용 릴리즈 안내 표면이다. GitHub Release body의 긴 
 - hero와 `전체 요약`이 내부 구현이나 upstream 버전명보다 이번 버전을 설치했을 때 사용자가 체감할 문서 열기, 미리보기, 설치, 업데이트 변화를 먼저 설명하는가
 - 사용자가 필요한 설치 방법, 첫 실행 안내, 업데이트 확인, 알려진 한계를 간결하게 확인할 수 있는가
 - Intel Mac과 Apple Silicon Mac이 같은 DMG를 사용한다는 안내가 최신 다운로드 주변 또는 FAQ/릴리즈 노트에 있는가
+- 최신 버전이 아닌 `docs/updates/v<version>.html`에는 최신 릴리즈 안내 banner가 있고, 최신 버전 페이지에는 해당 banner가 없는가
 - bundled `rhwp`를 안내해야 하는 release라면 `rhwp v<version>`과 upstream release 링크를 짧게 표시하고, commit/manifest/checksum 표는 GitHub Release body와 내부 release record로 연결하는가
 - 앱 자체 변화는 `주요 변경` 또는 필요 시 `알한글 앱 변화` section에서 짧게 구분하고, `rhwp` provenance와 한 목록에 과도하게 섞지 않는가
 - 특정 샘플 문서명이나 검증 fixture명 대신 "일부 HWP 양식 문서", "특수 문자/기호 표시", "텍스트 배경/음영"처럼 사용자가 이해할 수 있는 증상 단위로 일반화했는가
@@ -161,6 +162,8 @@ Pages 다운로드 버튼은 사용자를 위한 latest DMG URL을 사용한다.
 ```text
 https://github.com/postmelee/alhangeul-macos/releases/latest/download/alhangeul-macos-<version>.dmg
 ```
+
+이전 버전 안내 banner는 수동으로 버전마다 고치지 않는다. `scripts/ci/update-release-version-notices.sh --updates-dir docs/updates`가 `docs/updates/v*.html` 중 가장 높은 semantic version을 최신 릴리즈 노트로 보고, 이전 버전 페이지의 banner를 삽입/갱신하며 최신 버전 페이지의 banner를 제거한다. PR CI는 `--check` 모드로 source가 정규화되어 있는지 확인하고, `prepare-pages-artifact.sh`는 Pages artifact를 만들 때 같은 helper를 한 번 더 실행한다.
 
 ### Pages 배포 모델
 

--- a/scripts/ci/prepare-pages-artifact.sh
+++ b/scripts/ci/prepare-pages-artifact.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 usage() {
   cat <<EOF
 Usage: $0 --docs-dir <dir> --appcast <file> --output-dir <dir>
@@ -121,6 +123,7 @@ trap cleanup EXIT
 
 cp -R "$DOCS_REAL"/. "$TMP_DIR"/
 find "$TMP_DIR" -name .DS_Store -type f -delete
+"$SCRIPT_DIR/update-release-version-notices.sh" --updates-dir "$TMP_DIR/updates"
 cp "$APPCAST_REAL" "$TMP_DIR/appcast.xml"
 
 [ -f "$TMP_DIR/index.html" ] || fail "prepared artifact is missing index.html"

--- a/scripts/ci/update-release-version-notices.sh
+++ b/scripts/ci/update-release-version-notices.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $0 --updates-dir <dir> [--check]
+
+Updates release note version notices in docs/updates.
+
+Options:
+  --updates-dir  Directory containing v<version>.html release note pages.
+  --check        Check that notices are already up to date without writing.
+  -h, --help     Show this help.
+EOF
+}
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+UPDATES_DIR=""
+CHECK=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --updates-dir)
+      shift
+      [ "$#" -gt 0 ] || fail "--updates-dir requires a value"
+      UPDATES_DIR="$1"
+      ;;
+    --check)
+      CHECK=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown argument: $1"
+      ;;
+  esac
+  shift
+done
+
+[ -n "$UPDATES_DIR" ] || fail "--updates-dir is required"
+[ -d "$UPDATES_DIR" ] || fail "--updates-dir does not exist or is not a directory: $UPDATES_DIR"
+
+ruby - "$UPDATES_DIR" "$CHECK" <<'RUBY'
+updates_dir = ARGV.fetch(0)
+check_only = ARGV.fetch(1) == "1"
+
+VersionPage = Struct.new(:path, :version, :parts, keyword_init: true)
+
+pages = Dir.children(updates_dir).map do |entry|
+  match = entry.match(/\Av(\d+)\.(\d+)\.(\d+)\.html\z/)
+  next unless match
+
+  VersionPage.new(
+    path: File.join(updates_dir, entry),
+    version: "#{match[1]}.#{match[2]}.#{match[3]}",
+    parts: match.captures.map(&:to_i)
+  )
+end.compact
+
+if pages.empty?
+  warn "No release note pages found in #{updates_dir}"
+  exit 0
+end
+
+latest = pages.max_by(&:parts)
+latest_version = latest.version
+
+notice_pattern = %r{\n?[ \t]*<aside class="release-version-notice" aria-label="최신 릴리즈 안내">\n.*?[ \t]*</aside>\n\n}m
+
+def notice_for(version, latest_version)
+  [
+    '  <aside class="release-version-notice" aria-label="최신 릴리즈 안내">',
+    '    <div class="release-version-notice-inner">',
+    "      <p><strong>이 문서는 이전 버전(v#{version})의 릴리즈 노트입니다.</strong> 최신 버전 v#{latest_version}에서 수정 사항과 최신 설치 파일을 확인하세요.</p>",
+    '      <div class="release-version-notice-actions">',
+    "        <a class=\"notice-primary-link\" href=\"./v#{latest_version}.html\">최신 릴리즈 노트</a>",
+    '        <a class="notice-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"',
+    '          rel="noreferrer">GitHub 최신 릴리즈</a>',
+    '      </div>',
+    '    </div>',
+    '  </aside>',
+    '',
+    ''
+  ].join("\n")
+end
+
+changed = []
+
+pages.sort_by(&:parts).each do |page|
+  source = File.read(page.path)
+  updated = source.gsub(notice_pattern, "\n")
+
+  if page.version != latest_version
+    notice = notice_for(page.version, latest_version)
+    unless updated.sub!(/  <\/header>\n+/, "  </header>\n\n#{notice}")
+      abort "ERROR: could not find header insertion point in #{page.path}"
+    end
+  end
+
+  next if updated == source
+
+  changed << page.path
+  File.write(page.path, updated) unless check_only
+end
+
+if changed.empty?
+  puts "Release version notices are up to date for latest v#{latest_version}."
+elsif check_only
+  warn "ERROR: release version notices are stale for latest v#{latest_version}:"
+  changed.each { |path| warn "- #{path}" }
+  exit 1
+else
+  puts "Updated release version notices for latest v#{latest_version}:"
+  changed.each { |path| puts "- #{path}" }
+end
+RUBY


### PR DESCRIPTION
## Summary
- PR #312에서 검증된 이전 릴리즈 안내 자동화와 v0.1.4 기준 업데이트 페이지 notice 정규화를 main에 반영합니다.
- main merge 후 docs-only Pages deploy가 기존 public appcast를 보존하면서 업데이트 페이지를 배포합니다.

## Validation
- PR #312 CI 통과
- Release helper checks: pass
- Script syntax checks: pass
- macOS validation: skipped as expected for docs/release-helper scoped change