### PR TITLE
Task #302: 릴리즈 문서에 signed/notarized draft DMG smoke gate 반영

### DIFF
--- a/mydocs/manual/public_release_runbook.md
+++ b/mydocs/manual/public_release_runbook.md
@@ -23,6 +23,7 @@
 
 - public release 실행은 작업지시자의 명시 지시가 있을 때만 시작한다.
 - Git tag 생성, `Release Publish DMG` 실행, GitHub Release 게시, Sparkle appcast 갱신, Pages deployment, Homebrew tap 반영은 각각 별도 승인 gate로 본다.
+- signed/notarized DMG 설치 smoke는 public publish 전 필수 gate다. `draft=true`, `prerelease=false` 실행은 pre-public 검증이고, `draft=false`, `prerelease=false` 실행은 별도 승인된 official stable publish다.
 - workflow 기본값은 stale할 수 있다. `workflow_dispatch` 화면의 기본값을 그대로 사용하지 말고 항상 현재 release context와 대조한다.
 - password, app-specific password, App Store Connect API private key, exported signing identity, keychain credential payload, Sparkle private key, GitHub token은 문서, commit, PR, shell history에 남기지 않는다.
 - 실행하지 않은 수동 smoke, Intel Mac 실기기 확인, Sparkle 업데이트 확인은 성공으로 기록하지 않는다. 미실행 사유를 release record에 남긴다.
@@ -108,6 +109,7 @@ release owner가 다음 값을 명시적으로 확정해야 한다.
 
 - 앱 자체 bugfix, packaging, Pages/appcast, Homebrew, 문서 중심 release는 기본 title `Alhangeul v<version>`을 사용한다.
 - upstream `rhwp` 반영이 release의 중심 사용자-facing 변화이면 `Alhangeul v<version> (rhwp v<expected-rhwp-tag>)` 병기를 검토한다.
+- `draft=true`, `prerelease=false`는 signed/notarized DMG를 생성해 maintainer 설치 smoke를 수행하는 pre-public 검증 단계로 본다. 이 단계는 stable appcast와 Pages deployment를 성공 조건에 포함하지 않는다.
 - `draft=false`, `prerelease=false`일 때만 official stable release로 보고 Sparkle stable appcast와 Pages deployment까지 성공 조건에 포함한다.
 - `previous_release_ref`가 틀리면 delta checklist가 틀리므로 publish 전 반드시 workflow summary 또는 artifact에서 previous/candidate ref를 확인한다.
 
@@ -195,19 +197,17 @@ gh workflow run "Release Rehearsal DMG" \
 - unsigned rehearsal 결과는 signing/notarization 통과로 기록하지 않는다.
 - rehearsal에서 생성된 delta checklist는 초안이다. release owner가 누락/과잉 항목을 보정해야 한다.
 
-## Gate 4. Public publish
+## Gate 4. Pre-public signed/notarized DMG smoke
 
-public publish는 release owner가 tag, version, candidate commit, workflow input을 최종 승인한 뒤에만 실행한다.
+signed/notarized DMG smoke는 public publish 전에 통과해야 하는 blocking gate다. 이 gate는 GitHub Release를 official stable release로 공개하거나 stable appcast/Pages를 갱신하기 위한 단계가 아니다.
 
 사전 조건:
 
 - release candidate commit이 `main`에 반영되어 있다.
 - `v<version>` tag가 정확한 candidate commit을 가리킨다.
 - GitHub Release body, Pages 업데이트 문서, README 최신 요약, 내부 release record가 마지막 candidate commit 기준으로 다시 검토되어 있다.
-- draft signed/notarized DMG smoke 이후 추가 bugfix, tag 재지정, candidate commit 변경이 있었다면 사용자-facing 주요 변경 사항을 다시 작성했다.
 - `release` environment의 GitHub Actions variable/secret이 준비되어 있다.
-- `github-pages` environment가 release tag deployment를 허용한다.
-- `SPARKLE_ED_PRIVATE_KEY` secret이 stable appcast signing에 사용할 수 있게 등록되어 있다.
+- release owner가 `draft=true`, `prerelease=false` 입력으로 pre-public DMG smoke 실행을 승인했다.
 
 사용자-facing release note 최종 확인:
 
@@ -228,8 +228,8 @@ gh workflow run "Release Publish DMG" \
   -f expected_rhwp_tag=<expected-rhwp-tag> \
   -f require_latest_rhwp=<true-or-false> \
   -f include_rhwp_in_title=<true-or-false> \
