### PR TITLE
Task #301: docs-only Pages XML 도구 설치

### DIFF
--- a/.github/workflows/pages-docs-deploy.yml
+++ b/.github/workflows/pages-docs-deploy.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Install XML tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y libxml2-utils
+
       - name: Check release asset availability
         id: release_asset_gate
         shell: bash


### PR DESCRIPTION
## Summary
- docs-only Pages Deploy workflow에서 public appcast XML 검증 전에 libxml2-utils를 설치하도록 보강했습니다.
- Ubuntu runner에 xmllint가 없어서 main merge 후 Pages deploy가 실패한 문제를 해결합니다.

## Validation
- ruby -e 'require "psych"; Psych.parse_file(".github/workflows/pages-docs-deploy.yml"); puts "Parsed .github/workflows/pages-docs-deploy.yml"'
- git diff --check