### PR TITLE
Task #121: RawSvg/OLE·차트 리소스 렌더링 보강

### DIFF
--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -46,6 +46,8 @@ class CGTreeRenderer {
     private let maxPCXDecodedByteCount = 64 * 1024 * 1024
     private let maxPCXPixelByteCount = 64 * 1024 * 1024
     private let maxImageTileDrawCount = 4096
+    private let maxRawSvgFragmentBytes = 4 * 1024 * 1024
+    private let maxRawSvgRasterPixels = 67_108_864
 
     private var imageCache: [UInt16: CGImage] = [:]
     private weak var document: RhwpDocument?
@@ -224,6 +226,16 @@ class CGTreeRenderer {
         case .formObject:
             // 양식 개체는 M3 이후
             break
+
+        case .placeholder(let placeholder):
+            if shouldRenderFlowContent {
+                renderPlaceholder(placeholder, bbox: node.bbox, in: ctx)
+            }
+
+        case .rawSvg(let rawSvg):
+            if shouldRenderFlowContent {
+                renderRawSvg(rawSvg, bbox: node.bbox, in: ctx)
+            }
 
         case .footnoteMarker(let marker):
             if shouldRenderFlowContent {
@@ -1096,6 +1108,198 @@ class CGTreeRenderer {
         }
 
         ctx.restoreGState()
+    }
+
+    // MARK: - RawSvg / Placeholder
+
+    private func renderPlaceholder(_ placeholder: PlaceholderNode, bbox: BBox, in ctx: CGContext) {
+        guard let rect = validTopLeftRect(for: bbox) else { return }
+
+        ctx.saveGState()
+        ctx.clip(to: rect)
+
+        ctx.setFillColor(colorRefToCGColor(placeholder.fillColor))
+        ctx.fill(rect)
+
+        ctx.setStrokeColor(colorRefToCGColor(placeholder.strokeColor))
+        ctx.setLineWidth(1)
+        ctx.setLineDash(phase: 0, lengths: [6, 3])
+        ctx.stroke(rect.insetBy(dx: 0.5, dy: 0.5))
+        ctx.setLineDash(phase: 0, lengths: [])
+
+        let fontSize = min(max(min(rect.width, rect.height) * 0.06, 12), 28)
+        drawPlaceholderLabel(
+            placeholder.label,
+            in: visibleLabelRect(for: rect, in: ctx).insetBy(dx: 8, dy: 8),
+            color: colorRefToCGColor(placeholder.strokeColor),
+            fontSize: fontSize,
+            in: ctx
+        )
+
+        ctx.restoreGState()
+    }
+
+    private func renderRawSvg(_ rawSvg: RawSvgNode, bbox: BBox, in ctx: CGContext) {
+        guard let rect = validTopLeftRect(for: bbox),
+              rawSvg.svg.utf8.count <= maxRawSvgFragmentBytes,
+              !exceedsRawSvgRasterLimit(rect) else {
+            renderRawSvgFallback(bbox: bbox, in: ctx)
+            return
+        }
+
+        guard let imageData = decodeRawSvgSingleImageData(rawSvg.svg),
+              let image = decodeImage(imageData) else {
+            renderRawSvgFallback(bbox: bbox, in: ctx)
+            return
+        }
+
+        ctx.saveGState()
+        ctx.clip(to: rect)
+        drawImage(image, inTopLeftRect: rect, in: ctx)
+        ctx.restoreGState()
+    }
+
+    private func decodeRawSvgSingleImageData(_ svg: String) -> Data? {
+        guard let dataURL = RawSvgSingleImageDataURLParser.parseDataURL(svg) else {
+            return nil
+        }
+        return decodeBase64ImageDataURL(dataURL)
+    }
+
+    private func decodeBase64ImageDataURL(_ dataURL: String) -> Data? {
+        guard dataURL.lowercased().hasPrefix("data:"),
+              let commaIndex = dataURL.firstIndex(of: ",") else {
+            return nil
+        }
+
+        let metadata = String(dataURL[dataURL.index(dataURL.startIndex, offsetBy: 5)..<commaIndex])
+        let normalizedMetadata = metadata.lowercased()
+        let metadataParts = normalizedMetadata.split(separator: ";", omittingEmptySubsequences: false)
+        let mediaType = metadataParts.first.map(String.init) ?? ""
+        guard (mediaType.isEmpty || mediaType.hasPrefix("image/")),
+              mediaType != "image/svg+xml",
+              metadataParts.contains("base64") else {
+            return nil
+        }
+
+        let encoded = dataURL[dataURL.index(after: commaIndex)...]
+        let compact = String(encoded.unicodeScalars.filter { !$0.properties.isWhitespace })
+        guard !compact.isEmpty else {
+            return nil
+        }
+        return Data(base64Encoded: compact)
+    }
+
+    private func renderRawSvgFallback(bbox: BBox, in ctx: CGContext) {
+        guard let rect = validTopLeftRect(for: bbox) else { return }
+
+        ctx.saveGState()
+        ctx.clip(to: rect)
+        ctx.setFillColor(CGColor(gray: 0.97, alpha: 1.0))
+        ctx.fill(rect)
+        ctx.setStrokeColor(CGColor(gray: 0.45, alpha: 1.0))
+        ctx.setLineWidth(1)
+        ctx.setLineDash(phase: 0, lengths: [6, 3])
+        ctx.stroke(rect.insetBy(dx: 0.5, dy: 0.5))
+        ctx.setLineDash(phase: 0, lengths: [])
+
+        let fontSize = min(max(min(rect.width, rect.height) * 0.08, 12), 24)
+        drawPlaceholderLabel(
+            "SVG",
+            in: visibleLabelRect(for: rect, in: ctx).insetBy(dx: 8, dy: 8),
+            color: CGColor(gray: 0.35, alpha: 1.0),
+            fontSize: fontSize,
+            in: ctx
+        )
+
+        ctx.restoreGState()
+    }
+
+    private func drawPlaceholderLabel(
+        _ text: String,
+        in rect: CGRect,
+        color: CGColor,
+        fontSize: CGFloat,
+        in ctx: CGContext
+    ) {
+        guard !text.isEmpty,
+              isValidImageDrawSize(rect.size),
+              rect.width > 8,
+              rect.height > 8 else {
+            return
+        }
+
+        var resolvedFontSize = min(fontSize, rect.height * 0.65)
+        var line: CTLine?
+        var metrics = TextRunTypographicMetrics(width: 0, ascent: 0, descent: 0, leading: 0)
+
+        while resolvedFontSize >= 6 {
+            let font = resolveAppleFont(
+                hwpFontFamily: "Apple SD Gothic Neo",
+                bold: false,
+                italic: false,
+                size: resolvedFontSize
+            )
+            let attributes: [NSAttributedString.Key: Any] = [
+                coreTextFontKey: font,
+                coreTextForegroundColorKey: color,
+            ]
+            let candidateLine = CTLineCreateWithAttributedString(
+                NSAttributedString(string: text, attributes: attributes)
+            )
+            metrics = textRunTypographicMetrics(candidateLine)
+            if metrics.width <= rect.width || metrics.width <= 0 {
+                line = candidateLine
+                break
+            }
+            let scale = rect.width / metrics.width
+            let nextFontSize = floor(resolvedFontSize * scale)
+            if nextFontSize >= resolvedFontSize {
+                resolvedFontSize -= 1
+            } else {
+                resolvedFontSize = nextFontSize
+            }
+        }
+
+        guard let line, metrics.width.isFinite else { return }
+
+        let textX = max(0, (rect.width - metrics.width) / 2)
+        let textY = rect.height / 2 - (metrics.ascent - metrics.descent) / 2
+
+        ctx.saveGState()
+        ctx.translateBy(x: rect.minX, y: rect.minY + rect.height)
+        ctx.scaleBy(x: 1, y: -1)
+        ctx.textPosition = CGPoint(x: textX, y: textY)
+        CTLineDraw(line, ctx)
+        ctx.restoreGState()
+    }
+
+    private func validTopLeftRect(for bbox: BBox) -> CGRect? {
+        let rect = cgRect(bbox)
+        guard rect.origin.x.isFinite,
+              rect.origin.y.isFinite,
+              isValidImageDrawSize(rect.size) else {
+            return nil
+        }
+        return rect
+    }
+
+    private func visibleLabelRect(for rect: CGRect, in ctx: CGContext) -> CGRect {
+        let clipBounds = ctx.boundingBoxOfClipPath
+        guard !clipBounds.isNull, !clipBounds.isInfinite else {
+            return rect
+        }
+
+        let visibleRect = rect.intersection(clipBounds)
+        guard isValidImageDrawSize(visibleRect.size) else {
+            return rect
+        }
+        return visibleRect
+    }
+
+    private func exceedsRawSvgRasterLimit(_ rect: CGRect) -> Bool {
+        let pixelEstimate = Double(rect.width * rect.height)
+        return !pixelEstimate.isFinite || pixelEstimate > Double(maxRawSvgRasterPixels)
     }
 
     private func equationLocalBounds(equation: EquationNode, items: [EquationSVGDrawItem]) -> CGRect {
@@ -3760,6 +3964,81 @@ private enum EquationSVGTextAnchor {
     case start
     case middle
     case end
+}
+
+private final class RawSvgSingleImageDataURLParser: NSObject, XMLParserDelegate {
+    private var imageElementCount = 0
+    private var dataURL: String?
+    private var invalid = false
+
+    static func parseDataURL(_ fragment: String) -> String? {
+        let trimmed = fragment.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard isSingleSelfClosingImageFragment(trimmed),
+              let data = """
+              <root xmlns:xlink="http://www.w3.org/1999/xlink">\(trimmed)</root>
+              """.data(using: .utf8) else {
+            return nil
+        }
+
+        let delegate = RawSvgSingleImageDataURLParser()
+        let parser = XMLParser(data: data)
+        parser.delegate = delegate
+        parser.shouldProcessNamespaces = false
+        parser.shouldReportNamespacePrefixes = false
+        parser.shouldResolveExternalEntities = false
+
+        guard parser.parse(),
+              !delegate.invalid,
+              delegate.imageElementCount == 1,
+              let dataURL = delegate.dataURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+              dataURL.lowercased().hasPrefix("data:") else {
+            return nil
+        }
+        return dataURL
+    }
+
+    func parser(
+        _ parser: XMLParser,
+        didStartElement elementName: String,
+        namespaceURI: String?,
+        qualifiedName qName: String?,
+        attributes attributeDict: [String: String]
+    ) {
+        switch elementName.lowercased() {
+        case "root":
+            return
+        case "image":
+            imageElementCount += 1
+            guard imageElementCount == 1 else {
+                invalid = true
+                return
+            }
+            dataURL = attributeDict["xlink:href"] ?? attributeDict["href"]
+        default:
+            invalid = true
+        }
+    }
+
+    func parser(_ parser: XMLParser, foundCharacters string: String) {
+        if !string.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            invalid = true
+        }
+    }
+
+    private static func isSingleSelfClosingImageFragment(_ fragment: String) -> Bool {
+        guard fragment.hasPrefix("<image"),
+              fragment.hasSuffix("/>"),
+              fragment.unicodeScalars.filter({ $0 == "<" }).count == 1 else {
+            return false
+        }
+
+        let tagNameEnd = fragment.index(fragment.startIndex, offsetBy: "<image".count)
+        guard tagNameEnd < fragment.endIndex else {
+            return false
+        }
+        let next = fragment[tagNameEnd]
+        return next.isWhitespace || next == "/" || next == ">"
+    }
 }
 
 private final class EquationSVGFragmentParser: NSObject, XMLParserDelegate {

--- a/Sources/RhwpCoreBridge/RenderTree.swift
+++ b/Sources/RhwpCoreBridge/RenderTree.swift
@@ -57,6 +57,8 @@ enum RenderNodeType: Decodable {
     case textBox
     case equation(EquationNode)
     case formObject(FormObjectNode)
+    case placeholder(PlaceholderNode)
+    case rawSvg(RawSvgNode)
     case footnoteMarker(FootnoteMarkerNode)
     case unknown
 
@@ -92,6 +94,8 @@ enum RenderNodeType: Decodable {
         if let v = try? keyed.decode(GroupNode.self, forKey: .init("Group")) { self = .group(v); return }
         if let v = try? keyed.decode(EquationNode.self, forKey: .init("Equation")) { self = .equation(v); return }
         if let v = try? keyed.decode(FormObjectNode.self, forKey: .init("FormObject")) { self = .formObject(v); return }
+        if let v = try? keyed.decode(PlaceholderNode.self, forKey: .init("Placeholder")) { self = .placeholder(v); return }
+        if let v = try? keyed.decode(RawSvgNode.self, forKey: .init("RawSvg")) { self = .rawSvg(v); return }
         if let v = try? keyed.decode(FootnoteMarkerNode.self, forKey: .init("FootnoteMarker")) { self = .footnoteMarker(v); return }
         self = .unknown
     }
@@ -369,6 +373,22 @@ struct FormObjectNode: Decodable {
         case formType = "form_type"
         case caption, text
     }
+}
+
+struct PlaceholderNode: Decodable {
+    let fillColor: UInt32
+    let strokeColor: UInt32
+    let label: String
+
+    enum CodingKeys: String, CodingKey {
+        case fillColor = "fill_color"
+        case strokeColor = "stroke_color"
+        case label
+    }
+}
+
+struct RawSvgNode: Decodable {
+    let svg: String
 }
 
 struct FootnoteMarkerNode: Decodable {

--- a/mydocs/orders/20260602.md
+++ b/mydocs/orders/20260602.md
@@ -1,5 +1,11 @@
 # 오늘 할일 - 2026년 6월 2일
 
+## M014 — v0.1.4 Native Preview/Viewer Parity
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #121 | Swift native renderer RawSvg/OLE·차트 리소스 렌더링 보강 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+
 ## M900 — Release Operations
 
 | Issue | 타스크 | 상태 | 비고 |

--- a/mydocs/orders/20260602.md
+++ b/mydocs/orders/20260602.md
@@ -4,7 +4,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #121 | Swift native renderer RawSvg/OLE·차트 리소스 렌더링 보강 | 진행중 | M014, 수행계획서 작성 후 승인 대기 |
+| #121 | Swift native renderer RawSvg/OLE·차트 리소스 렌더링 보강 | 완료 | M014, 완료: 12:11 |
 
 ## M900 — Release Operations
 

--- a/mydocs/plans/task_m014_121.md
+++ b/mydocs/plans/task_m014_121.md
@@ -1,0 +1,132 @@
+# Task M014 #121 수행계획서
+
+## 목적
+
+Swift/CoreGraphics native renderer가 upstream `rhwp v0.7.13` render contract의 `RawSvg` 계열 정적 리소스를 crash 없이 소비하도록 보강한다. 목표는 Quick Look preview, Finder thumbnail, PDF/CoreGraphics fallback에서 OLE, chart, 복합 벡터 리소스가 비어 보이는 상태를 줄이고, 표시할 수 없는 payload는 명확한 fallback으로 남기는 것이다.
+
+## 배경
+
+현재 앱 저장소의 `rhwp-core.lock`과 bundled `rhwp-studio`는 모두 upstream `edwardkim/rhwp v0.7.13` (`b3e16ef212af81ef37d973ddb86d6816d3804642`) 기준이다. M014에서는 #280 visual diff harness, #281 overlay metadata 입력, #282 native compositor, #116 watermark/effect gate, #122 image fill/tile/placement 보강을 완료해 CoreGraphics fallback 경로의 비교 기준과 image draw helper가 정리됐다.
+
+하지만 Swift `RenderTree.swift`는 아직 `RenderNodeType::RawSvg`를 디코딩하지 않는다. `CGTreeRenderer`도 RawSvg payload를 그리는 경로가 없어 OLE, OOXML chart, 복합 SVG fragment 같은 정적 리소스가 빠지거나 `.unknown`으로 흡수될 가능성이 있다. upstream WebCanvas 계열은 단일 data URL image와 복합 SVG fragment를 처리하지만, CanvasKit direct renderer에도 `rawSvg` unsupported diagnostic 경로가 남아 있으므로 Swift 쪽은 무리한 의미 해석보다 안전한 표시와 fallback 경계를 먼저 세워야 한다.
+
+## 범위
+
+포함:
+
+- `RenderTree.swift`의 `RawSvg` 노드 디코딩 추가
+- upstream `RawSvg` payload shape 확인과 Swift 모델 필드 정의
+- 단일 image data URL, SVG fragment, 복합 SVG fragment 처리 전략 결정
+- macOS에서 SVG fragment를 bitmap 또는 image로 안전하게 rasterize하는 경로 검토
+- OLE, chart 등 정적 객체의 bbox, clipping, scale, transform 반영
+- 표시 불가 payload는 crash 없이 placeholder/fallback으로 처리
+- `samples/draw-group.hwp`, `samples/eq-01.hwp`와 작업 중 확인한 RawSvg/OLE/chart fixture로 visual diff 전후 수치 기록
+- Quick Look/Thumbnail/PDF CoreGraphics fallback 경로에서 같은 동작 확인
+
+제외:
+
+- OLE 객체 편집 또는 실행
+- 차트 데이터 편집
+- upstream `rhwp` RawSvg 생성 로직 수정
+- CanvasKit/Skia direct renderer의 `rawSvg` unsupported 해소
+- PageLayerTree/Skia 기본 경로 전환
+- Placeholder/FormObject 정적 프리뷰 (#110)
+- image fill/tile/placement 추가 보강 (#122 후속)
+- HostApp native viewer shell, DPR-aware viewport, page pooling 작업
+
+## 설계 방향
+
+구현은 `RenderTree.swift` 모델 확장과 `CGTreeRenderer` draw path 보강을 분리해서 진행한다. SVG payload를 완전히 해석하려고 하기보다, upstream이 이미 만든 정적 visual payload를 안전하게 표시하거나 fallback으로 드러내는 방향을 우선한다.
+
+1. current path와 upstream payload를 inventory한다.
+   - Swift render tree decoder가 `RawSvg`를 현재 어떻게 누락하는지 확인한다.
+   - sample별 render tree JSON에서 `RawSvg` payload key, bbox, transform, children, resource reference 형태를 기록한다.
+2. RawSvg 모델을 최소 범위로 정의한다.
+   - string SVG, data URL, optional MIME, width/height, resource id처럼 실제 JSON에 존재하는 필드만 우선 디코딩한다.
+   - 알 수 없는 필드는 렌더 실패가 아니라 fallback 판단 근거로 남긴다.
+3. 렌더 전략을 단계적으로 적용한다.
+   - 단일 raster image data URL은 기존 image decode/draw helper와 최대한 공유한다.
+   - SVG fragment는 AppKit/WebKit 의존 없이 가능한 CoreGraphics/ImageIO/CoreImage 경로를 우선 검토한다.
+   - 직접 rasterize가 어려운 payload는 bbox 안에 명확한 static placeholder를 그린다.
+4. 좌표와 clipping은 기존 renderer 규칙을 따른다.
+   - node bbox, transform, group clipping, table cell clipping과 충돌하지 않도록 `renderNode` 흐름에 붙인다.
+   - #122에서 정리한 image bbox fallback과 placement helper를 회귀시키지 않는다.
+5. visual diff와 fallback 여부를 같이 기록한다.
+   - 수치가 줄지 않는 경우에도 unsupported payload가 사용자에게 빈 화면 대신 명확히 보이는지 기록한다.
+
+## 예상 변경 파일
+
+| 파일 | 예상 변경 |
+|------|-----------|
+| `Sources/RhwpCoreBridge/RenderTree.swift` | `RawSvg` node type과 payload 모델 디코딩 추가 |
+| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | RawSvg draw path, raster image/SVG/fallback rendering 추가 |
+| `Sources/Shared/HwpPageImageRenderer.swift` | 필요 시 fallback diagnostic 또는 render metadata 연결 |
+| `Sources/Shared/HwpPreviewPDFRenderer.swift` | PDF/CoreGraphics fallback smoke 중 동일 renderer policy 확인 |
+| `scripts/render-debug-compare.sh` | 필요 시 RawSvg node count 또는 fallback 확인 보강 |
+| `scripts/preview-visual-diff-harness.sh` | 필요 시 #121 sample 실행 편의 보강 |
+| `mydocs/working/task_m014_121_stage*.md` | 단계별 관찰값, 설계 판단, diff 수치 기록 |
+| `mydocs/report/task_m014_121_report.md` | 최종 결과와 #110 handoff 정리 |
+
+## 잠정 단계
+
+1. Stage 1: RawSvg current path inventory와 baseline 측정
+   - `samples/draw-group.hwp`, `samples/eq-01.hwp` 기준 render tree JSON, native PNG, visual diff baseline을 남긴다.
+   - RawSvg/OLE/chart 양성 fixture가 부족하면 repository sample과 사용자 제공 fixture 후보를 확인한다.
+2. Stage 2: RawSvg payload 모델과 fallback 정책 설계
+   - 실제 JSON payload shape에 맞춰 Swift 모델 필드와 unsupported fallback 조건을 정한다.
+   - raster image data URL, SVG fragment, 복합 fragment를 분리해 처리 우선순위를 정리한다.
+3. Stage 3: RenderTree 디코딩과 CoreGraphics fallback 구현
+   - `RawSvg` node decoding을 추가하고, 최소 표시 또는 placeholder fallback을 구현한다.
+   - 기존 image, equation, group, form object path는 범위를 넓히지 않는다.
+4. Stage 4: visual diff와 renderer smoke 검증
+   - RawSvg target sample과 M014 공통 sample set을 전후 비교한다.
+   - Quick Look/Thumbnail/PDF CoreGraphics fallback의 non-crash와 extension registration hygiene를 확인한다.
+5. Stage 5: 최종 보고와 PR 게시 준비
+   - 지원된 payload, fallback된 payload, 남은 unsupported 유형, #110으로 넘길 사항을 정리한다.
+
+## 검증 계획
+
+기본 검증:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task121-baseline --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+
+./scripts/render-debug-compare.sh build.noindex/task121-render-debug --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task121-regression --page 1 \
+  samples/basic/request.hwp samples/복학원서.hwp samples/pic-crop-01.hwp \
+  samples/form-01.hwp samples/hwpx/form-002.hwpx samples/hwpx/hwpx-01.hwpx
+
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task121 CODE_SIGNING_ALLOWED=NO build
+
+git diff --check
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+수용 기준:
+
+- RawSvg node가 `.unknown`으로 사라지지 않고 Swift model에서 식별된다.
+- 지원 가능한 RawSvg 또는 raster image data URL payload가 bbox 안에 표시된다.
+- 표시 불가 payload는 crash 없이 명확한 placeholder/fallback으로 보인다.
+- OLE/chart/static resource bbox, transform, clipping이 기존 flow와 크게 어긋나지 않는다.
+- Quick Look preview, Finder thumbnail, PDF/CoreGraphics fallback이 같은 renderer path를 사용한다.
+- #122 image fill/tile/placement, #116 baked watermark gate, #282 compositor sample이 회귀하지 않는다.
+- visual diff 수치와 fallback 여부가 stage 문서와 최종 보고서에 남는다.
+
+## 리스크
+
+- upstream RawSvg JSON shape가 sample별로 다르면 Swift 모델을 너무 좁게 잡았을 때 payload가 다시 누락될 수 있다.
+- macOS 기본 framework만으로 SVG fragment를 안정적으로 rasterize하기 어려울 수 있다.
+- WebKit/AppKit 의존을 `RhwpCoreBridge`에 직접 넣으면 bridge 소유 경계와 코드 규칙을 위반할 수 있다.
+- SVG fragment의 intrinsic size와 node bbox scale을 잘못 해석하면 chart/OLE 위치가 rhwp-studio와 달라질 수 있다.
+- fallback placeholder가 visual diff 수치를 늘릴 수 있다. 이 경우 사용자-facing non-blank 개선과 pixel parity를 분리해 판단해야 한다.
+- RawSvg와 Placeholder/FormObject(#110)의 fallback 표현이 겹칠 수 있으므로 사용자에게 중복 placeholder처럼 보이지 않게 조심해야 한다.
+
+## 승인 요청 사항
+
+1. #121은 `devel` 기준 `local/task121` 브랜치에서 진행한다.
+2. 수행계획서 승인 후 Stage 1 RawSvg current path inventory와 baseline 측정부터 시작한다.
+3. 구현은 Swift/CoreGraphics fallback renderer 범위로 제한하고, upstream `rhwp` 수정, Skia 기본 경로 전환, OLE/chart editing은 다루지 않는다.

--- a/mydocs/plans/task_m014_121_impl.md
+++ b/mydocs/plans/task_m014_121_impl.md
@@ -1,0 +1,169 @@
+# Task M014 #121 구현계획서
+
+## 기준
+
+- 이슈: #121
+- 브랜치: `local/task121`
+- 기준 브랜치: `origin/devel` `1b767bd`
+- 수행계획서 커밋: `c8263e2`
+- core/studio 기준: rhwp `v0.7.13`, resolved commit `b3e16ef212af81ef37d973ddb86d6816d3804642`
+
+## 구현 목표
+
+Swift/CoreGraphics native renderer에서 upstream render tree의 `RawSvg` 계열 정적 리소스를 식별하고, 지원 가능한 payload는 bbox 안에 표시하며, 지원할 수 없는 payload는 빈 화면이나 crash 대신 명확한 fallback으로 남긴다. 구현은 Quick Look preview, Finder thumbnail, PDF/CoreGraphics fallback이 공유하는 `CGTreeRenderer` 경로를 우선 대상으로 삼는다.
+
+## 사전 확인 결과
+
+수행계획서 승인 직후 소스 변경 없이 현재 모델과 renderer 경로를 확인했다.
+
+- `Sources/RhwpCoreBridge/RenderTree.swift`의 `RenderNodeType`에는 `RawSvg` case가 없다.
+- `RenderNodeType.init(from:)`는 `Page`, `Image`, `Equation`, `FormObject` 등을 순서대로 디코딩하고, 매칭되지 않는 node type은 `.unknown`으로 둔다.
+- `ImageNode`는 #122에서 보강한 `fill_mode`, `original_size`, `crop`, `effect`, `brightness`, `contrast`, `text_wrap`를 이미 디코딩한다.
+- `EquationNode`는 `svg_content`를 갖지만, `CGTreeRenderer.renderEquation`은 equation 전용 SVG subset parser와 draw path를 사용한다. RawSvg/OLE/chart 범용 SVG payload를 여기에 섞지 않는 편이 안전하다.
+- `CGTreeRenderer.renderNode`에는 `.formObject`가 아직 no-op이고, RawSvg용 분기가 없다.
+- `HwpPageImageRenderer`와 `HwpPreviewPDFRenderer`의 CoreGraphics path는 `CGTreeRenderer` 결과를 공유하므로, RawSvg draw/fallback은 shared renderer에 붙이면 Quick Look/Thumbnail/PDF smoke에서 같이 확인할 수 있다.
+
+## Stage 구성
+
+| Stage | 목표 | 산출물 |
+|-------|------|--------|
+| Stage 1 | RawSvg current path inventory와 baseline 측정 | `mydocs/working/task_m014_121_stage1.md` |
+| Stage 2 | RawSvg payload 모델과 fallback/rendering 정책 설계 | `mydocs/working/task_m014_121_stage2.md` |
+| Stage 3 | RenderTree 디코딩과 CoreGraphics fallback 구현 | `RenderTree.swift`, `CGTreeRenderer.swift` 중심 변경 |
+| Stage 4 | visual diff, renderer smoke, shared path 회귀 검증 | `mydocs/working/task_m014_121_stage4.md` |
+| Stage 5 | 최종 보고와 PR 게시 준비 | `mydocs/report/task_m014_121_report.md` |
+
+## Stage 1 세부 계획
+
+소스 코드는 변경하지 않고 현재 입력과 누락 지점을 고정한다.
+
+- `samples/draw-group.hwp`, `samples/eq-01.hwp`의 render tree JSON을 생성한다.
+- render tree JSON에서 `RawSvg`, `rawSvg`, `raw_svg`, OLE/chart 관련 key 존재 여부를 확인한다.
+- target sample에 RawSvg 양성 fixture가 부족하면 repository sample 전체를 1차 scan하고, 범위 안에서 확인 가능한 fixture 후보를 기록한다.
+- `preview-visual-diff-harness`로 target sample baseline을 남긴다.
+- `render-debug-compare`로 native PNG, core SVG, node summary를 남긴다.
+- 현재 Swift decoder에서 RawSvg가 `.unknown`으로 흡수되는지, 아니면 upstream sample이 아직 RawSvg를 만들지 않는지 분리한다.
+
+검증:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task121-stage1-render-debug --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task121-stage1-baseline --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+
+git diff --check
+```
+
+산출물:
+
+- `build.noindex/task121-stage1-render-debug/`
+- `build.noindex/task121-stage1-baseline/`
+- `mydocs/working/task_m014_121_stage1.md`
+
+## Stage 2 세부 계획
+
+Stage 1 결과를 바탕으로 구현 전 정책을 문서로 고정한다.
+
+- 실제 JSON payload shape에 맞춰 `RawSvgNode` 필드를 정의한다.
+- data URL image, inline SVG string, SVG fragment, resource reference, unknown payload를 분리한다.
+- `RhwpCoreBridge`에 AppKit/WebKit 직접 의존을 넣지 않는 rasterize/fallback 경계를 결정한다.
+- 지원할 payload와 placeholder fallback payload를 구분한다.
+- fallback placeholder의 시각 표현, 색상, label, bbox clipping 기준을 정한다.
+- diagnostics는 기존 renderer metadata에 바로 확장할지, Stage 4 보고서의 render-debug 관찰값으로만 남길지 결정한다.
+
+검증:
+
+```bash
+git diff --check
+```
+
+산출물:
+
+- `mydocs/working/task_m014_121_stage2.md`
+
+## Stage 3 세부 계획
+
+승인된 정책에 따라 최소 구현을 적용한다.
+
+- `RenderTree.swift`에 `RawSvg` case와 `RawSvgNode` 모델을 추가한다.
+- `RenderNodeType.init(from:)`가 RawSvg를 `.unknown` 전에 디코딩하도록 한다.
+- `CGTreeRenderer.renderNode`에 `.rawSvg` 분기를 추가한다.
+- 지원 가능한 raster image data URL payload는 기존 image draw helper와 최대한 같은 bbox/clip 규칙으로 그린다.
+- SVG fragment를 직접 rasterize할 수 없는 경우 명확한 static fallback을 그린다.
+- fallback draw helper는 RawSvg 전용으로 유지해 #110 Placeholder/FormObject 범위와 섞이지 않게 한다.
+- 기존 `ImageNode`, `EquationNode`, `.formObject` 렌더 범위는 넓히지 않는다.
+
+검증:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task121-stage3-render-debug --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+
+xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task121 CODE_SIGNING_ALLOWED=NO build
+
+git diff --check
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+## Stage 4 세부 계획
+
+구현 후 target sample과 공통 sample set을 재측정한다.
+
+- Stage 1 target sample baseline을 같은 조건으로 재측정한다.
+- M014 공통 visual diff sample set에서 회귀를 확인한다.
+- `render-debug-compare`로 RawSvg node count, native non-white pixel, fallback 표시 여부를 확인한다.
+- Quick Look/Thumbnail/PDF CoreGraphics path가 같은 renderer 결과를 쓰는지 smoke한다.
+- WebKit readiness timeout이나 `qlmanage` rasterize 실패처럼 환경 요인이 있으면 보고서에 분리해 기록한다.
+
+검증:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task121-stage4-target --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task121-stage4-regression --page 1 \
+  samples/basic/request.hwp samples/복학원서.hwp samples/pic-crop-01.hwp \
+  samples/form-01.hwp samples/hwpx/form-002.hwpx samples/hwpx/hwpx-01.hwpx
+
+./scripts/render-debug-compare.sh build.noindex/task121-stage4-render-debug --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+
+git diff --check
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+산출물:
+
+- `mydocs/working/task_m014_121_stage4.md`
+
+## Stage 5 세부 계획
+
+최종 결과와 handoff를 정리하고 PR 게시 준비 상태로 만든다.
+
+- 지원한 RawSvg payload 유형과 fallback으로 남긴 유형을 표로 정리한다.
+- visual diff 전후 수치와 native PNG 시각 확인 결과를 기록한다.
+- #110 Placeholder/FormObject, #124 HostApp viewer path에 넘길 사항을 분리한다.
+- 오늘할일을 완료 상태로 갱신한다.
+- 최종 검증 명령과 `git status`를 확인한다.
+
+검증:
+
+```bash
+git status --short
+git log --oneline -5
+git diff --check
+```
+
+산출물:
+
+- `mydocs/report/task_m014_121_report.md`
+- `mydocs/orders/20260602.md` 완료 상태 갱신
+
+## 승인 필요 사항
+
+1. Stage 1은 소스 변경 없이 RawSvg 입력 존재 여부, decoder 누락 지점, target sample baseline을 확인하는 단계로 진행한다.
+2. Stage 2는 Stage 1에서 확인한 payload shape에 맞춰 Swift 모델과 fallback 정책을 문서로 고정한다.
+3. Stage 3 구현은 Swift/CoreGraphics fallback renderer에 한정하며, upstream `rhwp`, Skia 기본 경로, OLE/chart editing, Placeholder/FormObject 정적 프리뷰는 다루지 않는다.

--- a/mydocs/report/task_m014_121_report.md
+++ b/mydocs/report/task_m014_121_report.md
@@ -1,0 +1,117 @@
+# Task M014 #121 최종 보고서
+
+## 작업 요약
+
+| 항목 | 값 |
+|------|----|
+| 이슈 | [#121 Swift native renderer RawSvg/OLE·차트 리소스 렌더링 보강](https://github.com/postmelee/alhangeul-macos/issues/121) |
+| 마일스톤 | M014 |
+| 브랜치 | `local/task121` |
+| 기준 브랜치 | `devel` |
+| core/studio 기준 | `edwardkim/rhwp v0.7.13`, `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| 단계 | Stage 1 조사, Stage 2 정책 설계, Stage 3 구현, Stage 4 검증, Stage 5 최종 보고 |
+
+이번 작업은 Swift/CoreGraphics native renderer가 upstream render tree의 `RawSvg`와 `Placeholder` node를 `.unknown`으로 흡수하지 않고, 지원 가능한 payload는 표시하며 지원 불가 payload는 명확한 fallback으로 남기도록 보강했다.
+
+실제 repository sample에서는 RawSvg positive fixture를 찾지 못했으므로 RawSvg는 upstream contract와 synthetic JSON으로 검증했다. 작업 중 제공받은 `143E433F503322BD33.hwp`는 RawSvg가 아니라 OLE/chart-like object가 `Placeholder`로 내려오는 fixture로 확인되어 Placeholder 렌더링까지 포함했다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `Sources/RhwpCoreBridge/RenderTree.swift` | `RawSvg`와 `Placeholder` render node case 및 payload model decode 추가 |
+| `Sources/RhwpCoreBridge/CGTreeRenderer.swift` | RawSvg 단일 data image draw, 복합 SVG fallback, Placeholder dashed box/label 렌더링 추가 |
+| `mydocs/plans/task_m014_121.md` | 수행계획서 작성 |
+| `mydocs/plans/task_m014_121_impl.md` | 구현계획서 작성 |
+| `mydocs/working/task_m014_121_stage1.md` | RawSvg current path, sample baseline, visual diff readiness timeout 기록 |
+| `mydocs/working/task_m014_121_stage2.md` | upstream RawSvg contract와 Swift fallback 정책 정리 |
+| `mydocs/working/task_m014_121_stage3.md` | 구현 내용, synthetic smoke, Placeholder fixture 분석, build/policy check 기록 |
+| `mydocs/working/task_m014_121_stage4.md` | target/regression visual diff metric, render-debug 재측정, 수용 기준 점검 기록 |
+| `mydocs/orders/20260602.md` | #121 오늘할일 상태를 완료로 갱신 |
+
+## 변경 전·후 정량 비교
+
+최종 보고서 작성 직전 `devel..local/task121` 기준:
+
+| 항목 | 값 |
+|------|---:|
+| 변경 파일 | `9` |
+| 추가 라인 | `1569` |
+| Swift 소스 변경 파일 | `2` |
+| 작업/계획 보고 문서 | `6` |
+| Stage 4 visual diff target OK | `2/2` |
+| Stage 4 visual diff regression OK | `6/6` |
+| Stage 4 render-debug OK | `3/3` |
+
+Stage 3 전후 제공 fixture native non-white pixel:
+
+| 파일 | Stage 3 전 | Stage 3 후 |
+|------|-----------:|-----------:|
+| `143E433F503322BD33.hwp` page 1 | `105571` | `136906` |
+
+증가분은 OLE Placeholder box와 `OLE 개체 (BinData #2)` label이 표시되면서 생긴 사용자-facing non-blank 개선이다.
+
+## Visual Diff 결과
+
+Stage 4에서 visual diff harness를 sandbox 내부와 sandbox 밖에서 각각 실행했다.
+
+- sandbox 내부: Stage 1과 같은 readiness timeout 재현
+- sandbox 밖: target set과 regression set 모두 OK
+
+Target set:
+
+| 파일 | Status | ChangedPixels | ChangedPercent | MeanRGBDelta |
+|------|--------|--------------:|---------------:|-------------:|
+| `draw-group.hwp` | OK | `28960/3561228` | `0.8132%` | `0.4881` |
+| `eq-01.hwp` | OK | `230538/3562815` | `6.4707%` | `5.9354` |
+
+Regression set:
+
+| 파일 | Status | ChangedPixels | ChangedPercent | MeanRGBDelta |
+|------|--------|--------------:|---------------:|-------------:|
+| `request.hwp` | OK | `321284/1798071` | `17.8683%` | `10.9606` |
+| `복학원서.hwp` | OK | `257941/3562815` | `7.2398%` | `6.7272` |
+| `pic-crop-01.hwp` | OK | `72763/3562815` | `2.0423%` | `0.8092` |
+| `form-01.hwp` | OK | `28739/3562815` | `0.8066%` | `0.4843` |
+| `form-002.hwpx` | OK | `543087/3561228` | `15.2500%` | `17.3362` |
+| `hwpx-01.hwpx` | OK | `505312/3562815` | `14.1829%` | `15.1348` |
+
+## 검증 결과
+
+| 수용 기준 / 명령 | 결과 | 비고 |
+|------------------|------|------|
+| RawSvg node가 Swift model에서 식별된다 | OK | synthetic RenderTree JSON decode/render smoke |
+| 지원 가능한 RawSvg data image가 bbox 안에 표시된다 | OK | synthetic red PNG data image smoke |
+| 표시 불가 RawSvg payload가 fallback으로 보인다 | OK | synthetic complex SVG fallback smoke |
+| OLE Placeholder가 표시된다 | OK | `143E433F503322BD33.hwp` page 1 native PNG |
+| `./scripts/render-debug-compare.sh ... samples/draw-group.hwp samples/eq-01.hwp` | OK | native PNG와 summary 생성 |
+| `./scripts/render-debug-compare.sh ... 143E433F503322BD33.hwp` | OK | Placeholder fixture 확인 |
+| `./scripts/preview-visual-diff-harness.sh ... target` | OK | sandbox 밖 실행, `2/2` OK |
+| `./scripts/preview-visual-diff-harness.sh ... regression` | OK | sandbox 밖 실행, `6/6` OK |
+| `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task121 CODE_SIGNING_ALLOWED=NO build` | OK | sandbox 내부 cache 권한 실패 후 sandbox 밖 재시도에서 `** BUILD SUCCEEDED **` |
+| `git diff --check` | OK | 공백/patch 문제 없음 |
+| `./scripts/check-no-appkit.sh` | OK | `RhwpCoreBridge` AppKit/UIKit 의존 없음 |
+| `./scripts/check-extension-registration-hygiene.sh --check-only` | OK | Issues 없음 |
+
+optional core SVG raster diff는 일부 render-debug에서 `qlmanage rasterize failed`로 생성되지 않았다. 이는 Stage 1부터 반복된 local `qlmanage` rasterize 한계이며 native renderer PNG 생성과 visual diff harness 결과와는 분리한다.
+
+## 잔여 위험과 후속 작업
+
+| 항목 | 판단 |
+|------|------|
+| 실제 RawSvg positive fixture 부재 | RawSvg는 synthetic smoke와 upstream contract 기반으로 검증했다. 실물 fixture 확보 시 추가 회귀 검증이 필요하다. |
+| 복합 SVG chart/EMF rasterize | 현재는 CoreGraphics bridge 안에서 직접 rasterize하지 않고 `SVG` fallback으로 표시한다. |
+| `143E433F503322BD33.hwp` chart 복원 | mac renderer가 아니라 upstream core의 OLE/BinData 해석 문제로 분리했다. upstream 이슈 [edwardkim/rhwp#1251](https://github.com/edwardkim/rhwp/issues/1251)을 생성했다. |
+| visual diff harness sandbox readiness | sandbox 밖에서는 통과한다. harness 안정화는 별도 작업으로 분리하는 편이 맞다. |
+| `qlmanage` SVG raster diff | optional debug diff 한계로 남아 있다. |
+
+후속 후보:
+
+- RawSvg positive HWP/HWPX fixture 확보 후 실물 fixture 기반 회귀 테스트 추가
+- 복합 SVG chart/EMF raster backend 도입 여부 검토
+- visual diff harness의 sandbox/WebKit readiness 안정화
+- upstream `edwardkim/rhwp#1251` 결과가 나오면 core pin 갱신 또는 renderer 정책 재검토
+
+## 작업지시자 승인 요청
+
+이 보고서와 오늘할일 완료 처리를 커밋한 뒤 `publish/task121`로 push하고, `devel` 대상 PR을 생성한다.

--- a/mydocs/working/task_m014_121_stage1.md
+++ b/mydocs/working/task_m014_121_stage1.md
@@ -1,0 +1,321 @@
+# Task M014 #121 Stage 1 완료보고서
+
+## 개요
+
+Stage 1은 Swift/CoreGraphics native renderer의 RawSvg current path를 inventory하고, #121 target sample의 구현 전 기준선을 고정하는 단계다. 소스 코드는 변경하지 않았고, 기존 script와 bundled artifact만 사용했다.
+
+## 기준
+
+| 항목 | 값 |
+|------|----|
+| 이슈 | #121 Swift native renderer RawSvg/OLE·차트 리소스 렌더링 보강 |
+| 브랜치 | `local/task121` |
+| 기준 브랜치 | `origin/devel` `1b767bd` |
+| core/studio 기준 | `edwardkim/rhwp v0.7.13`, `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| 수행계획서 | `mydocs/plans/task_m014_121.md` |
+| 구현계획서 | `mydocs/plans/task_m014_121_impl.md` |
+
+## Current Path Inventory
+
+### Render tree model
+
+`Sources/RhwpCoreBridge/RenderTree.swift`의 `RenderNodeType`에는 현재 `RawSvg` case가 없다.
+
+- `RenderNodeType` case 목록은 `Page`, `Image`, `Group`, `Equation`, `FormObject` 등을 포함하지만 `RawSvg`는 없다.
+- `RenderNodeType.init(from:)`는 알려진 externally tagged enum을 순서대로 디코딩한 뒤, 매칭되지 않는 struct variant를 `.unknown`으로 둔다.
+- 따라서 upstream render tree JSON에 `{"RawSvg": ...}`가 들어오면 현재 Swift model은 이를 식별하지 못하고 `.unknown`으로 흡수할 가능성이 높다.
+
+관련 코드:
+
+- `Sources/RhwpCoreBridge/RenderTree.swift:38`
+- `Sources/RhwpCoreBridge/RenderTree.swift:79`
+- `Sources/RhwpCoreBridge/RenderTree.swift:96`
+
+### 기존 이미지/수식 경로
+
+`ImageNode`는 binary image resource 중심의 모델이다.
+
+- `bin_data_id`, `fill_mode`, `original_size`, `original_size_hu`, `crop`, `effect`, `brightness`, `contrast`, `text_wrap`를 디코딩한다.
+- #122 이후 `CGTreeRenderer.renderImage`와 overlay image path는 같은 `drawImage` helper를 사용한다.
+- RawSvg payload가 image data URL이나 inline SVG fragment로 내려오는 경우에는 `ImageNode`와 별도 모델이 필요하다.
+
+`EquationNode`는 `svg_content`를 갖지만 equation 전용이다.
+
+- `CGTreeRenderer.renderEquation`은 equation subset parser와 CoreGraphics draw path를 사용한다.
+- OLE/chart/복합 SVG fragment를 equation parser에 섞으면 책임 경계가 흐려지므로, Stage 2에서는 RawSvg 전용 모델과 fallback을 따로 설계해야 한다.
+
+관련 코드:
+
+- `Sources/RhwpCoreBridge/RenderTree.swift:299`
+- `Sources/RhwpCoreBridge/RenderTree.swift:339`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:205`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:219`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:738`
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:766`
+
+### Shared renderer path
+
+`HwpNativePageCompositor`는 page background, BehindText overlay, flow, InFrontOfText overlay 순서로 `CGTreeRenderer`를 호출한다. RawSvg draw/fallback을 `CGTreeRenderer`에 붙이면 Quick Look preview, Finder thumbnail, PDF/CoreGraphics fallback 경로에서 같은 renderer 결과를 확인할 수 있다.
+
+관련 코드:
+
+- `Sources/Shared/HwpNativePageCompositor.swift:3`
+- `Sources/Shared/HwpNativePageCompositor.swift:14`
+- `Sources/Shared/HwpNativePageCompositor.swift:34`
+
+## Target Render Debug Baseline
+
+명령:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task121-stage1-render-debug --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+```
+
+결과:
+
+| 파일 | RenderTreeJSONBytes | CoreSVGBytes | NativePNGSize | NativeNonWhitePixels | TextRuns | HangulRuns | MissingHangulGlyphs | 비고 |
+|------|--------------------:|-------------:|---------------|---------------------:|---------:|-----------:|--------------------:|------|
+| `draw-group.hwp` | `13998` | `19539` | `794x1123` | `7324` | `2` | `1` | `0` | `LAYOUT_OVERFLOW_DRAW` 2회 stderr |
+| `eq-01.hwp` | `233539` | `262660` | `794x1123` | `45708` | `71` | `37` | `0` | Equation 3개 |
+
+두 샘플 모두 optional core SVG raster diff는 생성되지 않았다.
+
+```text
+DiffReason: qlmanage rasterize failed
+```
+
+산출물:
+
+```text
+build.noindex/task121-stage1-render-debug/
+```
+
+## Target Node Type 확인
+
+`draw-group.hwp` 1페이지 node type:
+
+| NodeType | Count |
+|----------|------:|
+| `Body` | 1 |
+| `Column` | 1 |
+| `Footer` | 1 |
+| `Group` | 1 |
+| `Header` | 1 |
+| `Image` | 17 |
+| `Page` | 1 |
+| `PageBackground` | 1 |
+| `Rectangle` | 2 |
+| `TextLine` | 2 |
+| `TextRun` | 2 |
+
+`draw-group.hwp`의 image 17개는 모두 `fill_mode=null`, `text_wrap=Square`였다. 이 샘플은 이름과 달리 현재 upstream render tree 기준으로 RawSvg가 아니라 raster image node 집합으로 내려온다.
+
+`eq-01.hwp` 1페이지 node type:
+
+| NodeType | Count |
+|----------|------:|
+| `Body` | 1 |
+| `Column` | 1 |
+| `Equation` | 3 |
+| `Footer` | 1 |
+| `Header` | 1 |
+| `Line` | 8 |
+| `Page` | 1 |
+| `PageBackground` | 1 |
+| `Rectangle` | 2 |
+| `Table` | 2 |
+| `TableCell` | 2 |
+| `TextLine` | 20 |
+| `TextRun` | 71 |
+
+`eq-01.hwp`의 Equation node:
+
+| id | bbox | svgLength |
+|----|------|----------:|
+| `18` | `198.62000000000012,196.70360655737707,396.46666666666664x39.2` | `1533` |
+| `58` | `141.77333333333337,427.2428415300547,423.2x36.8` | `2072` |
+| `62` | `184.25333333333344,477.37617486338803,438.2x36.8` | `3757` |
+
+## RawSvg Key Search
+
+다음 문자열을 target render tree JSON에서 확인했다.
+
+```text
+RawSvg
+rawSvg
+raw_svg
+OLE
+ole
+Chart
+chart
+```
+
+결과:
+
+| 범위 | 결과 |
+|------|------|
+| `build.noindex/task121-stage1-render-debug/*-render-tree.json` | hit 없음 |
+
+판단:
+
+- target sample 두 개는 현재 `rhwp v0.7.13` 기준 RawSvg 양성 fixture가 아니다.
+- Swift decoder 누락은 코드 inventory상 분명하지만, 이 두 샘플만으로 RawSvg `.unknown` 흡수를 실증할 수는 없다.
+
+## Repository Sample Scan
+
+target sample에서 RawSvg가 나오지 않아 repository sample의 page 1 render tree를 1차 scan했다.
+
+명령:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task121-stage1-sample-scan --page 1 \
+  $(find samples -type f \( -name '*.hwp' -o -name '*.hwpx' \) -print)
+```
+
+결과:
+
+| 항목 | 값 |
+|------|---:|
+| 입력 HWP/HWPX 파일 수 | `174` |
+| 생성된 render tree JSON 수 | `165` |
+| 생성된 summary 수 | `165` |
+| scan command exit code | `1` |
+
+비고:
+
+- 동일 basename HWP/HWPX가 같은 output stem을 공유하는 경우가 있어 일부 산출물은 덮어쓰기 가능성이 있다.
+- command는 `FAIL: one or more render debug exports failed`로 종료했다. Stage 1 목적은 RawSvg fixture scan이므로, 생성된 JSON 전체를 기준으로 key search를 수행했다.
+
+생성된 165개 render tree JSON 전체에서 RawSvg/OLE/chart 관련 key search 결과:
+
+| Pattern | 결과 |
+|---------|------|
+| `RawSvg` / `rawSvg` / `raw_svg` | hit 없음 |
+| `OLE` / `ole` | hit 없음 |
+| `Chart` / `chart` | hit 없음 |
+
+생성 JSON 전체 node type aggregate:
+
+| NodeType | Count |
+|----------|------:|
+| `Body` | 165 |
+| `Column` | 181 |
+| `Ellipse` | 39 |
+| `Equation` | 148 |
+| `Footer` | 165 |
+| `FootnoteArea` | 5 |
+| `FootnoteMarker` | 24 |
+| `FormObject` | 65 |
+| `Group` | 26 |
+| `Header` | 162 |
+| `Image` | 175 |
+| `Line` | 1456 |
+| `MasterPage` | 12 |
+| `Page` | 165 |
+| `PageBackground` | 165 |
+| `Path` | 47 |
+| `Rectangle` | 1540 |
+| `Table` | 220 |
+| `TableCell` | 3750 |
+| `TextLine` | 6187 |
+| `TextRun` | 10003 |
+
+판단:
+
+- 현재 repository sample page 1 corpus에서는 RawSvg 양성 fixture를 확보하지 못했다.
+- #121 구현을 진행하려면 Stage 2에서 실제 upstream RawSvg payload shape 확인 방법을 먼저 정해야 한다.
+- 선택지는 외부 fixture 확보, upstream contract/serde shape 조사 기반 모델 설계, 또는 RawSvg hit가 없는 현 corpus에서는 fallback draw path를 설계만 하고 target fixture 확보 후 구현하는 방식이다.
+
+## Visual Diff Baseline
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task121-stage1-baseline --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+```
+
+sandbox 내부 실행 결과:
+
+| 파일 | 결과 |
+|------|------|
+| `draw-group.hwp` | readiness timeout, `navigation=pending`, `resourceRequests=0`, `documentRequests=0` |
+| `eq-01.hwp` | readiness timeout, `navigation=pending`, `resourceRequests=0`, `documentRequests=0` |
+
+sandbox 밖 권한 상승 재실행:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task121-stage1-baseline-escalated --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+```
+
+결과:
+
+| 파일 | 결과 |
+|------|------|
+| `draw-group.hwp` | readiness timeout, `page canvas not found for page 1`, `status=웹폰트 로딩 중...` |
+| `eq-01.hwp` | readiness timeout, `page canvas not found for page 1`, `status=웹폰트 로딩 중...` |
+
+산출물:
+
+```text
+build.noindex/task121-stage1-baseline/
+build.noindex/task121-stage1-baseline-escalated/
+```
+
+해석:
+
+- 이번 target sample에서는 `rhwp-studio` reference PNG가 생성되지 않아 `ChangedPercent`, `MeanRGBDelta` 같은 visual diff metric을 얻지 못했다.
+- 권한 상승 후에는 resource request가 발생했으므로 단순 sandbox extension 문제만은 아니며, bundled Studio page init이 `웹폰트 로딩 중...` 상태에서 멈춘다.
+- `./scripts/verify-rhwp-studio-assets.sh`는 통과했고 bundled font 파일은 존재한다.
+- 이 실패는 Swift native renderer의 RawSvg 구현 결함으로 해석하지 않고, Stage 2에서 target fixture와 reference capture 방법을 다시 정해야 할 harness readiness 이슈로 남긴다.
+
+## Stage 1 결론
+
+1. Swift `RenderNodeType`에는 RawSvg case가 없으므로, 실제 RawSvg node가 내려오면 현재 decoder는 이를 `.unknown`으로 처리할 가능성이 높다.
+2. `draw-group.hwp`는 현재 upstream render tree에서 17개 Image node로 내려오며 RawSvg fixture가 아니다.
+3. `eq-01.hwp`는 3개 Equation node를 포함하지만 RawSvg fixture가 아니다.
+4. repository sample page 1 scan의 생성 JSON 165개에서도 RawSvg/OLE/chart key를 찾지 못했다.
+5. target visual diff baseline은 Studio readiness timeout으로 metric을 만들지 못했다. render-debug baseline은 정상 생성됐다.
+
+## Stage 2 Handoff
+
+Stage 2에서는 구현 전 다음을 먼저 결정해야 한다.
+
+1. RawSvg payload shape를 어디서 확보할지 정한다.
+   - 실제 OLE/chart/RawSvg fixture를 작업지시자가 제공할 수 있는지 확인
+   - upstream `rhwp v0.7.13` serde shape를 조사해 모델을 설계할지 결정
+2. target visual diff harness가 `웹폰트 로딩 중...`에서 멈추는 문제를 Stage 2/4 검증 범위에 포함할지 결정한다.
+3. RawSvg 양성 fixture가 없을 때 이번 PR을 decoder/fallback scaffold로 진행할지, fixture 확보 전까지 구현을 보류할지 결정한다.
+4. `RhwpCoreBridge`는 AppKit/WebKit 직접 의존 금지이므로 SVG rasterize가 필요할 경우 Shared/AppKit 경계 또는 placeholder fallback을 우선 검토한다.
+
+## 검증
+
+실행한 명령:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task121-stage1-render-debug --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task121-stage1-baseline --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task121-stage1-baseline-escalated --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+
+./scripts/render-debug-compare.sh build.noindex/task121-stage1-sample-scan --page 1 \
+  $(find samples -type f \( -name '*.hwp' -o -name '*.hwpx' \) -print)
+
+./scripts/verify-rhwp-studio-assets.sh
+
+git diff --check
+```
+
+최종 결과:
+
+- `render-debug-compare` target baseline: OK
+- target visual diff harness: 실패, readiness timeout
+- repository sample scan: 일부 실패, 생성된 165개 JSON에서 RawSvg hit 없음
+- `verify-rhwp-studio-assets.sh`: OK
+- `git diff --check`: OK

--- a/mydocs/working/task_m014_121_stage2.md
+++ b/mydocs/working/task_m014_121_stage2.md
@@ -1,0 +1,228 @@
+# Task M014 #121 Stage 2 완료보고서
+
+## 개요
+
+Stage 2는 RawSvg 양성 fixture가 없는 상태에서 구현을 바로 시작하지 않고, upstream `rhwp v0.7.13`의 RawSvg payload contract와 Swift/CoreGraphics fallback 정책을 고정하는 단계다. 소스 코드는 변경하지 않았고, 로컬 Cargo git checkout에 있는 resolved core source를 기준으로 조사했다.
+
+## 기준
+
+| 항목 | 값 |
+|------|----|
+| 이슈 | #121 Swift native renderer RawSvg/OLE·차트 리소스 렌더링 보강 |
+| 브랜치 | `local/task121` |
+| 기준 브랜치 | `origin/devel` `1b767bd` |
+| core/studio 기준 | `edwardkim/rhwp v0.7.13`, `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| Stage 1 보고서 | `mydocs/working/task_m014_121_stage1.md` |
+| 구현계획서 | `mydocs/plans/task_m014_121_impl.md` |
+
+## Stage 1 입력 재확인
+
+Stage 1에서 target sample과 repository sample page 1 scan을 수행했지만 RawSvg 양성 JSON은 확보하지 못했다.
+
+| 범위 | 결과 |
+|------|------|
+| `samples/draw-group.hwp` page 1 | `Image` 17개, RawSvg 없음 |
+| `samples/eq-01.hwp` page 1 | `Equation` 3개, RawSvg 없음 |
+| repository sample scan 생성 JSON 165개 | RawSvg/OLE/chart key hit 없음 |
+| visual diff harness | `웹폰트 로딩 중...` readiness timeout으로 metric 없음 |
+
+따라서 Stage 2의 판단은 실제 fixture 실측이 아니라 upstream source contract 기반이다. visual diff harness 재시도는 RawSvg positive 입력이 없는 상태에서는 metric을 만들어도 #121 구현 여부를 판정할 수 없으므로 Stage 4로 미룬다.
+
+## Upstream RawSvg contract
+
+### Render tree node shape
+
+`src/renderer/render_tree.rs` 기준 `RenderNodeType`에는 다음 variant가 있다.
+
+```rust
+RawSvg(RawSvgNode)
+```
+
+`RawSvgNode`는 단일 필드 모델이다.
+
+```rust
+pub struct RawSvgNode {
+    pub svg: String,
+}
+```
+
+Swift `RenderTree.swift`가 소비하는 PageRenderTree JSON은 serde 기본 externally tagged enum이므로, 예상 JSON shape는 다음과 같다.
+
+```json
+{
+  "node_type": {
+    "RawSvg": {
+      "svg": "<image x=\"...\" y=\"...\" width=\"...\" height=\"...\" href=\"data:image/png;base64,...\"/>"
+    }
+  },
+  "bbox": {
+    "x": 10.0,
+    "y": 20.0,
+    "width": 100.0,
+    "height": 50.0
+  }
+}
+```
+
+Stage 3의 Swift model은 이 shape만 우선 대상으로 삼는다.
+
+### PaintOp JSON shape
+
+`src/paint/paint_op.rs`와 `src/paint/json.rs` 기준 PageLayerTree/paint op 경로의 RawSvg는 별도 shape다.
+
+```json
+{
+  "type": "rawSvg",
+  "bbox": { "x": 10.0, "y": 20.0, "width": 100.0, "height": 50.0 },
+  "svg": "<rect .../>"
+}
+```
+
+현재 macOS bridge의 주 경로는 `RhwpDocument.renderPageTreeJSON(at:)`가 반환하는 PageRenderTree다. Stage 3에서는 PaintOp/PageLayerTree parser를 추가하지 않는다. PageLayerTree 전환이나 full paint op replay가 필요해지는 시점에 별도 task로 다루는 편이 안전하다.
+
+## RawSvg 생성 경로
+
+upstream `src/renderer/layout/shape_layout.rs`에서 RawSvg는 OLE 중심으로 생성된다.
+
+| 경로 | payload 형태 | 비고 |
+|------|--------------|------|
+| HWPX 직접 `ooxml_chart` | OOXML 차트가 만든 복합 SVG fragment | `<g class="hwp-ooxml-chart">...` 계열 |
+| OLE container 내부 OOXML chart | OOXML 차트가 만든 복합 SVG fragment | 위와 동일 |
+| OLE container EMF preview | EMF 변환기가 만든 복합 SVG fragment | `<g transform="matrix(...)">...` 안에 rect/path/text 등 |
+| OLE native image | 단일 `<image ... data:.../>` fragment | BMP는 upstream에서 PNG 재인코딩 후 data URL로 들어간다 |
+
+`src/renderer/svg_fragment.rs`의 설명에 따르면 RawSvg fragment는 페이지 절대 좌표계를 사용한다. WebCanvas 경로는 복합 SVG를 `<svg width height viewBox="bbox">...</svg>`로 감싼 뒤 bbox 위치에 image로 draw한다. Swift Stage 3에서는 복합 SVG 직접 래스터라이즈를 구현하지 않지만, 향후 실제 래스터라이저를 붙일 때도 bbox 기반 viewBox 정책을 유지해야 한다.
+
+## Swift native renderer 현재 경계
+
+현재 `Sources/RhwpCoreBridge/RenderTree.swift`에는 `RawSvg` case가 없다. unknown struct variant는 `.unknown`으로 흡수된다.
+
+`Sources/RhwpCoreBridge/CGTreeRenderer.swift`는 `CoreGraphics`, `CoreText`, `Foundation`, `ImageIO` 기반이며 AppKit/UIKit/WebKit를 import하지 않는다. 이 경계는 `Sources/RhwpCoreBridge`에 AppKit/UIKit 직접 의존 금지 규칙과 맞다.
+
+기존 equation renderer는 equation 전용 SVG subset parser를 갖지만, RawSvg는 OLE/차트/EMF까지 포함하는 범용 SVG fragment다. equation parser에 RawSvg를 섞으면 지원 범위와 보안 경계가 불명확해지므로 재사용하지 않는다.
+
+## Stage 3 구현 정책
+
+### 지원할 payload
+
+Stage 3에서는 다음 payload만 실제 이미지로 표시한다.
+
+| 유형 | 판정 | 처리 |
+|------|------|------|
+| 단일 `<image ... xlink:href="data:..."/>` | 지원 | base64 data URL을 디코드하고 기존 `decodeImage`/`drawImage` 계열로 bbox에 그린다 |
+| 단일 `<image ... href="data:..."/>` | 지원 | `xlink:href`가 없을 때만 `href` 사용 |
+| PNG/JPEG/GIF 등 ImageIO가 디코딩 가능한 data image | 지원 | 기존 image pipeline과 같은 bbox/clip 기준 적용 |
+| BMP data image | 조건부 | upstream native image 경로는 BMP를 PNG로 재인코딩하므로 보통 PNG로 들어온다. 직접 BMP가 들어오면 `decodeImage` 성공 여부에 맡기고 실패 시 fallback |
+
+내부 `<image>`의 `x`, `y`, `width`, `height`는 draw 위치로 사용하지 않는다. upstream WebCanvas도 data URL만 추출한 뒤 `node.bbox`에 그리므로, Swift도 `node.bbox`를 단일 배치 기준으로 둔다.
+
+### fallback할 payload
+
+다음 payload는 Stage 3에서 직접 렌더링하지 않고 RawSvg 전용 placeholder로 표시한다.
+
+| 유형 | 이유 |
+|------|------|
+| OOXML chart 복합 SVG | CoreGraphics/ImageIO만으로 안전하고 예측 가능한 SVG rasterize를 보장하기 어렵다 |
+| EMF 변환 복합 SVG | path/text/transform/filter 등 SVG subset 범위가 넓다 |
+| `<svg>...</svg>` full document | 외부 resource/script/style 가능성을 포함하므로 bridge 내부에서 직접 로드하지 않는다 |
+| 외부 `file:`, `http:`, `https:` href | 외부 리소스 로딩 금지 |
+| 비-base64 data URL | upstream helper도 비-base64 data URL은 지원하지 않는다 |
+| malformed XML, 중첩 image, 복수 element image fragment | 단일 data image 판정 실패 |
+| 크기/좌표가 비정상인 bbox | draw 생략 또는 fallback |
+
+fallback은 upstream `Placeholder` node를 Swift에 구현한다는 의미가 아니다. #121에서는 RawSvg 렌더 실패 시 그리는 RawSvg 전용 fallback만 추가하고, upstream `RenderNodeType::Placeholder`/FormObject 정적 프리뷰는 #110 범위와 섞지 않는다.
+
+### 보안·리소스 guard
+
+upstream Skia path는 `MAX_SVG_FRAGMENT_BYTES = 4 MiB`, `MAX_SVG_RASTER_PIXELS = 67,108,864`를 두고, `resources_dir = None`, `resolve_string = None`으로 외부 href 로딩을 막는다. Swift Stage 3도 같은 방향으로 축소 적용한다.
+
+| guard | Stage 3 정책 |
+|-------|--------------|
+| RawSvg string size | 4 MiB 초과 시 fallback |
+| bbox | finite, width/height > 0인 경우만 draw/fallback |
+| bbox raster pixels | `ceil(width) * ceil(height)`가 67,108,864 초과면 fallback 또는 draw 생략 |
+| XML parse | `XMLParser` 사용, `shouldResolveExternalEntities = false` |
+| image href | `xlink:href` 우선, 없으면 `href`; `data:` scheme만 허용 |
+| data URL | `;base64`만 허용 |
+| external resource | 어떤 경우에도 로드하지 않음 |
+
+문자열 검색/정규식으로 payload를 해석하지 않는다. 단일 image 판정은 XMLParser 기반의 좁은 parser로 구현한다.
+
+### placeholder 시각 정책
+
+RawSvg fallback placeholder는 bbox 안에서만 그린다.
+
+| 속성 | 정책 |
+|------|------|
+| fill | 옅은 회색 계열 반투명 fill |
+| stroke | 회색 dashed stroke |
+| label | `SVG` |
+| clipping | bbox clip 적용 |
+| text | bbox가 충분히 클 때만 중앙 표시. 작은 bbox에서는 stroke/fill만 표시 |
+
+목표는 빈 영역이나 crash 대신 “여기에 지원되지 않은 SVG 리소스가 있음”을 보이는 것이다. upstream Skia도 RawSvg rasterize 실패 시 `"svg"` placeholder로 떨어진다.
+
+## Visual diff harness 판단
+
+지금 visual diff harness를 다시 시도해 metric을 만드는 것보다 RawSvg payload shape case를 확보하는 쪽이 우선이다.
+
+이유:
+
+1. Stage 1 target sample과 repository sample scan에서 RawSvg node가 없었다.
+2. RawSvg positive 입력이 없으면 visual diff metric은 harness readiness나 일반 renderer 회귀만 측정하고, #121의 성공 여부를 판정하지 못한다.
+3. Stage 1 harness는 `웹폰트 로딩 중...` readiness timeout이 있어 현재 기준으로 reference PNG 생성 자체가 불안정하다.
+4. 구현 전 가장 큰 불확실성은 Swift decoder가 받아야 할 JSON shape와 bridge 내부에서 허용할 payload 범위다. 이 부분은 upstream source로 확정 가능하다.
+
+따라서 Stage 3은 synthetic JSON/decode/render smoke로 RawSvg case를 강제 주입해 최소 동작을 확인하고, Stage 4에서 harness를 다시 시도한다. 실제 OLE/chart fixture가 추가되면 Stage 4 metric의 판정력이 올라간다.
+
+## Stage 3 Handoff
+
+승인되면 Stage 3에서 다음 범위만 소스 변경한다.
+
+1. `Sources/RhwpCoreBridge/RenderTree.swift`
+   - `case rawSvg(RawSvgNode)` 추가
+   - `RawSvgNode { svg: String }` 추가
+   - externally tagged `"RawSvg"` decode를 `.unknown` 전에 추가
+
+2. `Sources/RhwpCoreBridge/CGTreeRenderer.swift`
+   - `.rawSvg` match arm 추가
+   - RawSvg string/bbox guard 추가
+   - XMLParser 기반 단일 data image parser 추가
+   - data image decode 성공 시 기존 image drawing helper를 재사용
+   - 복합 SVG/실패 케이스는 RawSvg 전용 placeholder로 fallback
+
+3. 검증
+   - synthetic RawSvg JSON 또는 helper-level smoke로 decoder/fallback/data image path 확인
+   - 기존 target sample `draw-group.hwp`, `eq-01.hwp` render-debug smoke 재실행
+   - `xcodebuild` Debug build
+   - `git diff --check`
+   - extension registration hygiene check
+
+Stage 3에서도 `RhwpCoreBridge`에 AppKit/WebKit 의존을 추가하지 않는다. 복합 SVG를 실제로 래스터라이즈하는 기능은 별도 renderer backend 또는 Shared/AppKit 경계 설계가 필요할 때 후속 task로 분리한다.
+
+## 검증
+
+실행한 확인:
+
+```bash
+rg -n "RawSvg|raw_svg|rawSvg|PaintOp::RawSvg|RenderNodeType::RawSvg|struct RawSvg|enum RenderNodeType|enum PaintOp" \
+  /Users/melee/.cargo/git/checkouts /Users/melee/.cargo/registry/src
+
+nl -ba /Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/b3e16ef/src/renderer/render_tree.rs
+nl -ba /Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/b3e16ef/src/paint/paint_op.rs
+nl -ba /Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/b3e16ef/src/paint/json.rs
+nl -ba /Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/b3e16ef/src/renderer/svg_fragment.rs
+nl -ba /Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/b3e16ef/src/renderer/web_canvas.rs
+nl -ba /Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/b3e16ef/src/renderer/layout/shape_layout.rs
+nl -ba /Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/b3e16ef/src/renderer/skia/image_conv.rs
+nl -ba /Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/b3e16ef/src/renderer/skia/renderer.rs
+
+rg -n "RawSvg|rawSvg|Placeholder|RenderNodeType|CGImage|XMLParser|AppKit|UIKit|WKWebView" \
+  Sources/RhwpCoreBridge Sources/Shared scripts mydocs
+```
+
+최종 Stage 2 검증:
+
+```bash
+git diff --check
+```

--- a/mydocs/working/task_m014_121_stage3.md
+++ b/mydocs/working/task_m014_121_stage3.md
@@ -1,0 +1,234 @@
+# Task M014 #121 Stage 3 완료보고서
+
+## 개요
+
+Stage 3에서는 Swift native renderer가 upstream render tree의 `RawSvg`와 `Placeholder` node를 `.unknown`으로 흡수하지 않도록 모델을 확장하고, CoreGraphics 경계 안에서 렌더링 가능한 최소 정책을 구현했다.
+
+Stage 2에서는 upstream `Placeholder` 구현을 #121 범위 밖으로 두는 정책을 세웠지만, 작업 중 제공받은 `/Users/melee/Downloads/143E433F503322BD33.hwp`가 실제 OLE Placeholder 양성 fixture로 확인되어 범위를 조정했다. 이 fixture는 RawSvg는 아니지만 #121의 OLE 리소스 fallback 품질을 직접 검증할 수 있으므로, 사용자 승인 후 `Placeholder` 렌더링까지 포함했다.
+
+## 기준
+
+| 항목 | 값 |
+|------|----|
+| 이슈 | #121 Swift native renderer RawSvg/OLE·차트 리소스 렌더링 보강 |
+| 브랜치 | `local/task121` |
+| 기준 브랜치 | `origin/devel` `1b767bd` |
+| core/studio 기준 | `edwardkim/rhwp v0.7.13`, `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| Stage 1 보고서 | `mydocs/working/task_m014_121_stage1.md` |
+| Stage 2 보고서 | `mydocs/working/task_m014_121_stage2.md` |
+| 구현계획서 | `mydocs/plans/task_m014_121_impl.md` |
+
+## 구현 내용
+
+### RenderTree 모델
+
+`Sources/RhwpCoreBridge/RenderTree.swift`에 다음 node type을 추가했다.
+
+| NodeType | Swift 모델 | JSON shape |
+|----------|------------|------------|
+| `RawSvg` | `RawSvgNode { svg: String }` | `{"RawSvg":{"svg":"..."}}` |
+| `Placeholder` | `PlaceholderNode { fillColor, strokeColor, label }` | `{"Placeholder":{"fill_color":...,"stroke_color":...,"label":"..."}}` |
+
+decode 순서는 기존 known variant 이후 `.unknown` 전에 배치했다. 따라서 upstream JSON에 해당 variant가 들어오면 native renderer가 명시적으로 처리할 수 있다.
+
+### RawSvg 렌더링
+
+`Sources/RhwpCoreBridge/CGTreeRenderer.swift`에 `.rawSvg` case와 전용 renderer를 추가했다.
+
+지원 범위:
+
+| payload | 처리 |
+|---------|------|
+| 단일 self-closing `<image ... xlink:href="data:image/...;base64,..."/>` | base64 data URL을 디코드하고 기존 `decodeImage`/`drawImage` 경로로 bbox에 draw |
+| 단일 self-closing `<image ... href="data:image/...;base64,..."/>` | `xlink:href`가 없을 때만 `href` 사용 |
+| PNG/JPEG/GIF/PCX 등 기존 image decoder가 처리 가능한 data image | 기존 decoder에 위임 |
+
+fallback 범위:
+
+| payload | 처리 |
+|---------|------|
+| OOXML chart 복합 SVG fragment | `SVG` label이 있는 회색 점선 placeholder |
+| EMF preview 복합 SVG fragment | `SVG` label이 있는 회색 점선 placeholder |
+| full `<svg>...</svg>` 문서 | fallback |
+| 외부 `file:`, `http:`, `https:` href | fallback |
+| 비-base64 data URL, malformed XML, 복수 element | fallback |
+| 비정상 bbox 또는 guard 초과 | fallback 또는 draw 생략 |
+
+guard:
+
+| 항목 | 정책 |
+|------|------|
+| RawSvg string size | 4 MiB 초과 시 fallback |
+| bbox | finite, width/height > 0 |
+| raster pixel estimate | 67,108,864 초과 시 fallback |
+| XML parser | `XMLParser`, external entity resolve 비활성화 |
+| data URL | `data:image/*;base64,...`만 허용, nested `image/svg+xml` 제외 |
+
+복합 SVG를 직접 파싱하거나 WebKit/AppKit 래스터라이저를 붙이지 않았다. `RhwpCoreBridge`의 AppKit/UIKit 금지 경계를 유지하기 위해서다.
+
+### Placeholder 렌더링
+
+`Placeholder`는 upstream core SVG와 같은 의미의 OLE fallback 박스로 렌더링한다.
+
+| 요소 | 처리 |
+|------|------|
+| fill | `fill_color` |
+| stroke | `stroke_color`, dashed `[6, 3]` |
+| label | `label`을 중앙 배치 |
+| clip | 기존 parent clip과 bbox clip을 모두 존중 |
+| 부분 clipping | 실제 visible clip bounds 안에 label을 재배치 |
+
+제공 fixture처럼 OLE bbox가 body clip 밖으로 내려가는 경우 전체 bbox 중앙의 label이 잘릴 수 있었다. 그래서 label은 현재 clip path와 bbox의 교집합 안에서 배치하도록 보정했다.
+
+## Fixture 확인
+
+### Repository samples
+
+현재 repository samples는 RawSvg/Placeholder 양성 fixture가 아니다.
+
+명령:
+
+```bash
+find samples -type f \( -name '*.hwp' -o -name '*.hwpx' \) -exec build.noindex/task121-rawsvg-scan/rawsvg_scan {} +
+```
+
+결과:
+
+| 항목 | 값 |
+|------|---:|
+| DocumentsOpened | `174` |
+| PagesScanned | `1390` |
+| Failures | `0` |
+| DirectHits | `164` |
+| ImageOrEquationPages | `338` |
+| RawSvg positive page | `0` |
+| Placeholder positive page | `0` |
+
+`DirectHits`는 문서 본문에 `OLE`/`chart` 문자열이 있는 페이지다. 해당 hit 전체에서 `RawSvg=0`, `rawSvg=0`, `Placeholder=0`이었다.
+
+### 제공받은 fixture
+
+파일:
+
+```text
+/Users/melee/Downloads/143E433F503322BD33.hwp
+```
+
+분석 결과:
+
+| NodeType | Count |
+|----------|------:|
+| `RawSvg` | `0` |
+| `Placeholder` | `1` |
+| `Image` | `1` |
+
+Placeholder node:
+
+| 항목 | 값 |
+|------|----|
+| id | `265` |
+| bbox | `x=77.48`, `y=904.1866666666666`, `width=302.36`, `height=302.36` |
+| fill_color | `4293980400` (`0xFFF0F0F0`) |
+| stroke_color | `4285558896` (`0xFF707070`) |
+| label | `OLE 개체 (BinData #2)` |
+
+이 파일은 RawSvg fixture는 아니지만, OLE object가 image decode에 실패하거나 정적 preview 없이 내려올 때 upstream이 표시하는 Placeholder fixture로 유효하다.
+
+## 검증 결과
+
+### Synthetic RawSvg smoke
+
+실제 RawSvg HWP/HWPX fixture가 없으므로 synthetic RenderTree JSON으로 decode/render smoke를 수행했다.
+
+검증 대상:
+
+| case | 기대 |
+|------|------|
+| `{"RawSvg":{"svg":"<image ... data:image/png;base64,.../>"}}` | 빨간 PNG data image draw |
+| `{"RawSvg":{"svg":"<g class=\"hwp-ooxml-chart\">...</g>"}}` | `SVG` fallback placeholder |
+| `{"Placeholder":...}` | OLE placeholder draw |
+
+결과:
+
+| 항목 | 값 |
+|------|---:|
+| SyntheticNonWhitePixels | `6200` |
+| SyntheticRedPixels | `1600` |
+| SyntheticGrayPixels | `4600` |
+| 산출물 | `build.noindex/task121-rawsvg-synthetic/rawsvg-synthetic.png` |
+
+### Render debug
+
+명령:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task121-stage3-download-v2 --page 1 /Users/melee/Downloads/143E433F503322BD33.hwp
+./scripts/render-debug-compare.sh build.noindex/task121-stage3-target-v2 --page 1 samples/draw-group.hwp samples/eq-01.hwp
+```
+
+결과:
+
+| 파일 | RenderTreeJSONBytes | CoreSVGBytes | NativePNGSize | NativeNonWhitePixels | TextRuns | HangulRuns | MissingHangulGlyphs |
+|------|--------------------:|-------------:|---------------|---------------------:|---------:|-----------:|--------------------:|
+| `143E433F503322BD33.hwp` | `307461` | `628489` | `794x1123` | `136906` | `186` | `98` | `0` |
+| `draw-group.hwp` | `13998` | `19539` | `794x1123` | `7324` | `2` | `1` | `0` |
+| `eq-01.hwp` | `233539` | `262660` | `794x1123` | `45708` | `71` | `37` | `0` |
+
+`143E433F503322BD33.hwp`의 Stage 3 이전 native non-white 기준은 `105571`이었고, Placeholder 렌더링 후 `136906`으로 증가했다. 생성 PNG에서도 좌하단 OLE placeholder 박스와 `OLE 개체 (BinData #2)` label을 확인했다.
+
+세 render-debug 결과 모두 optional core SVG raster diff는 생성되지 않았다.
+
+```text
+DiffReason: qlmanage rasterize failed
+```
+
+이는 Stage 1과 동일한 local `qlmanage` rasterize 실패이며 native PNG 생성 자체는 성공했다.
+
+### Build / policy checks
+
+| 명령 | 결과 |
+|------|------|
+| `git diff --check` | 통과 |
+| `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task121 CODE_SIGNING_ALLOWED=NO build` | 통과, `** BUILD SUCCEEDED **` |
+| `./scripts/check-no-appkit.sh` | 통과, `RhwpCoreBridge` AppKit/UIKit 의존 없음 |
+| `./scripts/check-extension-registration-hygiene.sh --check-only` | 통과, Issues 없음 |
+
+비고:
+
+- 최초 `xcodebuild` sandbox 실행은 Sparkle fetch network 제한과 SwiftPM cache write 제한으로 실패했다.
+- 같은 명령을 승인된 escalated 실행으로 재시도해 빌드 성공을 확인했다.
+- extension hygiene는 `build.noindex/DerivedData-task121/.../Alhangeul.app` 개발 산출물이 존재한다는 warning만 냈고, 등록된 개발 provider는 없었다.
+
+## RawSvg fixture를 찾을 때의 특징
+
+RawSvg positive fixture는 “그림으로 삽입된 일반 이미지”가 아니라, upstream core가 OLE/차트 리소스를 inline SVG fragment로 내보내는 문서여야 한다.
+
+가능성이 높은 파일:
+
+| 유형 | 기대 RawSvg payload |
+|------|--------------------|
+| HWP/HWPX 안에 삽입된 OOXML chart | `<g class="hwp-ooxml-chart">...` 복합 SVG |
+| OLE container 내부 OOXML chart | `<g class="hwp-ooxml-chart">...` 복합 SVG |
+| OLE object의 EMF preview | `<g transform="matrix(...)">...` 복합 SVG |
+| OLE native image object | 단일 `<image ... xlink:href="data:image/png;base64,..."/>` |
+
+가능성이 낮은 파일:
+
+| 유형 | 이유 |
+|------|------|
+| 일반 “그림 넣기” 이미지 | 보통 `Image` node로 내려온다 |
+| 수식 | `Equation` node로 내려온다 |
+| 양식 컨트롤 | `FormObject` 계열이다 |
+| 문서 본문에 `OLE`/`chart`라는 글자가 있는 문서 | 텍스트 hit일 뿐 RawSvg가 아니다 |
+| 이번 제공 fixture 같은 Placeholder-only OLE | OLE fallback 검증에는 유효하지만 RawSvg positive는 아니다 |
+
+찾아볼 때는 한컴오피스에서 “개체 삽입”으로 들어간 Excel/PowerPoint/차트/OLE 개체가 실제 문서 안에 보이는 HWP/HWPX가 좋다. 단순 스크린샷이나 이미지로 붙인 차트는 RawSvg가 아니라 `Image`가 될 가능성이 높다.
+
+## 다음 단계 제안
+
+Stage 4는 다음 순서가 적절하다.
+
+1. 이번 Stage 3 변경을 기준으로 visual diff harness를 다시 시도한다.
+2. readiness timeout이 재현되면 harness 안정화만 별도 범위로 분리한다.
+3. 사용자가 RawSvg positive fixture를 확보하면 Stage 4 검증 입력에 추가한다.
+4. 실제 복합 SVG chart/EMF fixture가 생기면 fallback 유지 여부와 별도 raster backend 도입 필요성을 판단한다.

--- a/mydocs/working/task_m014_121_stage4.md
+++ b/mydocs/working/task_m014_121_stage4.md
@@ -1,0 +1,180 @@
+# Task M014 #121 Stage 4 완료보고서
+
+## 개요
+
+Stage 4에서는 Stage 3 구현을 기준으로 visual diff harness, render-debug, build/policy smoke를 다시 실행해 RawSvg/Placeholder renderer 보강이 기존 target sample과 M014 공통 sample set에 회귀를 만들지 않는지 확인했다.
+
+소스 코드는 변경하지 않았고, 검증 산출물과 관찰값만 정리했다.
+
+## 기준
+
+| 항목 | 값 |
+|------|----|
+| 이슈 | #121 Swift native renderer RawSvg/OLE·차트 리소스 렌더링 보강 |
+| 브랜치 | `local/task121` |
+| 기준 브랜치 | `origin/devel` `1b767bd` |
+| core/studio 기준 | `edwardkim/rhwp v0.7.13`, `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| Stage 3 커밋 | `b0c2e74` |
+| 구현계획서 | `mydocs/plans/task_m014_121_impl.md` |
+
+## Visual Diff Harness
+
+계획서의 target set과 regression set을 먼저 sandbox 내부에서 실행했다. 두 실행 모두 Stage 1과 같은 readiness timeout을 재현했다.
+
+```text
+[phase:readiness] rhwp-studio page 1 readiness timed out: navigation=pending; events=[]; scheme={resourceRequests=0, documentRequests=0}
+```
+
+같은 명령을 sandbox 밖에서 재시도하자 target set과 regression set 모두 정상적으로 studio/native/diff PNG와 summary를 생성했다. 따라서 이번 실패는 renderer 회귀가 아니라 local sandbox/WebKit readiness 제한으로 분리한다.
+
+### Target set
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task121-stage4-target-escalated --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+```
+
+결과:
+
+| 파일 | Status | ChangedPixels | ChangedPercent | MeanRGBDelta | NativeMs | 비고 |
+|------|--------|--------------:|---------------:|-------------:|---------:|------|
+| `draw-group.hwp` | OK | `28960/3561228` | `0.8132%` | `0.4881` | `1056.6` | 기존 image/group sample |
+| `eq-01.hwp` | OK | `230538/3562815` | `6.4707%` | `5.9354` | `19.0` | equation sample |
+
+산출물:
+
+```text
+build.noindex/task121-stage4-target-escalated/summary.md
+build.noindex/task121-stage4-target-escalated/studio/
+build.noindex/task121-stage4-target-escalated/native/
+build.noindex/task121-stage4-target-escalated/diff/
+```
+
+### Regression set
+
+명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task121-stage4-regression-escalated --page 1 \
+  samples/basic/request.hwp samples/복학원서.hwp samples/pic-crop-01.hwp \
+  samples/form-01.hwp samples/hwpx/form-002.hwpx samples/hwpx/hwpx-01.hwpx
+```
+
+결과:
+
+| 파일 | Status | ChangedPixels | ChangedPercent | MeanRGBDelta | NativeMs |
+|------|--------|--------------:|---------------:|-------------:|---------:|
+| `request.hwp` | OK | `321284/1798071` | `17.8683%` | `10.9606` | `1175.0` |
+| `복학원서.hwp` | OK | `257941/3562815` | `7.2398%` | `6.7272` | `44.6` |
+| `pic-crop-01.hwp` | OK | `72763/3562815` | `2.0423%` | `0.8092` | `4.6` |
+| `form-01.hwp` | OK | `28739/3562815` | `0.8066%` | `0.4843` | `2.2` |
+| `form-002.hwpx` | OK | `543087/3561228` | `15.2500%` | `17.3362` | `30.1` |
+| `hwpx-01.hwpx` | OK | `505312/3562815` | `14.1829%` | `15.1348` | `32.0` |
+
+산출물:
+
+```text
+build.noindex/task121-stage4-regression-escalated/summary.md
+build.noindex/task121-stage4-regression-escalated/studio/
+build.noindex/task121-stage4-regression-escalated/native/
+build.noindex/task121-stage4-regression-escalated/diff/
+```
+
+## Render Debug 재측정
+
+명령:
+
+```bash
+./scripts/render-debug-compare.sh build.noindex/task121-stage4-render-debug --page 1 \
+  samples/draw-group.hwp samples/eq-01.hwp
+
+./scripts/render-debug-compare.sh build.noindex/task121-stage4-download --page 1 \
+  /Users/melee/Downloads/143E433F503322BD33.hwp
+```
+
+결과:
+
+| 파일 | RenderTreeJSONBytes | CoreSVGBytes | NativePNGSize | NativeNonWhitePixels | TextRuns | HangulRuns | MissingHangulGlyphs |
+|------|--------------------:|-------------:|---------------|---------------------:|---------:|-----------:|--------------------:|
+| `draw-group.hwp` | `13998` | `19539` | `794x1123` | `7324` | `2` | `1` | `0` |
+| `eq-01.hwp` | `233539` | `262660` | `794x1123` | `45708` | `71` | `37` | `0` |
+| `143E433F503322BD33.hwp` | `307461` | `628489` | `794x1123` | `136906` | `186` | `98` | `0` |
+
+세 파일 모두 native PNG는 생성됐다. optional core SVG raster diff는 `qlmanage rasterize failed`로 생성되지 않았고, 이는 Stage 1/3과 같은 local `qlmanage` rasterize 한계다.
+
+## Node Type 확인
+
+Stage 4 render tree 기준 target sample의 node type은 Stage 1과 동일하게 유지됐다.
+
+`draw-group.hwp`:
+
+| NodeType | Count |
+|----------|------:|
+| `Image` | `17` |
+| `Group` | `1` |
+| `TextRun` | `2` |
+| `RawSvg` | `0` |
+| `Placeholder` | `0` |
+
+`eq-01.hwp`:
+
+| NodeType | Count |
+|----------|------:|
+| `Equation` | `3` |
+| `TextRun` | `71` |
+| `RawSvg` | `0` |
+| `Placeholder` | `0` |
+
+제공 fixture `143E433F503322BD33.hwp`:
+
+| NodeType | Count |
+|----------|------:|
+| `Image` | `1` |
+| `Placeholder` | `1` |
+| `RawSvg` | `0` |
+
+이 파일은 RawSvg positive가 아니라 OLE/chart-like object가 core에서 `Placeholder`로 내려오는 fixture다. 실제 OLE/chart payload 복원은 upstream core 정합성 작업으로 분리했고, 별도 upstream 이슈 `edwardkim/rhwp#1251`을 생성했다.
+
+## Build / Policy Check
+
+| 명령 | 결과 | 비고 |
+|------|------|------|
+| `git diff --check` | OK | 공백/patch 문제 없음 |
+| `./scripts/check-no-appkit.sh` | OK | `RhwpCoreBridge` AppKit/UIKit 의존 없음 |
+| `./scripts/check-extension-registration-hygiene.sh --check-only` | OK | Issues 없음 |
+| `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task121 CODE_SIGNING_ALLOWED=NO build` | OK | sandbox 내부 cache 권한 실패 후 sandbox 밖 재시도에서 `** BUILD SUCCEEDED **` |
+
+extension hygiene warning:
+
+```text
+development/test Alhangeul.app bundles exist under build.noindex or DerivedData; this is only a problem if they are registered.
+Quick Look preview provider path was not reported by PlugInKit.
+Thumbnail provider path was not reported by PlugInKit.
+```
+
+등록된 development provider나 legacy candidate는 없었다.
+
+## 수용 기준 점검
+
+| 수용 기준 | 결과 | 근거 |
+|-----------|------|------|
+| RawSvg node가 `.unknown`으로 사라지지 않고 Swift model에서 식별된다 | OK | Stage 3 synthetic RenderTree JSON으로 `.rawSvg` decode/render smoke 확인 |
+| 지원 가능한 RawSvg 또는 raster image data URL payload가 bbox 안에 표시된다 | OK | Stage 3 synthetic data image case에서 red pixels 확인 |
+| 표시 불가 payload는 crash 없이 명확한 placeholder/fallback으로 보인다 | OK | Stage 3 synthetic complex SVG fallback, Stage 4 Placeholder fixture render-debug 확인 |
+| OLE/chart/static resource bbox, transform, clipping이 기존 flow와 크게 어긋나지 않는다 | OK | `143E433F503322BD33.hwp` Placeholder가 body clip 안 visible 영역에 표시됨 |
+| Quick Look preview, Finder thumbnail, PDF/CoreGraphics fallback이 같은 renderer path를 사용한다 | OK | `CGTreeRenderer` 공통 경로 변경, visual diff harness native backend `coreGraphics` |
+| #122 image fill/tile/placement, #116 baked watermark gate, #282 compositor sample이 회귀하지 않는다 | OK | target/regression visual diff harness OK, render-debug native PNG 생성 |
+| visual diff 수치와 fallback 여부가 stage 문서와 최종 보고서에 남는다 | OK | Stage 4 보고서에 target/regression metric과 Placeholder fallback 여부 기록 |
+
+## 잔여 위험
+
+- 실제 RawSvg positive HWP/HWPX fixture는 아직 확보하지 못했다. 현재 구현은 upstream source contract와 synthetic JSON으로 RawSvg를 검증했다.
+- 복합 SVG chart/EMF는 Stage 3 정책대로 직접 rasterize하지 않고 `SVG` fallback으로 남긴다.
+- visual diff harness는 sandbox 내부에서 readiness timeout이 재현된다. sandbox 밖 실행은 통과하므로, harness 안정화 자체는 후속 작업으로 분리하는 편이 맞다.
+- `143E433F503322BD33.hwp`의 OLE/chart-like object는 현재 core에서 `Placeholder`로 내려온다. 실제 chart 복원은 upstream `edwardkim/rhwp#1251` 범위다.
+
+## 다음 단계
+
+Stage 5에서 최종 보고서를 작성하고 오늘할일을 완료로 갱신한 뒤 PR 게시 준비를 진행한다.


### PR DESCRIPTION
## 요약

- 대상 타스크: #121 Swift native renderer RawSvg/OLE·차트 리소스 렌더링 보강
- 왜: upstream render tree의 `RawSvg`/OLE fallback 리소스가 Swift native renderer에서 `.unknown` 또는 빈 영역으로 남을 수 있어 CoreGraphics fallback 품질을 보강했습니다.
- 무엇: `RenderTree`에 `RawSvg`/`Placeholder` decode를 추가하고, `CGTreeRenderer`에 단일 data image RawSvg draw, 복합 SVG fallback, OLE Placeholder 렌더링을 구현했습니다.
- 리뷰 포인트: `RhwpCoreBridge`의 AppKit/WebKit 금지 경계를 유지하면서 XML/data URL guard와 fallback 정책이 충분히 좁게 잡혔는지 확인해 주세요.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/83cf1bdfba50aa330b61193435bb779d78753467/mydocs/working/task_m014_121_stage1.md)** ([08f782d](https://github.com/postmelee/alhangeul-macos/commit/08f782dc80875be25b262396a1ab245c035b06bf)): RawSvg current path와 target sample baseline을 조사했습니다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/83cf1bdfba50aa330b61193435bb779d78753467/mydocs/working/task_m014_121_stage2.md)** ([bdb4929](https://github.com/postmelee/alhangeul-macos/commit/bdb4929f284f823b3c9dcfdda0e91834a91a2076)): upstream RawSvg contract와 Swift fallback 정책을 고정했습니다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/83cf1bdfba50aa330b61193435bb779d78753467/mydocs/working/task_m014_121_stage3.md)** ([b0c2e74](https://github.com/postmelee/alhangeul-macos/commit/b0c2e74b08e01576930434a1c76c7a2be7e030ee)): RawSvg/Placeholder decode와 CoreGraphics fallback 렌더링을 구현했습니다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/83cf1bdfba50aa330b61193435bb779d78753467/mydocs/working/task_m014_121_stage4.md)** ([4e67863](https://github.com/postmelee/alhangeul-macos/commit/4e678639f662496644aa5048a60ca5df292ad829)): visual diff, render-debug, build/policy smoke 검증을 정리했습니다.
- **[최종 보고](https://github.com/postmelee/alhangeul-macos/blob/83cf1bdfba50aa330b61193435bb779d78753467/mydocs/report/task_m014_121_report.md)** ([83cf1bd](https://github.com/postmelee/alhangeul-macos/commit/83cf1bdfba50aa330b61193435bb779d78753467)): 최종 결과와 후속 작업을 정리하고 오늘할일을 완료 처리했습니다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `RenderTree.swift` | `RawSvg`/`Placeholder` node case와 payload model decode 추가 | externally tagged enum decode 순서가 `.unknown` 전에 충분히 좁게 배치됐는지 |
| `CGTreeRenderer.swift` | RawSvg data image draw, 복합 SVG fallback, Placeholder dashed box/label 렌더링 추가 | XMLParser/data URL guard, bbox/clip 처리, AppKit/WebKit 의존 없음 |
| 작업 문서 | Stage별 조사/정책/검증과 최종 보고서 작성 | RawSvg 실물 fixture 부재와 upstream 분리가 명확한지 |

- 수행 계획서: [task_m014_121.md](https://github.com/postmelee/alhangeul-macos/blob/83cf1bdfba50aa330b61193435bb779d78753467/mydocs/plans/task_m014_121.md)
- 구현 계획서: [task_m014_121_impl.md](https://github.com/postmelee/alhangeul-macos/blob/83cf1bdfba50aa330b61193435bb779d78753467/mydocs/plans/task_m014_121_impl.md)
- 최종 보고서: [task_m014_121_report.md](https://github.com/postmelee/alhangeul-macos/blob/83cf1bdfba50aa330b61193435bb779d78753467/mydocs/report/task_m014_121_report.md)

## 핵심 리뷰 포인트

- RawSvg는 단일 self-closing `<image ... data:image/*;base64,.../>`만 실제 draw하고, 복합 SVG/외부 href/malformed payload는 fallback으로 둡니다.
- `RhwpCoreBridge`에 AppKit/WebKit 의존을 추가하지 않았고, `XMLParser.shouldResolveExternalEntities = false`로 외부 entity resolve를 막았습니다.
- `Placeholder` label은 bbox와 현재 clip의 visible 교집합 안에 배치해 부분 clipping fixture에서도 사용자가 OLE 객체 존재를 볼 수 있게 했습니다.

## 검증

- `./scripts/render-debug-compare.sh build.noindex/task121-stage4-render-debug --page 1 samples/draw-group.hwp samples/eq-01.hwp`
- `./scripts/render-debug-compare.sh build.noindex/task121-stage4-download --page 1 /Users/melee/Downloads/143E433F503322BD33.hwp`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task121-stage4-target-escalated --page 1 samples/draw-group.hwp samples/eq-01.hwp`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task121-stage4-regression-escalated --page 1 samples/basic/request.hwp samples/복학원서.hwp samples/pic-crop-01.hwp samples/form-01.hwp samples/hwpx/form-002.hwpx samples/hwpx/hwpx-01.hwpx`
- `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData-task121 CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
- `./scripts/check-no-appkit.sh`
- `./scripts/check-extension-registration-hygiene.sh --check-only`

검증 메모:

- visual diff harness는 sandbox 내부에서 readiness timeout을 재현했지만, sandbox 밖 target/regression 재시도는 모두 OK였습니다.
- `render-debug-compare`의 optional core SVG raster diff는 일부 샘플에서 `qlmanage rasterize failed`로 생성되지 않았습니다. native PNG 생성과 visual diff harness는 성공했습니다.
- extension hygiene는 Issues 없음입니다. build.noindex/DerivedData 아래 development app bundle 존재 warning만 있으며 등록된 development provider는 없었습니다.

## 관련 이슈

- [edwardkim/rhwp#1251](https://github.com/edwardkim/rhwp/issues/1251): `143E433F503322BD33.hwp`의 OLE/chart-like object 정합성 개선 upstream 이슈

## 후속 이슈 제안

- RawSvg positive HWP/HWPX fixture 확보 후 실물 fixture 기반 회귀 테스트 추가
- 복합 SVG chart/EMF raster backend 도입 여부 검토
- visual diff harness의 sandbox/WebKit readiness 안정화

## 남은 리스크

- 실제 RawSvg positive fixture는 아직 확보하지 못해 RawSvg는 upstream contract와 synthetic JSON으로 검증했습니다.
- 복합 SVG chart/EMF는 이번 PR에서 직접 rasterize하지 않고 `SVG` fallback으로 표시합니다.
- `143E433F503322BD33.hwp`는 현재 core에서 `Placeholder`로 내려오며, 실제 chart 복원은 upstream core 작업 범위입니다.
