### PR TITLE
Task #132: Copilot 보고서 리뷰 규칙 정렬

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -19,8 +19,9 @@ Rendering and extension checks:
 - HostApp viewer code should keep document opening, security-scoped URLs, page cache, page selection, and zoom state separated in the store/view layers.
 
 Workflow and verification:
-- PRs normally target `devel`, including Skia common backend/provenance work, except HostApp native macOS shell, Skia viewport, and Swift editing UI/overlay work which targets `native-viewer-editor`; retired `devel-webview` is not a PR target. Maintainer PR heads normally come from `publish/taskN` and are backed by a GitHub Issue and Korean task documents under `mydocs/`. Branch policy details live in `mydocs/tech/branch_strategy_webview_native.md`.
-- PR descriptions should use `.github/pull_request_template.md`, separate the direct target task from contextual related issues, link each Stage summary to its report and commit, and list only verification that was actually run.
+- PRs normally target `devel`; native shell, Skia viewport, and Swift editing work targets `native-viewer-editor`. Retired `devel-webview` is not a PR target. Maintainer PR heads use `publish/taskN` with a GitHub Issue and Korean `mydocs/` task docs.
+- PR descriptions should use `.github/pull_request_template.md`, separate target task from related context, link each Stage summary to its report and commit, and list only verification actually run.
+- For `mydocs/plans/**`, `mydocs/working/**`, and `mydocs/report/**`, apply `.github/instructions/hyperfall-documents.instructions.md`; use this file for branch, build, architecture, and release-risk checks.
 - When a change touches RustBridge, core dependency, FFI, or generated bridge artifacts, expect `./scripts/build-rust-macos.sh` or `--verify-lock`, `./scripts/check-no-appkit.sh`, `xcodegen generate`, and HostApp `xcodebuild` as applicable.
 - When rendering behavior changes, expect `./scripts/validate-stage3-render.sh`; for visual differences or renderer bug fixes, expect `./scripts/render-debug-compare.sh` on relevant samples.
 - Do not request release, signing, notarization, or Homebrew Cask work unless the PR is explicitly about distribution.

--- a/.github/instructions/hyperfall-documents.instructions.md
+++ b/.github/instructions/hyperfall-documents.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "mydocs/plans/**/*.md,mydocs/working/**/*.md,mydocs/report/**/*.md"
+---
+
+# Hyper-waterfall document review rules
+
+Write review comments in Korean. For these paths, prioritize traceability and verification reliability over wording/style preference.
+
+- Plans in `mydocs/plans/**`: check issue number, milestone code, base branch, scope/exclusions, stage plan, validation commands, risks, and approval request. Flag missing or conflicting task metadata, stage boundaries, or validation plans.
+- Stage reports in `mydocs/working/**`: check stage purpose, output table, change extent/body-loss note when applicable, actual verification commands and results, residual risk, next-stage impact, and approval request. Flag reports that cite commands not run or omit failed verification.
+- Final reports in `mydocs/report/**`: check task summary table, changed-files table, before/after quantitative comparison when applicable, acceptance criteria OK/MISS table, verification results, residual risks/follow-ups, and approval request.
+- File naming and location: plans are `task_m{milestone}_{issue}.md` or `_impl.md`; stage reports are `task_m{milestone}_{issue}_stage{N}.md` in `working/`; final reports are `task_m{milestone}_{issue}_report.md` in `report/`. Flag final reports in `working/`, stage reports in `report/`, or missing milestone codes.
+- Only leave comments when traceability, folder/naming policy, stage/commit linkage, actual verification, approval boundary, or PR readiness is ambiguous or wrong. Do not leave wording-only review comments.


### PR DESCRIPTION
## 요약

- 대상 타스크: #132 (Closes #132)
- 왜: Copilot Code Review가 보고서/계획서 규칙을 repo-wide 지침만으로 판단해 반복적인 형식 지적이 발생할 수 있어 정렬했습니다.
- 무엇: 전역 Copilot 지침을 압축하고, `mydocs/plans/**`, `mydocs/working/**`, `mydocs/report/**` 전용 path-specific instruction을 추가했습니다.
- 리뷰 포인트: `applyTo` 범위와 보고서 형식 지적 우선순위가 현재 운영 기준과 맞는지 확인 부탁드립니다.

## PR base

- base: `devel`

## 변경 내역

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `.github/copilot-instructions.md` | workflow/review 지침을 전역 기준 중심으로 압축하고 mydocs 전용 instruction 참조를 추가했습니다. | Copilot instruction 4,000자 제한 유지 |
| `.github/instructions/hyperfall-documents.instructions.md` | plans/working/report 전용 보고서 리뷰 기준을 추가했습니다. | `applyTo` 경로 범위와 검토 우선순위 |

## 핵심 리뷰 포인트

- `mydocs/plans/**`, `mydocs/working/**`, `mydocs/report/**`에만 path-specific instruction이 적용되는지 확인 부탁드립니다.
- 보고서 형식 지적이 단순 문체보다 추적성/검증 신뢰성 문제에 집중되도록 우선순위를 정리했습니다.

## 검증

- `git diff --check HEAD~1..HEAD`
- `.github/copilot-instructions.md` 4,000자 제한 확인

## 관련 이슈

- 없음

## 후속 이슈 제안

- 없음

## 남은 리스크

- 실제 Copilot Code Review 적용 여부는 PR 생성 후 GitHub Copilot review에서 확인해야 합니다.