### PR TITLE
Task #122: Swift native renderer 이미지 fill mode parity 보강

### DIFF
--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -45,6 +45,7 @@ class CGTreeRenderer {
     private let maxPCXImageDimension = 16_384
     private let maxPCXDecodedByteCount = 64 * 1024 * 1024
     private let maxPCXPixelByteCount = 64 * 1024 * 1024
+    private let maxImageTileDrawCount = 4096
 
     private var imageCache: [UInt16: CGImage] = [:]
     private weak var document: RhwpDocument?
@@ -64,6 +65,32 @@ class CGTreeRenderer {
     private enum ArcSegment {
         case line(CGPoint)
         case curve(CGPoint, CGPoint, CGPoint)
+    }
+
+    private enum ImageFillPolicy {
+        case fitToSize
+        case placement(ImagePlacement)
+        case tile(ImageTileMode)
+    }
+
+    private enum ImagePlacement {
+        case leftTop
+        case centerTop
+        case rightTop
+        case leftCenter
+        case center
+        case rightCenter
+        case leftBottom
+        case centerBottom
+        case rightBottom
+    }
+
+    private enum ImageTileMode {
+        case all
+        case horizontalTop
+        case horizontalBottom
+        case verticalLeft
+        case verticalRight
     }
 
     func render(
@@ -724,16 +751,14 @@ class CGTreeRenderer {
         ctx.saveGState()
         applyTransform(img.transform, bbox: bbox, in: ctx)
 
-        let drawImage = preparedImage(for: cgImage, node: img)
-        let r = cgRect(bbox)
-        let drawRect = imageDestinationRect(for: img, size: r.size)
-        // CG draw(image:) 는 이미지를 rect에 맞춰 그리지만 상하 반전으로 그린다.
-        // 이미지 영역에서만 Y축 반전하여 올바르게 표시한다.
-        ctx.saveGState()
-        ctx.translateBy(x: r.minX, y: r.minY + r.height)
-        ctx.scaleBy(x: 1, y: -1)
-        ctx.draw(drawImage, in: drawRect)
-        ctx.restoreGState()
+        let prepared = preparedImage(for: cgImage, node: img)
+        drawImage(
+            prepared,
+            node: img,
+            bbox: bbox,
+            decodedImageSize: cgSize(of: cgImage),
+            in: ctx
+        )
 
         ctx.restoreGState()
     }
@@ -765,18 +790,18 @@ class CGTreeRenderer {
         applyTransform(node.transform, bbox: image.bbox, in: ctx)
 
         let appliesAdjustments = !(image.bakedWatermark && image.source.data != nil)
-        let drawImage = preparedImage(
+        let prepared = preparedImage(
             for: cgImage,
             node: node,
             applyingAdjustments: appliesAdjustments
         )
-        let rect = cgRect(image.bbox)
-        let drawRect = imageDestinationRect(for: node, size: rect.size)
-        ctx.saveGState()
-        ctx.translateBy(x: rect.minX, y: rect.minY + rect.height)
-        ctx.scaleBy(x: 1, y: -1)
-        ctx.draw(drawImage, in: drawRect)
-        ctx.restoreGState()
+        drawImage(
+            prepared,
+            node: node,
+            bbox: image.bbox,
+            decodedImageSize: cgSize(of: cgImage),
+            in: ctx
+        )
 
         ctx.restoreGState()
         return true
@@ -1452,19 +1477,286 @@ class CGTreeRenderer {
         }
     }
 
-    private func imageDestinationRect(for img: ImageNode, size: CGSize) -> CGRect {
-        let fullRect = CGRect(origin: .zero, size: size)
-        guard let fillMode = img.fillMode?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !fillMode.isEmpty else {
-            return fullRect
+    private func normalizedImageFillPolicy(_ fillMode: String?) -> ImageFillPolicy {
+        guard let fillMode else { return .fitToSize }
+
+        switch normalizedStyleKey(fillMode) {
+        case "",
+             "fittosize",
+             "stretch",
+             "stretchtofit",
+             "none":
+            return .fitToSize
+        case "lefttop":
+            return .placement(.leftTop)
+        case "centertop":
+            return .placement(.centerTop)
+        case "righttop":
+            return .placement(.rightTop)
+        case "leftcenter":
+            return .placement(.leftCenter)
+        case "center", "centercenter":
+            return .placement(.center)
+        case "rightcenter":
+            return .placement(.rightCenter)
+        case "leftbottom":
+            return .placement(.leftBottom)
+        case "centerbottom":
+            return .placement(.centerBottom)
+        case "rightbottom":
+            return .placement(.rightBottom)
+        case "tileall":
+            return .tile(.all)
+        case "tilehorztop", "tilehoriztop", "tilehorizontaltop":
+            return .tile(.horizontalTop)
+        case "tilehorzbottom", "tilehorizbottom", "tilehorizontalbottom":
+            return .tile(.horizontalBottom)
+        case "tilevertleft", "tileverticalleft":
+            return .tile(.verticalLeft)
+        case "tilevertright", "tileverticalright":
+            return .tile(.verticalRight)
+        default:
+            return .fitToSize
+        }
+    }
+
+    private func drawImage(
+        _ image: CGImage,
+        node: ImageNode,
+        bbox: BBox,
+        decodedImageSize: CGSize,
+        in ctx: CGContext
+    ) {
+        let bboxRect = cgRect(bbox)
+        let policy = normalizedImageFillPolicy(node.fillMode)
+        switch policy {
+        case .fitToSize:
+            drawImage(image, inTopLeftRect: bboxRect, in: ctx)
+        case .placement(let placement):
+            guard let naturalSize = imageNaturalDrawSize(
+                for: node,
+                decodedImageSize: decodedImageSize,
+                drawImageSize: cgSize(of: image)
+            ) else {
+                drawImage(image, inTopLeftRect: bboxRect, in: ctx)
+                return
+            }
+            let destination = imagePlacementRect(
+                placement,
+                in: bboxRect,
+                size: naturalSize
+            )
+            ctx.saveGState()
+            ctx.clip(to: bboxRect)
+            drawImage(image, inTopLeftRect: destination, in: ctx)
+            ctx.restoreGState()
+        case .tile(let tileMode):
+            guard let tileSize = imageNaturalDrawSize(
+                for: node,
+                decodedImageSize: decodedImageSize,
+                drawImageSize: cgSize(of: image)
+            ) else {
+                drawImage(image, inTopLeftRect: bboxRect, in: ctx)
+                return
+            }
+            drawTiledImage(image, bbox: bboxRect, tileMode: tileMode, tileSize: tileSize, in: ctx)
+        }
+    }
+
+    private func imageNaturalDrawSize(
+        for node: ImageNode,
+        decodedImageSize: CGSize,
+        drawImageSize: CGSize
+    ) -> CGSize? {
+        if let originalSize = node.originalSize,
+           originalSize.count >= 2 {
+            let size = CGSize(width: CGFloat(originalSize[0]), height: CGFloat(originalSize[1]))
+            if isValidImageDrawSize(size) {
+                return size
+            }
         }
 
-        switch fillMode.replacingOccurrences(of: "_", with: "").lowercased() {
-        case "fittosize", "stretch", "stretchtofit":
-            return fullRect
-        default:
-            return fullRect
+        if isValidImageDrawSize(decodedImageSize) {
+            return decodedImageSize
         }
+        if isValidImageDrawSize(drawImageSize) {
+            return drawImageSize
+        }
+        return nil
+    }
+
+    private func imagePlacementRect(
+        _ placement: ImagePlacement,
+        in bbox: CGRect,
+        size: CGSize
+    ) -> CGRect {
+        let x: CGFloat
+        switch placement {
+        case .leftTop, .leftCenter, .leftBottom:
+            x = bbox.minX
+        case .centerTop, .center, .centerBottom:
+            x = bbox.midX - size.width / 2
+        case .rightTop, .rightCenter, .rightBottom:
+            x = bbox.maxX - size.width
+        }
+
+        let y: CGFloat
+        switch placement {
+        case .leftTop, .centerTop, .rightTop:
+            y = bbox.minY
+        case .leftCenter, .center, .rightCenter:
+            y = bbox.midY - size.height / 2
+        case .leftBottom, .centerBottom, .rightBottom:
+            y = bbox.maxY - size.height
+        }
+
+        return CGRect(origin: CGPoint(x: x, y: y), size: size)
+    }
+
+    private func drawImage(_ image: CGImage, inTopLeftRect rect: CGRect, in ctx: CGContext) {
+        guard isValidImageDrawSize(rect.size) else { return }
+
+        // CG draw(image:) 는 현재 top-left renderer 좌표계에서 상하 반전되므로,
+        // 이미지 draw call 내부에서만 국소적으로 Y축을 뒤집는다.
+        ctx.saveGState()
+        ctx.translateBy(x: rect.minX, y: rect.minY + rect.height)
+        ctx.scaleBy(x: 1, y: -1)
+        ctx.draw(image, in: CGRect(origin: .zero, size: rect.size))
+        ctx.restoreGState()
+    }
+
+    private func drawTiledImage(
+        _ image: CGImage,
+        bbox: CGRect,
+        tileMode: ImageTileMode,
+        tileSize: CGSize,
+        in ctx: CGContext
+    ) {
+        guard isValidImageDrawSize(tileSize), isValidImageDrawSize(bbox.size) else {
+            drawImage(image, inTopLeftRect: bbox, in: ctx)
+            return
+        }
+
+        ctx.saveGState()
+        ctx.clip(to: bbox)
+        var drawCount = 0
+
+        func drawTile(at origin: CGPoint) -> Bool {
+            guard drawCount < maxImageTileDrawCount else {
+                return false
+            }
+            drawImage(
+                image,
+                inTopLeftRect: CGRect(origin: origin, size: tileSize),
+                in: ctx
+            )
+            drawCount += 1
+            return true
+        }
+
+        switch tileMode {
+        case .all:
+            var y = bbox.minY
+            while y < bbox.maxY {
+                var x = bbox.minX
+                while x < bbox.maxX {
+                    guard drawTile(at: CGPoint(x: x, y: y)) else {
+                        ctx.restoreGState()
+                        return
+                    }
+                    x += tileSize.width
+                }
+                y += tileSize.height
+            }
+        case .horizontalTop:
+            drawHorizontalTiles(
+                image,
+                y: bbox.minY,
+                bbox: bbox,
+                tileSize: tileSize,
+                in: ctx,
+                drawCount: &drawCount
+            )
+        case .horizontalBottom:
+            drawHorizontalTiles(
+                image,
+                y: bbox.maxY - tileSize.height,
+                bbox: bbox,
+                tileSize: tileSize,
+                in: ctx,
+                drawCount: &drawCount
+            )
+        case .verticalLeft:
+            drawVerticalTiles(
+                image,
+                x: bbox.minX,
+                bbox: bbox,
+                tileSize: tileSize,
+                in: ctx,
+                drawCount: &drawCount
+            )
+        case .verticalRight:
+            drawVerticalTiles(
+                image,
+                x: bbox.maxX - tileSize.width,
+                bbox: bbox,
+                tileSize: tileSize,
+                in: ctx,
+                drawCount: &drawCount
+            )
+        }
+
+        ctx.restoreGState()
+    }
+
+    private func drawHorizontalTiles(
+        _ image: CGImage,
+        y: CGFloat,
+        bbox: CGRect,
+        tileSize: CGSize,
+        in ctx: CGContext,
+        drawCount: inout Int
+    ) {
+        var x = bbox.minX
+        while x < bbox.maxX {
+            guard drawCount < maxImageTileDrawCount else { return }
+            drawImage(
+                image,
+                inTopLeftRect: CGRect(origin: CGPoint(x: x, y: y), size: tileSize),
+                in: ctx
+            )
+            drawCount += 1
+            x += tileSize.width
+        }
+    }
+
+    private func drawVerticalTiles(
+        _ image: CGImage,
+        x: CGFloat,
+        bbox: CGRect,
+        tileSize: CGSize,
+        in ctx: CGContext,
+        drawCount: inout Int
+    ) {
+        var y = bbox.minY
+        while y < bbox.maxY {
+            guard drawCount < maxImageTileDrawCount else { return }
+            drawImage(
+                image,
+                inTopLeftRect: CGRect(origin: CGPoint(x: x, y: y), size: tileSize),
+                in: ctx
+            )
+            drawCount += 1
+            y += tileSize.height
+        }
+    }
+
+    private func cgSize(of image: CGImage) -> CGSize {
+        CGSize(width: CGFloat(image.width), height: CGFloat(image.height))
+    }
+
+    private func isValidImageDrawSize(_ size: CGSize) -> Bool {
+        size.width.isFinite && size.height.isFinite && size.width > 0 && size.height > 0
     }
 
     // MARK: - 그룹

--- a/mydocs/orders/20260601.md
+++ b/mydocs/orders/20260601.md
@@ -4,7 +4,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #122 | Swift native renderer 이미지 fill mode·타일·배치 parity 보강 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+| #122 | Swift native renderer 이미지 fill mode·타일·배치 parity 보강 | 완료 | 완료: 13:12, 최종 보고서 작성 후 PR 승인 대기 |
 
 ## M040 — v0.4 안정화
 

--- a/mydocs/orders/20260601.md
+++ b/mydocs/orders/20260601.md
@@ -1,5 +1,11 @@
 # 오늘 할일 - 2026년 6월 1일
 
+## M014 — v0.1.4 Native Preview/Viewer Parity
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #122 | Swift native renderer 이미지 fill mode·타일·배치 parity 보강 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+
 ## M040 — v0.4 안정화
 
 | Issue | 타스크 | 상태 | 비고 |

--- a/mydocs/plans/task_m014_122.md
+++ b/mydocs/plans/task_m014_122.md
@@ -1,0 +1,120 @@
+# Task M014 #122 수행계획서
+
+## 목적
+
+Swift/CoreGraphics native renderer가 upstream `rhwp v0.7.13`의 이미지 fill mode, 원본 크기, crop, 배치, 반복 타일 정보를 일관되게 반영하도록 보강한다. 목표는 Quick Look preview, Finder thumbnail, PDF/CoreGraphics fallback에서 bundled `rhwp-studio v0.7.13` 기준 출력과의 차이를 줄이고, #106/#116/#282에서 정리한 crop/effect/overlay/watermark 처리와 충돌하지 않는 image draw 정책을 세우는 것이다.
+
+## 배경
+
+현재 앱 저장소의 `rhwp-core.lock`과 bundled `rhwp-studio`는 모두 upstream `edwardkim/rhwp v0.7.13` (`b3e16ef212af81ef37d973ddb86d6816d3804642`) 기준이다. #106은 Swift/CoreGraphics renderer의 이미지 crop/effect/brightness/contrast와 `FitToSize` 중심 최소 보강을 다뤘고, #282/#116 이후 Quick Look/Thumbnail/PDF CoreGraphics fallback은 overlay image path도 함께 사용한다.
+
+하지만 현재 Swift renderer의 destination rect 계산은 `FitToSize`/stretch 계열 외 fill mode를 충분히 구분하지 못한다. 특히 원본 크기 배치, 좌/중/우 및 상/중/하 정렬, 반복 타일 이미지는 bbox 전체 draw로 폴백할 가능성이 높다. upstream `v0.7.13` 기준 WebCanvas/CanvasKit/PageLayerTree 계열은 `ImageFillMode`, crop, original size, tile/placement 처리 경로를 갖고 있으므로 Swift/CoreGraphics fallback도 같은 contract를 소비해야 한다.
+
+## 범위
+
+포함:
+
+- `ImageNode.fill_mode`, `original_size`, `original_size_hu`, `crop` 조합의 Swift 처리 정책 정리
+- metadata overlay image path의 `fillMode`, `originalSize`, `originalSizeHU`, `crop` 처리 확인
+- `FitToSize`, `None`, 좌/중/우 및 상/중/하 배치 모드 구현
+- `TileAll`, `TileHorzTop/Bottom`, `TileVertLeft/Right` 등 타일 모드 구현
+- bbox clipping, transform, crop, effect/brightness/contrast 적용 순서 검증
+- #106 crop/effect 처리, #282 overlay compositor, #116 baked watermark adjustment gate와 충돌하지 않는 적용 순서 문서화
+- visual diff harness로 image sample 전후 수치 기록
+
+제외:
+
+- RawSvg/OLE/차트 렌더링 (#121)
+- Placeholder/FormObject 정적 프리뷰 (#110)
+- upstream `rhwp` 수정
+- PageLayerTree/Skia 기본 경로 전환
+- HostApp native viewer shell/page pool 구현
+- 새 sample fixture 제작이 필요한 대형 범위 확장
+
+## 설계 방향
+
+구현은 기존 Swift/CoreGraphics renderer의 image decode/effect/crop 경로를 재사용하면서 destination rect와 tiling policy를 분리하는 방향으로 진행한다.
+
+1. current path inventory를 먼저 고정한다.
+   - render tree `ImageNode` path와 overlay metadata image path가 어떤 필드를 읽고 어떤 필드를 버리는지 확인한다.
+   - `CGTreeRenderer.imageDestinationRect(for:size:)`의 현재 fill mode 분기와 fallback을 기록한다.
+2. fill mode별 destination policy를 명시한다.
+   - stretch 계열은 기존 bbox fill 정책을 유지한다.
+   - `None` 및 placement 계열은 original size 또는 original size HU를 우선 사용하고, 누락 시 image pixel size와 bbox fallback 기준을 정한다.
+   - tile 계열은 tile origin, repetition axis, clipping rect를 명시한다.
+3. 이미지 전처리와 배치 순서를 분리한다.
+   - crop/effect/brightness/contrast/baked watermark gate는 bitmap 준비 단계로 두고, fill/tile/placement는 draw 단계에서 처리한다.
+   - `bakedWatermark == true` payload에는 #116의 후처리 생략 조건을 유지한다.
+4. overlay metadata와 render tree path의 정책을 맞춘다.
+   - 가능한 경우 같은 helper 또는 같은 enum interpretation을 사용한다.
+   - overlay-only metadata의 필드 누락은 명확한 fallback으로 남긴다.
+5. visual diff는 sample별로 수치를 남긴다.
+   - 개선이 기대되는 image sample과 회귀 위험 sample을 분리해 측정한다.
+
+## 예상 변경 파일
+
+| 파일 | 예상 변경 |
+|------|-----------|
+| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | fill mode별 image destination/tile draw 정책 구현 |
+| `Sources/RhwpCoreBridge/RenderTree.swift` | 필요 시 image fill/original size/crop 디코딩 확인 또는 accessor 보강 |
+| `Sources/RhwpCoreBridge/PageOverlayImages.swift` | overlay image metadata의 fill/original/crop 필드 소비 여부 확인 |
+| `Sources/Shared/HwpNativePageCompositor.swift` | overlay image path가 renderer 정책을 공유하도록 필요 시 제한적 조정 |
+| `scripts/preview-visual-diff-harness.sh` | 필요 시 #122 sample preset 또는 output naming 보강 |
+| `mydocs/working/task_m014_122_stage*.md` | 단계별 관찰값, diff 수치, 판단 기록 |
+| `mydocs/report/task_m014_122_report.md` | 최종 결과와 후속 이슈 정리 |
+
+## 잠정 단계
+
+1. Stage 1: current path inventory와 baseline 측정
+   - render tree/overlay image path의 fill/original/crop 필드 소비 현황을 정리한다.
+   - `samples/pic-crop-01.hwp`, `samples/tac-img-02.hwp`, `samples/tac-img-02.hwpx` 기준 visual diff baseline을 남긴다.
+2. Stage 2: fill mode 정책 설계와 최소 helper 분리
+   - placement, none, tile 계열의 destination/tile rect 계산 규칙을 문서화하고 helper boundary를 정한다.
+3. Stage 3: CoreGraphics image placement/tile 구현
+   - 기존 crop/effect/baked watermark 처리를 유지하면서 draw 단계에 fill mode 정책을 반영한다.
+4. Stage 4: overlay metadata path parity 확인
+   - render tree image와 overlay image가 같은 fill/tile/placement 정책을 쓰는지 확인하고 차이를 줄인다.
+5. Stage 5: visual diff, smoke, 최종 보고
+   - sample별 전후 diff 수치와 회귀 여부를 기록하고 최종 보고서와 PR 게시 준비를 수행한다.
+
+## 검증 계획
+
+기본 검증:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task122-baseline --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task122-regression --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp samples/복학원서.hwp
+
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task122 CODE_SIGNING_ALLOWED=NO build
+
+git diff --check
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+수용 기준:
+
+- `FitToSize` 기존 동작이 회귀하지 않는다.
+- `None` 및 placement 계열 이미지가 bbox 전체 stretch로 보이지 않고 original size/position 정책을 따른다.
+- tile 계열 이미지가 지정 축과 bbox clipping 안에서 반복된다.
+- crop/effect/brightness/contrast와 #116 baked watermark gate가 기존 sample에서 회귀하지 않는다.
+- Quick Look/Thumbnail/PDF CoreGraphics fallback이 같은 renderer policy를 사용한다.
+- visual diff 결과와 미해결 차이가 보고서에 남는다.
+
+## 리스크
+
+- upstream `ImageFillMode` 이름과 Swift enum/string mapping이 일부 sample에서 예상과 다를 수 있다.
+- original size, original size HU, image pixel size가 동시에 존재할 때 우선순위를 잘못 잡으면 크기 회귀가 생길 수 있다.
+- tile origin과 clipping 순서가 rhwp-studio/WebCanvas와 다르면 visual diff는 줄어도 특정 문서에서 반복 패턴이 어긋날 수 있다.
+- overlay metadata path와 render tree path가 서로 다른 좌표계 또는 transform 적용 순서를 사용할 수 있다.
+- CoreGraphics pattern/tile drawing은 scale과 interpolation 품질에 따라 환경별 작은 차이를 만들 수 있다.
+
+## 승인 요청 사항
+
+1. #122는 `devel` 기준 `local/task122` 브랜치에서 진행한다.
+2. 수행계획서 승인 후 Stage 1 current path inventory와 baseline 측정부터 시작한다.
+3. 구현은 Swift/CoreGraphics fallback renderer 범위로 제한하고, upstream `rhwp` 수정이나 Skia/PageLayerTree 기본 전환은 다루지 않는다.

--- a/mydocs/plans/task_m014_122_impl.md
+++ b/mydocs/plans/task_m014_122_impl.md
@@ -1,0 +1,170 @@
+# Task M014 #122 구현계획서
+
+## 기준
+
+- 이슈: #122
+- 브랜치: `local/task122`
+- 기준 브랜치: `origin/devel` `cfb60a0`
+- 수행계획서 커밋: `f2e995e`
+- core 기준: rhwp `v0.7.13`, resolved commit `b3e16ef212af81ef37d973ddb86d6816d3804642`
+
+## 구현 목표
+
+Swift/CoreGraphics native renderer가 이미지 `fill_mode`, `original_size`, `original_size_hu`, `crop` 조합을 upstream `rhwp-studio v0.7.13` renderer와 같은 의미로 소비하게 한다. 구현은 Quick Look preview, Finder thumbnail, PDF/CoreGraphics fallback이 공유하는 `CGTreeRenderer` 경로를 우선 대상으로 삼고, overlay image path도 같은 draw policy를 사용하도록 유지한다.
+
+## 사전 조사 결과
+
+수행계획서 승인 직후 소스 수정 없이 current path inventory와 baseline 측정을 수행했다.
+
+확인한 현재 코드 경로:
+
+- `RenderTree.swift`의 `ImageNode`는 `fill_mode`, `original_size`, `original_size_hu`, `crop`, `effect`, `brightness`, `contrast`, `text_wrap`를 이미 디코딩한다.
+- `PageOverlayImages.swift`는 render tree image supplement에서 `fillMode`, `originalSize`, `originalSizeHU`, `crop`을 overlay model로 병합한다.
+- `CGTreeRenderer.renderImage`와 `renderOverlayImage`는 모두 `ImageNode`를 통해 `preparedImage`와 `imageDestinationRect`를 호출한다.
+- `preparedImage`는 현재 `crop`과 effect/brightness/contrast를 bitmap 준비 단계에서 처리한다.
+- `imageDestinationRect(for:size:)`는 `FitToSize`/stretch 계열과 그 외 모드 모두 `fullRect`를 반환하므로 placement/tile mode는 구현되어 있지 않다.
+
+baseline 측정:
+
+| 샘플 | ChangedPercent | MeanRGBDelta | NativeBackend | StudioCapture | 비고 |
+|------|---------------:|-------------:|---------------|---------------|------|
+| `samples/pic-crop-01.hwp` | `2.0423%` | `0.8092` | `coreGraphics` | `domComposite` | image 2개, `fill_mode=null`, crop 있음 |
+| `samples/tac-img-02.hwp` | `4.1085%` | `3.6656` | `coreGraphics` | `canvasDataURL` | image 1개, `fill_mode=null`, crop 있음 |
+| `samples/tac-img-02.hwpx` | `4.1085%` | `3.6656` | `coreGraphics` | `domComposite` | image 1개, `fill_mode=null`, crop 있음 |
+
+첫 sandbox 실행은 WebKit readiness timeout으로 실패했고, 같은 harness를 권한 상승 실행해 성공했다.
+
+```text
+build.noindex/task122-stage1-baseline/
+build.noindex/task122-stage1-baseline-escalated/
+build.noindex/task122-stage1-overlay/
+build.noindex/task122-stage1-render-debug/
+```
+
+추가로 대표 image sample 11개 첫 페이지를 훑었지만 non-null `fill_mode` fixture는 발견하지 못했다. 따라서 Stage 2에서 placement/tile 계산 helper는 upstream contract 기준으로 구현하되, visual diff sample은 기존 crop/effect 회귀 방지 중심으로 해석한다. non-null fill/tile fixture가 필요하면 후속 단계에서 fixture 확보 범위를 작업지시자에게 별도 확인한다.
+
+## upstream 기준 해석
+
+upstream `v0.7.13`의 CanvasKit renderer는 image draw를 다음 흐름으로 처리한다.
+
+1. crop이 있으면 source rect를 만든다.
+2. `fillMode == fitToSize`면 bbox 전체에 draw한다.
+3. 그 외 모드는 `originalSize`를 우선 tile/image 크기로 쓰고, 없으면 image pixel size로 폴백한다.
+4. bbox로 clip한 뒤 tile mode면 반복 draw, 아니면 placement 좌표에 원본 크기로 draw한다.
+5. tile mode는 `tileAll`, `tileHorzTop`, `tileHorzBottom`, `tileVertLeft`, `tileVertRight`를 구분한다.
+6. placement mode는 `leftTop`, `centerTop`, `rightTop`, `leftCenter`, `center`, `rightCenter`, `leftBottom`, `centerBottom`, `rightBottom`를 구분한다.
+
+Swift/CoreGraphics 구현은 이 의미를 그대로 따르되, 기존 좌상단 원점 context와 CGImage 상하 반전 처리에 맞게 helper boundary를 잡는다.
+
+## Stage 구성
+
+| Stage | 목표 | 산출물 |
+|-------|------|--------|
+| Stage 1 | current path inventory와 baseline 정리 | `task_m014_122_stage1.md` |
+| Stage 2 | fill/tile/placement helper 설계 | `task_m014_122_stage2.md` |
+| Stage 3 | CoreGraphics image draw 구현 | `CGTreeRenderer.swift` 중심 변경 |
+| Stage 4 | overlay path parity와 visual diff 회귀 smoke | `task_m014_122_stage4.md` |
+| Stage 5 | 최종 보고와 PR 게시 준비 | `task_m014_122_report.md` |
+
+## Stage 1 세부 계획
+
+이미 수행한 사전 조사를 단계 보고서로 정리한다.
+
+- Swift model, overlay supplement, compositor, renderer 호출 경로를 파일/라인 기준으로 기록
+- upstream CanvasKit/WebCanvas fill/tile contract 요약
+- baseline visual diff, overlay metadata smoke, render debug 산출물 위치 기록
+- 현재 sample set의 한계, 특히 non-null `fill_mode` fixture 부족을 리스크로 남김
+
+검증:
+
+```bash
+git diff --check
+```
+
+## Stage 2 세부 계획
+
+코드 변경 전 helper 설계를 문서로 고정한다.
+
+- normalized fill mode enum 또는 private helper 범위 결정
+- `FitToSize`/stretch/null/unknown fallback 정책 결정
+- `original_size`, `original_size_hu`, image pixel size 우선순위 결정
+- placement rect 계산 규칙 결정
+- tile draw loop, clip rect, max tile draw guard 필요 여부 결정
+- crop/effect/baked watermark gate와 fill/tile draw 순서 확정
+
+검증:
+
+```bash
+git diff --check
+```
+
+## Stage 3 세부 계획
+
+`CGTreeRenderer`에 최소 구현을 적용한다.
+
+- `imageDestinationRect` 단일 rect 반환 구조를 draw policy/helper 구조로 교체
+- render tree image와 overlay image가 같은 helper를 사용하게 유지
+- placement mode는 bbox clip 후 원본 크기 draw
+- tile mode는 bbox clip 후 축별 반복 draw
+- unknown mode는 기존 full bbox draw fallback 유지
+- 기존 `preparedImage`의 crop/effect/baked watermark gate는 변경하지 않음
+
+검증:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task122-stage3-render-debug --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp
+
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task122 CODE_SIGNING_ALLOWED=NO build
+
+git diff --check
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+## Stage 4 세부 계획
+
+visual diff와 overlay/renderer 회귀를 확인한다.
+
+- 계획서 baseline 3개 sample 재측정
+- #116 regression sample set에서 image/effect/watermark 회귀 확인
+- overlay metadata smoke로 overlay path가 계속 renderable인지 확인
+- sandbox WebKit readiness 실패는 권한 상승 실행 필요 조건으로 보고서에 남김
+
+검증:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task122-stage4-baseline --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task122-stage4-regression --page 1 \
+  samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp samples/복학원서.hwp
+
+./scripts/overlay-metadata-smoke.sh build.noindex/task122-stage4-overlay --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx
+
+git diff --check
+```
+
+## Stage 5 세부 계획
+
+최종 결과를 정리하고 PR 게시 준비를 수행한다.
+
+- 최종 보고서에 구현 범위, baseline/after 수치, fixture 한계, 후속 필요 항목 기록
+- 오늘할일 완료 처리
+- 최종 검증 명령 재실행
+- `publish/task122` 브랜치와 PR 준비는 최종 보고 승인 후 진행
+
+검증:
+
+```bash
+git status --short
+git log --oneline -5
+```
+
+## 승인 필요 사항
+
+1. Stage 1은 이미 수행한 소스 수정 없는 조사/측정 결과를 단계 보고서로 정리한다.
+2. Stage 2는 코드 변경 전 fill/tile/placement helper 설계를 문서로 고정한다.
+3. non-null `fill_mode` fixture가 현재 sample 첫 페이지 조사에서 부족하므로, 이번 PR의 visual diff는 기존 crop/effect 회귀 방지 중심으로 해석하고 placement/tile 자체는 upstream contract 기반 helper/단위 판단으로 구현한다.

--- a/mydocs/report/task_m014_122_report.md
+++ b/mydocs/report/task_m014_122_report.md
@@ -1,0 +1,171 @@
+# Task M014 #122 최종 보고서 - Swift native renderer 이미지 fill mode·타일·배치 parity 보강
+
+## 작업 개요
+
+- 이슈: #122 Swift native renderer 이미지 fill mode·타일·배치 parity 보강
+- 마일스톤: M014 (`v0.1.4 Native Preview/Viewer Parity`)
+- 브랜치: `local/task122`
+- 기준 브랜치: `devel`
+- core/studio 기준: `edwardkim/rhwp v0.7.13`, `b3e16ef212af81ef37d973ddb86d6816d3804642`
+- 목표: Quick Look/Thumbnail/PDF CoreGraphics fallback에서 upstream image `fill_mode`, placement, tile contract를 소비하도록 Swift native renderer의 image draw path를 보강한다.
+
+## 작업 요약
+
+#122는 Swift/CoreGraphics image draw path가 `fill_mode`를 bbox 전체 draw로만 처리하던 한계를 보강하는 작업이다. 이번 작업은 `CGTreeRenderer` 내부에 fill policy normalization, natural size 선택, placement/tile draw helper를 추가하고, render tree image와 overlay image가 같은 helper를 사용하도록 정리했다.
+
+- Stage 1: current path inventory와 baseline visual diff를 정리했다.
+- Stage 2: upstream `v0.7.13` 기준 fill/tile/placement helper 설계를 문서화했다.
+- Stage 3: `CGTreeRenderer.swift`에 CoreGraphics image placement/tile helper를 구현했다.
+- Stage 4: visual diff, render-debug, overlay metadata, extension registration hygiene 회귀 검증을 수행했다.
+
+## 최종 결론
+
+Swift native renderer는 이제 다음 image fill 정책을 처리한다.
+
+- `nil`, empty, `fitToSize`, `stretch`, `stretchToFit`, `none`, unknown: 기존처럼 bbox 전체 draw
+- placement: `leftTop`, `centerTop`, `rightTop`, `leftCenter`, `center`, `rightCenter`, `leftBottom`, `centerBottom`, `rightBottom`
+- tile: `tileAll`, `tileHorzTop`, `tileHorzBottom`, `tileVertLeft`, `tileVertRight`
+- alias: `tileHorizTop`, `tileHorizontalTop`, `tileHorizBottom`, `tileHorizontalBottom`, `tileVerticalLeft`, `tileVerticalRight`
+
+known placement/tile mode는 bbox clip 안에서 natural size로 draw한다. natural size는 `originalSize`를 우선하고, 없으면 원본 decoded image size, prepared image size 순서로 폴백한다. `originalSizeHU`는 upstream crop 계산과 충돌하지 않도록 draw size 계산에 사용하지 않았다.
+
+현재 sample set에서는 non-null `fill_mode` fixture가 없어 placement/tile positive visual proof는 확보하지 못했다. 대신 기존 image/crop sample의 bbox fallback 결과가 Stage 1 baseline과 동일하게 유지되는 것을 확인했다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | image fill policy enum, normalization, natural size, placement/tile draw helper, top-left rect CGImage draw helper 추가 |
+| `mydocs/plans/task_m014_122.md` | 수행계획서 |
+| `mydocs/plans/task_m014_122_impl.md` | 구현계획서 |
+| `mydocs/working/task_m014_122_stage1.md` | current path inventory와 baseline 보고 |
+| `mydocs/working/task_m014_122_stage2.md` | fill helper 설계 보고 |
+| `mydocs/working/task_m014_122_stage3.md` | 구현 완료 보고 |
+| `mydocs/working/task_m014_122_stage4.md` | 회귀 검증 보고 |
+| `mydocs/orders/20260601.md` | 오늘할일 완료 상태 갱신 |
+
+변경하지 않은 범위:
+
+- RustBridge C ABI
+- `rhwp-core.lock`
+- upstream `rhwp`
+- `RenderTree.swift` model schema
+- `PageOverlayImages.swift` overlay model schema
+- `HwpNativePageCompositor` pass order
+- `project.yml` / Xcode project
+
+## 구현 상세
+
+`CGTreeRenderer`의 기존 `imageDestinationRect(for:size:)` 방식은 단일 destination rect만 반환해 placement/tile draw를 표현하기 어려웠다. 이를 다음 helper 구조로 교체했다.
+
+- `normalizedImageFillPolicy(_:)`
+- `imageNaturalDrawSize(for:decodedImageSize:drawImageSize:)`
+- `drawImage(_:node:bbox:decodedImageSize:in:)`
+- `imagePlacementRect(_:in:size:)`
+- `drawImage(_:inTopLeftRect:in:)`
+- `drawTiledImage(_:bbox:tileMode:tileSize:in:)`
+
+render tree image와 overlay image는 모두 같은 draw helper를 호출한다. 기존 bitmap 준비 단계는 유지했다.
+
+- `preparedImage`의 crop/effect/brightness/contrast 적용 순서 유지
+- #116 baked watermark의 adjustment skip gate 유지
+- `applyTransform` 호출 위치 유지
+- tile draw cap은 upstream CanvasKit과 같은 `4096`
+- invalid size 또는 unknown mode는 bbox 전체 draw로 보수적 fallback
+
+## 변경 전·후 정량 비교
+
+Stage 4 visual diff는 Stage 1 baseline과 같은 세 sample을 같은 조건으로 재측정했다.
+
+기준:
+
+- Page: `1`
+- NativePolicy: `coreGraphicsOnly`
+- StudioReleaseTag: `v0.7.13`
+- StudioResolvedCommit: `b3e16ef212af81ef37d973ddb86d6816d3804642`
+- Viewport: `1400x1800`
+- SettleMs: `120`
+- DiffPixelThreshold: `12`
+
+| 파일 | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | StudioCapture | NativeBackend | Stage 1 NativeMs | Stage 4 NativeMs |
+|------|--------------:|---------------:|-------------:|------------:|------------|---------------|---------------|-----------------:|-----------------:|
+| `pic-crop-01.hwp` | `72763/3562815` | `2.0423%` | `0.8092` | `186` | `121,234 1345x1814` | `domComposite` | `coreGraphics` | `1021.7` | `1077.5` |
+| `tac-img-02.hwp` | `146377/3562815` | `4.1085%` | `3.6656` | `255` | `121,159 1345x1965` | `canvasDataURL` | `coreGraphics` | `23.7` | `23.4` |
+| `tac-img-02.hwpx` | `146377/3562815` | `4.1085%` | `3.6656` | `255` | `121,159 1345x1965` | `domComposite` | `coreGraphics` | `4.2` | `3.9` |
+
+해석:
+
+- ChangedPixels, ChangedPercent, MeanRGBDelta, MaxRGBDelta, DiffBounds가 Stage 1 baseline과 동일하다.
+- 현재 sample들은 `fill_mode == null`이므로 새 placement/tile branch는 직접 시각 검증되지 않았다.
+- 기존 bbox fallback path의 회귀는 관찰되지 않았다.
+
+## Render Debug / Metadata 검증
+
+`render-debug-compare` 결과:
+
+| 파일 | NativePNGSize | NativeNonWhitePixels | TextRuns | HangulRuns | MissingHangulGlyphs |
+|------|---------------|---------------------:|---------:|-----------:|--------------------:|
+| `pic-crop-01.hwp` | `794x1123` | `39870` | `2` | `0` | `0` |
+| `tac-img-02.hwp` | `794x1123` | `38410` | `18` | `6` | `0` |
+| `tac-img-02.hwpx` | `794x1123` | `38410` | `18` | `6` | `0` |
+
+`overlay-metadata-smoke` 결과:
+
+| 파일 | UpstreamImages | Overlay | Behind | Front | Renderable | BinLinked | TreeImages | TreeEmbeddedAvailable | Wraps |
+|------|---------------:|--------:|-------:|------:|-----------:|----------:|-----------:|----------------------:|-------|
+| `pic-crop-01.hwp` | `2` | `0` | `0` | `0` | `0` | `0` | `2` | `2/2` | `Square:2` |
+| `tac-img-02.hwp` | `1` | `0` | `0` | `0` | `0` | `0` | `1` | `1/1` | `TopAndBottom:1` |
+| `tac-img-02.hwpx` | `1` | `0` | `0` | `0` | `0` | `0` | `1` | `1/1` | `TopAndBottom:1` |
+
+fill mode fixture 확인:
+
+| 항목 | Count |
+|------|------:|
+| `fill_mode == null` | `4` |
+| non-null `fill_mode` | `0` |
+
+## 검증 결과
+
+| 검증 | 결과 |
+|------|------|
+| `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task122 CODE_SIGNING_ALLOWED=NO build` | OK |
+| `./scripts/preview-visual-diff-harness.sh build.noindex/task122-stage4-visual-escalated --page 1 ...` | OK |
+| `./scripts/render-debug-compare.sh build.noindex/task122-stage4-render-debug-hwp --page 1 ...` | OK |
+| `./scripts/render-debug-compare.sh build.noindex/task122-stage4-render-debug-hwpx --page 1 ...` | OK |
+| `./scripts/overlay-metadata-smoke.sh build.noindex/task122-stage4-overlay --page 1 ...` | OK |
+| `./scripts/check-extension-registration-hygiene.sh --check-only` | OK, Issues 없음 |
+| `git diff --check` | OK |
+
+비고:
+
+- `preview-visual-diff-harness.sh`는 sandbox 내부에서 Stage 1과 같은 WebKit readiness timeout이 발생해 sandbox 밖에서 재실행했다.
+- `xcodebuild`도 Sparkle package resolve와 SwiftPM/clang cache write 권한 제한 때문에 sandbox 밖 재실행으로 최종 통과를 확인했다.
+- `render-debug-compare`의 optional core SVG raster diff는 로컬 `qlmanage rasterize failed`로 생성되지 않았지만, native PNG와 summary는 정상 생성됐다.
+
+## 산출물
+
+```text
+build.noindex/task122-stage1-baseline-escalated/
+build.noindex/task122-stage3-render-debug/
+build.noindex/task122-stage4-visual-escalated/
+build.noindex/task122-stage4-render-debug-hwp/
+build.noindex/task122-stage4-render-debug-hwpx/
+build.noindex/task122-stage4-overlay/
+```
+
+## 잔여 위험과 한계
+
+- repository sample set에서 non-null `fill_mode` fixture를 확보하지 못했다. 실제 placement/tile 문서의 visual positive proof는 후속 fixture 확보 후 보강해야 한다.
+- `none` 의미는 upstream CanvasKit layer replay와 WebCanvas 사이에 차이가 있을 수 있으나, 이번 구현은 WebCanvas와 기존 Swift bbox fallback 동작을 우선했다.
+- tile draw cap 도달 시 public diagnostic은 추가하지 않았다. 현재 `CGTreeRenderer`에 unsupported diagnostics surface가 없으므로 향후 필요 시 별도 이슈로 다룬다.
+- CoreGraphics image interpolation과 scale 차이에 따른 pixel-level diff는 여전히 남는다.
+
+## 후속 제안
+
+1. non-null `fill_mode` HWP/HWPX fixture를 확보해 placement/tile positive visual test를 추가한다.
+2. `render-debug-compare.sh` output naming이 같은 basename의 HWP/HWPX를 같은 directory에서 덮는 문제를 별도 보강 후보로 등록한다.
+3. #121 RawSvg/OLE/chart, #110 Placeholder/FormObject 작업에서도 이번 helper가 bbox fallback을 유지하는지 sample set으로 재확인한다.
+
+## 작업지시자 승인 요청
+
+이 보고서를 기준으로 #122 PR을 `devel` 대상으로 게시하고 리뷰를 요청한다. PR merge 후에는 `pr-merge-cleanup` 절차로 이슈 close, publish branch 삭제, local branch/worktree 정리를 수행한다.

--- a/mydocs/report/task_m014_122_report.md
+++ b/mydocs/report/task_m014_122_report.md
@@ -17,6 +17,7 @@
 - Stage 2: upstream `v0.7.13` 기준 fill/tile/placement helper 설계를 문서화했다.
 - Stage 3: `CGTreeRenderer.swift`에 CoreGraphics image placement/tile helper를 구현했다.
 - Stage 4: visual diff, render-debug, overlay metadata, extension registration hygiene 회귀 검증을 수행했다.
+- PR review follow-up: `samples/basic/BookReview.hwp` page 2에서 placement 계열 non-null `fill_mode` fixture를 찾아 render-debug positive 검증을 보강했다.
 
 ## 최종 결론
 
@@ -29,7 +30,7 @@ Swift native renderer는 이제 다음 image fill 정책을 처리한다.
 
 known placement/tile mode는 bbox clip 안에서 natural size로 draw한다. natural size는 `originalSize`를 우선하고, 없으면 원본 decoded image size, prepared image size 순서로 폴백한다. `originalSizeHU`는 upstream crop 계산과 충돌하지 않도록 draw size 계산에 사용하지 않았다.
 
-현재 sample set에서는 non-null `fill_mode` fixture가 없어 placement/tile positive visual proof는 확보하지 못했다. 대신 기존 image/crop sample의 bbox fallback 결과가 Stage 1 baseline과 동일하게 유지되는 것을 확인했다.
+Stage 4 최초 regression sample set은 `fill_mode == null`만 포함했기 때문에 bbox fallback 보존 확인에 초점이 있었다. PR review follow-up에서는 `samples/basic/BookReview.hwp` page 2의 `LeftBottom`/`RightBottom` fixture로 placement positive 검증을 보강했다. tile 계열 fixture는 repository sample과 로컬 Downloads 스캔에서 찾지 못해 후속 fixture 확보 대상으로 남긴다.
 
 ## 변경 파일 목록과 영향 범위
 
@@ -96,7 +97,7 @@ Stage 4 visual diff는 Stage 1 baseline과 같은 세 sample을 같은 조건으
 해석:
 
 - ChangedPixels, ChangedPercent, MeanRGBDelta, MaxRGBDelta, DiffBounds가 Stage 1 baseline과 동일하다.
-- 현재 sample들은 `fill_mode == null`이므로 새 placement/tile branch는 직접 시각 검증되지 않았다.
+- Stage 4 visual diff sample들은 `fill_mode == null`이므로 bbox fallback 회귀 검증에 해당한다.
 - 기존 bbox fallback path의 회귀는 관찰되지 않았다.
 
 ## Render Debug / Metadata 검증
@@ -108,6 +109,7 @@ Stage 4 visual diff는 Stage 1 baseline과 같은 세 sample을 같은 조건으
 | `pic-crop-01.hwp` | `794x1123` | `39870` | `2` | `0` | `0` |
 | `tac-img-02.hwp` | `794x1123` | `38410` | `18` | `6` | `0` |
 | `tac-img-02.hwpx` | `794x1123` | `38410` | `18` | `6` | `0` |
+| `BookReview.hwp` page 2 | `794x1123` | `296408` | `117` | `81` | `0` |
 
 `overlay-metadata-smoke` 결과:
 
@@ -117,12 +119,20 @@ Stage 4 visual diff는 Stage 1 baseline과 같은 세 sample을 같은 조건으
 | `tac-img-02.hwp` | `1` | `0` | `0` | `0` | `0` | `0` | `1` | `1/1` | `TopAndBottom:1` |
 | `tac-img-02.hwpx` | `1` | `0` | `0` | `0` | `0` | `0` | `1` | `1/1` | `TopAndBottom:1` |
 
-fill mode fixture 확인:
+Stage 4 최초 sample의 fill mode fixture 확인:
 
 | 항목 | Count |
 |------|------:|
 | `fill_mode == null` | `4` |
 | non-null `fill_mode` | `0` |
+
+PR review follow-up placement positive fixture 확인:
+
+| 파일 | Page | ImageCount | `fill_mode == null` | NonNullFillModeCount | FillModeHistogram |
+|------|-----:|-----------:|--------------------:|---------------------:|-------------------|
+| `samples/basic/BookReview.hwp` | `2` | `3` | `0` | `3` | `LeftBottom=1`, `RightBottom=2` |
+
+첨부 확인 요청을 받았던 `/Users/melee/Downloads/143E433F503322BD33.hwp`는 image node 1개가 있었지만 `fill_mode == null`이라 non-null fixture가 아니었다. repository sample과 Downloads 추가 스캔에서 확인한 전체 non-null mode는 `FitToSize`, `None`, `LeftBottom`, `RightBottom`이며, tile 계열 fixture는 찾지 못했다.
 
 ## 검증 결과
 
@@ -132,6 +142,8 @@ fill mode fixture 확인:
 | `./scripts/preview-visual-diff-harness.sh build.noindex/task122-stage4-visual-escalated --page 1 ...` | OK |
 | `./scripts/render-debug-compare.sh build.noindex/task122-stage4-render-debug-hwp --page 1 ...` | OK |
 | `./scripts/render-debug-compare.sh build.noindex/task122-stage4-render-debug-hwpx --page 1 ...` | OK |
+| `./scripts/render-debug-compare.sh build.noindex/task122-review-bookreview-placement --page 2 samples/basic/BookReview.hwp` | OK |
+| `rg -o '"fill_mode":"[^"]+"' build.noindex/task122-review-bookreview-placement/BookReview-page2-render-tree.json` | OK, `LeftBottom=1`, `RightBottom=2` |
 | `./scripts/overlay-metadata-smoke.sh build.noindex/task122-stage4-overlay --page 1 ...` | OK |
 | `./scripts/check-extension-registration-hygiene.sh --check-only` | OK, Issues 없음 |
 | `git diff --check` | OK |
@@ -151,18 +163,19 @@ build.noindex/task122-stage4-visual-escalated/
 build.noindex/task122-stage4-render-debug-hwp/
 build.noindex/task122-stage4-render-debug-hwpx/
 build.noindex/task122-stage4-overlay/
+build.noindex/task122-review-bookreview-placement/
 ```
 
 ## 잔여 위험과 한계
 
-- repository sample set에서 non-null `fill_mode` fixture를 확보하지 못했다. 실제 placement/tile 문서의 visual positive proof는 후속 fixture 확보 후 보강해야 한다.
+- placement 계열은 `BookReview.hwp` page 2로 positive 검증을 보강했지만, tile 계열 fixture는 repository sample과 로컬 Downloads에서 확보하지 못했다. 실제 tile 문서의 visual positive proof는 후속 fixture 확보 후 보강해야 한다.
 - `none` 의미는 upstream CanvasKit layer replay와 WebCanvas 사이에 차이가 있을 수 있으나, 이번 구현은 WebCanvas와 기존 Swift bbox fallback 동작을 우선했다.
 - tile draw cap 도달 시 public diagnostic은 추가하지 않았다. 현재 `CGTreeRenderer`에 unsupported diagnostics surface가 없으므로 향후 필요 시 별도 이슈로 다룬다.
 - CoreGraphics image interpolation과 scale 차이에 따른 pixel-level diff는 여전히 남는다.
 
 ## 후속 제안
 
-1. non-null `fill_mode` HWP/HWPX fixture를 확보해 placement/tile positive visual test를 추가한다.
+1. tile 계열 non-null `fill_mode` HWP/HWPX fixture를 확보해 tile positive visual test를 추가한다.
 2. `render-debug-compare.sh` output naming이 같은 basename의 HWP/HWPX를 같은 directory에서 덮는 문제를 별도 보강 후보로 등록한다.
 3. #121 RawSvg/OLE/chart, #110 Placeholder/FormObject 작업에서도 이번 helper가 bbox fallback을 유지하는지 sample set으로 재확인한다.
 

--- a/mydocs/working/task_m014_122_stage1.md
+++ b/mydocs/working/task_m014_122_stage1.md
@@ -1,0 +1,252 @@
+# Task M014 #122 Stage 1 완료보고서
+
+## 개요
+
+Stage 1은 Swift/CoreGraphics renderer의 현재 image draw 경로를 inventory하고, #122 대상 sample의 baseline visual diff를 고정하는 단계다. 소스 코드는 변경하지 않았고, 기존 script와 local/bundled artifact만 사용해 측정했다.
+
+## 기준
+
+| 항목 | 값 |
+|------|----|
+| 이슈 | #122 Swift native renderer 이미지 fill mode·타일·배치 렌더링 parity 보강 |
+| 브랜치 | `local/task122` |
+| 기준 브랜치 | `origin/devel` `cfb60a0` |
+| core/studio 기준 | `edwardkim/rhwp v0.7.13`, `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| 수행계획서 | `mydocs/plans/task_m014_122.md` |
+| 구현계획서 | `mydocs/plans/task_m014_122_impl.md` |
+
+## Current Path Inventory
+
+### Render tree model
+
+`Sources/RhwpCoreBridge/RenderTree.swift`의 `ImageNode`는 #122에 필요한 입력 필드를 이미 디코딩한다.
+
+- `fillMode`
+- `originalSize`
+- `originalSizeHU`
+- `effect`
+- `brightness`
+- `contrast`
+- `textWrap`
+- `crop`
+
+따라서 Stage 3 구현의 중심은 모델 추가가 아니라 현재 입력을 draw 단계에서 제대로 소비하는 것이다.
+
+### Render tree image draw path
+
+`Sources/RhwpCoreBridge/CGTreeRenderer.swift` 기준 render tree image는 다음 흐름을 탄다.
+
+1. `renderImage`가 `binDataId`로 이미지를 가져온다.
+2. `preparedImage(for:node:)`가 crop과 effect/brightness/contrast를 적용한다.
+3. `imageDestinationRect(for:size:)`가 destination rect를 계산한다.
+4. Y축 반전된 국소 좌표계에서 `ctx.draw(drawImage, in: drawRect)`를 호출한다.
+
+현재 핵심 한계는 `imageDestinationRect(for:size:)`다. `fillMode`를 normalize하긴 하지만 `FitToSize`/stretch 계열과 default 모두 `fullRect`를 반환한다. 결과적으로 placement/tile mode가 들어와도 bbox 전체 stretch로 보인다.
+
+### Overlay image draw path
+
+`Sources/RhwpCoreBridge/PageOverlayImages.swift`는 render tree image supplement에서 overlay image model로 다음 필드를 병합한다.
+
+- `fillMode`
+- `originalSize`
+- `originalSizeHU`
+- `crop`
+- `effect`
+- `brightness`
+- `contrast`
+- `transform`
+
+`Sources/RhwpCoreBridge/CGTreeRenderer.swift`의 `renderOverlayImage`는 이 overlay model을 다시 `ImageNode`로 변환한 뒤 render tree image와 같은 `preparedImage` / `imageDestinationRect` path를 사용한다. 따라서 Stage 3에서 공통 image draw helper를 만들면 render tree image와 overlay image가 같은 fill/tile/placement 정책을 공유할 수 있다.
+
+### Native compositor path
+
+`Sources/Shared/HwpPageImageRenderer.swift`는 CoreGraphics renderer에서 `document.renderPageTree(at:)`와 `document.pageOverlayImages(at:renderTree:)`를 함께 가져온 뒤 `HwpNativePageCompositor.render`에 넘긴다.
+
+`Sources/Shared/HwpNativePageCompositor.swift`는 다음 순서를 유지한다.
+
+1. page background
+2. BehindText overlay
+3. flow excluding page overlays
+4. InFrontOfText overlay
+
+#122는 이 pass ordering 자체를 바꾸지 않고, 각 image pass 안에서 destination/tile 정책을 보강하는 범위로 유지한다.
+
+## Upstream Contract
+
+upstream `v0.7.13`의 CanvasKit image renderer는 다음 의미로 동작한다.
+
+1. crop이 있으면 source rect를 계산한다.
+2. `fillMode == fitToSize`면 bbox 전체에 draw한다.
+3. 그 외 모드는 `originalSize`를 tile/image size로 우선 사용하고, 없으면 image pixel size로 폴백한다.
+4. bbox로 clip한다.
+5. tile mode는 반복 draw한다.
+6. placement mode는 bbox 내부 기준 좌표에 원본 크기로 draw한다.
+
+확인한 tile mode:
+
+- `tileAll`
+- `tileHorzTop`
+- `tileHorzBottom`
+- `tileVertLeft`
+- `tileVertRight`
+
+확인한 placement mode:
+
+- `leftTop`
+- `centerTop`
+- `rightTop`
+- `leftCenter`
+- `center`
+- `rightCenter`
+- `leftBottom`
+- `centerBottom`
+- `rightBottom`
+
+Stage 2에서는 이 contract를 Swift/CoreGraphics 좌상단 원점 좌표계와 기존 CGImage Y축 반전 처리에 맞게 helper로 설계한다.
+
+## Baseline Visual Diff
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task122-stage1-baseline --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx
+```
+
+첫 실행은 sandbox 내부 WebKit readiness timeout으로 실패했다.
+
+```text
+rhwp-studio page 1 readiness timed out: navigation=pending; events=[]; scheme={resourceRequests=0, documentRequests=0}
+```
+
+같은 명령을 권한 상승 실행한 결과는 성공했다.
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task122-stage1-baseline-escalated --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx
+```
+
+| 파일 | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | StudioCapture | NativeBackend | NativeMs |
+|------|--------------:|---------------:|-------------:|------------:|------------|---------------|---------------|---------:|
+| `pic-crop-01.hwp` | `72763/3562815` | `2.0423%` | `0.8092` | `186` | `121,234 1345x1814` | `domComposite` | `coreGraphics` | `1021.7` |
+| `tac-img-02.hwp` | `146377/3562815` | `4.1085%` | `3.6656` | `255` | `121,159 1345x1965` | `canvasDataURL` | `coreGraphics` | `23.7` |
+| `tac-img-02.hwpx` | `146377/3562815` | `4.1085%` | `3.6656` | `255` | `121,159 1345x1965` | `domComposite` | `coreGraphics` | `4.2` |
+
+산출물:
+
+```text
+build.noindex/task122-stage1-baseline/
+build.noindex/task122-stage1-baseline-escalated/
+```
+
+해석:
+
+- `pic-crop-01.hwp`는 image crop/fill 계열 sample로 diff가 낮다.
+- `tac-img-02.hwp`와 `tac-img-02.hwpx`는 같은 diff 수치를 보인다.
+- `tac-img-02.hwp`는 reference capture가 `canvasDataURL`, `tac-img-02.hwpx`는 `domComposite`다.
+- Stage 4 이후 비교 시 같은 capture mode 차이를 함께 기록해야 한다.
+
+## Overlay Metadata Smoke
+
+명령:
+
+```bash
+./scripts/overlay-metadata-smoke.sh build.noindex/task122-stage1-overlay --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx
+```
+
+결과:
+
+| 파일 | UpstreamImages | Overlay | Behind | Front | Renderable | BinLinked | TreeImages | TreeEmbeddedAvailable | Wraps |
+|------|---------------:|--------:|-------:|------:|-----------:|----------:|-----------:|-----------------------|-------|
+| `pic-crop-01.hwp` | `2` | `0` | `0` | `0` | `0` | `0` | `2` | `2/2` | `Square:2` |
+| `tac-img-02.hwp` | `1` | `0` | `0` | `0` | `0` | `0` | `1` | `1/1` | `TopAndBottom:1` |
+| `tac-img-02.hwpx` | `1` | `0` | `0` | `0` | `0` | `0` | `1` | `1/1` | `TopAndBottom:1` |
+
+산출물:
+
+```text
+build.noindex/task122-stage1-overlay/
+```
+
+해석:
+
+- 이번 baseline sample 3개에는 PageLayerTree overlay image가 없다.
+- #122의 Stage 3 구현은 render tree image path에서 먼저 효과가 나고, overlay path는 같은 helper를 공유하는지 회귀 smoke로 확인하는 방식이 맞다.
+
+## Render Tree Debug
+
+명령:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task122-stage1-render-debug --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx
+```
+
+동일 basename인 `tac-img-02.hwp`와 `tac-img-02.hwpx`는 output stem이 겹치므로 별도 output directory로 다시 실행했다.
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task122-stage1-render-debug-hwp --page 1 \
+  samples/tac-img-02.hwp
+
+./scripts/render-debug-compare.sh build.noindex/task122-stage1-render-debug-hwpx --page 1 \
+  samples/tac-img-02.hwpx
+```
+
+확인한 image node:
+
+| 파일 | Image count | fill_mode | original_size | original_size_hu | crop | text_wrap |
+|------|------------:|-----------|---------------|------------------|------|-----------|
+| `pic-crop-01.hwp` | `2` | `null` | `null` | 있음 | 있음 | `Square` |
+| `tac-img-02.hwp` | `1` | `null` | `null` | 있음 | 있음 | `TopAndBottom` |
+| `tac-img-02.hwpx` | `1` | `null` | `null` | 있음 | 있음 | `TopAndBottom` |
+
+추가로 대표 image sample 11개 첫 페이지를 훑었지만 non-null `fill_mode` fixture는 찾지 못했다.
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task122-stage1-fill-scan --page 1 \
+  samples/hwp-img-001.hwp samples/img-start-001.hwp \
+  samples/pic-in-head-01.hwp samples/pic-in-head-02.hwp samples/pic-in-table-01.hwp \
+  samples/20250130-hongbo.hwp samples/aift.hwp samples/biz_plan.hwp \
+  samples/k-water-rfp.hwp samples/kps-ai.hwp samples/복학원서.hwp
+```
+
+결과 요약:
+
+| 샘플군 | image count | non-null fill_mode |
+|--------|------------:|-------------------:|
+| Stage 1 baseline 3개 | `4` | `0` |
+| 추가 scan 11개 | `18` | `0` |
+
+## 판단
+
+1. Swift model은 #122 입력을 이미 보존한다.
+2. 실제 결함 지점은 `CGTreeRenderer`의 draw destination/tile policy 부재다.
+3. render tree image와 overlay image는 이미 같은 `ImageNode` path로 수렴하므로, Stage 3 구현은 공통 helper로 묶는 것이 맞다.
+4. 현재 sample set은 crop/effect 회귀 측정에는 충분하지만, placement/tile mode 자체를 pixel diff로 증명하기에는 non-null `fill_mode` fixture가 부족하다.
+5. Stage 2는 upstream CanvasKit/WebCanvas contract를 기준으로 helper 설계를 먼저 고정하고, Stage 3 구현 후 기존 sample에서는 회귀가 없는지 확인하는 방향이 타당하다.
+
+## 리스크
+
+- non-null `fill_mode` fixture가 없으면 tile/placement 자체의 visual diff 개선 수치를 이번 PR에서 직접 증명하기 어렵다.
+- `original_size_hu`와 `original_size`의 우선순위를 잘못 잡으면 현재 `fill_mode=null` sample에는 영향이 없더라도 후속 fixture에서 크기 회귀가 생길 수 있다.
+- `tac-img-02.hwp`와 `tac-img-02.hwpx`처럼 basename이 같은 파일은 일부 debug script output stem이 겹치므로 단계별 산출물 directory를 분리해야 한다.
+- WebKit reference capture는 sandbox 내부에서 readiness timeout이 날 수 있어, Stage 4 visual diff는 권한 상승 실행 필요 조건을 명시해야 한다.
+
+## 검증
+
+```bash
+git diff --check
+```
+
+Stage 1 보고서 작성 후 기준으로 통과했다.
+
+## 다음 단계 요청
+
+Stage 2에서는 코드 변경 전 `CGTreeRenderer`의 fill/tile/placement helper 설계를 문서로 고정한다. 특히 다음 항목을 확정한다.
+
+- fill mode normalization
+- `FitToSize`/stretch/null/unknown fallback
+- `original_size`, `original_size_hu`, image pixel size 우선순위
+- crop/effect/baked watermark gate와 draw policy 적용 순서
+- tile loop와 clip/max tile guard 정책

--- a/mydocs/working/task_m014_122_stage2.md
+++ b/mydocs/working/task_m014_122_stage2.md
@@ -1,0 +1,258 @@
+# Task M014 #122 Stage 2 완료보고서
+
+## 개요
+
+Stage 2는 코드 변경 전 Swift/CoreGraphics image fill/tile/placement helper 설계를 고정하는 단계다. Stage 1에서 확인한 것처럼 Swift model은 입력 필드를 이미 보존하지만 `CGTreeRenderer`의 draw destination 정책이 bbox 전체 draw로 고정되어 있다. Stage 3 구현은 이 문서의 설계를 기준으로 최소 변경한다.
+
+## 기준
+
+| 항목 | 값 |
+|------|----|
+| 이슈 | #122 Swift native renderer 이미지 fill mode·타일·배치 렌더링 parity 보강 |
+| 브랜치 | `local/task122` |
+| 기준 브랜치 | `origin/devel` `cfb60a0` |
+| core/studio 기준 | `edwardkim/rhwp v0.7.13`, `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| 선행 단계 | `mydocs/working/task_m014_122_stage1.md` |
+
+## 설계 목표
+
+- render tree image와 overlay image가 같은 fill/tile/placement draw policy를 사용한다.
+- 기존 `crop`, `effect`, `brightness`, `contrast`, #116 baked watermark gate는 유지한다.
+- `fill_mode == nil`, `FitToSize`, `None`, unknown mode는 현재 bbox 전체 draw 동작을 보존한다.
+- known placement/tile mode만 bbox clip + original size 기반 draw로 전환한다.
+- Swift/AppKit/CoreGraphics 좌표계에 맞춰 CGImage Y축 반전 문제를 helper 안으로 숨긴다.
+
+## 현재 변경 대상
+
+Stage 3의 코드 변경은 우선 `Sources/RhwpCoreBridge/CGTreeRenderer.swift`에 제한한다.
+
+변경 대상 함수:
+
+- `renderImage(_:bbox:in:)`
+- `renderOverlayImage(_:in:document:)`
+- `imageDestinationRect(for:size:)`
+
+예상 helper:
+
+- `normalizedImageFillPolicy(_:)`
+- `imageNaturalDrawSize(for:decodedImageSize:drawImageSize:)`
+- `drawImage(_:node:bbox:in:)`
+- `drawImage(_:inTopLeftRect:in:)`
+- `drawTiledImage(_:bbox:tileMode:tileSize:in:)`
+
+필요 시 private enum을 `CGTreeRenderer` 내부에 둔다. 새 public API나 bridge ABI 변경은 하지 않는다.
+
+## Fill Mode Normalization
+
+입력 `fillMode`는 문자열이므로 다음 정규화를 적용한다.
+
+1. 앞뒤 whitespace 제거
+2. `_`, `-`, 공백 제거
+3. lowercase
+
+정책:
+
+| normalized 값 | 정책 | 이유 |
+|----------------|------|------|
+| `nil`, empty | `.fitToSize` | 현재 render tree picture path 동작 보존 |
+| `fittosize`, `stretch`, `stretchtofit` | `.fitToSize` | 기존 Swift 동작과 upstream bbox draw 의미 |
+| `none` | `.fitToSize` | upstream WebCanvas가 `ImageFillMode::None`을 `FitToSize`와 같은 branch로 처리하고, 현재 Swift bbox draw와도 일치 |
+| `lefttop` | `.placement(.leftTop)` | known placement |
+| `centertop` | `.placement(.centerTop)` | known placement |
+| `righttop` | `.placement(.rightTop)` | known placement |
+| `leftcenter` | `.placement(.leftCenter)` | known placement |
+| `center`, `centercenter` | `.placement(.center)` | known placement 및 alias |
+| `rightcenter` | `.placement(.rightCenter)` | known placement |
+| `leftbottom` | `.placement(.leftBottom)` | known placement |
+| `centerbottom` | `.placement(.centerBottom)` | known placement |
+| `rightbottom` | `.placement(.rightBottom)` | known placement |
+| `tileall` | `.tile(.all)` | known tile |
+| `tilehorztop`, `tilehoriztop`, `tilehorizontaltop` | `.tile(.horizontalTop)` | known tile |
+| `tilehorzbottom`, `tilehorizbottom`, `tilehorizontalbottom` | `.tile(.horizontalBottom)` | known tile |
+| `tilevertleft`, `tileverticalleft` | `.tile(.verticalLeft)` | known tile |
+| `tilevertright`, `tileverticalright` | `.tile(.verticalRight)` | known tile |
+| 그 외 | `.fitToSize` | 기존 full bbox fallback 보존 |
+
+실제 Swift 구현에서는 정규화 후 lowercase 문자열만 비교하므로 `tilehoriztop`, `tilehorizbottom`, `tileverticalleft`, `tileverticalright` alias도 함께 두는 편이 안전하다.
+
+## Size Policy
+
+known placement/tile mode에서 사용할 draw size 우선순위:
+
+1. `ImageNode.originalSize`가 2개 이상의 positive finite 값이면 사용
+2. 아니면 원본 decode 직후 `CGImage.width/height` 사용
+3. 이것도 invalid이면 prepared image size 사용
+4. 여전히 invalid이면 `.fitToSize` fallback
+
+`originalSizeHU`는 draw size 계산에 사용하지 않는다.
+
+이유:
+
+- upstream render tree 문서상 `original_size`는 fill mode가 배치 모드일 때 원래 크기대로 배치하기 위한 display coordinate 값이다.
+- upstream `compute_image_crop_src`는 현재 `original_size_hu`를 crop scale 계산에 사용하지 않고 75 HU/px 표준 룰을 사용한다.
+- 현재 Swift `croppedImage`도 `imageCropUnitsPerPixel = 75.0`을 사용하므로 `originalSizeHU`를 새 size policy에 끼워 넣으면 오히려 #106/#116 이후 crop 동작과 충돌할 수 있다.
+
+주의:
+
+- `preparedImage`는 crop/effect가 적용된 이미지일 수 있다.
+- tile/placement fallback size는 crop 이후 이미지 크기가 아니라 원본 decoded image size를 우선 사용한다. upstream CanvasKit도 crop source rect와 destination size를 분리한다.
+- `originalSize`가 있으면 crop 여부와 관계없이 destination tile/image size는 `originalSize`를 따른다.
+
+## Draw Order
+
+Stage 3의 image draw 순서:
+
+1. `CGImage` decode 또는 cache hit
+2. 원본 decoded image size 저장
+3. `preparedImage(for:node:applyingAdjustments:)`
+   - crop 적용
+   - effect/brightness/contrast 적용
+   - overlay baked watermark adjustment skip 유지
+4. fill policy normalization
+5. bbox rect 계산
+6. policy별 draw
+
+정책별 draw:
+
+| 정책 | 동작 |
+|------|------|
+| `.fitToSize` | bbox 전체 draw |
+| `.placement` | bbox clip 후 natural size로 placement rect에 draw |
+| `.tile` | bbox clip 후 tile loop로 반복 draw |
+
+## CGImage 좌표계 설계
+
+기존 코드는 bbox local coordinate로 이동한 뒤 Y축을 뒤집고 `ctx.draw(image, in:)`를 호출한다. 이 방식은 full bbox draw에는 문제가 없지만, partial placement/tile rect를 단순히 `drawRect`로 전달하면 top/bottom 위치가 뒤집힐 수 있다.
+
+Stage 3에서는 destination rect를 항상 현재 renderer의 top-left page coordinate로 계산한다. 실제 CGImage draw 직전에만 다음 helper로 국소 flip을 적용한다.
+
+```swift
+private func drawImage(_ image: CGImage, inTopLeftRect rect: CGRect, in ctx: CGContext) {
+    ctx.saveGState()
+    ctx.translateBy(x: rect.minX, y: rect.minY + rect.height)
+    ctx.scaleBy(x: 1, y: -1)
+    ctx.draw(image, in: CGRect(origin: .zero, size: rect.size))
+    ctx.restoreGState()
+}
+```
+
+이 helper를 사용하면 placement와 tile 계산은 모두 top-left 좌표계로 유지할 수 있다.
+
+## Placement Rect
+
+placement rect는 bbox와 natural size를 기준으로 계산한다.
+
+| Placement | x | y |
+|-----------|---|---|
+| leftTop | `bbox.minX` | `bbox.minY` |
+| centerTop | `bbox.midX - width / 2` | `bbox.minY` |
+| rightTop | `bbox.maxX - width` | `bbox.minY` |
+| leftCenter | `bbox.minX` | `bbox.midY - height / 2` |
+| center | `bbox.midX - width / 2` | `bbox.midY - height / 2` |
+| rightCenter | `bbox.maxX - width` | `bbox.midY - height / 2` |
+| leftBottom | `bbox.minX` | `bbox.maxY - height` |
+| centerBottom | `bbox.midX - width / 2` | `bbox.maxY - height` |
+| rightBottom | `bbox.maxX - width` | `bbox.maxY - height` |
+
+draw 전에는 `ctx.clip(to: bbox)`를 적용한다. natural size가 bbox보다 커도 clip으로 잘라낸다.
+
+## Tile Loop
+
+tile mode는 bbox clip 안에서 natural size로 반복 draw한다.
+
+| Tile mode | 시작점/반복 |
+|-----------|-------------|
+| tileAll | `x = bbox.minX`, `y = bbox.minY`부터 양방향 반복 |
+| tileHorzTop | `y = bbox.minY`, `x = bbox.minX`부터 수평 반복 |
+| tileHorzBottom | `y = bbox.maxY - tileHeight`, `x = bbox.minX`부터 수평 반복 |
+| tileVertLeft | `x = bbox.minX`, `y = bbox.minY`부터 수직 반복 |
+| tileVertRight | `x = bbox.maxX - tileWidth`, `y = bbox.minY`부터 수직 반복 |
+
+guard:
+
+- `tileWidth <= 0` 또는 `tileHeight <= 0`이면 `.fitToSize` fallback
+- 최대 tile draw count는 upstream CanvasKit과 같은 `4096`으로 둔다.
+- 한계에 도달하면 그 지점에서 중단한다. 현재 `CGTreeRenderer`에는 unsupported diagnostics surface가 없으므로 Stage 3에서는 별도 public diagnostic을 추가하지 않는다.
+
+## Transform/Clip Policy
+
+기존 `applyTransform(node.transform, bbox: bbox, in: ctx)` 호출은 유지한다.
+
+순서:
+
+1. renderer는 현재처럼 image별 `ctx.saveGState()`
+2. `applyTransform`
+3. fill/tile/placement draw helper 호출
+4. helper 내부에서 필요한 경우 `ctx.clip(to: bboxRect)`
+5. 각 draw call마다 `drawImage(_:inTopLeftRect:in:)`로 CGImage flip
+6. renderer image scope의 `ctx.restoreGState()`
+
+upstream CanvasKit도 `withImageTransform(..., () => drawImageOp(...))` 안에서 bbox clip을 수행하므로 이 순서는 upstream과 맞는다.
+
+## Overlay Path Policy
+
+overlay path는 Stage 3에서 별도 구현을 만들지 않는다.
+
+- `renderOverlayImage`는 현재처럼 `RhwpPageOverlayImage`를 `ImageNode`로 변환한다.
+- `bakedWatermark == true && source.data != nil`이면 adjustment skip gate를 유지한다.
+- 이후 draw helper는 render tree image와 동일하게 호출한다.
+
+이렇게 하면 #282 overlay compositor와 #116 baked watermark gate를 건드리지 않고 fill/tile/placement 정책만 공유할 수 있다.
+
+## Fallback Policy
+
+다음 경우는 기존 bbox 전체 draw로 폴백한다.
+
+- `fillMode`가 nil 또는 empty
+- `fitToSize`, `stretch`, `stretchToFit`, `none`
+- unknown fill mode
+- natural size 계산 실패
+- tile size가 0 이하
+
+fallback은 실패를 숨기는 목적이 아니라 기존 sample 회귀를 막기 위한 보수적 정책이다. Stage 1에서 non-null `fill_mode` fixture가 부족했기 때문에 unknown mode를 original-size placement로 바꾸지 않는다.
+
+## Stage 3 구현 단위
+
+예상 변경은 다음 순서로 진행한다.
+
+1. private enum/helper 추가
+2. `renderImage`가 원본 decoded size와 prepared image를 함께 넘기도록 수정
+3. `renderOverlayImage`도 같은 helper를 사용하도록 수정
+4. 기존 `imageDestinationRect(for:size:)`는 제거하거나 `.fitToSize` 전용 helper로 축소
+5. `git diff --check`와 build 검증
+
+## 검증 계획
+
+Stage 3 구현 후 최소 검증:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task122-stage3-render-debug --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp
+
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task122 CODE_SIGNING_ALLOWED=NO build
+
+git diff --check
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+Stage 4에서 visual diff와 regression smoke를 별도로 수행한다.
+
+## 리스크
+
+- `none`의 의미는 upstream CanvasKit layer replay와 WebCanvas 사이에 차이가 있을 수 있다. 이번 작업에서는 WebCanvas와 기존 Swift 동작을 우선해 bbox draw로 둔다.
+- 현재 sample set에는 non-null `fill_mode` fixture가 부족해 Stage 3에서 tile/placement 개선을 visual diff로 직접 증명하기 어렵다.
+- tile/placement rect는 CGImage flip helper가 잘못되면 상하 위치가 반대로 나타날 수 있다.
+- tile draw cap에 도달하는 문서는 이번 작업에서 별도 diagnostics가 없으므로, 향후 diagnostic surface가 필요할 수 있다.
+
+## 검증
+
+```bash
+git diff --check
+```
+
+Stage 2 보고서 작성 후 기준으로 통과했다.
+
+## 다음 단계 요청
+
+Stage 3에서는 이 설계에 따라 `CGTreeRenderer.swift`에 실제 fill/tile/placement draw helper를 구현한다. 구현 범위는 Swift/CoreGraphics renderer 내부로 제한하고, render tree model/overlay model/upstream core는 변경하지 않는다.

--- a/mydocs/working/task_m014_122_stage3.md
+++ b/mydocs/working/task_m014_122_stage3.md
@@ -1,0 +1,127 @@
+# Task M014 #122 Stage 3 완료보고서
+
+## 개요
+
+Stage 3에서는 Stage 2 설계에 따라 Swift/CoreGraphics renderer의 image fill mode 처리 경로를 구현했다. 변경 범위는 `CGTreeRenderer.swift` 내부 helper와 image draw 호출부로 제한했고, render tree model, overlay model, Rust bridge ABI, upstream core pin은 변경하지 않았다.
+
+## 기준
+
+| 항목 | 값 |
+|------|----|
+| 이슈 | #122 Swift native renderer 이미지 fill mode·타일·배치 렌더링 parity 보강 |
+| 브랜치 | `local/task122` |
+| 선행 단계 | `mydocs/working/task_m014_122_stage2.md` |
+| 변경 파일 | `Sources/RhwpCoreBridge/CGTreeRenderer.swift` |
+
+## 구현 내용
+
+### Fill Policy
+
+`fillMode` 문자열을 다음 순서로 정규화해 private policy로 변환한다.
+
+- 앞뒤 whitespace 제거
+- `_`, `-`, 공백, tab 제거
+- lowercase 비교
+
+정책 매핑:
+
+- `nil`, empty, `fitToSize`, `stretch`, `stretchToFit`, `none`, unknown: bbox 전체 draw
+- placement: `leftTop`, `centerTop`, `rightTop`, `leftCenter`, `center`, `rightCenter`, `leftBottom`, `centerBottom`, `rightBottom`
+- tile: `tileAll`, `tileHorzTop`, `tileHorzBottom`, `tileVertLeft`, `tileVertRight`
+- tile alias: `tileHorizTop`, `tileHorizontalTop`, `tileHorizBottom`, `tileHorizontalBottom`, `tileVerticalLeft`, `tileVerticalRight`
+
+`none`과 unknown은 기존 Swift 동작과 upstream WebCanvas 기준에 맞춰 bbox 전체 draw로 유지했다.
+
+### Natural Size
+
+placement/tile draw size는 다음 순서로 선택한다.
+
+1. `ImageNode.originalSize`가 positive finite 2개 이상이면 사용
+2. 아니면 원본 decode 직후 `CGImage.width/height` 사용
+3. 아니면 crop/effect 적용 후 prepared image size 사용
+4. 실패하면 bbox 전체 draw로 fallback
+
+`originalSizeHU`는 Stage 2 설계대로 draw size 계산에 사용하지 않았다.
+
+### Draw Helper
+
+render tree image와 overlay image 모두 다음 공용 helper 경로를 사용한다.
+
+- decode/cache된 원본 `CGImage`의 size를 보존
+- 기존 `preparedImage`로 crop/effect/brightness/contrast 적용
+- #116 baked watermark는 기존처럼 adjustment skip 유지
+- bbox 전체 draw, placement draw, tile draw를 `drawImage(_:node:bbox:decodedImageSize:in:)`로 분기
+- `drawImage(_:inTopLeftRect:in:)` 내부에서만 CGImage Y축 flip 처리
+
+placement/tile mode에서는 bbox clip을 적용한다. tile mode는 upstream CanvasKit과 같은 최대 draw count `4096`에서 중단한다.
+
+## 보존한 동작
+
+- `fillMode == nil`인 기존 sample의 bbox 전체 draw 동작
+- crop source rect 계산의 `75 HU/px` 규칙
+- effect/brightness/contrast 적용 순서
+- overlay image supplement merge와 baked watermark adjustment skip
+- `applyTransform` 호출 위치
+- public API와 FFI ABI
+
+## 검증
+
+### Build
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task122 CODE_SIGNING_ALLOWED=NO build
+```
+
+결과: 통과.
+
+비고:
+
+- 최초 sandbox 실행은 Sparkle package resolve 중 `github.com` DNS 차단으로 실패했다.
+- 네트워크 허용 재실행에서 build가 통과했다.
+- 최종 incremental sandbox 실행은 SwiftPM/clang cache write 권한 제한으로 실패했다.
+- 최종 소스 기준 sandbox 외부 재실행에서 `** BUILD SUCCEEDED ** [5.221 sec]`로 통과했다.
+
+### Render Debug Compare
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task122-stage3-render-debug --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp
+```
+
+결과: 두 sample 모두 native PNG 생성 성공.
+
+| Sample | Native PNG | NativeNonWhitePixels | 비고 |
+|--------|------------|----------------------|------|
+| `pic-crop-01.hwp` | `794x1123` | `39870` | `OK` |
+| `tac-img-02.hwp` | `794x1123` | `38410` | `OK` |
+
+`render-debug-compare`의 core SVG raster diff는 `qlmanage rasterize failed`로 생성되지 않았다. Stage 3의 최소 smoke 목적은 native renderer가 기존 nil fill_mode sample을 계속 렌더링하는지 확인하는 것이며, Stage 4에서 visual diff regression을 별도 수행한다.
+
+### Diff Check
+
+```bash
+git diff --check
+```
+
+결과: 통과.
+
+### Extension Registration Hygiene
+
+```bash
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+결과: Issues 없음.
+
+경고는 기존 build.noindex/DerivedData 아래 개발용 `Alhangeul.app` bundle 존재와 PlugInKit provider path 미보고뿐이며, development registration은 없었다.
+
+## 리스크와 후속 확인
+
+- 현재 sample set의 first page image node들은 `fill_mode == null`이라 tile/placement mode 자체를 시각 fixture로 직접 증명하지는 못했다.
+- 이번 구현은 upstream CanvasKit/WebCanvas 정책과 Swift 기존 fallback 보존을 기준으로 한 코드 경로 보강이다.
+- Stage 4에서는 visual diff regression과 추가 smoke를 수행하고, 가능한 경우 non-null fill_mode fixture 확보 여부를 다시 확인한다.
+
+## 다음 단계 요청
+
+Stage 4에서는 구현 후 regression 검증을 수행한다. 기본 대상은 visual diff harness, render debug artifact 확인, Quick Look/Thumbnail hygiene 재확인이다.

--- a/mydocs/working/task_m014_122_stage4.md
+++ b/mydocs/working/task_m014_122_stage4.md
@@ -1,0 +1,167 @@
+# Task M014 #122 Stage 4 완료보고서
+
+## 개요
+
+Stage 4에서는 Stage 3 구현 이후 preview visual diff, render-debug sanity, overlay metadata smoke, extension registration hygiene를 재실행해 회귀 여부를 확인했다. Stage 4에서 추가 소스 변경은 없고, 검증 결과와 fixture 한계를 문서화한다.
+
+## 기준
+
+| 항목 | 값 |
+|------|----|
+| 이슈 | #122 Swift native renderer 이미지 fill mode·타일·배치 렌더링 parity 보강 |
+| 브랜치 | `local/task122` |
+| 구현 커밋 | `81afc8c Task #122 Stage 3: 이미지 fill 렌더 helper 구현` |
+| Stage 4 산출물 | `build.noindex/task122-stage4-*` |
+| 기준 baseline | `mydocs/working/task_m014_122_stage1.md` |
+
+## Preview Visual Diff
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task122-stage4-visual --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx
+```
+
+sandbox 내부 실행은 Stage 1과 같은 WebKit readiness timeout으로 실패했다.
+
+```text
+rhwp-studio page 1 readiness timed out: navigation=pending; events=[]; scheme={resourceRequests=0, documentRequests=0}
+```
+
+동일 명령을 sandbox 밖에서 재실행했다.
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task122-stage4-visual-escalated --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx
+```
+
+결과: 세 sample 모두 OK.
+
+| 파일 | ChangedPixels | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | StudioCapture | NativeBackend | Stage 1 NativeMs | Stage 4 NativeMs |
+|------|--------------:|---------------:|-------------:|------------:|------------|---------------|---------------|-----------------:|-----------------:|
+| `pic-crop-01.hwp` | `72763/3562815` | `2.0423%` | `0.8092` | `186` | `121,234 1345x1814` | `domComposite` | `coreGraphics` | `1021.7` | `1077.5` |
+| `tac-img-02.hwp` | `146377/3562815` | `4.1085%` | `3.6656` | `255` | `121,159 1345x1965` | `canvasDataURL` | `coreGraphics` | `23.7` | `23.4` |
+| `tac-img-02.hwpx` | `146377/3562815` | `4.1085%` | `3.6656` | `255` | `121,159 1345x1965` | `domComposite` | `coreGraphics` | `4.2` | `3.9` |
+
+해석:
+
+- ChangedPixels, ChangedPercent, MeanRGBDelta, MaxRGBDelta, DiffBounds가 Stage 1 baseline과 동일하다.
+- Stage 3의 fill helper 구현은 현재 세 sample의 기존 bbox draw 결과를 바꾸지 않았다.
+- NativeMs는 실행 시점 변동이 있으나 regression 신호로 보이지 않는다.
+
+산출물:
+
+```text
+build.noindex/task122-stage4-visual/
+build.noindex/task122-stage4-visual-escalated/
+```
+
+## Render Debug Sanity
+
+처음에는 세 sample을 같은 output directory로 실행했으나 `tac-img-02.hwp`와 `tac-img-02.hwpx`가 같은 basename이라 summary 파일이 덮이는 것을 확인했다. 기록을 명확히 하기 위해 HWP/HWPX output directory를 분리했다.
+
+명령:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task122-stage4-render-debug-hwp --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp
+
+./scripts/render-debug-compare.sh build.noindex/task122-stage4-render-debug-hwpx --page 1 \
+  samples/tac-img-02.hwpx
+```
+
+결과: 세 sample 모두 OK.
+
+| 파일 | NativePNGSize | NativeNonWhitePixels | TextRuns | HangulRuns | MissingHangulGlyphs |
+|------|---------------|---------------------:|---------:|-----------:|--------------------:|
+| `pic-crop-01.hwp` | `794x1123` | `39870` | `2` | `0` | `0` |
+| `tac-img-02.hwp` | `794x1123` | `38410` | `18` | `6` | `0` |
+| `tac-img-02.hwpx` | `794x1123` | `38410` | `18` | `6` | `0` |
+
+`render-debug-compare`의 optional core SVG raster diff는 `qlmanage rasterize failed`로 생성되지 않았다. native PNG와 summary는 정상 생성됐다.
+
+산출물:
+
+```text
+build.noindex/task122-stage4-render-debug-hwp/
+build.noindex/task122-stage4-render-debug-hwpx/
+```
+
+## Fill Mode Fixture 확인
+
+Stage 4 render tree 산출물에서 `fill_mode`를 다시 확인했다.
+
+```bash
+rg -o '"fill_mode":null' build.noindex/task122-stage4-render-debug-hwp \
+  build.noindex/task122-stage4-render-debug-hwpx | wc -l
+
+rg -o '"fill_mode":"[^"]+"' build.noindex/task122-stage4-render-debug-hwp \
+  build.noindex/task122-stage4-render-debug-hwpx | wc -l
+```
+
+결과:
+
+| 항목 | Count |
+|------|------:|
+| `fill_mode == null` | `4` |
+| non-null `fill_mode` | `0` |
+
+현재 검증 sample은 Stage 3 구현의 fallback 보존과 기존 image path 회귀 방지에는 유효하지만, 실제 tile/placement mode를 시각 fixture로 직접 증명하지는 못한다.
+
+## Overlay Metadata Smoke
+
+명령:
+
+```bash
+./scripts/overlay-metadata-smoke.sh build.noindex/task122-stage4-overlay --page 1 \
+  samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx
+```
+
+결과: 세 sample 모두 OK.
+
+| 파일 | UpstreamImages | Overlay | Behind | Front | Renderable | BinLinked | TreeImages | TreeEmbeddedAvailable | Wraps |
+|------|---------------:|--------:|-------:|------:|-----------:|----------:|-----------:|----------------------:|-------|
+| `pic-crop-01.hwp` | `2` | `0` | `0` | `0` | `0` | `0` | `2` | `2/2` | `Square:2` |
+| `tac-img-02.hwp` | `1` | `0` | `0` | `0` | `0` | `0` | `1` | `1/1` | `TopAndBottom:1` |
+| `tac-img-02.hwpx` | `1` | `0` | `0` | `0` | `0` | `0` | `1` | `1/1` | `TopAndBottom:1` |
+
+산출물:
+
+```text
+build.noindex/task122-stage4-overlay/
+```
+
+## Extension Registration Hygiene
+
+명령:
+
+```bash
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+결과: Issues 없음.
+
+비고:
+
+- development registration 없음.
+- build.noindex/DerivedData 아래 개발용 `Alhangeul.app` bundle 존재 경고는 등록되어 있지 않으므로 문제 없음.
+- PlugInKit provider path 미보고 경고는 기존 smoke와 동일하다.
+
+## Diff Check
+
+명령:
+
+```bash
+git diff --check
+```
+
+결과: 통과.
+
+## 결론
+
+Stage 3 구현 이후 기존 image/crop sample의 visual diff 수치는 Stage 1 baseline과 동일했다. render-debug, overlay metadata, extension registration hygiene도 실패 없이 통과했다. 남은 한계는 non-null `fill_mode` sample 부재이며, 실제 tile/placement positive fixture 확보는 후속 보강 후보로 남긴다.
+
+## 다음 단계 요청
+
+Stage 5에서는 최종 정리 단계로 넘어가 Task #122 최종 보고서 작성, today order 갱신, 최종 검증 결과 정리, PR 준비 여부 확인을 진행한다.

--- a/mydocs/working/task_m014_122_stage4.md
+++ b/mydocs/working/task_m014_122_stage4.md
@@ -109,6 +109,45 @@ rg -o '"fill_mode":"[^"]+"' build.noindex/task122-stage4-render-debug-hwp \
 
 현재 검증 sample은 Stage 3 구현의 fallback 보존과 기존 image path 회귀 방지에는 유효하지만, 실제 tile/placement mode를 시각 fixture로 직접 증명하지는 못한다.
 
+## PR Review Follow-up: Placement Positive Fixture
+
+Copilot review에서 Stage 4 검증 sample이 `fill_mode == null`만 포함해 placement/tile branch positive 검증이 부족하다는 지적이 있었다. 이후 repository sample과 Downloads의 HWP/HWPX를 추가 스캔했고, repository sample인 `samples/basic/BookReview.hwp` page 2에서 placement 계열 non-null `fill_mode`를 확인했다.
+
+첨부 확인 요청을 받았던 `/Users/melee/Downloads/143E433F503322BD33.hwp`는 image node 1개가 있었지만 `fill_mode == null`이라 positive fixture가 아니었다.
+
+추가 검증 명령:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task122-review-bookreview-placement --page 2 \
+  samples/basic/BookReview.hwp
+
+rg -o '"fill_mode":"[^"]+"' \
+  build.noindex/task122-review-bookreview-placement/BookReview-page2-render-tree.json
+
+rg -o '"node_type":\{"Image"' \
+  build.noindex/task122-review-bookreview-placement/BookReview-page2-render-tree.json | wc -l
+
+rg -o '"fill_mode":null' \
+  build.noindex/task122-review-bookreview-placement/BookReview-page2-render-tree.json | wc -l
+```
+
+결과:
+
+| 파일 | Page | ImageCount | `fill_mode == null` | NonNullFillModeCount | FillModeHistogram | NativePNGSize | NativeNonWhitePixels | TextRuns | MissingHangulGlyphs |
+|------|-----:|-----------:|--------------------:|---------------------:|-------------------|---------------|---------------------:|---------:|--------------------:|
+| `samples/basic/BookReview.hwp` | `2` | `3` | `0` | `3` | `LeftBottom=1`, `RightBottom=2` | `794x1123` | `296408` | `117` | `0` |
+
+render-debug 산출물:
+
+```text
+build.noindex/task122-review-bookreview-placement/BookReview-page2-render-tree.json
+build.noindex/task122-review-bookreview-placement/BookReview-page2-core.svg
+build.noindex/task122-review-bookreview-placement/BookReview-page2-native.png
+build.noindex/task122-review-bookreview-placement/BookReview-page2-summary.txt
+```
+
+추가 스캔에서 확인한 전체 non-null mode는 `FitToSize`, `None`, `LeftBottom`, `RightBottom`이었다. 로컬 repository sample과 Downloads에서는 `TileAll`, `TileHorz*`, `TileVert*`, `LeftTop`, `Center*`, `RightTop` fixture를 찾지 못했다. 따라서 이번 follow-up은 placement branch positive 검증을 보강하고, tile branch visual positive fixture 부재는 남은 한계로 명시한다.
+
 ## Overlay Metadata Smoke
 
 명령:
@@ -160,7 +199,7 @@ git diff --check
 
 ## 결론
 
-Stage 3 구현 이후 기존 image/crop sample의 visual diff 수치는 Stage 1 baseline과 동일했다. render-debug, overlay metadata, extension registration hygiene도 실패 없이 통과했다. 남은 한계는 non-null `fill_mode` sample 부재이며, 실제 tile/placement positive fixture 확보는 후속 보강 후보로 남긴다.
+Stage 3 구현 이후 기존 image/crop sample의 visual diff 수치는 Stage 1 baseline과 동일했다. render-debug, overlay metadata, extension registration hygiene도 실패 없이 통과했다. PR review follow-up으로 `BookReview.hwp` page 2에서 `LeftBottom`/`RightBottom` placement positive fixture를 추가 확인했다. 남은 한계는 tile 계열 positive fixture 부재이며, 실제 tile visual proof 확보는 후속 보강 후보로 남긴다.
 
 ## 다음 단계 요청
 


### PR DESCRIPTION
## 요약

- 대상 타스크: #122 Swift native renderer 이미지 fill mode·타일·배치 parity 보강
- 왜: Swift/CoreGraphics image draw path가 `fill_mode`를 bbox 전체 draw로만 처리해 upstream `rhwp v0.7.13`의 placement/tile contract를 소비하지 못했다.
- 무엇: `CGTreeRenderer`에 fill policy normalization, natural size fallback, placement/tile draw helper를 추가하고 render tree image와 overlay image가 같은 helper를 쓰게 했다.
- Copilot review follow-up: `samples/basic/BookReview.hwp` page 2에서 `LeftBottom=1`, `RightBottom=2` placement positive fixture를 확인하고 Stage 4/최종 보고서에 반영했다.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/publish/task122/mydocs/working/task_m014_122_stage1.md)**: current image render path와 baseline visual diff를 정리했다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/publish/task122/mydocs/working/task_m014_122_stage2.md)**: fill/tile/placement helper 설계와 fallback 정책을 고정했다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/publish/task122/mydocs/working/task_m014_122_stage3.md)**: `CGTreeRenderer` image fill helper를 구현했다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/publish/task122/mydocs/working/task_m014_122_stage4.md)**: visual diff, render-debug, overlay metadata, extension hygiene 회귀 검증을 수행했다.
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/publish/task122/mydocs/report/task_m014_122_report.md)**: 최종 보고서와 오늘할일 완료 상태를 정리했다.
- **[PR review follow-up](https://github.com/postmelee/alhangeul-macos/blob/publish/task122/mydocs/working/task_m014_122_stage4.md#pr-review-follow-up-placement-positive-fixture)**: `BookReview.hwp` page 2 placement positive fixture 검증을 추가했다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | fill policy enum, normalization, natural size, placement/tile draw helper 추가 | fallback과 좌표계 flip이 기존 bbox draw를 깨지 않는지 |
| image draw path | render tree image와 overlay image가 같은 helper 사용 | #116 baked watermark adjustment skip 유지 |
| 검증 문서 | Stage 4/최종 보고서에 `BookReview.hwp` page 2 positive fixture 결과 추가 | placement positive 확인, tile fixture 부재 한계 명시 |
| 오늘할일 | #122 완료 상태 갱신 | PR 승인 대기 상태 |

- 수행 계획서: [task_m014_122.md](https://github.com/postmelee/alhangeul-macos/blob/publish/task122/mydocs/plans/task_m014_122.md)
- 구현 계획서: [task_m014_122_impl.md](https://github.com/postmelee/alhangeul-macos/blob/publish/task122/mydocs/plans/task_m014_122_impl.md)
- Stage 4 보고서: [task_m014_122_stage4.md](https://github.com/postmelee/alhangeul-macos/blob/publish/task122/mydocs/working/task_m014_122_stage4.md)
- 최종 보고서: [task_m014_122_report.md](https://github.com/postmelee/alhangeul-macos/blob/publish/task122/mydocs/report/task_m014_122_report.md)

## 핵심 리뷰 포인트

- `normalizedImageFillPolicy(_:)`가 upstream `v0.7.13`의 placement/tile 이름과 기존 Swift fallback을 보수적으로 매핑하는지.
- `imageNaturalDrawSize`가 `originalSize -> decoded CGImage size -> prepared image size` 순서를 따르고, `originalSizeHU`를 draw size에 섞지 않는지.
- `drawImage(_:inTopLeftRect:in:)`와 bbox clip이 CoreGraphics top-left renderer 좌표계에서 placement/tile 상하 위치를 뒤집지 않는지.

## 검증

- `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task122 CODE_SIGNING_ALLOWED=NO build`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task122-stage4-visual-escalated --page 1 samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx`
- `./scripts/render-debug-compare.sh build.noindex/task122-stage4-render-debug-hwp --page 1 samples/pic-crop-01.hwp samples/tac-img-02.hwp`
- `./scripts/render-debug-compare.sh build.noindex/task122-stage4-render-debug-hwpx --page 1 samples/tac-img-02.hwpx`
- `./scripts/render-debug-compare.sh build.noindex/task122-review-bookreview-placement --page 2 samples/basic/BookReview.hwp`
- `rg -o '"fill_mode":"[^"]+"' build.noindex/task122-review-bookreview-placement/BookReview-page2-render-tree.json` → `LeftBottom=1`, `RightBottom=2`
- `./scripts/overlay-metadata-smoke.sh build.noindex/task122-stage4-overlay --page 1 samples/pic-crop-01.hwp samples/tac-img-02.hwp samples/tac-img-02.hwpx`
- `./scripts/check-extension-registration-hygiene.sh --check-only`
- `git diff --check`

## 시각 비교 첨부

`samples/basic/BookReview.hwp` page 2 기준 PR #326 merge 전/후 native renderer 비교.

- before: `cfb60a0` PR #326 merge 전
- after: `b0f304b` PR #326 merge 후
- diff pixels: `173160`
- diff ratio: `19.4199%`
- max channel delta: `150`

개별 이미지:

| Before | After | Diff |
|---|---|---|
|<img width="300" alt="BookReview-page2-native" src="https://github.com/user-attachments/assets/9b601d95-aaa6-4708-99ee-c56e8f0894cd" />|<img width="300" alt="BookReview-page2-native" src="https://github.com/user-attachments/assets/015a07ec-2002-4227-b2c4-b76a495cf5ef" />|<img width="300" alt="BookReview-page2-before-after-diff" src="https://github.com/user-attachments/assets/76a2ede4-863f-4364-a69b-8eeabc7d0d4d" />|

## 관련 이슈

- Refs #106
- Refs #116
- Refs #280
- Refs #282

## 후속 이슈 제안

- tile 계열 non-null `fill_mode` HWP/HWPX fixture를 확보해 tile positive visual test를 추가한다.
- `render-debug-compare.sh`가 같은 basename의 HWP/HWPX를 같은 output directory에서 덮는 문제를 보강한다.

## 남은 리스크

- placement 계열은 `BookReview.hwp` page 2로 positive 검증을 보강했지만, tile 계열 fixture는 repository sample과 로컬 Downloads에서 확보하지 못했다.
- `none` 의미는 upstream CanvasKit layer replay와 WebCanvas 사이에 차이가 있을 수 있어 이번 PR은 WebCanvas와 기존 Swift fallback을 우선했다.
- tile draw cap 도달 시 public diagnostic은 추가하지 않았다.