-  -f draft=<true-or-false> \
-  -f prerelease=<true-or-false>
+  -f draft=true \
+  -f prerelease=false
 ```
 
 workflow가 확인해야 하는 것:
@@ -240,20 +240,86 @@ workflow가 확인해야 하는 것:
 - Developer ID certificate import
 - notarytool credential store
 - `./scripts/release.sh <version>` public mode 성공
-- public DMG와 `.sha256` 생성
-- GitHub Release asset upload
-- non-draft/non-prerelease 상태 검증
-- official stable release일 때 Sparkle appcast 생성과 Pages artifact deploy
+- signed/notarized DMG와 `.sha256` 생성
+- GitHub draft release asset 또는 Actions artifact upload
+- stable appcast 생성과 Pages artifact deploy skip
 
 중단 기준:
 
 - tag가 candidate commit과 다르다.
 - signed/notarized DMG 생성, staple, Gatekeeper 검증 중 하나라도 실패한다.
-- GitHub Release가 의도와 다르게 draft/prerelease 상태다.
-- official stable release인데 appcast signing 또는 Pages deployment가 실패한다.
-- public DMG SHA256이 release note, asset, Cask 반영 입력과 일치하지 않는다.
+- GitHub Release가 의도와 다르게 non-draft official release로 공개됐다.
+- draft/prerelease 실행인데 stable appcast 또는 Pages deployment가 갱신됐다.
+- draft DMG SHA256이 workflow summary, asset, release record 입력과 일치하지 않는다.
 
-## Gate 5. Public artifact 확인
+maintainer smoke:
+
+- draft release asset 또는 Actions artifact DMG를 release machine에 내려받는다.
+- DMG mount layout, app first launch, Finder Quick Look preview, Finder thumbnail을 확인한다.
+- 가능한 경우 다음 명령으로 Gatekeeper, universal slice, Sparkle extension refresh를 확인한다.
+
+```bash
+shasum -a 256 -c build.noindex/release/alhangeul-macos-<version>.dmg.sha256
+scripts/ci/verify-universal-macos-app.sh build.noindex/release/Alhangeul.app
+xcrun stapler validate build.noindex/release/Alhangeul.app
+xcrun stapler validate build.noindex/release/alhangeul-macos-<version>.dmg
+spctl --assess --type execute --verbose build.noindex/release/Alhangeul.app
+spctl --assess --type open --context context:primary-signature --verbose build.noindex/release/alhangeul-macos-<version>.dmg
+scripts/smoke-finder-integration.sh --version <version>
+scripts/smoke-sparkle-extension-refresh.sh \
+  --expected-version <version> \
+  --expected-build <build>
+```
+
+주의:
+
+- draft DMG는 Homebrew Cask URL/SHA256, Sparkle enclosure, public Pages 다운로드 링크로 사용하지 않는다.
+- 실행하지 못한 smoke는 성공으로 쓰지 않고 release record에 미실행 사유를 남긴다.
+- draft smoke 이후 bugfix, tag 재지정, candidate commit 변경이 있으면 Gate 2 또는 Gate 4로 돌아가 사용자-facing 주요 변경 사항과 산출물을 다시 확인한다.
+
+## Gate 5. Official stable publish
+
+official stable publish는 Gate 4의 signed/notarized draft DMG smoke가 통과한 뒤, release owner가 `draft=false`, `prerelease=false` 실행을 별도로 승인한 경우에만 진행한다.
+
+사전 조건:
+
+- Gate 4 draft signed/notarized DMG smoke가 통과했다.
+- GitHub Release body, Pages 업데이트 문서, README 최신 요약, 내부 release record가 draft smoke 이후 최종 candidate 기준으로 다시 검토되어 있다.
+- `github-pages` environment가 release tag deployment를 허용한다.
+- `SPARKLE_ED_PRIVATE_KEY` secret이 stable appcast signing에 사용할 수 있게 등록되어 있다.
+
+GitHub Actions 예시:
+
+```bash
+gh workflow run "Release Publish DMG" \
+  --ref v<version> \
+  -f version=<version> \
+  -f previous_release_ref=<previous-release-ref> \
+  -f expected_rhwp_tag=<expected-rhwp-tag> \
+  -f require_latest_rhwp=<true-or-false> \
+  -f include_rhwp_in_title=<true-or-false> \
+  -f draft=false \
+  -f prerelease=false
+```
+
+workflow가 확인해야 하는 것:
+
+- tag ref와 checkout HEAD 일치
+- `rhwp-core.lock`의 `expected_rhwp_tag` 일치
+- `require_latest_rhwp=true`인 경우 upstream latest 일치
+- signed/notarized DMG와 `.sha256` 생성
+- GitHub Release asset upload
+- non-draft/non-prerelease 상태 검증
+- Sparkle appcast 생성과 Pages artifact deploy
+
+중단 기준:
+
+- Gate 4 이후 candidate commit, tag, release body가 바뀌었는데 draft smoke를 반복하지 않았다.
+- GitHub Release가 의도와 다르게 draft/prerelease 상태다.
+- appcast signing 또는 Pages deployment가 실패한다.
+- official stable public DMG SHA256이 release note, asset, Cask 반영 입력과 일치하지 않는다.
+
+## Gate 6. Public artifact 확인
 
 workflow 완료 후 다음을 확인한다.
 
@@ -283,7 +349,7 @@ record에 남길 값:
 - signing/notarization/staple/Gatekeeper 결과
 - 실행하지 않은 수동 확인 항목과 사유
 
-## Gate 6. Pages와 Sparkle 확인
+## Gate 7. Pages와 Sparkle 확인
 
 official stable release일 때만 수행한다.
 
@@ -302,7 +368,7 @@ official stable release일 때만 수행한다.
 
 docs-only Pages workflow는 Sparkle appcast를 새로 만들지 않는다. release 직후 docs-only Pages 배포가 필요하면 public appcast 보존 기준을 확인한다.
 
-## Gate 7. 설치본과 Finder smoke
+## Gate 8. 설치본과 Finder smoke
 
 실제 설치본 기준 smoke는 release record에 실행 여부를 명확히 남긴다.
 
@@ -333,7 +399,7 @@ scripts/smoke-sparkle-extension-refresh.sh \
 - Intel Mac 실기기 smoke를 실행하지 않았으면 성공으로 쓰지 않는다.
 - 이전 설치본이나 PlugInKit 캐시로 false positive가 의심되면 [`release_packaging_dmg_guide.md`](release_packaging_dmg_guide.md)의 registration hygiene 옵션을 따른다.
 
-## Gate 8. Homebrew Cask
+## Gate 9. Homebrew Cask
 
 Homebrew는 public DMG asset과 SHA256이 확정된 뒤 별도 승인으로 진행한다.
 
@@ -368,7 +434,7 @@ brew uninstall --cask alhangeul
 - `brew audit --cask --new`는 upstream Homebrew 제출 수준 참고 검증이며, maintainer tap 공개 gate와 구분한다.
 - Homebrew 안내 문구는 tap context 검증이 끝난 뒤 README, Pages, GitHub Release/릴리즈 노트에 일관되게 반영한다.
 
-## Gate 9. Release record와 최종 보고
+## Gate 10. Release record와 최종 보고
 
 릴리즈 완료 후 다음 파일을 갱신하거나 확인한다.
 

--- a/mydocs/manual/release_distribution_guide.md
+++ b/mydocs/manual/release_distribution_guide.md
@@ -11,6 +11,7 @@
 - 릴리스/배포 작업은 저장소 소유자의 명시 지시가 있을 때만 수행한다.
 - Claude와 Codex가 임의로 버전 태그, GitHub Release, Homebrew Cask PR, 서명/공증 작업을 시작하지 않는다.
 - public release 실행, GitHub Release 게시, Sparkle appcast 갱신, Homebrew Cask 반영은 각각 작업지시자의 명시 승인 후 수행한다.
+- signed/notarized DMG 설치 smoke는 public publish 전 필수 gate다. `draft=true`, `prerelease=false` 실행으로 만든 pre-public DMG를 maintainer가 직접 확인한 뒤에만 official stable publish로 넘어간다.
 - 인증서 private key, Apple Developer 계정, notarization credential, GitHub token, Homebrew tap 권한은 작업지시자가 직접 관리한다.
 - 민감 정보는 문서, commit, PR, shell history에 남기지 않는다.
 - Team ID, signing identity 표시명, keychain profile name처럼 비밀이 아닌 운영 식별자는 [`release_environment.md`](../tech/release_environment.md)에만 기록한다.
@@ -80,11 +81,11 @@
 4. [`release_packaging_dmg_guide.md`](release_packaging_dmg_guide.md)의 릴리스 전 확인과 build 검증을 수행한다.
 5. 필요한 경우 `Release Rehearsal DMG` workflow를 실행하고 DMG/checksum과 delta checklist artifact를 확인한다.
 6. [`release_signing_notarization_guide.md`](release_signing_notarization_guide.md)의 credential 확인을 수행한다.
-7. `Release Publish DMG` workflow 또는 `scripts/release.sh <version>` public mode로 signed/notarized DMG를 생성한다.
-8. public DMG SHA256을 기록하고 app/extension universal slice, DMG layout, Finder Quick Look, Finder thumbnail smoke를 반복한다.
-9. [`release_github_pages_sparkle_guide.md`](release_github_pages_sparkle_guide.md)의 release note와 delta checklist를 실제 SHA256/provenance로 보정한다.
-10. GitHub Release를 공식 release 기준으로 게시하고 `Release Publish DMG` workflow 결과를 확인한다.
-11. Pages deployment URL, Pages 업데이트 페이지, latest DMG link, stable Sparkle appcast를 확인한다.
+7. release tag 생성 후 `Release Publish DMG` workflow를 `draft=true`, `prerelease=false`로 실행해 pre-public signed/notarized DMG를 생성한다.
+8. maintainer가 draft release asset 또는 Actions artifact DMG를 내려받아 app/extension universal slice, Gatekeeper, DMG layout, Finder Quick Look, Finder thumbnail smoke를 확인한다.
+9. draft smoke 통과 후 [`release_github_pages_sparkle_guide.md`](release_github_pages_sparkle_guide.md)의 release note와 delta checklist를 실제 SHA256/provenance로 보정한다.
+10. 작업지시자 별도 승인 후 `Release Publish DMG` workflow를 `draft=false`, `prerelease=false` official stable release 기준으로 실행한다.
+11. GitHub Release asset, Pages deployment URL, Pages 업데이트 페이지, latest DMG link, stable Sparkle appcast를 post-publish public surface로 확인한다.
 12. Homebrew 배포를 진행할 경우 #209에서 [`release_homebrew_cask_guide.md`](release_homebrew_cask_guide.md)에 따라 `postmelee/homebrew-tap`에 Cask를 반영하고 tap context 검증을 수행한다.
 13. [`mydocs/release/v<version>.md`](../release/)와 최종 release report에 실제 결과와 잔여 위험을 기록한다.
 
@@ -93,6 +94,7 @@
 - release version과 release candidate commit
 - `devel`에서 `main`으로 반영할 release PR 범위
 - Developer ID 서명/notarization 실행 시점
+- pre-public signed/notarized draft DMG 설치 smoke를 수행할 maintainer와 기록 위치
 - GitHub Release를 draft/prerelease가 아닌 public release로 게시할 시점
 - Cask 초안의 `sha256 :no_check`를 public DMG 생성 후 실제 digest로 교체할 시점
 - `postmelee/homebrew-tap` 공개 배포를 #209에서 진행할 시점
@@ -116,15 +118,16 @@
 - [ ] Finder thumbnail smoke test 완료
 - [ ] 기존 public 설치본에서 Sparkle 업데이트 후 `scripts/smoke-sparkle-extension-refresh.sh --expected-version <version> --expected-build <build>` 기본 모드 통과
 - [ ] 개발용 zip 산출물 생성
-- [ ] public DMG 산출물 생성
-- [ ] public DMG 안의 app/extension 실행 파일 `arm64 + x86_64` universal 검증
+- [ ] pre-public signed/notarized draft DMG 산출물 생성
+- [ ] draft DMG 안의 app/extension 실행 파일 `arm64 + x86_64` universal 검증
+- [ ] maintainer가 draft release asset 또는 Actions artifact DMG를 직접 설치 smoke 완료
 - [ ] app notarization submit 전 signing preflight 통과: Developer ID, Team ID, timestamp, hardened runtime, `get-task-allow` 부재, Sparkle nested component 존재 확인
-- [ ] public DMG 안의 app bundle `Contents/Info.plist`에 `NSHumanReadableCopyright`가 포함되어 있고 현재 release 저작권자 문구와 일치하는지 확인
-- [ ] public DMG 안의 app bundle `Contents/Resources/Legal/{LICENSE,THIRD_PARTY_LICENSES.md,FONTS.md}` 존재 확인
-- [ ] public DMG 안의 app bundle `Contents/Resources/Legal/*` 파일이 release candidate commit의 canonical `LICENSE`, `THIRD_PARTY_LICENSES.md`, `Sources/HostApp/Resources/rhwp-studio/fonts/FONTS.md`와 같은지 확인
+- [ ] draft DMG 안의 app bundle `Contents/Info.plist`에 `NSHumanReadableCopyright`가 포함되어 있고 현재 release 저작권자 문구와 일치하는지 확인
+- [ ] draft DMG 안의 app bundle `Contents/Resources/Legal/{LICENSE,THIRD_PARTY_LICENSES.md,FONTS.md}` 존재 확인
+- [ ] draft DMG 안의 app bundle `Contents/Resources/Legal/*` 파일이 release candidate commit의 canonical `LICENSE`, `THIRD_PARTY_LICENSES.md`, `Sources/HostApp/Resources/rhwp-studio/fonts/FONTS.md`와 같은지 확인
 - [ ] Intel Mac 실기기 smoke 실행 여부와 결과 또는 미실행 사유 기록
-- [ ] public DMG SHA256 기록
-- [ ] public DMG layout smoke 완료
+- [ ] draft DMG SHA256 기록
+- [ ] draft DMG layout smoke 완료
 - [ ] DMG root에 `설치 안내.txt` 같은 보조 안내 파일이 노출되지 않는지 확인
 - [ ] DMG background가 720x460 PNG 기준인지 확인
 - [ ] release note에 `rhwp-core.lock`, `rhwp-studio` manifest, third-party notices 기준 기록
@@ -139,7 +142,9 @@
 - [ ] repository Pages source가 `workflow`인지 확인
 - [ ] `github-pages` environment가 docs-only `main` branch와 release tag ref `v*`를 허용하는지 확인
 - [ ] release workflow와 docs-only workflow가 `pages-deploy` concurrency group으로 Pages deployment를 취소 없이 직렬화하는지 확인
+- [ ] draft/prerelease 실행에서 stable appcast와 Pages deployment가 skip된 것을 pre-public 검증 단계의 정상 동작으로 확인
 - [ ] `Release Publish DMG` workflow를 공식 release 기준 `draft=false`, `prerelease=false`로 실행
+- [ ] official stable public DMG 산출물과 SHA256 기록
 - [ ] `deploy-pages` job이 성공하고 `page_url`이 `https://postmelee.github.io/alhangeul-macos/`를 가리키는지 확인
 - [ ] public `https://postmelee.github.io/alhangeul-macos/appcast.xml`이 새 stable item과 Sparkle EdDSA signature를 제공하는지 확인
 - [ ] docs-only Pages workflow가 public appcast를 보존하며 stale repository `docs/appcast.xml` fallback을 사용하지 않는지 확인

--- a/mydocs/manual/release_github_pages_sparkle_guide.md
+++ b/mydocs/manual/release_github_pages_sparkle_guide.md
@@ -8,6 +8,7 @@
 
 - GitHub Release 게시, release asset upload, Sparkle appcast 갱신, Pages deployment는 작업지시자의 명시 승인 후 수행한다.
 - draft 또는 prerelease가 아닌 official release에서만 stable appcast와 Pages deployment를 실행한다.
+- `draft=true`, `prerelease=false` release workflow 실행은 signed/notarized DMG를 public publish 전에 smoke하기 위한 pre-public 검증 단계다. 이 단계에서 stable appcast와 Pages deployment가 skip되는 것은 정상 동작이다.
 - `main`에 merge된 `docs/**` 변경의 docs-only Pages 자동 배포는 승인된 merge 결과를 반영하는 운영 경로이며, Sparkle appcast를 새로 생성하지 않고 기존 public appcast를 보존한다.
 - GitHub token과 Sparkle EdDSA private key는 저장소에 기록하지 않는다.
 
@@ -17,7 +18,7 @@
 - 릴리즈 상세 기록 `mydocs/release/v<version>.md`가 현재 release candidate 기준으로 갱신되었는가
 - 직전 public release 대비 delta checklist가 생성되고 release owner가 보정했는가
 - GitHub Release body의 `이번 버전의 주요 변경 사항`에 `변경 요약`, `포함된 rhwp 변화`, `알한글 앱 변화`가 실제 사용자-facing 내용으로 보정되었는가
-- 마지막 release candidate 변경, bugfix PR, draft signed/notarized DMG smoke 이후 GitHub Release body와 Pages 업데이트 문서를 다시 검토했는가
+- 마지막 release candidate 변경, bugfix PR, draft signed/notarized DMG smoke 이후 official stable publish 전에 GitHub Release body와 Pages 업데이트 문서를 다시 검토했는가
 - `변경 요약`과 `알한글 앱 변화`가 특정 검증 샘플명, issue 번호, 내부 구현 용어가 아니라 사용자가 보는 증상과 개선 결과 중심으로 쓰였는가
 - GitHub Release title이 기본형 `Alhangeul v<version>`을 쓰는가, 또는 upstream `rhwp` 반영 중심 release라서 `(rhwp vX.Y.Z)` 병기 조건을 충족하는가
 - `rhwp-core.lock`의 core repository와 commit이 release note에 기록되었는가
@@ -110,7 +111,7 @@ Release note에 포함할 내용:
 - 검증 fixture, 샘플 파일명, issue 번호, PR 번호, stage 번호는 public Pages와 GitHub Release의 주요 변경 요약에 쓰지 않는다. 해당 정보는 내부 release record, 검증 결과, changelog provenance에 둔다.
 - `PUA`, `sentinel`, `render tree`, `CoreGraphics`처럼 일반 사용자가 바로 이해하기 어려운 구현 용어는 먼저 "특수 문자/기호 표시", "텍스트 배경/음영", "Quick Look 미리보기" 같은 사용자 용어로 설명하고, 필요할 때만 괄호나 metadata에서 기술 용어를 보충한다.
 - workflow default, README 정렬, manifest/checksum/provenance 같은 운영 변경은 사용자에게 직접 영향을 주는 설치, 업데이트, 보안 검증, 배포 경로 변화가 있을 때만 주요 변경에 넣는다. 그렇지 않으면 `Release metadata`, 내부 release record, 최종 보고서로 분리한다.
-- draft signed/notarized DMG smoke 이후 bugfix PR, tag 재지정, release candidate 변경이 있으면 publish 전에 주요 변경 사항을 최종 candidate 기준으로 다시 작성한다.
+- draft signed/notarized DMG smoke 이후 bugfix PR, tag 재지정, release candidate 변경이 있으면 official stable publish 전에 주요 변경 사항을 최종 candidate 기준으로 다시 작성한다.
 
 공개 표면별 역할:
 
@@ -238,11 +239,12 @@ export한 파일 내용 전체를 `SPARKLE_ED_PRIVATE_KEY` secret 값으로 등�
 `Release Publish DMG` workflow의 appcast 동작 기준:
 
 - `draft=false`이고 `prerelease=false`인 공식 release에서만 stable appcast를 갱신한다.
-- draft 또는 prerelease 실행에서는 stable appcast를 갱신하지 않고 step summary에 skip 사유만 남긴다.
-- workflow는 signed/notarized DMG를 GitHub Release asset으로 업로드한 뒤 `sign_update --ed-key-file - -p`로 DMG EdDSA signature를 만든다.
-- `scripts/ci/write-sparkle-appcast.sh`가 tag 고정 DMG URL과 release notes URL로 `appcast.xml`을 생성한다.
-- workflow는 generated `appcast.xml`을 Pages artifact root의 `appcast.xml`로 포함한다.
-- `deploy-pages` job이 성공해야 stable appcast 배포 성공으로 본다. branch push fallback을 기본 경로로 사용하지 않는다.
+- `draft=true`, `prerelease=false` 실행은 pre-public signed/notarized DMG smoke 단계다. 이 단계에서는 stable appcast를 갱신하지 않고 step summary에 skip 사유만 남긴다.
+- prerelease 실행도 stable appcast와 Pages deployment를 갱신하지 않는다.
+- official stable release에서는 workflow가 signed/notarized DMG를 GitHub Release asset으로 업로드한 뒤 `sign_update --ed-key-file - -p`로 DMG EdDSA signature를 만든다.
+- official stable release에서는 `scripts/ci/write-sparkle-appcast.sh`가 tag 고정 DMG URL과 release notes URL로 `appcast.xml`을 생성한다.
+- official stable release에서는 workflow가 generated `appcast.xml`을 Pages artifact root의 `appcast.xml`로 포함한다.
+- official stable release의 `deploy-pages` job이 성공해야 stable appcast 배포 성공으로 본다. branch push fallback을 기본 경로로 사용하지 않는다.
 
 appcast enclosure URL은 latest URL이 아니라 tag 고정 URL을 사용한다.
 

--- a/mydocs/orders/20260602.md
+++ b/mydocs/orders/20260602.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 6월 2일
+
+## M900 — Release Operations
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #302 | 릴리즈 문서에 signed/notarized draft DMG smoke gate 반영 | 진행중 | M900, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260602.md
+++ b/mydocs/orders/20260602.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #302 | 릴리즈 문서에 signed/notarized draft DMG smoke gate 반영 | 진행중 | M900, 수행계획서 작성 후 승인 대기 |
+| #302 | 릴리즈 문서에 signed/notarized draft DMG smoke gate 반영 | 진행중 | M900, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260602.md
+++ b/mydocs/orders/20260602.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #302 | 릴리즈 문서에 signed/notarized draft DMG smoke gate 반영 | 진행중 | M900, 구현계획서 작성 후 승인 대기 |
+| #302 | 릴리즈 문서에 signed/notarized draft DMG smoke gate 반영 | 완료 | M900, 완료: 17:42 |

--- a/mydocs/plans/task_m900_301.md
+++ b/mydocs/plans/task_m900_301.md
@@ -90,11 +90,12 @@ public DMG SHA256 확정 후 별도 승인 gate에서 필요하면 다음 파일
 3. Stage 3: source preflight와 rehearsal
    - lock/provenance, bundled asset, no-AppKit, Debug/Release build, render smoke, release helper dry-run을 수행한다.
    - 승인 후 rehearsal DMG 또는 workflow를 실행하고 delta checklist 초안을 보정한다.
-4. Stage 4: main/tag/public publish gate
+4. Stage 4: main/tag/pre-public smoke와 official publish gate
    - `devel` release candidate를 `main`에 반영할 PR 준비 자료를 완성한다.
-   - `v0.1.4` tag, `Release Publish DMG`, GitHub Release, Pages/Sparkle은 release owner 승인 후 실행한다.
+   - `v0.1.4` tag 생성 후 `Release Publish DMG`를 `draft=true`, `prerelease=false`로 실행해 signed/notarized DMG 설치 smoke를 수행한다.
+   - draft smoke 통과 후 별도 승인으로 `Release Publish DMG`를 `draft=false`, `prerelease=false` official stable 기준으로 실행한다.
 5. Stage 5: post-publish 확인과 Homebrew gate
-   - public artifact, SHA256, signing/notarization/Gatekeeper, Pages, appcast, Finder smoke, Sparkle update smoke를 기록한다.
+   - GitHub Release asset, official stable public DMG SHA256, Pages 다운로드 링크, stable appcast, public 설치본 smoke, Sparkle update smoke를 기록한다.
    - Homebrew 반영은 public DMG SHA256 확정 후 별도 승인으로 처리한다.
 
 ## 검증 계획
@@ -127,10 +128,22 @@ scripts/ci/write-release-notes.sh 0.1.4 0123456789abcdef0123456789abcdef01234567
 scripts/ci/check-release-notes-template.sh build.noindex/release/release-notes-0.1.4.md
 ```
 
-승인 gate 이후:
+pre-public draft smoke 승인 후:
 
 ```bash
-./scripts/release.sh --skip-notarize 0.1.4
+gh workflow run "Release Publish DMG" --ref v0.1.4 \
+  -f version=0.1.4 \
+  -f previous_release_ref=v0.1.3 \
+  -f expected_rhwp_tag=v0.7.13 \
+  -f require_latest_rhwp=true \
+  -f include_rhwp_in_title=true \
+  -f draft=true \
+  -f prerelease=false
+```
+
+official stable publish 승인 후:
+
+```bash
 gh workflow run "Release Publish DMG" --ref v0.1.4 \
   -f version=0.1.4 \
   -f previous_release_ref=v0.1.3 \
@@ -154,7 +167,7 @@ scripts/smoke-sparkle-extension-refresh.sh --expected-version 0.1.4 --expected-b
 - release workflow 기본 입력이 stale한 상태에서 workflow_dispatch를 실행하면 lock guard에서 실패하거나 잘못된 delta checklist가 생성될 수 있다.
 - `rhwp v0.7.13`은 렌더링/저장 호환성 변화가 많으므로 release note에서 앱 viewer, Quick Look, Thumbnail 영향과 한계를 분리해야 한다.
 - public publish는 GitHub Actions release environment secret과 Pages environment 설정에 의존하므로, secret 값은 기록하지 않고 존재와 검증 결과만 남겨야 한다.
-- rehearsal DMG, 개발용 zip, public DMG의 산출물 계층을 섞으면 Homebrew SHA나 Sparkle enclosure가 잘못될 수 있다.
+- rehearsal DMG, 개발용 zip, pre-public draft DMG, official stable public DMG의 산출물 계층을 섞으면 Homebrew SHA나 Sparkle enclosure가 잘못될 수 있다.
 - Intel Mac 실기기 smoke, GUI Quick Look preview, Sparkle update smoke를 실행하지 못하면 성공으로 기록하지 않고 미실행 사유를 남겨야 한다.
 - 운영 milestone은 제품 버전과 직접 대응하지 않으므로, 문서명과 오늘할일 표기에서 `M900+` 예약 영역을 일관되게 사용해야 한다.
 

--- a/mydocs/plans/task_m900_301_impl.md
+++ b/mydocs/plans/task_m900_301_impl.md
@@ -4,9 +4,9 @@
 
 이 구현계획서는 `v0.1.4` public release 준비와 배포 실행을 5단계로 나눈다. 확정된 release identity는 `version=0.1.4`, `build=10`, `previous_release_ref=v0.1.3`, `expected_rhwp_tag=v0.7.13`이다.
 
-각 단계는 하이퍼-워터폴 승인 gate를 가진다. Stage 1~2는 release candidate source와 communication 정렬, Stage 3은 source preflight와 rehearsal, Stage 4는 `main` 반영과 public publish gate, Stage 5는 post-publish 확인과 Homebrew gate다.
+각 단계는 하이퍼-워터폴 승인 gate를 가진다. Stage 1~2는 release candidate source와 communication 정렬, Stage 3은 source preflight와 rehearsal, Stage 4는 `main` 반영, pre-public signed/notarized DMG smoke, official stable publish gate, Stage 5는 post-publish public surface 확인과 Homebrew gate다.
 
-public publish, GitHub Release 게시, Pages/Sparkle 갱신, Homebrew tap 반영은 이 구현계획 승인만으로 실행하지 않는다. 해당 단계에서 작업지시자의 별도 명시 승인을 받은 뒤 진행한다.
+pre-public signed/notarized DMG smoke, public publish, GitHub Release 게시, Pages/Sparkle 갱신, Homebrew tap 반영은 이 구현계획 승인만으로 실행하지 않는다. 해당 단계에서 작업지시자의 별도 명시 승인을 받은 뒤 진행한다.
 
 ## Stage 1: Release Candidate Source Metadata 정렬
 
@@ -162,13 +162,13 @@ hdiutil verify build.noindex/release/alhangeul-macos-0.1.4-rehearsal.dmg
 
 ### 승인 요청
 
-Stage 3 완료보고서 기준으로 Stage 4 진행 승인을 요청한다. Stage 4의 `main` PR, tag 생성, public publish는 별도 승인 gate다.
+Stage 3 완료보고서 기준으로 Stage 4 진행 승인을 요청한다. Stage 4의 `main` PR, tag 생성, pre-public signed/notarized DMG smoke, official stable publish는 별도 승인 gate다.
 
-## Stage 4: Main/Tag/Public Publish Gate
+## Stage 4: Main/Tag/Pre-public Smoke와 Official Publish Gate
 
 ### 목표
 
-검증된 `devel` release candidate를 `main`으로 반영하고, `v0.1.4` tag와 public publish workflow 실행을 준비한다.
+검증된 `devel` release candidate를 `main`으로 반영하고, `v0.1.4` tag 생성, pre-public signed/notarized DMG smoke, official stable publish workflow 실행을 승인 gate별로 준비한다.
 
 ### 변경 파일
 
@@ -181,8 +181,11 @@ Stage 3 완료보고서 기준으로 Stage 4 진행 승인을 요청한다. Stag
 2. release PR 본문에 release record, 검증 결과, known limitations, publish input을 정리한다.
 3. 작업지시자 승인 후 `devel -> main` release PR을 만들고 merge한다.
 4. 작업지시자 승인 후 `v0.1.4` tag를 정확한 `main` candidate commit에 만든다.
-5. 작업지시자 승인 후 `Release Publish DMG` workflow를 실행한다.
-6. workflow summary에서 tag/ref 일치, `expected_rhwp_tag`, public DMG, GitHub Release, Pages/Sparkle job 결과를 확인한다.
+5. 작업지시자 승인 후 `Release Publish DMG` workflow를 `draft=true`, `prerelease=false`로 실행해 signed/notarized DMG를 생성한다.
+6. maintainer가 draft release asset 또는 Actions artifact DMG를 직접 설치 smoke하고, stable appcast와 Pages deployment가 skip된 것을 확인한다.
+7. draft smoke 통과 후 GitHub Release body, Pages 업데이트 문서, README 최신 요약, 내부 release record를 최종 candidate 기준으로 다시 검토한다.
+8. 작업지시자 별도 승인 후 `Release Publish DMG` workflow를 `draft=false`, `prerelease=false` official stable 기준으로 실행한다.
+9. workflow summary에서 tag/ref 일치, `expected_rhwp_tag`, public DMG, GitHub Release, Pages/Sparkle job 결과를 확인한다.
 
 ### 검증
 
@@ -193,7 +196,20 @@ gh pr view <release-pr> --repo postmelee/alhangeul-macos --json number,state,mer
 gh release view v0.1.4 --repo postmelee/alhangeul-macos --json tagName,name,isDraft,isPrerelease,assets,url
 ```
 
-publish workflow 승인 입력:
+pre-public draft smoke 승인 입력:
+
+```bash
+gh workflow run "Release Publish DMG" --ref v0.1.4 \
+  -f version=0.1.4 \
+  -f previous_release_ref=v0.1.3 \
+  -f expected_rhwp_tag=v0.7.13 \
+  -f require_latest_rhwp=true \
+  -f include_rhwp_in_title=true \
+  -f draft=true \
+  -f prerelease=false
+```
+
+official stable publish 승인 입력:
 
 ```bash
 gh workflow run "Release Publish DMG" --ref v0.1.4 \
@@ -210,17 +226,17 @@ gh workflow run "Release Publish DMG" --ref v0.1.4 \
 
 - `mydocs/working/task_m900_301_stage4.md`
 - 보정된 `mydocs/release/v0.1.4.md`
-- 단계 커밋: `Task #301 Stage 4: public publish gate 확인`
+- 단계 커밋: `Task #301 Stage 4: pre-public smoke와 official publish gate 확인`
 
 ### 승인 요청
 
 Stage 4 완료보고서 기준으로 Stage 5 진행 승인을 요청한다.
 
-## Stage 5: Post-publish 확인과 Homebrew Gate
+## Stage 5: Post-publish Public Surface 확인과 Homebrew Gate
 
 ### 목표
 
-public artifact와 update surface를 검증하고, Homebrew는 public DMG SHA256 확정 후 별도 승인으로 반영한다.
+official stable publish 이후 public artifact와 update surface를 검증하고, Homebrew는 public DMG SHA256 확정 후 별도 승인으로 반영한다.
 
 ### 변경 파일
 
@@ -234,7 +250,7 @@ public artifact와 update surface를 검증하고, Homebrew는 public DMG SHA256
 
 ### 작업
 
-1. GitHub Release URL, public DMG URL, SHA256, size, asset 목록을 확인한다.
+1. GitHub Release URL, official stable public DMG URL, SHA256, size, asset 목록을 확인한다.
 2. Pages `updates/v0.1.4.html`, latest download, stable appcast item, Sparkle EdDSA signature를 확인한다.
 3. release machine에서 가능한 범위의 stapler, `spctl`, universal slice 검증을 반복한다.
 4. Finder Quick Look/Thumbnail smoke와 Sparkle extension refresh smoke를 실행하거나 미실행 사유를 기록한다.
@@ -284,14 +300,14 @@ brew uninstall --cask alhangeul
 | 구현계획 승인 | Stage 1 source metadata 수정 |
 | Stage 1 승인 | Stage 2 release communication 작성 |
 | Stage 2 승인 | Stage 3 build/preflight/rehearsal |
-| Stage 3 승인 | `devel -> main` release PR, tag 생성, public publish |
+| Stage 3 승인 | `devel -> main` release PR, tag 생성, pre-public signed/notarized DMG smoke, official stable publish |
 | Stage 4 승인 | post-publish smoke, Homebrew gate |
 | Homebrew 별도 승인 | Cask SHA 고정, tap 반영, Homebrew 설치 안내 공개 |
 
 ## 검증/기록 원칙
 
 - 실행하지 않은 smoke는 성공으로 기록하지 않는다.
-- rehearsal DMG와 public DMG SHA256을 섞지 않는다.
+- rehearsal DMG, pre-public draft DMG, official stable public DMG SHA256을 섞지 않는다.
 - secret 값은 어떤 문서, commit, PR, shell history에도 기록하지 않는다.
 - public artifact URL, SHA256, workflow run URL, Pages URL, appcast 결과는 `mydocs/release/v0.1.4.md`에 남긴다.
 - GitHub-hosted workflow에서만 생성된 산출물은 workflow summary와 artifact를 기준으로 기록하고, 가능한 검증은 release machine에서 재실행한다.

--- a/mydocs/plans/task_m900_302.md
+++ b/mydocs/plans/task_m900_302.md
@@ -1,0 +1,126 @@
+# Task M900 #302 수행계획서
+
+## 목적
+
+모든 public release에서 signed/notarized DMG 설치 smoke가 public publish 이후 사후 확인으로 밀리지 않도록, 릴리즈 운영 문서에 draft signed/notarized DMG smoke를 pre-public 필수 gate로 명확히 고정한다.
+
+이 작업은 실제 `v0.1.4` 배포를 실행하지 않는다. 릴리즈 문서의 승인 경계와 Stage 4/5 용어를 정리해, 이후 #301 같은 릴리즈 실행 타스크가 public publish 전 검증과 post-publish 확인을 혼동하지 않게 만드는 문서 정렬 작업이다.
+
+| 항목 | 값 |
+|------|----|
+| GitHub Issue | #302 |
+| GitHub milestone | `Release Operations` |
+| 문서 분류 코드 | M900 (`task_m900_302.md`) |
+| 기준 브랜치 | `devel` |
+| 작업 브랜치 | `local/task302` |
+
+## 배경
+
+#301 `v0.1.4` public release 준비 중, signed/notarized DMG 설치 smoke가 public publish 이후 Stage 5에 처음 배치되면 publish-blocking gate가 아니라 사후 검증처럼 읽힌다는 문제가 확인되었다.
+
+현재 `public_release_runbook.md`는 `draft=false`, `prerelease=false`일 때만 official stable release로 보고 Pages/Sparkle을 갱신한다는 기준을 이미 갖고 있고, `release_github_pages_sparkle_guide.md`도 draft/prerelease 실행에서는 stable appcast를 갱신하지 않는다고 설명한다. 다만 release flow와 #301 Stage 4/5 문맥에서는 signed/notarized DMG smoke가 public publish 전에 통과해야 하는 gate인지, publish 뒤 public surface 확인인지가 충분히 분리되어 있지 않다.
+
+따라서 draft signed/notarized DMG는 stable appcast/Pages를 갱신하지 않는 pre-public 검증 산출물로 정의하고, 공식 stable publish는 그 smoke 통과 후 `draft=false`, `prerelease=false`로 별도 승인받아 실행하는 순서를 문서화한다.
+
+## 범위
+
+포함:
+
+- `mydocs/manual/release_distribution_guide.md`에 signed/notarized DMG 설치 smoke가 public publish 전 필수 gate임을 명시
+- `mydocs/manual/public_release_runbook.md`에 tag 생성 후 `draft=true` workflow로 signed/notarized DMG를 만들고, maintainer가 draft release asset 또는 Actions artifact DMG를 직접 설치 smoke한 뒤 official stable publish로 넘어가는 순서 반영
+- `mydocs/manual/release_github_pages_sparkle_guide.md`에 draft/prerelease 실행은 stable Sparkle appcast와 Pages를 갱신하지 않는 pre-public 검증 단계임을 명시
+- 현재 릴리즈 문서에서 Stage 4/5 용어가 위 정책과 충돌하면 최소 범위로 보정
+- 변경한 문서가 public publish, Pages/Sparkle, Homebrew gate의 별도 승인 원칙을 계속 유지하는지 검증
+
+제외:
+
+- 실제 `v0.1.4` 배포 실행
+- signing/notarization credential 설정 또는 workflow 실행
+- tag 생성, GitHub Release publish, Pages/Sparkle 배포, Homebrew Cask 갱신
+- release workflow 동작 자체의 코드 변경
+- #301의 source metadata, release note, 산출물 검증 결과 보정
+
+## 설계 방향
+
+핵심 정책은 산출물 계층과 승인 gate를 분리하는 것이다.
+
+1. `Release Publish DMG` workflow는 `draft=true`, `prerelease=false` 조합에서도 signed/notarized DMG를 만들 수 있는 pre-public 검증 경로로 설명한다.
+2. draft signed/notarized DMG smoke는 release owner가 직접 설치, Gatekeeper, Finder Quick Look/Thumbnail, Sparkle extension refresh 등 public release 전에 확인해야 하는 blocking gate로 둔다.
+3. draft/prerelease 실행은 stable Sparkle appcast와 public Pages deployment를 갱신하지 않아야 하며, 이 skip은 실패가 아니라 pre-public 검증 단계의 정상 동작으로 설명한다.
+4. official stable publish는 draft smoke 통과 후 별도 승인으로 `draft=false`, `prerelease=false`를 실행하는 단계로 둔다.
+5. Stage 5는 GitHub Release asset, Pages 다운로드 링크, stable appcast, Homebrew 같은 public surface의 사후 확인과 후속 gate로 한정한다.
+6. 문서에는 secret 값이나 credential payload를 기록하지 않고, 승인 경계와 확인 항목만 남긴다.
+
+## 예상 변경 파일
+
+- `mydocs/manual/release_distribution_guide.md`
+- `mydocs/manual/public_release_runbook.md`
+- `mydocs/manual/release_github_pages_sparkle_guide.md`
+- `mydocs/plans/task_m900_301.md` (필요 시 Stage 4/5 용어 보정)
+- `mydocs/plans/task_m900_301_impl.md` (필요 시 Stage 4/5 용어 보정)
+- `mydocs/release/v0.1.4.md` (필요 시 release execution gate 문구 보정)
+- `mydocs/orders/20260602.md`
+- `mydocs/plans/task_m900_302_impl.md`
+- `mydocs/working/task_m900_302_stage{N}.md`
+- `mydocs/report/task_m900_302_report.md`
+
+## 잠정 단계
+
+1. Stage 1: 현재 릴리즈 gate 문맥 감사
+   - 대상 manual 3개와 #301 계획/구현계획/release record의 Stage 4/5 문구를 대조한다.
+   - draft signed/notarized DMG smoke, official stable publish, post-publish public surface 확인이 섞인 지점을 표로 정리한다.
+2. Stage 2: pre-public signed/notarized DMG smoke gate 문서화
+   - `release_distribution_guide.md`와 `public_release_runbook.md`의 release flow, Gate 4/5, 최종 체크리스트를 보정한다.
+   - tag 생성 후 `draft=true` workflow로 DMG를 만들고 설치 smoke 통과 후 official stable publish로 넘어가는 승인 경계를 명시한다.
+3. Stage 3: Pages/Sparkle와 현재 release 문서 정렬
+   - `release_github_pages_sparkle_guide.md`에 draft/prerelease 실행의 stable appcast/Pages skip 의미를 pre-public 검증 단계로 명시한다.
+   - #301 관련 문서에서 Stage 4/5 용어가 충돌하면 최소 문구만 보정한다.
+4. Stage 4: 문서 검증과 최종 보고
+   - 문서 간 용어, 승인 gate, 제외 범위, secret 기록 금지 원칙을 재검증한다.
+   - 단계 보고서와 최종 결과보고서를 작성하고 PR 게시 준비 상태로 정리한다.
+
+## 검증 계획
+
+문서 감사:
+
+```bash
+rg -n "draft=true|draft=false|signed/notarized|pre-public|post-publish|Public artifact|Pages|Sparkle|Stage 4|Stage 5" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md \
+  mydocs/manual/release_github_pages_sparkle_guide.md \
+  mydocs/plans/task_m900_301.md \
+  mydocs/plans/task_m900_301_impl.md \
+  mydocs/release/v0.1.4.md
+```
+
+문서 검증:
+
+```bash
+rg -n "draft signed/notarized DMG|pre-public|public publish 전|post-publish|stable appcast|Pages deployment" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md \
+  mydocs/manual/release_github_pages_sparkle_guide.md
+git diff --check
+git status --short
+```
+
+필요 시 #301 문서 보정 검증:
+
+```bash
+rg -n "Stage 4|Stage 5|draft signed/notarized|post-publish|Homebrew gate" \
+  mydocs/plans/task_m900_301.md \
+  mydocs/plans/task_m900_301_impl.md \
+  mydocs/release/v0.1.4.md
+```
+
+## 리스크
+
+- `Release Publish DMG`라는 workflow 이름 때문에 draft 검증 실행과 official stable publish 실행이 같은 단계로 오해될 수 있다.
+- draft signed/notarized DMG가 GitHub Release draft asset인지 Actions artifact인지에 따라 설치 smoke 절차와 기록 위치가 달라질 수 있다.
+- Stage 5의 public surface 확인을 너무 좁히면 Homebrew gate, Finder smoke, Sparkle update smoke의 실제 확인 시점이 누락될 수 있다.
+- #301 문서를 과도하게 고치면 이미 승인된 release execution 계획 범위를 흔들 수 있으므로, 이 작업에서는 정책 충돌을 없애는 문구 보정에 한정한다.
+- manual 문서는 반복 적용 가능한 정책만 담아야 하므로, #301 고유 결과나 SHA256 같은 일회성 release 기록을 manual에 복제하지 않는다.
+
+## 승인 요청 사항
+
+이 수행계획서 기준으로 구현계획서 작성 단계 진행 승인을 요청한다.

--- a/mydocs/plans/task_m900_302_impl.md
+++ b/mydocs/plans/task_m900_302_impl.md
@@ -1,0 +1,207 @@
+# Task M900 #302 구현계획서
+
+## 개요
+
+이 구현계획서는 릴리즈 운영 문서에 signed/notarized draft DMG smoke를 public publish 전 필수 gate로 반영하는 작업을 4단계로 나눈다.
+
+작업의 핵심은 `Release Publish DMG` workflow의 draft 실행과 official stable publish 실행을 문서상 분리하는 것이다. `draft=true` 실행은 signed/notarized DMG를 만들고 maintainer 설치 smoke를 수행하는 pre-public 검증 단계로 정의한다. `draft=false`, `prerelease=false` 실행은 draft smoke 통과 후 별도 승인으로 진행하는 official stable publish 단계로 정의한다.
+
+이 작업은 릴리즈 실행 문서 정렬만 수행한다. tag 생성, workflow 실행, GitHub Release publish, stable appcast/Pages 배포, Homebrew Cask 갱신은 이 구현계획 승인만으로 실행하지 않는다.
+
+## Stage 1: 현재 릴리즈 Gate 문맥 감사
+
+### 목표
+
+현재 릴리즈 manual과 #301 릴리즈 실행 문서에서 draft signed/notarized DMG smoke, official stable publish, post-publish public surface 확인이 섞인 지점을 식별한다.
+
+### 변경 파일
+
+- `mydocs/working/task_m900_302_stage1.md`
+
+### 작업
+
+1. `release_distribution_guide.md`, `public_release_runbook.md`, `release_github_pages_sparkle_guide.md`의 release flow와 gate 문구를 검색한다.
+2. #301 수행계획서, 구현계획서, `v0.1.4` release record의 Stage 4/5 문구를 확인한다.
+3. 다음 세 범주가 문서에서 어떻게 쓰이는지 표로 정리한다.
+   - pre-public draft signed/notarized DMG smoke
+   - official stable publish (`draft=false`, `prerelease=false`)
+   - post-publish public surface 확인
+4. 문서 보정 대상을 확정하고, #301 문서는 정책 충돌 제거에 필요한 문구만 고친다는 제한을 기록한다.
+
+### 검증
+
+```bash
+rg -n "draft=true|draft=false|signed/notarized|pre-public|post-publish|Public artifact|Pages|Sparkle|Stage 4|Stage 5" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md \
+  mydocs/manual/release_github_pages_sparkle_guide.md \
+  mydocs/plans/task_m900_301.md \
+  mydocs/plans/task_m900_301_impl.md \
+  mydocs/release/v0.1.4.md
+git diff --check
+```
+
+### 단계 산출물
+
+- `mydocs/working/task_m900_302_stage1.md`
+- 단계 커밋: `Task #302 Stage 1: release gate 문맥 감사`
+
+### 승인 요청
+
+Stage 1 완료보고서 기준으로 Stage 2 진행 승인을 요청한다.
+
+## Stage 2: Pre-public DMG Smoke Gate 문서화
+
+### 목표
+
+릴리즈 entrypoint와 runbook에 signed/notarized DMG 설치 smoke가 public publish 전 필수 gate임을 명시한다.
+
+### 변경 파일
+
+- `mydocs/manual/release_distribution_guide.md`
+- `mydocs/manual/public_release_runbook.md`
+- `mydocs/working/task_m900_302_stage2.md`
+
+### 작업
+
+1. `release_distribution_guide.md`의 전체 release flow와 최종 체크리스트에서 signed/notarized draft DMG smoke를 public publish 전 gate로 분리한다.
+2. `public_release_runbook.md`에서 tag 생성 이후 `Release Publish DMG`를 `draft=true`, `prerelease=false`로 실행해 signed/notarized DMG를 만드는 pre-public gate를 추가한다.
+3. maintainer가 draft release asset 또는 Actions artifact DMG를 내려받아 설치 smoke를 수행해야 함을 명시한다.
+4. official stable publish는 draft smoke 통과 후 별도 승인으로 `draft=false`, `prerelease=false`를 실행하는 단계임을 명시한다.
+5. Gate 번호와 이름을 바꿀 경우 뒤쪽 Gate와 release record 필수 항목의 용어가 자연스럽게 이어지는지 함께 보정한다.
+
+### 검증
+
+```bash
+rg -n "draft signed/notarized DMG|draft=true|pre-public|public publish 전|official stable|post-publish" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md
+rg -n "Git tag 생성|Release Publish DMG|draft=false|prerelease=false|Homebrew" \
+  mydocs/manual/public_release_runbook.md
+git diff --check
+```
+
+### 단계 산출물
+
+- `mydocs/working/task_m900_302_stage2.md`
+- 단계 커밋: `Task #302 Stage 2: pre-public DMG smoke gate 문서화`
+
+### 승인 요청
+
+Stage 2 완료보고서 기준으로 Stage 3 진행 승인을 요청한다.
+
+## Stage 3: Pages/Sparkle와 현재 Release 문서 정렬
+
+### 목표
+
+draft/prerelease 실행이 stable Sparkle appcast와 Pages를 갱신하지 않는 pre-public 검증 단계임을 분명히 하고, #301 관련 문서의 Stage 4/5 용어를 같은 정책에 맞춘다.
+
+### 변경 파일
+
+- `mydocs/manual/release_github_pages_sparkle_guide.md`
+- `mydocs/plans/task_m900_301.md` (필요 시)
+- `mydocs/plans/task_m900_301_impl.md` (필요 시)
+- `mydocs/release/v0.1.4.md` (필요 시)
+- `mydocs/working/task_m900_302_stage3.md`
+
+### 작업
+
+1. `release_github_pages_sparkle_guide.md`에 draft/prerelease 실행에서 stable appcast와 Pages deployment를 skip하는 이유가 pre-public 검증 경계임을 명시한다.
+2. GitHub Release body와 Pages 문서는 draft smoke 이후 candidate 변경이 있으면 official stable publish 전에 다시 검토해야 한다는 기존 기준을 유지한다.
+3. #301 수행계획서와 구현계획서에서 Stage 4는 draft signed/notarized DMG smoke와 official stable publish approval gate를 다루고, Stage 5는 post-publish public surface 확인과 Homebrew gate를 다루도록 문구를 보정한다.
+4. `mydocs/release/v0.1.4.md`의 release execution gate가 public publish 전 signed/notarized DMG smoke를 필수 조건으로 읽히는지 확인하고 필요 시 보정한다.
+5. #301 고유 SHA256, workflow run 결과, release 실행 결과를 새로 단정하지 않는다.
+
+### 검증
+
+```bash
+rg -n "draft|prerelease|stable appcast|Pages deployment|pre-public|official stable" \
+  mydocs/manual/release_github_pages_sparkle_guide.md
+rg -n "Stage 4|Stage 5|draft signed/notarized|pre-public|post-publish|Homebrew gate" \
+  mydocs/plans/task_m900_301.md \
+  mydocs/plans/task_m900_301_impl.md \
+  mydocs/release/v0.1.4.md
+git diff --check
+```
+
+### 단계 산출물
+
+- `mydocs/working/task_m900_302_stage3.md`
+- 단계 커밋: `Task #302 Stage 3: Pages Sparkle와 release 문서 정렬`
+
+### 승인 요청
+
+Stage 3 완료보고서 기준으로 Stage 4 진행 승인을 요청한다.
+
+## Stage 4: 통합 검증과 최종 보고
+
+### 목표
+
+릴리즈 문서 묶음의 gate 용어와 승인 경계를 재검증하고, 최종 결과보고서와 PR 게시 준비를 완료한다.
+
+### 변경 파일
+
+- `mydocs/working/task_m900_302_stage4.md`
+- `mydocs/report/task_m900_302_report.md`
+- `mydocs/orders/20260602.md`
+
+### 작업
+
+1. 릴리즈 manual 3개와 #301 관련 문서의 gate 용어를 최종 검색한다.
+2. public publish, GitHub Release 게시, Pages/Sparkle 갱신, Homebrew Cask 반영이 모두 별도 승인 gate로 남아 있는지 확인한다.
+3. secret 값, credential payload, 일회성 SHA256 또는 workflow 실행 결과가 manual에 추가되지 않았는지 확인한다.
+4. `git diff --check`와 `git status --short`를 실행한다.
+5. Stage 4 완료보고서와 최종 결과보고서를 작성한다.
+6. 오늘할일의 #302 상태를 완료로 갱신한다.
+
+### 검증
+
+```bash
+rg -n "draft signed/notarized DMG|pre-public|official stable|post-publish|public surface|Homebrew gate" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md \
+  mydocs/manual/release_github_pages_sparkle_guide.md \
+  mydocs/plans/task_m900_301.md \
+  mydocs/plans/task_m900_301_impl.md \
+  mydocs/release/v0.1.4.md
+rg -n "password|private key|token|credential payload|SHA256" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md \
+  mydocs/manual/release_github_pages_sparkle_guide.md
+git diff --check
+git status --short
+```
+
+### 단계 산출물
+
+- `mydocs/working/task_m900_302_stage4.md`
+- `mydocs/report/task_m900_302_report.md`
+- 완료 처리된 `mydocs/orders/20260602.md`
+- 단계/최종 커밋: `Task #302 Stage 4 + 최종 보고서: 릴리즈 smoke gate 문서화 완료`
+
+### 승인 요청
+
+최종 결과보고서 기준으로 PR 게시 단계 진행 승인을 요청한다.
+
+## 전체 승인 Gate
+
+| Gate | 승인 없이 진행 금지 항목 |
+|------|--------------------------|
+| 수행계획 승인 | 구현계획서 작성 이후의 실제 릴리즈 문서 수정 |
+| 구현계획 승인 | Stage 1 감사 보고서 작성 |
+| Stage 1 승인 | 릴리즈 manual 본문 수정 |
+| Stage 2 승인 | Pages/Sparkle manual과 #301 관련 문서 보정 |
+| Stage 3 승인 | 최종 보고서 작성과 오늘할일 완료 처리 |
+| 최종 결과보고 승인 | `publish/task302` push와 PR 생성 |
+
+## 검증/기록 원칙
+
+- 실행하지 않은 workflow, smoke, signing/notarization 결과를 성공으로 기록하지 않는다.
+- manual에는 반복 적용 가능한 정책과 gate만 남기고, 특정 release의 SHA256 또는 일회성 workflow 결과는 `mydocs/release/`에만 둔다.
+- draft signed/notarized DMG, official stable public DMG, rehearsal DMG의 산출물 계층을 섞지 않는다.
+- secret 값과 credential payload는 어떤 문서, commit, PR, shell history에도 기록하지 않는다.
+- #301 문서는 정책 충돌 제거 범위에서만 보정하고, release execution 자체는 #301 승인 흐름을 따른다.
+
+## 승인 요청 사항
+
+이 구현계획서 기준으로 Stage 1 진행 승인을 요청한다.

--- a/mydocs/release/v0.1.4.md
+++ b/mydocs/release/v0.1.4.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.4` build `10` source preflight와 local/rehearsal DMG 검증 완료, Stage 4 승인 대기 |
+| 상태 | `v0.1.4` build `10` source preflight와 local/rehearsal DMG 검증 완료, Stage 4 pre-public signed/notarized DMG smoke 승인 대기 |
 | 목표 Git tag | `v0.1.4` |
 | 목표 app version | `0.1.4` |
 | 목표 build | `10` |
@@ -18,7 +18,7 @@
 | Homebrew Cask | public DMG SHA256 확정 후 별도 반영 예정 |
 | Release 실행 이슈 | [#301](https://github.com/postmelee/alhangeul-macos/issues/301) |
 
-이 문서는 `rhwp v0.7.13` 반영과 `v0.1.4` public release 후보의 source metadata, release communication, 검증 예정 항목을 기록한다. public GitHub Release, signed/notarized DMG, stable Sparkle appcast, Pages 배포, Homebrew Cask 반영 결과는 release workflow와 별도 승인 단계가 끝난 뒤 같은 문서에 보강한다.
+이 문서는 `rhwp v0.7.13` 반영과 `v0.1.4` public release 후보의 source metadata, release communication, 검증 예정 항목을 기록한다. pre-public signed/notarized DMG smoke, official stable GitHub Release, stable Sparkle appcast, Pages 배포, Homebrew Cask 반영 결과는 release workflow와 별도 승인 단계가 끝난 뒤 같은 문서에 보강한다.
 
 ## 사용자용 요약
 
@@ -101,7 +101,8 @@ Stage 3 local/rehearsal 검증 결과:
 
 Stage 4 이후 보강할 검증:
 
-- signed/notarized public DMG, GitHub Release asset, stable Sparkle appcast, Pages deploy 확인
+- pre-public signed/notarized draft DMG smoke 확인
+- official stable public DMG, GitHub Release asset, stable Sparkle appcast, Pages deploy 확인
 - public installed app 기준 Finder Quick Look/Thumbnail smoke
 - About 창의 `rhwp v0.7.13 (b3e16ef)` 표시 확인
 - public DMG SHA256, Sparkle EdDSA signature, Homebrew Cask digest 기록
@@ -136,8 +137,10 @@ public 배포 전에 다음 조건을 모두 만족해야 한다.
 - [ ] `local/task301` 변경을 `publish/task301` PR로 게시하고 `devel`에 merge
 - [ ] `devel`의 release candidate commit을 `main`에 반영하는 release PR 승인과 merge
 - [ ] `main`의 최종 release commit에 `v0.1.4` tag 생성
-- [ ] signed/notarized Release package build와 설치본 smoke 통과
+- [ ] `Release Publish DMG` `draft=true`, `prerelease=false` 실행으로 pre-public signed/notarized DMG 생성
+- [ ] maintainer가 draft release asset 또는 Actions artifact DMG를 직접 설치 smoke 통과
 - [ ] GitHub Release body가 `scripts/ci/write-release-notes.sh` template 기준으로 생성됐는지 확인
+- [ ] `Release Publish DMG` `draft=false`, `prerelease=false` official stable publish 실행
 - [ ] public DMG `alhangeul-macos-0.1.4.dmg` SHA256 기록
 - [ ] stable Sparkle appcast의 `sparkle:shortVersionString=0.1.4`, `sparkle:version=10`, EdDSA signature 확인
 - [ ] public Pages `updates/v0.1.4.html`와 `appcast.xml` URL 확인

--- a/mydocs/report/task_m900_302_report.md
+++ b/mydocs/report/task_m900_302_report.md
@@ -1,0 +1,85 @@
+# Task M900 #302 최종 결과보고서
+
+## 작업 요약
+
+| 항목 | 값 |
+|------|----|
+| Issue | [#302](https://github.com/postmelee/alhangeul-macos/issues/302) |
+| Milestone | `Release Operations` |
+| 문서 코드 | `M900` |
+| 브랜치 | `local/task302` |
+| 단계 수 | 4단계 |
+| 범위 | 릴리즈 운영 문서의 pre-public signed/notarized DMG smoke gate 정렬 |
+
+이번 작업은 public release 문서에서 signed/notarized DMG 설치 smoke가 post-publish 사후 검증으로 밀려 읽히지 않도록, `draft=true`, `prerelease=false` 실행을 pre-public 검증 단계로 정의하고 `draft=false`, `prerelease=false` 실행을 official stable publish로 분리했다.
+
+실제 `v0.1.4` 배포 실행, tag 생성, workflow 실행, GitHub Release 게시, Pages/Sparkle 배포, Homebrew Cask 갱신은 수행하지 않았다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/manual/release_distribution_guide.md` | 권한 원칙, 전체 release flow, public release 전 확정 항목, 최종 체크리스트에 pre-public draft signed/notarized DMG smoke gate 반영 |
+| `mydocs/manual/public_release_runbook.md` | Gate 4를 pre-public signed/notarized DMG smoke로 분리하고 Gate 5 official stable publish를 신설 |
+| `mydocs/manual/release_github_pages_sparkle_guide.md` | draft/prerelease 실행의 stable appcast/Pages skip 의미와 official stable publish 전 release body/Pages 재검토 기준 보강 |
+| `mydocs/plans/task_m900_301.md` | #301 수행계획서 Stage 4/5 용어와 workflow 입력 예시를 #302 정책에 맞게 보정 |
+| `mydocs/plans/task_m900_301_impl.md` | #301 구현계획서 Stage 4를 pre-public smoke와 official publish gate로 정렬 |
+| `mydocs/release/v0.1.4.md` | release execution gate에 pre-public draft DMG smoke와 official stable publish 조건 반영 |
+| `mydocs/plans/task_m900_302.md` | #302 수행계획서 |
+| `mydocs/plans/task_m900_302_impl.md` | #302 구현계획서 |
+| `mydocs/working/task_m900_302_stage1.md` | Stage 1 release gate 문맥 감사 보고 |
+| `mydocs/working/task_m900_302_stage2.md` | Stage 2 pre-public DMG smoke gate 문서화 보고 |
+| `mydocs/working/task_m900_302_stage3.md` | Stage 3 Pages/Sparkle와 #301 문서 정렬 보고 |
+| `mydocs/working/task_m900_302_stage4.md` | Stage 4 통합 검증 보고 |
+| `mydocs/orders/20260602.md` | #302 오늘할일 완료 처리 |
+
+## 변경 전·후 정량 비교
+
+| 항목 | 변경 전 | 변경 후 |
+|------|--------|--------|
+| Stage 보고서 | 없음 | Stage 1~4 보고서 작성 |
+| 최종 결과보고서 | 없음 | `task_m900_302_report.md` 작성 |
+| runbook Gate 구조 | Gate 4 `Public publish`, Gate 5 `Public artifact 확인` | Gate 4 `Pre-public signed/notarized DMG smoke`, Gate 5 `Official stable publish`, Gate 6 이후 public 확인 |
+| Sparkle/Pages draft 기준 | draft/prerelease appcast skip 기준은 있었으나 pre-public smoke 의미가 약함 | draft smoke 단계에서 stable appcast/Pages skip이 정상 동작임을 명시 |
+| #301 Stage 4/5 경계 | Stage 4 public publish, Stage 5 post-publish 확인 | Stage 4 pre-public smoke와 official publish gate, Stage 5 post-publish public surface와 Homebrew gate |
+| 통합 검증 | 미실행 | Stage 4 `rg` 2건, `git diff --check`, `git status --short` 통과 |
+
+## 검증 결과
+
+| 수용 기준 | 결과 | 비고 |
+|-----------|------|------|
+| public signed/notarized DMG 설치 smoke가 public publish 이전 gate로 문서화 | OK | `release_distribution_guide.md`, `public_release_runbook.md`에 반영 |
+| Stage 5가 GitHub Release asset, Pages 다운로드 링크, Sparkle stable feed 등 public surface 사후 검증으로 정의 | OK | #301 구현계획서와 runbook Gate 6~8에 반영 |
+| draft release smoke와 official stable publish의 승인 경계가 드러남 | OK | `draft=true`/`draft=false` workflow 입력 예시와 Gate 분리 반영 |
+| 실제 release 실행, signing/notarization 실행, Homebrew 갱신 제외 | OK | 실행하지 않았고 문서에도 별도 승인 gate로 유지 |
+| `git diff --check` | OK | 출력 없음 |
+| secret/credential 값 유입 없음 | OK | 검색 결과는 기존 정책 문구와 체크리스트 항목으로 한정 |
+
+실행한 통합 검증:
+
+```bash
+rg -n "draft signed/notarized DMG|pre-public|official stable|post-publish|public surface|Homebrew gate" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md \
+  mydocs/manual/release_github_pages_sparkle_guide.md \
+  mydocs/plans/task_m900_301.md \
+  mydocs/plans/task_m900_301_impl.md \
+  mydocs/release/v0.1.4.md
+rg -n "password|private key|token|credential payload|SHA256" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md \
+  mydocs/manual/release_github_pages_sparkle_guide.md
+git diff --check
+git status --short
+```
+
+## 잔여 위험과 후속 작업
+
+- #302는 문서 정렬 작업이므로 실제 `v0.1.4` signed/notarized draft DMG smoke 결과는 #301 실행 단계에서 확인해야 한다.
+- GitHub Actions가 생성하는 draft release asset 또는 Actions artifact의 실제 위치는 workflow run 결과에 따라 `mydocs/release/v0.1.4.md`에 기록해야 한다.
+- Homebrew Cask 반영은 public DMG URL과 SHA256 확정 후 별도 승인으로 진행해야 한다.
+- Stage 4 이후 PR 게시와 리뷰/merge는 아직 수행하지 않았다.
+
+## 작업지시자 승인 요청
+
+이 최종 결과보고서 기준으로 `publish/task302` 원격 push와 `devel` 대상 Open PR 생성 단계 진행 승인을 요청한다.

--- a/mydocs/working/task_m900_302_stage1.md
+++ b/mydocs/working/task_m900_302_stage1.md
@@ -1,0 +1,90 @@
+# Task M900 #302 Stage 1 완료보고서
+
+## 단계 목적
+
+Stage 1의 목적은 릴리즈 manual과 #301 릴리즈 실행 문서에서 다음 세 범주가 어떻게 섞여 있는지 감사하고, Stage 2 이후 보정 대상을 확정하는 것이다.
+
+- pre-public draft signed/notarized DMG smoke
+- official stable publish (`draft=false`, `prerelease=false`)
+- post-publish public surface 확인
+
+이번 단계에서는 본문 정책 문서를 수정하지 않고 문맥 감사와 보정 후보 확정만 수행했다.
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/working/task_m900_302_stage1.md` | Stage 1 감사 결과, 보정 대상, 검증 결과, 다음 단계 영향 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 릴리즈 manual 본문 변경 없음.
+- #301 수행계획서, 구현계획서, `v0.1.4` release record 변경 없음.
+- 이번 커밋 대상은 Stage 1 완료보고서 1개로 한정한다.
+
+## 감사 결과
+
+### 범주별 현재 문맥
+
+| 범주 | 현재 확인 위치 | 판단 |
+|------|----------------|------|
+| pre-public draft signed/notarized DMG smoke | `public_release_runbook.md` Gate 4 사전 조건, `release_github_pages_sparkle_guide.md` release note 확인 기준 | 용어는 존재하지만 독립 gate가 아니다. public publish 사전 조건 또는 release note 재검토 조건으로만 읽힌다. |
+| official stable publish | `public_release_runbook.md` Gate 1/4, `release_distribution_guide.md` 전체 flow와 최종 체크리스트, `release_github_pages_sparkle_guide.md` appcast 기준 | `draft=false`, `prerelease=false`일 때 official stable release로 보는 기준은 이미 있다. 다만 draft smoke 통과 후 official publish로 넘어간다는 순서가 entrypoint/runbook에 충분히 드러나지 않는다. |
+| post-publish public surface 확인 | `public_release_runbook.md` Gate 5/6/7/8/9, #301 Stage 5 | Public artifact, Pages/Sparkle, installed smoke, Homebrew gate가 publish 이후 확인 단계로 정리되어 있다. 다만 signed/notarized 설치 smoke 일부가 이 범주로 밀려 읽힐 위험이 있다. |
+
+### 문서별 보정 대상
+
+| 문서 | 보정 필요성 | Stage 2/3 반영 방향 |
+|------|------------|---------------------|
+| `mydocs/manual/release_distribution_guide.md` | 전체 release flow에서 signed/notarized DMG 생성 뒤 바로 public DMG SHA256과 post-publish 흐름으로 넘어간다. | draft signed/notarized DMG smoke를 public publish 전 gate로 flow와 최종 체크리스트에 추가한다. |
+| `mydocs/manual/public_release_runbook.md` | Gate 4가 tag, workflow input, official publish를 한 단계로 다루며 draft smoke는 사전 조건 문구에만 있다. | tag 생성 후 `draft=true`, `prerelease=false` workflow로 signed/notarized DMG smoke를 수행하는 pre-public gate를 분리한다. |
+| `mydocs/manual/release_github_pages_sparkle_guide.md` | draft/prerelease 실행에서 stable appcast skip 기준은 있으나, pre-public 검증 단계라는 의미가 약하다. | stable appcast/Pages skip이 draft signed/notarized DMG smoke의 정상 동작임을 명시한다. |
+| `mydocs/plans/task_m900_301.md` | Stage 4가 public publish gate, Stage 5가 post-publish 확인으로 되어 있으나 draft signed/notarized smoke 통과 조건이 분리되어 있지 않다. | #301 범위를 흔들지 않고 Stage 4에 draft smoke gate와 official publish 승인 경계를 덧붙인다. |
+| `mydocs/plans/task_m900_301_impl.md` | Stage 4 작업이 `draft=false` publish 실행 예시 중심이고, Stage 5에 installed smoke가 배치되어 있다. | Stage 4를 draft signed/notarized smoke와 official stable publish gate로 읽히게 보정하고, Stage 5는 public surface 확인과 Homebrew gate로 한정한다. |
+| `mydocs/release/v0.1.4.md` | release execution gate에 signed/notarized Release package build와 설치본 smoke가 있으나 draft pre-public gate 문맥은 명확하지 않다. | 필요 시 public publish 전 조건임을 짧게 보강한다. 일회성 SHA256이나 실행 결과는 추가하지 않는다. |
+
+## 검증 결과
+
+Stage 1 구현계획서의 검증 명령을 실행했다.
+
+```bash
+rg -n "draft=true|draft=false|signed/notarized|pre-public|post-publish|Public artifact|Pages|Sparkle|Stage 4|Stage 5" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md \
+  mydocs/manual/release_github_pages_sparkle_guide.md \
+  mydocs/plans/task_m900_301.md \
+  mydocs/plans/task_m900_301_impl.md \
+  mydocs/release/v0.1.4.md
+```
+
+결과 요약:
+
+- `release_distribution_guide.md`는 `Release Publish DMG` 공식 실행과 post-publish Pages/Sparkle 확인을 갖고 있으나, draft signed/notarized smoke gate가 별도 단계로 분리되어 있지 않다.
+- `public_release_runbook.md`는 Gate 4 사전 조건에 draft signed/notarized DMG smoke 이후 재검토를 언급하고, Gate 5 이후 public artifact/Pages/Sparkle/installed smoke를 다룬다.
+- `release_github_pages_sparkle_guide.md`는 draft/prerelease 실행에서 stable appcast를 갱신하지 않는다고 설명하지만, pre-public smoke 단계라는 정책 의미를 더 명시할 필요가 있다.
+- #301 문서는 Stage 4 `main/tag/public publish gate`, Stage 5 `post-publish 확인과 Homebrew gate` 구조이며, #302 정책을 반영하려면 Stage 4에 draft smoke gate를 명시하는 보정이 필요하다.
+
+```bash
+git diff --check
+```
+
+결과: 출력 없음. whitespace 오류 없음.
+
+## 잔여 위험
+
+- `Release Publish DMG` workflow 이름이 draft 검증과 official stable publish 양쪽에 쓰이므로, Stage 2에서 같은 workflow의 입력값 차이를 명확히 써야 한다.
+- Gate 번호를 바꾸면 runbook 뒤쪽 Gate 5~9 참조가 함께 밀릴 수 있다. Stage 2에서는 번호 변경 여부를 최소화할지, 새 gate로 분리할지 먼저 결정해야 한다.
+- #301 문서를 과도하게 고치면 이미 승인된 release execution 계획 범위를 흔들 수 있다. Stage 3에서는 정책 충돌 제거에 필요한 문구만 보정해야 한다.
+
+## 다음 단계 영향
+
+Stage 2에서는 `release_distribution_guide.md`와 `public_release_runbook.md`를 보정한다. 우선순위는 다음과 같다.
+
+1. draft signed/notarized DMG smoke를 public publish 전 필수 gate로 명시한다.
+2. `draft=true`, `prerelease=false` 실행과 `draft=false`, `prerelease=false` official stable publish를 분리한다.
+3. post-publish public surface 확인은 Stage 5 이후 성격으로 유지한다.
+4. public release 실행, GitHub Release 게시, Pages/Sparkle 갱신, Homebrew Cask 반영의 별도 승인 원칙은 유지한다.
+
+## 승인 요청
+
+Stage 1 감사 결과 기준으로 Stage 2 `Pre-public DMG Smoke Gate 문서화` 진행 승인을 요청한다.

--- a/mydocs/working/task_m900_302_stage2.md
+++ b/mydocs/working/task_m900_302_stage2.md
@@ -1,0 +1,107 @@
+# Task M900 #302 Stage 2 완료보고서
+
+## 단계 목적
+
+Stage 2의 목적은 릴리즈 entrypoint와 runbook에 signed/notarized DMG 설치 smoke가 public publish 전 필수 gate임을 명시하는 것이다.
+
+이번 단계에서는 `release_distribution_guide.md`와 `public_release_runbook.md`만 보정했다. Pages/Sparkle 세부 가이드와 #301 관련 문서 정렬은 Stage 3 범위로 남겼다.
+
+## 산출물
+
+| 파일 | 줄 수 | 내용 |
+|------|------:|------|
+| `mydocs/manual/release_distribution_guide.md` | 169 | 전체 release flow, public release 전 확정 항목, 최종 체크리스트에 pre-public draft signed/notarized DMG smoke gate 추가 |
+| `mydocs/manual/public_release_runbook.md` | 476 | Gate 4를 pre-public signed/notarized DMG smoke로 분리하고 Gate 5를 official stable publish로 신설 |
+| `mydocs/working/task_m900_302_stage2.md` | 신규 | Stage 2 변경 요약, 검증 결과, 다음 단계 영향 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 기존 권한 원칙과 secret 기록 금지 원칙은 유지했다.
+- `Release Rehearsal DMG`는 그대로 unsigned rehearsal 성격으로 남겼다.
+- `Release Publish DMG` workflow의 두 입력 조합을 문서상 분리했다.
+  - `draft=true`, `prerelease=false`: pre-public signed/notarized DMG smoke
+  - `draft=false`, `prerelease=false`: official stable publish
+- runbook Gate 번호는 새 Gate 5 추가로 뒤쪽 public 확인 gate가 1씩 밀렸다.
+  - Gate 6: Public artifact 확인
+  - Gate 7: Pages와 Sparkle 확인
+  - Gate 8: 설치본과 Finder smoke
+  - Gate 9: Homebrew Cask
+  - Gate 10: Release record와 최종 보고
+
+## 변경 요약
+
+### `release_distribution_guide.md`
+
+- 권한 원칙에 signed/notarized DMG 설치 smoke가 public publish 전 필수 gate임을 추가했다.
+- 전체 release flow를 다음 순서로 정렬했다.
+  1. release tag 생성
+  2. `Release Publish DMG`를 `draft=true`, `prerelease=false`로 실행해 pre-public signed/notarized DMG 생성
+  3. maintainer가 draft release asset 또는 Actions artifact DMG로 설치 smoke 수행
+  4. release note와 delta checklist 최종 보정
+  5. 별도 승인 후 `draft=false`, `prerelease=false` official stable publish 실행
+  6. GitHub Release asset, Pages, stable Sparkle appcast를 post-publish public surface로 확인
+- public release 전 확정 항목에 draft DMG smoke 담당 maintainer와 기록 위치를 추가했다.
+- 최종 체크리스트에서 pre-public draft DMG 생성, draft DMG SHA256/layout/universal slice/Legal 확인, maintainer 설치 smoke, official stable public DMG 산출물과 SHA256 기록을 분리했다.
+
+### `public_release_runbook.md`
+
+- 권한과 중단 원칙에 draft smoke와 official stable publish의 입력값 차이를 명시했다.
+- Gate 1 판정 기준에서 `draft=true`, `prerelease=false`를 pre-public 검증 단계로 정의했다.
+- Gate 4를 `Pre-public signed/notarized DMG smoke`로 변경했다.
+  - `draft=true`, `prerelease=false` workflow 예시를 추가했다.
+  - stable appcast와 Pages deploy skip을 pre-public 단계의 기대 동작으로 기록했다.
+  - maintainer smoke 명령과 수동 확인 후보를 추가했다.
+  - draft DMG를 Homebrew Cask, Sparkle enclosure, public Pages 다운로드 링크로 쓰지 않는다고 명시했다.
+- Gate 5를 `Official stable publish`로 신설했다.
+  - Gate 4 통과 후 별도 승인으로 `draft=false`, `prerelease=false` 실행만 허용했다.
+  - official stable release에서만 non-draft/non-prerelease 상태, Sparkle appcast, Pages artifact deploy를 확인하도록 분리했다.
+
+## 검증 결과
+
+Stage 2 구현계획서의 검증 명령을 실행했다.
+
+```bash
+rg -n "draft signed/notarized DMG|draft=true|pre-public|public publish 전|official stable|post-publish" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md
+```
+
+결과 요약:
+
+- `release_distribution_guide.md`에 public publish 전 필수 gate, `draft=true` pre-public 실행, `draft=false` official stable 실행, post-publish public surface 확인이 모두 검색됐다.
+- `public_release_runbook.md`에 권한 원칙, Gate 1 판정 기준, Gate 4 pre-public smoke, Gate 5 official stable publish가 모두 검색됐다.
+
+```bash
+rg -n "Git tag 생성|Release Publish DMG|draft=false|prerelease=false|Homebrew" \
+  mydocs/manual/public_release_runbook.md
+```
+
+결과 요약:
+
+- Gate 4는 `draft=true`, `prerelease=false` 입력 예시를 포함한다.
+- Gate 5는 `draft=false`, `prerelease=false` 입력 예시를 포함한다.
+- Homebrew는 Gate 9로 남아 있고 public DMG asset과 SHA256 확정 후 별도 승인 조건을 유지한다.
+
+```bash
+git diff --check
+```
+
+결과: 출력 없음. whitespace 오류 없음.
+
+## 잔여 위험
+
+- `release_github_pages_sparkle_guide.md`는 아직 Stage 2에서 수정하지 않았다. draft/prerelease 실행의 stable appcast/Pages skip 의미는 Stage 3에서 해당 문서에 직접 반영해야 한다.
+- #301 수행계획서와 구현계획서는 아직 기존 Stage 4/5 용어를 유지한다. Stage 3에서 #302 정책과 충돌하지 않도록 최소 문구 보정이 필요하다.
+- Gate 4 maintainer smoke 명령은 산출물을 release machine의 `build.noindex/release/` 기준으로 내려받은 뒤 실행하는 형태다. 실제 workflow artifact 경로가 다르면 release record에 실제 경로를 기록해야 한다.
+
+## 다음 단계 영향
+
+Stage 3에서는 다음 작업을 수행한다.
+
+1. `release_github_pages_sparkle_guide.md`에 draft/prerelease 실행이 stable appcast와 Pages를 갱신하지 않는 pre-public 검증 단계임을 명시한다.
+2. #301 수행계획서와 구현계획서에서 Stage 4를 draft signed/notarized DMG smoke와 official stable publish approval gate로 읽히게 보정한다.
+3. `mydocs/release/v0.1.4.md`에서 public publish 전 signed/notarized DMG smoke 조건이 명확한지 확인하고 필요 시 짧게 보정한다.
+
+## 승인 요청
+
+Stage 2 결과 기준으로 Stage 3 `Pages/Sparkle와 현재 Release 문서 정렬` 진행 승인을 요청한다.

--- a/mydocs/working/task_m900_302_stage3.md
+++ b/mydocs/working/task_m900_302_stage3.md
@@ -1,0 +1,109 @@
+# Task M900 #302 Stage 3 완료보고서
+
+## 단계 목적
+
+Stage 3의 목적은 Pages/Sparkle 가이드와 현재 `v0.1.4` release 문서를 Stage 2에서 확정한 gate 정책에 맞추는 것이다.
+
+핵심 기준은 다음과 같다.
+
+- `draft=true`, `prerelease=false` 실행은 pre-public signed/notarized DMG smoke 단계다.
+- draft/prerelease 실행에서 stable appcast와 Pages deployment가 skip되는 것은 정상 동작이다.
+- `draft=false`, `prerelease=false` 실행만 official stable publish로 보며, Stage 5는 post-publish public surface 확인과 Homebrew gate로 둔다.
+
+## 산출물
+
+| 파일 | 줄 수 | 내용 |
+|------|------:|------|
+| `mydocs/manual/release_github_pages_sparkle_guide.md` | 264 | draft/prerelease appcast skip의 pre-public 검증 의미와 official stable publish 전 release body/Pages 재검토 기준 보강 |
+| `mydocs/plans/task_m900_301.md` | 176 | #301 수행계획서 Stage 4/5 용어와 workflow 입력 예시 정렬 |
+| `mydocs/plans/task_m900_301_impl.md` | 317 | #301 구현계획서 Stage 4를 pre-public smoke와 official publish gate로 분리 |
+| `mydocs/release/v0.1.4.md` | 177 | release execution gate에 pre-public draft DMG smoke와 official stable publish 조건 반영 |
+| `mydocs/working/task_m900_302_stage3.md` | 신규 | Stage 3 변경 요약, 검증 결과, 다음 단계 영향 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- #301의 source metadata, release note 후보, 검증 결과 SHA256은 변경하지 않았다.
+- #301 release execution 자체를 실행하지 않았고, workflow run 결과를 새로 단정하지 않았다.
+- `release_github_pages_sparkle_guide.md`에는 반복 적용 가능한 정책만 추가했고, 특정 release 결과값은 넣지 않았다.
+- Stage 3 변경은 기존 문서의 Gate 구조와 승인 경계를 보정하는 문구 변경에 한정했다.
+
+## 변경 요약
+
+### `release_github_pages_sparkle_guide.md`
+
+- 권한 원칙에 `draft=true`, `prerelease=false` 실행이 pre-public signed/notarized DMG smoke 단계임을 추가했다.
+- draft smoke 이후 official stable publish 전에 GitHub Release body와 Pages 업데이트 문서를 다시 검토해야 한다고 명시했다.
+- `Release Publish DMG` appcast 동작 기준을 다음처럼 분리했다.
+  - official stable release에서만 stable appcast 갱신
+  - `draft=true`, `prerelease=false`에서는 stable appcast skip
+  - prerelease 실행도 stable appcast와 Pages deployment skip
+  - official stable release에서만 generated `appcast.xml`과 Pages artifact 배포 성공을 appcast 배포 성공으로 판정
+
+### #301 수행계획서와 구현계획서
+
+- Stage 4를 `main/tag/pre-public smoke와 official publish gate`로 보정했다.
+- Stage 4 작업에 `draft=true`, `prerelease=false` pre-public signed/notarized DMG smoke를 추가했다.
+- Stage 4 작업에 draft smoke 통과 후 `draft=false`, `prerelease=false` official stable publish를 별도 승인 gate로 추가했다.
+- Stage 5를 post-publish public surface 확인과 Homebrew gate로 정렬했다.
+- workflow 입력 예시에 pre-public draft smoke와 official stable publish 입력을 모두 남겼다.
+- rehearsal DMG, 개발용 zip, pre-public draft DMG, official stable public DMG의 산출물 계층을 섞지 않는다고 보강했다.
+
+### `mydocs/release/v0.1.4.md`
+
+- 상태를 Stage 4 pre-public signed/notarized DMG smoke 승인 대기로 정리했다.
+- Stage 4 이후 보강할 검증에 pre-public draft DMG smoke와 official stable public DMG 확인을 분리했다.
+- release execution gate에 `draft=true`, `prerelease=false` pre-public DMG 생성, maintainer 설치 smoke, `draft=false`, `prerelease=false` official stable publish 조건을 추가했다.
+
+## 검증 결과
+
+Stage 3 구현계획서의 검증 명령을 실행했다.
+
+```bash
+rg -n "draft|prerelease|stable appcast|Pages deployment|pre-public|official stable" \
+  mydocs/manual/release_github_pages_sparkle_guide.md
+```
+
+결과 요약:
+
+- 권한 원칙에 pre-public 검증 단계와 skip 정상 동작이 검색됐다.
+- GitHub Release 생성 전 확인과 주요 변경 사항 작성 기준에 official stable publish 전 재검토 문구가 검색됐다.
+- appcast 동작 기준에 `draft=false`, `draft=true`, prerelease, official stable release 조건이 모두 검색됐다.
+
+```bash
+rg -n "Stage 4|Stage 5|draft signed/notarized|pre-public|post-publish|Homebrew gate|draft=true|draft=false" \
+  mydocs/plans/task_m900_301.md \
+  mydocs/plans/task_m900_301_impl.md \
+  mydocs/release/v0.1.4.md
+```
+
+결과 요약:
+
+- #301 수행계획서와 구현계획서에 Stage 4 pre-public smoke와 official publish gate가 검색됐다.
+- #301 구현계획서에 `draft=true`와 `draft=false` workflow 입력 예시가 모두 검색됐다.
+- #301 Stage 5는 post-publish public surface 확인과 Homebrew gate로 검색됐다.
+- `v0.1.4` release record에 pre-public signed/notarized DMG smoke 승인 대기와 official stable publish 조건이 검색됐다.
+
+```bash
+git diff --check
+```
+
+결과: 출력 없음. whitespace 오류 없음.
+
+## 잔여 위험
+
+- #301 release execution은 아직 실제 Stage 4 승인 대기 상태다. 이 문서 보정은 실행 순서 정렬이며, 실제 tag/workflow/release asset 결과를 보장하지 않는다.
+- `draft=true` workflow 실행 산출물이 draft release asset과 Actions artifact 중 어디에 남는지는 실제 workflow run 결과에 따라 release record에 기록해야 한다.
+- Stage 4 최종 검증에서는 세 릴리즈 manual과 #301 관련 문서 전체에서 같은 gate 용어가 유지되는지 다시 확인해야 한다.
+
+## 다음 단계 영향
+
+Stage 4에서는 다음을 수행한다.
+
+1. 릴리즈 manual 3개와 #301 관련 문서 전체에서 gate 용어를 최종 검색한다.
+2. public publish, GitHub Release 게시, Pages/Sparkle 갱신, Homebrew Cask 반영이 별도 승인 gate로 유지되는지 확인한다.
+3. secret 값, credential payload, 일회성 SHA256 또는 workflow 실행 결과가 manual에 추가되지 않았는지 확인한다.
+4. Stage 4 완료보고서와 최종 결과보고서를 작성하고 오늘할일을 완료로 갱신한다.
+
+## 승인 요청
+
+Stage 3 결과 기준으로 Stage 4 `통합 검증과 최종 보고` 진행 승인을 요청한다.

--- a/mydocs/working/task_m900_302_stage4.md
+++ b/mydocs/working/task_m900_302_stage4.md
@@ -1,0 +1,78 @@
+# Task M900 #302 Stage 4 완료보고서
+
+## 단계 목적
+
+Stage 4의 목적은 #302에서 변경한 릴리즈 문서 묶음을 통합 검증하고, 최종 결과보고서와 오늘할일 완료 처리를 마치는 것이다.
+
+이번 단계에서는 추가 정책 본문을 새로 만들지 않고, Stage 1~3 결과가 같은 gate 용어와 승인 경계를 유지하는지 확인했다.
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/working/task_m900_302_stage4.md` | Stage 4 통합 검증 결과와 다음 PR 단계 승인 요청 |
+| `mydocs/report/task_m900_302_report.md` | #302 최종 결과보고서 |
+| `mydocs/orders/20260602.md` | #302 상태 완료 처리 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- Stage 4에서 릴리즈 manual 본문은 추가 수정하지 않았다.
+- Stage 4에서 #301 관련 문서와 `v0.1.4` release record도 추가 수정하지 않았다.
+- 오늘할일은 #302 행의 상태와 비고만 완료 상태로 갱신했다.
+
+## 검증 결과
+
+구현계획서 Stage 4의 통합 검증 명령을 실행했다.
+
+```bash
+rg -n "draft signed/notarized DMG|pre-public|official stable|post-publish|public surface|Homebrew gate" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md \
+  mydocs/manual/release_github_pages_sparkle_guide.md \
+  mydocs/plans/task_m900_301.md \
+  mydocs/plans/task_m900_301_impl.md \
+  mydocs/release/v0.1.4.md
+```
+
+결과 요약:
+
+- 세 릴리즈 manual과 #301 관련 문서에서 `pre-public`, `official stable`, `post-publish`, `Homebrew gate` 용어가 의도한 위치에 검색됐다.
+- `release_distribution_guide.md`는 전체 flow와 최종 체크리스트에서 draft smoke, official stable publish, post-publish public surface 확인을 분리한다.
+- `public_release_runbook.md`는 Gate 4 pre-public signed/notarized DMG smoke, Gate 5 official stable publish, Gate 6 이후 public artifact/Pages/Homebrew 확인 구조를 유지한다.
+- `release_github_pages_sparkle_guide.md`는 draft/prerelease 실행에서 stable appcast와 Pages deployment skip을 pre-public 검증 단계의 정상 동작으로 설명한다.
+
+```bash
+rg -n "password|private key|token|credential payload|SHA256" \
+  mydocs/manual/release_distribution_guide.md \
+  mydocs/manual/public_release_runbook.md \
+  mydocs/manual/release_github_pages_sparkle_guide.md
+```
+
+결과 요약:
+
+- 검색 결과는 기존 secret 기록 금지 문구, Sparkle private key 취급 원칙, SHA256 체크리스트/기록 위치 설명으로 한정됐다.
+- 실제 credential payload, token 값, private key 값, 특정 release의 새 SHA256 digest는 manual에 추가되지 않았다.
+
+```bash
+git diff --check
+git status --short
+```
+
+결과:
+
+- `git diff --check`: 출력 없음. whitespace 오류 없음.
+- Stage 4 보고서와 최종 결과보고서 작성 전 기준 `git status --short`: 출력 없음.
+
+## 잔여 위험
+
+- 이 작업은 문서 정책 정렬이며 실제 `v0.1.4` tag, workflow, GitHub Release asset, Pages/Sparkle 배포 결과를 검증하지 않는다.
+- 실제 `Release Publish DMG` `draft=true` 실행에서 draft release asset과 Actions artifact 중 어디에 산출물이 남는지는 #301 실행 시 release record에 기록해야 한다.
+- Homebrew Cask 반영은 여전히 public DMG SHA256 확정 후 별도 승인 gate로 남아 있다.
+
+## 다음 단계 영향
+
+최종 결과보고서 승인 후에는 PR 게시 단계로 진행할 수 있다. PR 게시 시에는 `publish/task302` 원격 브랜치를 만들고 `devel` 대상 Open PR을 생성해야 한다.
+
+## 승인 요청
+
+Stage 4 통합 검증과 최종 결과보고서 기준으로 PR 게시 단계 진행 승인을 요청한다.


### PR DESCRIPTION
## 요약

- 대상 타스크: #302 릴리즈 문서의 signed/notarized draft DMG smoke gate 정렬
- 왜: signed/notarized DMG 설치 smoke가 public publish 이후 사후 검증처럼 읽히는 혼선을 제거하기 위해
- 무엇: `draft=true` pre-public smoke와 `draft=false` official stable publish를 manual/runbook/#301 문서에서 분리
- 리뷰 포인트: Gate 4/5 용어, Pages/Sparkle skip 의미, #301 Stage 4/5 handoff 문구

Closes #302

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/efc68d5a90600eb2253b65d83b808050aad70ace/mydocs/working/task_m900_302_stage1.md)** ([4a149e7](https://github.com/postmelee/alhangeul-macos/commit/4a149e7)): release gate 문맥 감사와 보정 대상 확정
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/efc68d5a90600eb2253b65d83b808050aad70ace/mydocs/working/task_m900_302_stage2.md)** ([4873481](https://github.com/postmelee/alhangeul-macos/commit/4873481)): entrypoint/runbook에 pre-public DMG smoke gate 문서화
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/efc68d5a90600eb2253b65d83b808050aad70ace/mydocs/working/task_m900_302_stage3.md)** ([47a2a53](https://github.com/postmelee/alhangeul-macos/commit/47a2a53)): Pages/Sparkle 기준과 #301 release 문서 정렬
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/efc68d5a90600eb2253b65d83b808050aad70ace/mydocs/working/task_m900_302_stage4.md)** ([efc68d5](https://github.com/postmelee/alhangeul-macos/commit/efc68d5)): 통합 검증, 최종 보고, 오늘할일 완료 처리

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| Release runbook | Gate 4 pre-public smoke, Gate 5 official stable publish로 분리 | `draft=true`/`draft=false` 입력 경계 |
| Release guide | 전체 flow와 체크리스트에 pre-public draft DMG smoke 추가 | post-publish public surface와 섞이지 않는지 |
| Pages/Sparkle guide | draft/prerelease skip을 pre-public 검증 정상 동작으로 명시 | stable appcast/Pages 조건 |
| #301 문서 | Stage 4/5 용어와 workflow 입력 예시 정렬 | 기존 release 실행 범위를 흔들지 않는지 |

- 수행 계획서: [task_m900_302.md](https://github.com/postmelee/alhangeul-macos/blob/efc68d5a90600eb2253b65d83b808050aad70ace/mydocs/plans/task_m900_302.md)
- 구현 계획서: [task_m900_302_impl.md](https://github.com/postmelee/alhangeul-macos/blob/efc68d5a90600eb2253b65d83b808050aad70ace/mydocs/plans/task_m900_302_impl.md)
- 최종 보고서: [task_m900_302_report.md](https://github.com/postmelee/alhangeul-macos/blob/efc68d5a90600eb2253b65d83b808050aad70ace/mydocs/report/task_m900_302_report.md)

## 핵심 리뷰 포인트

- `Release Publish DMG` workflow가 draft smoke와 official stable publish 양쪽에 쓰이므로 입력값 경계가 충분히 명확한지 확인해 주세요.
- #301 문서 보정이 release execution 범위를 바꾸지 않고 Stage 4/5 용어만 정렬하는지 확인해 주세요.
- draft DMG, rehearsal DMG, official stable public DMG의 산출물 계층이 Homebrew/Sparkle 문맥에서 섞이지 않는지 확인해 주세요.

## 검증

- `rg -n "draft signed/notarized DMG|pre-public|official stable|post-publish|public surface|Homebrew gate" mydocs/manual/release_distribution_guide.md mydocs/manual/public_release_runbook.md mydocs/manual/release_github_pages_sparkle_guide.md mydocs/plans/task_m900_301.md mydocs/plans/task_m900_301_impl.md mydocs/release/v0.1.4.md`
- `rg -n "password|private key|token|credential payload|SHA256" mydocs/manual/release_distribution_guide.md mydocs/manual/public_release_runbook.md mydocs/manual/release_github_pages_sparkle_guide.md`
- `git diff --check`
- `git status --short`

## 관련 이슈

없음

## 후속 이슈 제안

없음

## 남은 리스크

- 실제 `v0.1.4` signed/notarized draft DMG smoke 결과는 #301 실행 단계에서 별도로 확인해야 합니다.
- workflow 산출물이 draft release asset과 Actions artifact 중 어디에 남는지는 실제 run 결과에 따라 `mydocs/release/v0.1.4.md`에 기록해야 합니다.
