### PR TITLE
Task #301: docs-only Pages XML 도구 설치 main 반영

### DIFF
--- a/.github/workflows/pages-docs-deploy.yml
+++ b/.github/workflows/pages-docs-deploy.yml
@@ -46,6 +46,13 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
+      - name: Install XML tools
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y libxml2-utils
+
       - name: Check release asset availability
         id: release_asset_gate
         shell: bash


### PR DESCRIPTION
## Summary
- PR #314에서 검증된 docs-only Pages Deploy workflow의 xmllint 의존성 설치 fix를 main에 반영합니다.
- main merge 후 docs-only Pages Deploy를 재실행해 v0.1.3 이전 버전 안내 배너를 public Pages에 반영합니다.

## Validation
- PR #314 CI 통과
- Release helper checks: pass
- Script syntax checks: pass
- macOS validation: skipped as expected for workflow-only change