### PR TITLE
Task #258: Thumbnail cache signature와 Skia opt-in smoke

### DIFF
--- a/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift
+++ b/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift
@@ -5,22 +5,34 @@ struct HwpThumbnailRenderRequest {
     let fileURL: URL
     let maximumSize: CGSize
     let maximumPixelSize: CGSize
+    let policy: HwpPageRenderPolicy
+    let renderSignature: HwpThumbnailRenderSignature
     let key: HwpThumbnailCacheKey
 
-    init(fileURL: URL, maximumSize: CGSize, scale: CGFloat) throws {
+    init(
+        fileURL: URL,
+        maximumSize: CGSize,
+        scale: CGFloat,
+        policy: HwpPageRenderPolicy = .coreGraphicsOnly,
+        renderSignature: HwpThumbnailRenderSignature? = nil
+    ) throws {
         let values = try fileURL.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey])
         let pixelWidth = Self.pixelBucket(for: maximumSize.width, scale: scale)
         let pixelHeight = Self.pixelBucket(for: maximumSize.height, scale: scale)
+        let resolvedSignature = renderSignature ?? HwpThumbnailRenderSignature(policy: policy)
 
         self.fileURL = fileURL
         self.maximumSize = maximumSize
         self.maximumPixelSize = CGSize(width: pixelWidth, height: pixelHeight)
+        self.policy = policy
+        self.renderSignature = resolvedSignature
         self.key = HwpThumbnailCacheKey(
             path: fileURL.path,
             modificationTime: values.contentModificationDateKeyTimeInterval,
             fileSize: values.fileSize ?? 0,
             pixelWidth: pixelWidth,
-            pixelHeight: pixelHeight
+            pixelHeight: pixelHeight,
+            renderSignature: resolvedSignature
         )
     }
 
@@ -34,12 +46,94 @@ struct HwpThumbnailRenderRequest {
     }
 }
 
+struct HwpThumbnailRenderSignature: Hashable {
+    private static let rendererOptionVersion = "thumbnail-renderer-v1"
+    private static let coreReleaseTag = "v0.7.13"
+    private static let coreCommit = "b3e16ef212af81ef37d973ddb86d6816d3804642"
+    private static let coreEnabledFeatures = "native-skia"
+    private static let maxDimensionPolicyVersion = "skia-max-dimension-0"
+
+    let backendPolicy: String
+    let rendererOptionVersion: String
+    let coreReleaseTag: String
+    let coreCommit: String
+    let coreEnabledFeatures: String
+    let maxDimensionPolicyVersion: String
+
+    init(
+        policy: HwpPageRenderPolicy,
+        rendererOptionVersion: String = Self.rendererOptionVersion,
+        coreReleaseTag: String = Self.coreReleaseTag,
+        coreCommit: String = Self.coreCommit,
+        coreEnabledFeatures: String = Self.coreEnabledFeatures,
+        maxDimensionPolicyVersion: String = Self.maxDimensionPolicyVersion
+    ) {
+        self.backendPolicy = Self.policyIdentifier(policy)
+        self.rendererOptionVersion = rendererOptionVersion
+        self.coreReleaseTag = coreReleaseTag
+        self.coreCommit = coreCommit
+        self.coreEnabledFeatures = coreEnabledFeatures
+        self.maxDimensionPolicyVersion = maxDimensionPolicyVersion
+    }
+
+    var identifier: String {
+        [
+            backendPolicy,
+            rendererOptionVersion,
+            coreReleaseTag,
+            coreCommit,
+            coreEnabledFeatures,
+            maxDimensionPolicyVersion
+        ].joined(separator: "|")
+    }
+
+    private static func policyIdentifier(_ policy: HwpPageRenderPolicy) -> String {
+        switch policy {
+        case .coreGraphicsOnly:
+            return "coreGraphicsOnly"
+        case .skiaOptIn:
+            return "skiaOptIn"
+        }
+    }
+}
+
 struct HwpThumbnailCacheKey: Hashable {
     let path: String
     let modificationTime: TimeInterval
     let fileSize: Int
     let pixelWidth: Int
     let pixelHeight: Int
+    let renderSignature: HwpThumbnailRenderSignature
+}
+
+enum HwpThumbnailCacheEvent: CustomStringConvertible, Equatable {
+    case miss
+    case exactHit
+    case largerBucketHit(pixelWidth: Int, pixelHeight: Int)
+
+    var description: String {
+        switch self {
+        case .miss:
+            return "miss"
+        case .exactHit:
+            return "exactHit"
+        case .largerBucketHit(let pixelWidth, let pixelHeight):
+            return "largerBucketHit(\(pixelWidth)x\(pixelHeight))"
+        }
+    }
+}
+
+struct HwpThumbnailRenderResult {
+    let page: HwpRenderedPage
+    let cacheEvent: HwpThumbnailCacheEvent
+    let requestedKey: HwpThumbnailCacheKey
+    let matchedKey: HwpThumbnailCacheKey
+}
+
+private struct HwpThumbnailCacheHit {
+    let key: HwpThumbnailCacheKey
+    let page: HwpRenderedPage
+    let event: HwpThumbnailCacheEvent
 }
 
 private extension URLResourceValues {
@@ -60,7 +154,7 @@ final class HwpThumbnailRenderCache {
 
     private var cachedPages: [HwpThumbnailCacheKey: HwpRenderedPage] = [:]
     private var accessOrder: [HwpThumbnailCacheKey] = []
-    private var inFlight: [HwpThumbnailCacheKey: [(Result<HwpRenderedPage, Error>) -> Void]] = [:]
+    private var inFlight: [HwpThumbnailCacheKey: [(Result<HwpThumbnailRenderResult, Error>) -> Void]] = [:]
 
     private init() {}
 
@@ -68,11 +162,30 @@ final class HwpThumbnailRenderCache {
         for request: HwpThumbnailRenderRequest,
         completion: @escaping (Result<HwpRenderedPage, Error>) -> Void
     ) {
+        renderedPageResult(for: request) { result in
+            switch result {
+            case .success(let renderResult):
+                completion(.success(renderResult.page))
+            case .failure(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
+    func renderedPageResult(
+        for request: HwpThumbnailRenderRequest,
+        completion: @escaping (Result<HwpThumbnailRenderResult, Error>) -> Void
+    ) {
         stateQueue.async {
-            if let (matchedKey, cached) = self.cachedPage(for: request.key) {
-                self.touch(matchedKey)
+            if let hit = self.cachedPage(for: request.key) {
+                self.touch(hit.key)
                 self.workerQueue.async {
-                    completion(.success(cached))
+                    completion(.success(HwpThumbnailRenderResult(
+                        page: hit.page,
+                        cacheEvent: hit.event,
+                        requestedKey: request.key,
+                        matchedKey: hit.key
+                    )))
                 }
                 return
             }
@@ -88,18 +201,29 @@ final class HwpThumbnailRenderCache {
                     try HwpPageImageRenderer.renderFirstPage(
                         fileURL: request.fileURL,
                         maximumPixelSize: request.maximumPixelSize,
-                        embeddedThumbnailPolicy: .never
+                        embeddedThumbnailPolicy: .never,
+                        policy: request.policy
                     )
                 }
 
                 self.stateQueue.async {
                     let callbacks = self.inFlight.removeValue(forKey: request.key) ?? []
-                    if case .success(let page) = result {
+                    let callbackResult: Result<HwpThumbnailRenderResult, Error>
+                    switch result {
+                    case .success(let page):
                         self.store(page, for: request.key)
+                        callbackResult = .success(HwpThumbnailRenderResult(
+                            page: page,
+                            cacheEvent: .miss,
+                            requestedKey: request.key,
+                            matchedKey: request.key
+                        ))
+                    case .failure(let error):
+                        callbackResult = .failure(error)
                     }
                     for callback in callbacks {
                         self.workerQueue.async {
-                            callback(result)
+                            callback(callbackResult)
                         }
                     }
                 }
@@ -122,12 +246,16 @@ final class HwpThumbnailRenderCache {
         accessOrder.append(key)
     }
 
-    private func cachedPage(for requestedKey: HwpThumbnailCacheKey) -> (HwpThumbnailCacheKey, HwpRenderedPage)? {
+    private func cachedPage(for requestedKey: HwpThumbnailCacheKey) -> HwpThumbnailCacheHit? {
         if let cached = cachedPages[requestedKey] {
-            return (requestedKey, cached)
+            return HwpThumbnailCacheHit(
+                key: requestedKey,
+                page: cached,
+                event: .exactHit
+            )
         }
 
-        var bestMatch: (HwpThumbnailCacheKey, HwpRenderedPage)?
+        var bestMatch: HwpThumbnailCacheHit?
         var bestArea = Int.max
 
         for (candidateKey, page) in cachedPages {
@@ -135,6 +263,7 @@ final class HwpThumbnailRenderCache {
                 candidateKey.path == requestedKey.path,
                 candidateKey.modificationTime == requestedKey.modificationTime,
                 candidateKey.fileSize == requestedKey.fileSize,
+                candidateKey.renderSignature == requestedKey.renderSignature,
                 candidateKey.pixelWidth >= requestedKey.pixelWidth,
                 candidateKey.pixelHeight >= requestedKey.pixelHeight
             else {
@@ -144,7 +273,14 @@ final class HwpThumbnailRenderCache {
             let area = candidateKey.pixelWidth * candidateKey.pixelHeight
             if area < bestArea {
                 bestArea = area
-                bestMatch = (candidateKey, page)
+                bestMatch = HwpThumbnailCacheHit(
+                    key: candidateKey,
+                    page: page,
+                    event: .largerBucketHit(
+                        pixelWidth: candidateKey.pixelWidth,
+                        pixelHeight: candidateKey.pixelHeight
+                    )
+                )
             }
         }
 

--- a/mydocs/orders/20260603.md
+++ b/mydocs/orders/20260603.md
@@ -17,4 +17,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, Stage 2 완료 보고서 승인 대기 |
+| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, Stage 3 완료 보고서 승인 대기 |

--- a/mydocs/orders/20260603.md
+++ b/mydocs/orders/20260603.md
@@ -17,4 +17,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, Stage 4 완료 보고서 승인 대기 |
+| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 완료 | M020, 최종 보고서 작성, 완료: 19:40 |

--- a/mydocs/orders/20260603.md
+++ b/mydocs/orders/20260603.md
@@ -12,3 +12,9 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #110 | Swift native renderer Placeholder/FormObject 정적 프리뷰 보강 | 완료 | M014, 최종 보고서 및 PR 본문 초안 준비, 완료: 18:22 |
+
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260603.md
+++ b/mydocs/orders/20260603.md
@@ -17,4 +17,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, Stage 3 완료 보고서 승인 대기 |
+| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, Stage 4 완료 보고서 승인 대기 |

--- a/mydocs/orders/20260603.md
+++ b/mydocs/orders/20260603.md
@@ -17,4 +17,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, 구현계획서 작성 후 승인 대기 |
+| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, Stage 1 완료 보고서 승인 대기 |

--- a/mydocs/orders/20260603.md
+++ b/mydocs/orders/20260603.md
@@ -17,4 +17,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260603.md
+++ b/mydocs/orders/20260603.md
@@ -17,4 +17,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, Stage 1 완료 보고서 승인 대기 |
+| #258 | Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke | 진행중 | M020, Stage 2 완료 보고서 승인 대기 |

--- a/mydocs/plans/task_m020_258.md
+++ b/mydocs/plans/task_m020_258.md
@@ -1,0 +1,86 @@
+# Task #258 수행계획서
+
+## 목적
+
+Finder Thumbnail 기본 렌더링은 CoreGraphics로 유지하면서, 장기 PageLayerTree/Skia 전환을 안전하게 재개할 수 있도록 thumbnail cache signature, backend opt-in 진단 경로, 대표 smoke 기준을 정리한다.
+
+## 배경
+
+#259에서 Quick Look/Thumbnail 기본 정책은 CoreGraphics 유지, Skia는 opt-in diagnostic backend로 고정됐다. #305에서는 `복학원서.hwp` PUA 깨짐을 release-blocking 최소 보정으로 처리했지만, 장기적으로는 Swift/CoreGraphics에 보정 로직을 계속 복제하기보다 upstream PageLayerTree `displayText`와 Skia/PageLayerTree 소비 경로를 검증하는 방향이 맞다.
+
+현재 `HwpThumbnailRenderCache`는 파일 경로, 수정 시각, 파일 크기, pixel bucket을 cache key로 사용한다. backend, renderer option version, core provenance, `native-skia` feature 같은 render signature가 key에 포함되지 않으면 backend 또는 render option 변경 후 stale thumbnail을 재사용할 위험이 있다.
+
+## 범위
+
+포함 범위:
+
+- Finder Thumbnail default renderer를 CoreGraphics로 유지하는 source/document 기준 확인
+- `HwpThumbnailRenderCache` cache key와 큰 pixel bucket 재사용 조건에 backend/render signature를 반영
+- 요청 `maximumSize`와 `scale`을 pixel bucket, optional `maxDimension` 정책으로 해석하는 기준 정리
+- Thumbnail surface에서 Skia opt-in diagnostic/smoke 경로를 검토하고 실패 시 CoreGraphics fallback 또는 fallback tile 순서를 확인
+- `복학원서.hwp`, `KTX.hwp`, `request.hwp`, `hwpx-01.hwpx`, `hwp-multi-001.hwp` 중심의 대표 smoke 결과 기록
+- Quick Look 단일 PNG, 다중 PDF, Finder Thumbnail을 독립 gate로 나눌지 판단 근거 기록
+- PageLayerTree `displayText` 소비로 PUA 표시 문자열 계약을 Swift/CoreGraphics 복제 없이 처리할 수 있는지 장기 판단 정리
+
+제외 범위:
+
+- Finder Thumbnail의 Skia default 전환
+- Quick Look preview 적용 변경
+- Swift CoreGraphics renderer visual parity 보정
+- Swift PageLayerTree replay renderer 신규 구현
+- upstream `rhwp` 수정 또는 unreleased commit pin 적용
+- Finder provider 등록과 public 배포 smoke 전체 재정리
+
+## 설계 방향
+
+기본 정책은 `.coreGraphicsOnly`를 유지한다. Skia는 thumbnail smoke/helper 또는 명시 opt-in 경로에서만 선택되도록 두고, 제품 기본 surface의 동작을 바꾸지 않는다.
+
+Cache key에는 기존 file metadata와 pixel bucket을 유지하면서, render signature를 별도 구성 요소로 추가한다. signature 후보는 backend policy, renderer option version, core commit/tag, `native-skia` feature 활성화 여부, `maximumSize`/`scale`/`maxDimension` 해석 정책 version이다. 같은 signature 안에서는 큰 pixel bucket 결과를 작은 요청에 재사용할 수 있지만, signature가 다르면 재사용하지 않는다.
+
+Skia opt-in path는 실패 원인을 diagnostics로 남긴 뒤 CoreGraphics fallback이 가능한지 확인한다. CoreGraphics fallback도 실패하면 기존 fallback tile 정책을 유지한다.
+
+## 예상 변경 파일
+
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `scripts/smoke-quicklook-skia-policy.sh`
+- 신규 또는 보강 smoke helper: `scripts/*thumbnail*`
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- `mydocs/working/task_m020_258_stage{N}.md`
+- `mydocs/report/task_m020_258_report.md`
+
+## 잠정 단계
+
+1. Stage 1: 현재 Thumbnail cache/provider와 Shared renderer contract 조사
+   - CoreGraphics default 유지 상태, cache key 구성, fallback tile 순서, Skia opt-in 호출 가능 지점을 정리한다.
+2. Stage 2: render signature/cache 설계 및 source 반영
+   - cache key에 backend/render signature를 추가하고, 같은 signature 안에서만 큰 bucket 재사용이 가능하게 한다.
+3. Stage 3: Thumbnail Skia opt-in diagnostic/smoke 경로 보강
+   - 제품 기본은 CoreGraphics로 유지하면서 opt-in smoke에서 backend, fallback, latency, cache hit/miss를 기록할 수 있게 한다.
+4. Stage 4: 대표 샘플 smoke와 장기 gate 정리
+   - 대표 문서와 크기 bucket별 결과를 기록하고, Quick Look 단일 PNG/다중 PDF/Finder Thumbnail gate 분리 기준과 PageLayerTree `displayText` 장기 판단을 문서화한다.
+
+## 검증 계획
+
+- `git diff --check`
+- `scripts/check-no-appkit.sh`
+- `xcodegen generate`
+- `xcodebuild -project Alhangeul.xcodeproj -scheme Alhangeul -configuration Debug -destination 'platform=macOS' build`
+- 대표 thumbnail smoke helper 또는 보강된 smoke script 실행
+- Skia opt-in smoke 결과에서 backend, fallback, latency, cache hit/miss 기록 확인
+- CoreGraphics default 유지 여부 source grep 확인
+
+## 리스크
+
+- Thumbnail extension smoke는 Finder/Quick Look 캐시와 extension 등록 상태에 영향을 받을 수 있어 재현성이 낮을 수 있다.
+- `maxDimension` 정책을 성급히 고정하면 Quick Look과 Thumbnail의 scale 해석이 불필요하게 결합될 수 있다.
+- render signature에 core provenance를 포함할 때 source에서 직접 읽을 수 있는 안정적인 값이 부족하면 lock file 또는 build-time constant 설계가 필요할 수 있다.
+- Skia fallback smoke를 제품 기본 경로와 섞으면 #259의 CoreGraphics default 결론을 되돌리는 회귀가 생길 수 있다.
+
+## 승인 요청 사항
+
+1. 위 범위처럼 #258을 release blocker가 아닌 M020 장기 renderer/cache 기반 정리 작업으로 진행하는 방향
+2. Finder Thumbnail default는 CoreGraphics로 유지하고 Skia는 opt-in diagnostic/smoke 경로로만 다루는 방향
+3. 수행계획서 승인 후 구현계획서(`task_m020_258_impl.md`) 작성 단계로 진행하는 것

--- a/mydocs/plans/task_m020_258_impl.md
+++ b/mydocs/plans/task_m020_258_impl.md
@@ -1,0 +1,283 @@
+# Task M020 #258 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_258.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #258 Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 브랜치: `local/task258`
+- 작업 위치: `/Users/melee/Documents/projects/rhwp-mac`
+- 기준 브랜치: `devel`
+- 선행 상태: #255/#256/#257/#278/#259/#305는 완료됐고, #259 결론에 따라 Quick Look/Thumbnail 기본 정책은 CoreGraphics 유지, Skia는 opt-in diagnostic backend로 정리됐다.
+- 목표: Finder Thumbnail 기본 CoreGraphics 정책을 유지하면서 cache key/reuse 조건에 render signature를 반영하고, Skia opt-in thumbnail smoke에서 backend/fallback/latency/cache hit-miss를 반복 측정할 수 있게 한다.
+
+## 구현 원칙
+
+- Finder Thumbnail 제품 기본 경로는 `.coreGraphicsOnly`를 유지한다.
+- Skia는 helper 또는 명시 opt-in 경로에서만 선택하고, 기본 provider 동작을 Skia-first로 바꾸지 않는다.
+- cache key는 기존 file metadata invalidation과 pixel bucket을 유지하되, backend/render signature가 다르면 cache를 재사용하지 않는다.
+- 같은 render signature 안에서는 큰 pixel bucket 결과를 작은 요청에 재사용하는 기존 최적화를 유지한다.
+- Skia 실패는 Shared renderer의 CoreGraphics fallback을 먼저 사용하고, CoreGraphics까지 실패한 경우에만 기존 fallback tile 정책으로 간다.
+- `Sources/RhwpCoreBridge`에는 AppKit/UIKit 의존을 추가하지 않는다.
+- `project.yml`을 원본으로 유지하고 `Alhangeul.xcodeproj`를 직접 수정하지 않는다.
+- public release, signing/notarization, Finder provider 등록 smoke 전체 재정리는 수행하지 않는다.
+
+## Thumbnail Cache/Signature Contract
+
+| 항목 | 정책 |
+|---|---|
+| 기본 backend | Finder Thumbnail provider는 `.coreGraphicsOnly` |
+| opt-in backend | smoke/helper에서 `.skiaOptIn` 명시 |
+| file invalidation | path, modification time, file size 유지 |
+| pixel bucket | `maximumSize * scale`을 16부터 2048까지 power-of-two bucket으로 반올림하는 기존 정책 유지 |
+| render signature | backend policy, renderer option version, core commit, `native-skia` feature, thumbnail max-dimension policy version 포함 후보 |
+| reuse 조건 | file identity, render signature가 같고 candidate pixel bucket이 요청 bucket 이상일 때만 재사용 |
+| fallback 순서 | Skia opt-in 실패 시 CoreGraphics fallback, 이후 provider fallback tile |
+| diagnostics | backend, fallback reason, latency, pixel size, png bytes, cache hit/miss, matched bucket |
+
+Stage 1에서 source와 lock/provenance 구조를 확인한 뒤, Stage 2에서 실제 signature 필드와 version 문자열을 확정한다.
+
+## Stage 1. Thumbnail cache/provider와 renderer contract inventory
+
+### 목표
+
+현재 Finder Thumbnail cache key, provider fallback, Shared renderer diagnostics, core provenance 입력을 조사해 Stage 2-3의 source 변경 범위를 고정한다.
+
+### 작업
+
+1. `HwpThumbnailRenderCache`의 request key, in-flight key, 큰 bucket 재사용 조건을 정리한다.
+2. `HwpThumbnailProvider`의 기본 render request, success log, provider fallback tile 순서를 정리한다.
+3. `HwpPageImageRenderer`의 `.coreGraphicsOnly`/`.skiaOptIn`, diagnostics, fallback reason mapping을 정리한다.
+4. `rhwp-core.lock`와 Rust bridge 산출물에서 render signature에 사용할 수 있는 core commit/feature provenance를 확인한다.
+5. 기존 Quick Look Skia smoke helper 구조를 확인하고 thumbnail 전용 helper로 재사용할 수 있는 compile input을 고정한다.
+6. Quick Look 단일 PNG, 다중 PDF, Finder Thumbnail gate 분리 기준을 Stage 1 보고서에 초안으로 남긴다.
+
+### 산출물
+
+- `mydocs/plans/task_m020_258_impl.md`
+- `mydocs/working/task_m020_258_stage1.md`
+
+### 검증
+
+```bash
+rg -n "HwpThumbnailRenderCache|HwpThumbnailProvider|HwpThumbnailCacheKey|maximumPixelSize|pixelBucket|cachedPage|fallbackReply" \
+  Sources/ThumbnailExtension
+rg -n "coreGraphicsOnly|skiaOptIn|backendUsed|fallbackReason|pngBytes|durationMs|renderFirstPage|renderPage" \
+  Sources/Shared Sources/QLExtension scripts --glob '!**/Resources/**'
+rg -n "rhwp_commit|rhwp_enabled_features|native-skia" rhwp-core.lock scripts Sources
+rg -n "#258|Stage 1|Thumbnail|cache|signature|Skia|CoreGraphics" \
+  mydocs/plans/task_m020_258_impl.md mydocs/working/task_m020_258_stage1.md
+git diff --check
+```
+
+### 완료 기준
+
+- cache key와 재사용 조건의 현재 한계가 문서화된다.
+- Stage 2에서 추가할 render signature 필드와 source 변경 파일이 확정된다.
+- Stage 3에서 만들거나 보강할 thumbnail smoke helper의 입력/출력 형식이 확정된다.
+- Swift source는 아직 변경하지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #258 Stage 1: Thumbnail cache signature 입력 조사
+```
+
+## Stage 2. Render signature와 cache reuse source 반영
+
+### 목표
+
+Thumbnail cache key와 in-flight/reuse 조건에 render signature를 추가해 backend 또는 render option 변경 후 stale thumbnail을 재사용하지 않게 한다.
+
+### 작업
+
+1. `HwpThumbnailRenderSignature` 또는 동등한 값 타입을 추가한다.
+2. signature에 backend policy, renderer option version, core provenance, `native-skia` feature, thumbnail max-dimension policy version을 반영한다.
+3. `HwpThumbnailRenderRequest`가 기본 `.coreGraphicsOnly` policy와 signature를 갖도록 한다.
+4. `HwpThumbnailCacheKey`에 signature를 추가한다.
+5. `cachedPage(for:)`의 큰 bucket 재사용 guard에 signature equality를 추가한다.
+6. `renderFirstPage` 호출에 request policy를 전달하되 provider 기본은 `.coreGraphicsOnly`로 유지한다.
+7. cache hit/miss와 matched bucket을 확인할 수 있는 내부 diagnostics 반환 구조가 필요한지 구현한다.
+8. Stage 2 보고서에 source 변경과 cache contract를 기록한다.
+
+### 산출물
+
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- 필요 시 `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+- `mydocs/working/task_m020_258_stage2.md`
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "HwpThumbnailRenderSignature|HwpThumbnailCacheKey|renderSignature|coreGraphicsOnly|skiaOptIn|cachedPage|matchedKey|maximumPixelSize" \
+  Sources/ThumbnailExtension Sources/Shared
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask258 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+### 완료 기준
+
+- Finder Thumbnail 기본 요청은 `.coreGraphicsOnly` signature를 사용한다.
+- cache exact hit, in-flight key, 큰 bucket 재사용 모두 signature를 구분한다.
+- 같은 signature 안의 큰 bucket 재사용은 유지된다.
+- AppKit/UIKit guard와 ThumbnailExtension build가 통과한다.
+
+### 커밋 메시지
+
+```text
+Task #258 Stage 2: Thumbnail render signature cache key 반영
+```
+
+## Stage 3. Thumbnail Skia opt-in diagnostic smoke helper
+
+### 목표
+
+제품 provider 기본 정책을 바꾸지 않고, 대표 문서와 요청 크기별로 CoreGraphics/Skia opt-in thumbnail 렌더 결과를 비교 측정하는 helper를 만든다.
+
+### 작업
+
+1. thumbnail 전용 Swift smoke helper를 추가하거나 Quick Look smoke helper를 분리 재사용한다.
+2. helper는 입력 파일과 요청 size/scale bucket을 받아 `.coreGraphicsOnly`와 `.skiaOptIn`을 각각 측정한다.
+3. output에는 backend, fallback reason, latency, pixel size, png bytes, cache hit/miss, matched bucket, output bytes를 기록한다.
+4. Skia opt-in 실패 시 CoreGraphics fallback이 사용됐는지 diagnostics로 확인한다.
+5. CoreGraphics fallback도 실패하는 오류에서는 provider fallback tile 순서가 유지되는지 source/보고서로 확인한다.
+6. helper compile script를 추가하고 `build.noindex/task258-*` 아래에 산출물이 생기게 한다.
+7. Stage 3 보고서에 helper 사용법과 샘플 1-2개 smoke 결과를 기록한다.
+
+### 산출물
+
+- 신규 `scripts/smoke-thumbnail-skia-policy.sh`
+- 신규 `scripts/thumbnail_skia_policy_smoke.swift`
+- 필요 시 `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- 필요 시 `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+- `mydocs/working/task_m020_258_stage3.md`
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+rg -n "Thumbnail Skia|CacheHit|CacheMiss|coreGraphicsOnly|skiaOptIn|fallback|latency|bucket" \
+  scripts mydocs/working/task_m020_258_stage3.md
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask258 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+### 완료 기준
+
+- helper가 CoreGraphics와 Skia opt-in thumbnail 결과를 같은 입력/size bucket에서 측정한다.
+- smoke output에 backend, fallback, latency, cache hit/miss가 남는다.
+- Finder Thumbnail provider 기본 정책은 CoreGraphics로 유지된다.
+
+### 커밋 메시지
+
+```text
+Task #258 Stage 3: Thumbnail Skia opt-in smoke helper 추가
+```
+
+## Stage 4. 대표 샘플 smoke와 장기 gate 정리
+
+### 목표
+
+대표 문서와 size bucket에서 Thumbnail CoreGraphics/Skia opt-in 결과를 기록하고, PageLayerTree/Skia 장기 전환 gate를 문서화한다.
+
+### 작업
+
+1. 대표 문서 smoke를 실행한다.
+   - `samples/복학원서.hwp`
+   - `samples/basic/KTX.hwp`
+   - `samples/basic/request.hwp`
+   - `samples/hwpx/hwpx-01.hwpx`
+   - `samples/hwp-multi-001.hwp`
+2. 최소 3개 size/scale bucket을 측정한다.
+   - 작은 Finder thumbnail 후보
+   - 보통 Finder thumbnail 후보
+   - 큰 Retina thumbnail 후보
+3. latency, fallback, cache hit/miss, memory/hang 관측 결과를 Stage 4 보고서에 기록한다.
+4. Quick Look 단일 PNG, Quick Look 다중 PDF, Finder Thumbnail을 독립 gate로 둘지 판단을 정리한다.
+5. PageLayerTree `displayText`가 `U+F012B -> (인)`, `U+F081C -> 숨김` 같은 계약을 Swift/CoreGraphics 복제 없이 처리할 수 있는지 장기 판단을 정리한다.
+6. `mydocs/tech/skia_quicklook_thumbnail_backend.md`에 반복 적용 가능한 gate 기준만 갱신한다.
+
+### 산출물
+
+- `mydocs/working/task_m020_258_stage4.md`
+- 필요 시 `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- `build.noindex/task258-thumbnail-policy-*` smoke 산출물
+
+### 검증
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+rg -n "#258|Thumbnail|cache signature|render signature|PageLayerTree|displayText|Quick Look|Finder Thumbnail|skiaOptIn|CoreGraphics" \
+  mydocs/working/task_m020_258_stage4.md mydocs/tech/skia_quicklook_thumbnail_backend.md
+git diff --check
+git status --short --branch
+```
+
+### 완료 기준
+
+- 대표 샘플과 size bucket별 smoke 결과가 기록된다.
+- Thumbnail cache signature와 Skia opt-in gate 기준이 장기 기술 문서에 반영된다.
+- Quick Look/Thumbnail gate 분리 여부와 PageLayerTree `displayText` 장기 전환 판단이 문서화된다.
+
+### 커밋 메시지
+
+```text
+Task #258 Stage 4: Thumbnail Skia smoke와 장기 gate 정리
+```
+
+## Stage 5. 최종 보고서와 PR 준비
+
+### 목표
+
+#258 완료 기준을 최종 보고서에 대응시키고 오늘할일 완료 처리와 PR 게시 준비 상태를 만든다.
+
+### 작업
+
+1. Stage 1-4 산출물과 검증 결과를 최종 보고서에 정리한다.
+2. Thumbnail default가 CoreGraphics로 유지됐다는 점을 source와 문서 기준으로 확인한다.
+3. cache key/reuse 조건이 backend/render signature를 반영한다는 점을 정리한다.
+4. Skia opt-in smoke 결과의 backend, fallback, latency, cache hit/miss를 요약한다.
+5. 남은 PageLayerTree/Skia 장기 전환 후속 여부를 정리한다.
+6. 오늘할일을 완료로 갱신한다.
+7. PR 본문에 포함할 summary와 검증 결과를 준비한다.
+
+### 산출물
+
+- `mydocs/report/task_m020_258_report.md`
+- `mydocs/orders/20260603.md`
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask258 CODE_SIGNING_ALLOWED=NO build
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-final-thumbnail-policy \
+  samples/복학원서.hwp samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx
+rg -n "#258|Thumbnail|CoreGraphics|skiaOptIn|cache|signature|fallback|latency|hit|miss|PageLayerTree" \
+  mydocs/report/task_m020_258_report.md mydocs/orders/20260603.md Sources/ThumbnailExtension scripts
+git diff --check
+git status --short --branch
+```
+
+### 완료 기준
+
+- #258 완료 기준이 최종 보고서에서 모두 대응된다.
+- 작업 브랜치에 미커밋 변경이 없다.
+- PR 생성 전 publish 준비 상태다.
+
+### 커밋 메시지
+
+```text
+Task #258 Stage 5 + 최종 보고서: Thumbnail cache diagnostic 결과 정리
+```

--- a/mydocs/report/task_m020_258_report.md
+++ b/mydocs/report/task_m020_258_report.md
@@ -1,0 +1,198 @@
+# Task M020 #258 최종 결과 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+| --- | --- |
+| 이슈 | [#258 Thumbnail renderer signature/cache diagnostic 설계와 Skia opt-in smoke](https://github.com/postmelee/alhangeul-macos/issues/258) |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 기준 브랜치 | `devel` |
+| 작업 브랜치 | `local/task258` |
+| 대상 surface | Finder Thumbnail extension |
+| core provenance | `rhwp v0.7.13`, `b3e16ef212af81ef37d973ddb86d6816d3804642`, `native-skia` |
+| 단계 수 | 5단계 |
+
+목표는 Finder Thumbnail 기본 renderer를 CoreGraphics로 유지하면서, backend/render option 변경 뒤 stale thumbnail을 재사용하지 않도록 cache signature를 도입하고, Skia opt-in thumbnail smoke에서 backend/fallback/latency/cache event를 반복 측정할 수 있게 하는 것이었다.
+
+결론:
+
+- `HwpThumbnailRenderCache` key와 in-flight/reuse 조건에 render signature를 반영했다.
+- Finder Thumbnail provider 기본 policy는 `.coreGraphicsOnly` 그대로 유지했다.
+- 같은 signature 안에서는 큰 pixel bucket 재사용을 유지하고, signature가 다르면 cache exact hit, in-flight join, larger bucket reuse가 분리된다.
+- Thumbnail 전용 smoke helper를 추가해 `.coreGraphicsOnly`와 `.skiaOptIn`을 같은 파일/요청 bucket에서 비교 측정할 수 있게 했다.
+- 대표 5개 샘플 smoke에서 40 rows 모두 `OK`, fallback 0, 각 파일/정책 cache event가 `miss -> exactHit -> largerBucketHit -> largerBucketHit`로 확인됐다.
+- Quick Look 단일 PNG, Quick Look 다중 PDF, Finder Thumbnail rollout gate는 분리해서 판단하는 기준으로 정리했다.
+- `PageLayerTree displayText`는 Swift/CoreGraphics mapping을 계속 늘리는 방식보다 PageLayerTree/Skia 소비 경로로 검증하는 것이 장기 방향이라고 문서화했다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+| --- | --- |
+| `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift` | `HwpThumbnailRenderSignature`, signature-aware cache key/reuse, cache event/result diagnostics 추가 |
+| `scripts/smoke-thumbnail-skia-policy.sh` | Thumbnail Skia policy smoke wrapper 추가 |
+| `scripts/thumbnail_skia_policy_smoke.swift` | CoreGraphics/Skia opt-in thumbnail 정책, request bucket, cache event 측정 runner 추가 |
+| `mydocs/plans/task_m020_258.md` | 수행계획서 추가 |
+| `mydocs/plans/task_m020_258_impl.md` | 단계별 구현계획서 추가 |
+| `mydocs/working/task_m020_258_stage1.md` | cache/provider/renderer contract inventory 보고 |
+| `mydocs/working/task_m020_258_stage2.md` | source 변경과 cache signature contract 보고 |
+| `mydocs/working/task_m020_258_stage3.md` | smoke helper 추가와 2개 샘플 smoke 보고 |
+| `mydocs/working/task_m020_258_stage4.md` | 대표 5개 샘플 smoke와 장기 gate 보고 |
+| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | #258 반복 smoke gate와 `PageLayerTree displayText` 장기 판단 추가 |
+| `mydocs/orders/20260603.md` | 오늘할일 등록과 완료 처리 |
+
+전체 diff 규모:
+
+| 항목 | 값 |
+| --- | ---: |
+| 변경 파일 | 11 |
+| insertions | 1,588 |
+| deletions | 13 |
+
+## Source contract
+
+`HwpThumbnailRenderSignature`는 다음 입력을 포함한다.
+
+| 항목 | 값 |
+| --- | --- |
+| backend policy | `coreGraphicsOnly` 또는 `skiaOptIn` |
+| renderer option version | `thumbnail-renderer-v1` |
+| core release tag | `v0.7.13` |
+| core commit | `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| core enabled features | `native-skia` |
+| max-dimension policy version | `skia-max-dimension-0` |
+
+적용 위치:
+
+- memory cache key
+- in-flight render coalescing key
+- render 성공 후 store key
+- larger bucket reuse guard
+
+Provider가 만드는 `HwpThumbnailRenderRequest`는 여전히 기본 `.coreGraphicsOnly`다. Skia는 smoke/helper 또는 명시 opt-in request에서만 선택된다.
+
+## Smoke 결과
+
+Stage 3 기본 smoke:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+결과:
+
+| File | Policy | large miss | exact hit | larger bucket hit | Backend | Fallback |
+| --- | --- | ---: | ---: | ---: | --- | ---: |
+| `request.hwp` | `coreGraphicsOnly` | 1 | 1 | 2 | `coreGraphics` | 0 |
+| `request.hwp` | `skiaOptIn` | 1 | 1 | 2 | `skia` | 0 |
+| `KTX.hwp` | `coreGraphicsOnly` | 1 | 1 | 2 | `coreGraphics` | 0 |
+| `KTX.hwp` | `skiaOptIn` | 1 | 1 | 2 | `skia` | 0 |
+
+Stage 4 대표 smoke:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+```
+
+전체 결과:
+
+| 항목 | 결과 |
+| --- | --- |
+| row 수 | 5 files x 2 policies x 4 requests = 40 |
+| 실패 row | 0 |
+| fallback | 0 |
+| cache event 패턴 | 각 파일/정책에서 `miss -> exactHit -> largerBucketHit(1024x1024) -> largerBucketHit(1024x1024)` |
+| Skia opt-in backend | 모든 opt-in row `skia` |
+| CoreGraphics backend | 모든 CoreGraphics row `coreGraphics` |
+
+대표 수치:
+
+| File | CoreGraphics first render ms | CoreGraphics output bytes | Skia first render ms | Skia output bytes | Skia PNG bytes |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `복학원서.hwp` | 1117.887 | 193700 | 57.548 | 155048 | 150336 |
+| `KTX.hwp` | 55.776 | 484340 | 57.876 | 164259 | 151997 |
+| `request.hwp` | 26.741 | 126597 | 61.184 | 120977 | 121702 |
+| `hwpx-01.hwpx` | 32.436 | 198454 | 60.173 | 171054 | 187773 |
+| `hwp-multi-001.hwp` | 28.042 | 196066 | 57.656 | 165485 | 178958 |
+
+Smoke stdout에는 일부 `LAYOUT_OVERFLOW` 진단 로그가 있었지만 helper 실패는 없었다. 이 로그는 Stage 4 cache/signature 실패로 보지 않고, visual parity 판단은 #259 readiness 범위로 둔다.
+
+## 단계별 결과
+
+| Stage | 커밋 | 결과 |
+| --- | --- | --- |
+| 계획 | `0223a6e`, `0392ae1` | 수행계획서, 구현계획서, 오늘할일 등록 |
+| Stage 1 | `a754400` | Thumbnail cache/provider와 Shared renderer contract 조사 |
+| Stage 2 | `bf88b87` | render signature와 signature-aware cache reuse source 반영 |
+| Stage 3 | `913c699` | Thumbnail Skia opt-in smoke helper 추가 |
+| Stage 4 | `ffd6a02` | 대표 샘플 smoke와 장기 gate 정리 |
+| Stage 5 | 현재 | 최종 보고서와 오늘할일 완료 처리, PR 준비 |
+
+## 검증 결과
+
+최종 단계에서 재실행한 검증:
+
+| 검증 | 결과 |
+| --- | --- |
+| `./scripts/check-no-appkit.sh` | 통과 |
+| `xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask258 CODE_SIGNING_ALLOWED=NO build` | 통과: sandbox 밖 재실행에서 `** BUILD SUCCEEDED **` |
+| `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-final-thumbnail-policy samples/복학원서.hwp samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx` | 통과, 3 files x 2 policies x 4 requests = 24 rows 모두 `OK`, fallback 0 |
+| `rg -n "#258\|Thumbnail\|CoreGraphics\|skiaOptIn\|cache\|signature\|fallback\|latency\|hit\|miss\|PageLayerTree" mydocs/report/task_m020_258_report.md mydocs/orders/20260603.md Sources/ThumbnailExtension scripts` | 통과 |
+| `git diff --check` | 통과 |
+| `git status --short --branch` | 통과, 최종 보고서와 오늘할일 완료 처리 변경만 확인 |
+
+Sandbox 제약:
+
+- `xcodebuild`는 sandbox 내부에서 Swift/clang module cache와 SwiftPM diagnostics 파일 쓰기 제한으로 실패했다.
+- 같은 명령을 권한 허용 상태로 재실행했고 build가 통과했다.
+
+Stage 2-4에서 실행한 주요 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask258 CODE_SIGNING_ALLOWED=NO build
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+git diff --check
+```
+
+## 수용 기준 대응
+
+| 수용 기준 | 결과 | 근거 |
+| --- | --- | --- |
+| Finder Thumbnail 기본 경로 CoreGraphics 유지 | OK | Provider request 기본값과 `HwpThumbnailRenderRequest` 기본 policy가 `.coreGraphicsOnly` |
+| cache key가 render signature 반영 | OK | `HwpThumbnailCacheKey.renderSignature` 추가 |
+| backend/render option 변경 시 stale thumbnail 재사용 방지 | OK | exact key, in-flight key, larger bucket reuse 모두 signature equality 사용 |
+| 같은 signature 안의 큰 bucket 재사용 유지 | OK | `largerBucketHit(1024x1024)` smoke로 확인 |
+| Skia opt-in backend/fallback/latency/cache event 측정 | OK | `thumbnail_skia_policy_smoke.swift` summary/detail 기록 |
+| 대표 샘플 smoke 결과 기록 | OK | Stage 4 대표 5개 샘플, 40 rows OK, fallback 0 |
+| Quick Look/Thumbnail gate 분리 판단 기록 | OK | 기술 문서와 Stage 4 보고서에 분리 기준 추가 |
+| `PageLayerTree displayText` 장기 판단 기록 | OK | 기술 문서와 Stage 4 보고서에 Swift mapping 확장보다 PageLayerTree 소비가 장기 방향임을 기록 |
+
+## 잔여 위험과 후속 작업
+
+| 항목 | 내용 |
+| --- | --- |
+| `Skia first` 전환 | 이번 작업은 default 전환 근거가 아니라 opt-in diagnostic 기반이다. 기본 전환 여부는 #259 visual/performance/package readiness에서 판단한다. |
+| visual parity | Thumbnail smoke는 render 성공과 cache event 검증이다. Skia/CoreGraphics/reference visual diff와 page 구조 누락 여부는 #259 범위다. |
+| forced fallback fixture | 대표 smoke에서는 Skia fallback이 발생하지 않았다. fallback 강제 fixture 또는 오류 주입은 별도 follow-up 후보다. |
+| provenance constant drift | signature source constant가 `rhwp-core.lock`과 어긋날 수 있다. core update 시 signature constant 갱신 또는 generated provenance constant 후속이 필요하다. |
+| Finder system cache | helper는 extension 내부 cache contract 검증이다. Finder/LaunchServices 시스템 cache와 설치본 smoke는 이번 task 범위 밖이다. |
+| pixel rounding | Skia opt-in 결과에서 긴 변이 CoreGraphics보다 1px 큰 row가 있다. Stage 4 cache 실패는 아니지만 #259 visual gate 입력으로 남긴다. |
+
+## Handoff
+
+- #259는 이 결과를 Thumbnail surface의 opt-in diagnostic 입력으로 사용한다.
+- PR 리뷰에서는 `HwpThumbnailRenderCache`의 signature-aware key/reuse 조건과 smoke helper output 해석을 우선 확인하면 된다.
+- Stage 4 대표 smoke 산출물은 `build.noindex/task258-thumbnail-policy-representative/summary.txt`에 있다.
+- 최종 smoke 산출물은 `build.noindex/task258-final-thumbnail-policy/summary.txt`에 남긴다.
+
+## 작업지시자 승인 요청
+
+최종 보고서 작성과 오늘할일 완료 처리를 승인하면 `publish/task258` 원격 브랜치를 만들고 `devel` 대상 Open PR 게시 단계로 진행한다. PR merge 후에는 `pr-merge-cleanup` 절차로 이슈 close와 브랜치/worktree 정리를 진행한다.

--- a/mydocs/tech/skia_quicklook_thumbnail_backend.md
+++ b/mydocs/tech/skia_quicklook_thumbnail_backend.md
@@ -247,10 +247,42 @@ Skia optional backend는 다음 순서로 진행한다.
 - cache hit/miss가 backend 선택과 충돌하지 않는다.
 - 대표 크기별 thumbnail smoke 결과가 보고서에 남는다.
 
+반복 smoke gate:
+
+- `./scripts/smoke-thumbnail-skia-policy.sh <out-dir> <samples...>`를 Thumbnail cache/signature 반복 smoke의 표준 helper로 사용한다.
+- 대표 smoke는 HWP 세로 문서, HWP 가로 문서, HWPX 문서, 다중 페이지 HWP를 포함한다.
+- 각 파일은 `coreGraphicsOnly`와 `skiaOptIn` policy를 모두 실행하고, `large`, `large-repeat`, `medium-after-large`, `small-after-large` request를 같은 순서로 측정한다.
+- 통과 기준은 모든 row `OK`, policy별 첫 요청 `miss`, 같은 bucket 반복 요청 `exactHit`, 작은 요청의 큰 bucket 재사용 `largerBucketHit`, fallback 미발생 또는 사유 문서화다.
+- `coreGraphicsOnly`와 `skiaOptIn`의 render signature가 다르므로 두 policy 사이의 cache hit는 허용하지 않는다.
+- Skia opt-in row의 backend가 `skia`가 아니면 fallback reason을 기록하고, #259 default 전환 판단에서는 별도 known limitation 또는 follow-up으로 분리한다.
+- 1px 수준의 bitmap pixel rounding 차이는 Stage 4 cache 실패로 보지 않는다. 다만 page size, aspect ratio, 잘림 여부는 #259 visual gate에서 다시 확인한다.
+
+2026-06-03 #258 Stage 4 대표 smoke 기준선:
+
+- 샘플: `samples/복학원서.hwp`, `samples/basic/KTX.hwp`, `samples/basic/request.hwp`, `samples/hwpx/hwpx-01.hwpx`, `samples/hwp-multi-001.hwp`
+- 결과: 5 files x 2 policies x 4 requests = 40 rows 모두 `OK`
+- cache event: 각 파일/정책에서 `miss -> exactHit -> largerBucketHit(1024x1024) -> largerBucketHit(1024x1024)`
+- fallback: 모든 row `-`
+- Skia opt-in backend: 모든 opt-in row `skia`
+- 산출물: `build.noindex/task258-thumbnail-policy-representative/summary.txt`
+
 비책임:
 
 - Quick Look provider와 다중 페이지 PDF path는 #257에서 처리한다.
 - 전체 visual/performance/package readiness 판단은 #259에서 처리한다.
+
+## PageLayerTree displayText 장기 판단
+
+`U+F012B -> (인)`, `U+F081C -> 숨김` 같은 표시 문자열 계약은 upstream `PageLayerTree`의 `displayText` 소비 경로에서 처리하는 것이 장기적으로 맞다. Swift/CoreGraphics `PageRenderTree` renderer에 PUA mapping을 계속 추가하면 core release마다 보정 규칙을 중복 유지해야 한다.
+
+#258은 Swift `PageLayerTree` renderer를 구현하지 않는다. 대신 Thumbnail cache에 render signature를 넣고 Skia opt-in smoke를 반복 가능하게 만들어, PageLayerTree/Skia 경로가 Quick Look 또는 Thumbnail surface별로 안전하게 검증될 수 있는 기반을 둔다.
+
+장기 gate는 다음처럼 둔다.
+
+- release-blocking 회귀처럼 좁은 범위에서는 CoreGraphics 최소 보정을 유지할 수 있다.
+- 새로운 PUA/표시 문자열 보정은 가능하면 Swift mapping 확장이 아니라 PageLayerTree `displayText` 소비 또는 Skia/PageLayerTree backend 검증으로 연결한다.
+- `복학원서.hwp` 같은 displayText 민감 샘플은 #259 visual readiness에 포함한다.
+- Skia/PageLayerTree 경로가 `displayText`를 반영하지 못하거나 CoreGraphics fallback과 다른 사용자-facing glyph를 보이면 `Skia first` 전환을 막고 원인을 upstream/downstream follow-up으로 분리한다.
 
 ## #259 release readiness gate
 

--- a/mydocs/working/task_m020_258_stage1.md
+++ b/mydocs/working/task_m020_258_stage1.md
@@ -1,0 +1,150 @@
+# Task #258 Stage 1 완료 보고서
+
+## 단계 목적
+
+Finder Thumbnail cache/provider와 Shared renderer contract를 조사해 Stage 2의 render signature source 반영 범위와 Stage 3의 thumbnail smoke helper 입력/출력 형식을 고정한다. 이번 단계는 inventory 단계이므로 Swift source는 변경하지 않는다.
+
+## 산출물
+
+| 파일 | 내용 |
+|---|---|
+| `mydocs/working/task_m020_258_stage1.md` | Stage 1 조사 결과와 다음 단계 입력 정리 |
+| `mydocs/orders/20260603.md` | #258 상태를 Stage 1 완료 보고서 승인 대기로 갱신 |
+
+Swift source 변경은 없다.
+
+## 조사 결과
+
+### Thumbnail cache key와 재사용 조건
+
+현재 `HwpThumbnailRenderRequest`는 `maximumSize`와 `scale`을 pixel bucket으로 변환하고, `HwpThumbnailCacheKey`에 path, modification time, file size, pixel width, pixel height만 넣는다. `HwpThumbnailCacheKey`에는 backend policy, renderer option version, core provenance, `native-skia` feature 여부가 없다.
+
+현재 cache exact hit, in-flight key, store key는 모두 같은 `HwpThumbnailCacheKey`를 사용한다. 큰 bucket 재사용도 path, modification time, file size가 같고 candidate pixel width/height가 요청 bucket 이상이면 허용한다. 따라서 backend 또는 render option이 바뀌어도 file metadata와 bucket이 같으면 stale thumbnail을 재사용할 수 있다.
+
+Stage 2에서는 다음 구조를 추가하는 방향이 맞다.
+
+- `HwpThumbnailRenderSignature: Hashable`
+- `HwpThumbnailRenderRequest.policy: HwpPageRenderPolicy`
+- `HwpThumbnailRenderRequest.renderSignature`
+- `HwpThumbnailCacheKey.renderSignature`
+
+큰 bucket 재사용 guard에는 `candidateKey.renderSignature == requestedKey.renderSignature`를 추가한다.
+
+### Thumbnail provider 기본 정책과 fallback 순서
+
+현재 `HwpThumbnailProvider`는 `HwpThumbnailRenderRequest(fileURL:maximumSize:scale:)`만 만들고 backend policy를 명시하지 않는다. `HwpThumbnailRenderCache`도 `HwpPageImageRenderer.renderFirstPage(..., embeddedThumbnailPolicy: .never)`를 호출하면서 policy를 넘기지 않는다. `HwpPageImageRenderer.renderFirstPage`의 기본값이 `.coreGraphicsOnly`이므로 Finder Thumbnail 제품 기본 경로는 CoreGraphics다.
+
+Fallback 순서는 다음과 같다.
+
+1. render cache가 `HwpPageImageRenderer.renderFirstPage`를 호출한다.
+2. 렌더 성공 시 page image로 `QLThumbnailReply`를 만든다.
+3. 렌더 실패 중 `HwpDocumentFallbackClassifier.shouldUseThumbnailFallback` 대상이면 provider fallback tile을 반환한다.
+4. fallback 대상이 아니면 error를 그대로 반환한다.
+
+Skia opt-in을 Stage 3 helper에서 추가할 때도 제품 provider 기본은 그대로 `.coreGraphicsOnly`로 유지해야 한다. Skia opt-in 실패는 Shared renderer가 CoreGraphics fallback을 먼저 반환하고, Shared renderer 자체가 error를 던지는 경우에만 provider fallback tile로 가는 구조가 맞다.
+
+### Shared renderer contract
+
+Shared renderer는 `HwpPageRenderPolicy.coreGraphicsOnly`와 `HwpPageRenderPolicy.skiaOptIn`을 제공한다. Diagnostics에는 policy, backendUsed, fallbackReason, pageSize, pixelSize, pngBytes, durationMs가 있다.
+
+`.skiaOptIn`은 `renderSkiaPage`를 먼저 호출한다. Skia PNG가 성공하면 backendUsed는 `.skia`이고 pngBytes와 Skia/decode latency가 diagnostics에 남는다. Skia 실패나 PNG decode 실패 시 `renderCoreGraphicsPage`로 fallback하며, 이 경우 backendUsed는 `.coreGraphics`, policy는 `.skiaOptIn`, fallbackReason과 Skia 시도 latency가 함께 남는다.
+
+현재 Skia ABI 호출은 `maxDimension: 0`을 넘긴다. Thumbnail에서 optional `maxDimension` 정책을 도입하려면 Stage 2 또는 Stage 3에서 별도 policy version을 signature에 넣어야 한다.
+
+### Core provenance 입력
+
+`rhwp-core.lock`에서 render signature에 사용할 수 있는 안정 입력은 다음과 같다.
+
+| 필드 | 현재 값 |
+|---|---|
+| `rhwp_ref_kind` | `release-tag` |
+| `rhwp_release_tag` | `v0.7.13` |
+| `rhwp_commit` | `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| `rhwp_enabled_features` | `native-skia` |
+
+Stage 2 source에는 lock 파일을 runtime에서 직접 읽는 방식보다, 우선 compile-time constant 성격의 signature string을 Thumbnail source에 둔다. 값은 `rhwp-core.lock`과 일치하도록 보고서와 grep 검증으로 묶는다. 이후 build setting 또는 generated provenance constant가 필요하면 별도 후속으로 분리한다.
+
+### Thumbnail smoke helper 입력/출력 형식
+
+기존 Quick Look helper는 `CoreGraphics`와 `skiaOptIn`을 같은 입력 문서에서 측정하고 summary/detail 파일을 쓴다. 출력에는 backend page count, fallback count, PNG byte, elapsed seconds, renderMs가 포함된다.
+
+Thumbnail helper는 Quick Look helper를 그대로 쓰기보다 다음 값을 추가해야 한다.
+
+입력:
+
+- output directory
+- 요청 size/scale preset 또는 명시 값
+- HWP/HWPX 파일 목록
+- policy set: `.coreGraphicsOnly`, `.skiaOptIn`
+
+출력:
+
+- file name
+- request size
+- scale
+- pixel bucket
+- render signature
+- policy
+- backendUsed
+- fallbackReason
+- pageSize
+- pixelSize
+- pngBytes
+- durationMs.totalMs
+- output PNG bytes
+- cache event: miss, exact hit, larger bucket hit
+- matched bucket
+
+cache hit/miss를 helper에서 관측하려면 Stage 2에서 `HwpThumbnailRenderCache`가 cache event를 completion 결과 또는 test-facing diagnostic으로 돌려줄 수 있어야 한다. 단, provider의 public behavior는 바꾸지 않는다.
+
+### Gate 분리 초안
+
+Quick Look 단일 PNG, Quick Look 다중 PDF, Finder Thumbnail은 같은 Shared renderer contract를 쓰지만 gate는 분리한다.
+
+| Surface | 독립 gate가 필요한 이유 |
+|---|---|
+| Quick Look 단일 PNG | 단일 page image encode/decode latency와 visual output이 핵심이다. direct PNG reply 최적화 가능성이 따로 있다. |
+| Quick Look 다중 PDF | page별 bitmap을 PDF container에 넣으므로 page count, PDF byte size, multi-page latency가 별도 위험이다. |
+| Finder Thumbnail | request size/scale bucket, cache reuse, Finder cache interaction, small image latency가 핵심이다. |
+
+PageLayerTree `displayText` 장기 전환은 #305 잔여 위험과 연결된다. #258에서는 Swift/CoreGraphics PUA 보정 추가가 아니라, Thumbnail/Quick Look surface가 backend/render signature와 gate를 분리해 PageLayerTree/Skia 소비 경로를 안전하게 실험할 수 있는 기반을 만든다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Swift source와 기존 기술 문서 본문은 변경하지 않았다. 오늘할일은 상태 문구만 갱신했다. 신규 Stage 1 보고서는 기존 문서 내용을 대체하지 않고 조사 결과를 별도 기록한다.
+
+## 검증 결과
+
+| 검증 | 결과 |
+|---|---|
+| `rg -n "HwpThumbnailRenderCache\|HwpThumbnailProvider\|HwpThumbnailCacheKey\|maximumPixelSize\|pixelBucket\|cachedPage\|fallbackReply" Sources/ThumbnailExtension` | 통과 |
+| `rg -n "coreGraphicsOnly\|skiaOptIn\|backendUsed\|fallbackReason\|pngBytes\|durationMs\|renderFirstPage\|renderPage" Sources/Shared Sources/QLExtension scripts --glob '!**/Resources/**'` | 통과 |
+| `rg -n "rhwp_commit\|rhwp_enabled_features\|native-skia" rhwp-core.lock scripts Sources` | 통과 |
+| `rg -n "#258\|Stage 1\|Thumbnail\|cache\|signature\|Skia\|CoreGraphics" mydocs/plans/task_m020_258_impl.md mydocs/working/task_m020_258_stage1.md` | 통과 |
+| `git diff --check` | 통과 |
+
+## 잔여 위험
+
+| 항목 | 내용 |
+|---|---|
+| runtime provenance | Stage 2에서 compile-time signature string을 먼저 쓰면 `rhwp-core.lock`과 source constant가 어긋날 수 있다. 보고서/grep 검증으로 묶되, generated provenance constant는 후속 후보로 둔다. |
+| cache diagnostics API | cache hit/miss를 helper에서 관측하려면 provider behavior를 바꾸지 않는 내부 결과 타입이 필요하다. |
+| `maxDimension` 정책 | 현재 Skia path는 `maxDimension: 0`이다. Thumbnail용 maxDimension을 실제로 넘길지 여부는 cache signature와 함께 고정해야 한다. |
+| Finder integration smoke | Stage 3 helper smoke는 Debug/helper 기준이다. Finder 등록/시스템 cache smoke는 이번 task 범위에서 전체 재정리하지 않는다. |
+
+## 다음 단계 영향
+
+Stage 2는 `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`를 중심으로 진행한다. 예상 source 변경은 다음과 같다.
+
+- `HwpThumbnailRenderSignature` 추가
+- `HwpThumbnailRenderRequest`에 `policy`, `renderSignature` 추가
+- `HwpThumbnailCacheKey`에 `renderSignature` 추가
+- `cachedPage(for:)` reuse guard에 signature equality 추가
+- render 호출에 request policy 전달
+- 필요 시 cache event diagnostics 타입 추가
+
+Stage 3는 Stage 2에서 생긴 cache event diagnostics를 사용해 thumbnail smoke helper를 만든다.
+
+## 승인 요청
+
+Stage 1 조사와 완료 보고를 승인하면 Stage 2 `Render signature와 cache reuse source 반영`으로 진행한다.

--- a/mydocs/working/task_m020_258_stage2.md
+++ b/mydocs/working/task_m020_258_stage2.md
@@ -1,0 +1,97 @@
+# Task #258 Stage 2 완료 보고서
+
+## 단계 목적
+
+Thumbnail cache key와 in-flight/reuse 조건에 render signature를 추가해 backend 또는 render option 변경 후 stale thumbnail을 재사용하지 않게 한다. Finder Thumbnail provider의 제품 기본 정책은 CoreGraphics로 유지한다.
+
+## 산출물
+
+| 파일 | 내용 |
+|---|---|
+| `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift` | render signature, cache event/result 타입, signature-aware cache reuse 적용 |
+| `mydocs/working/task_m020_258_stage2.md` | Stage 2 변경과 검증 결과 기록 |
+| `mydocs/orders/20260603.md` | #258 상태를 Stage 2 완료 보고서 승인 대기로 갱신 |
+
+## Source 변경
+
+### Render signature
+
+`HwpThumbnailRenderSignature`를 추가했다. signature에는 다음 항목이 들어간다.
+
+| 항목 | 값 |
+|---|---|
+| backend policy | `coreGraphicsOnly` 또는 `skiaOptIn` |
+| renderer option version | `thumbnail-renderer-v1` |
+| core release tag | `v0.7.13` |
+| core commit | `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| core enabled features | `native-skia` |
+| max-dimension policy version | `skia-max-dimension-0` |
+
+`HwpThumbnailRenderRequest`는 기본 policy를 `.coreGraphicsOnly`로 유지한다. 별도 signature가 주어지지 않으면 policy에서 기본 signature를 만든다.
+
+### Cache key와 in-flight key
+
+`HwpThumbnailCacheKey`에 `renderSignature`를 추가했다. 이 key는 다음 위치에 그대로 사용된다.
+
+- memory cache dictionary key
+- access order key
+- in-flight render coalescing key
+- render 성공 후 store key
+
+따라서 backend policy나 render option signature가 다르면 exact hit와 in-flight join 모두 분리된다.
+
+### 큰 bucket 재사용 조건
+
+`cachedPage(for:)`의 larger bucket reuse guard에 `candidateKey.renderSignature == requestedKey.renderSignature` 조건을 추가했다. 기존 file metadata invalidation과 candidate pixel bucket 조건은 유지했다.
+
+즉 같은 signature 안에서는 큰 bucket 결과를 작은 요청에 재사용할 수 있지만, signature가 다르면 같은 파일과 같은 pixel bucket이어도 재사용하지 않는다.
+
+### Cache event diagnostics
+
+Stage 3 helper가 cache hit/miss를 관측할 수 있도록 내부 결과 타입을 추가했다.
+
+- `HwpThumbnailCacheEvent.miss`
+- `HwpThumbnailCacheEvent.exactHit`
+- `HwpThumbnailCacheEvent.largerBucketHit(pixelWidth:pixelHeight:)`
+- `HwpThumbnailRenderResult`
+
+기존 provider가 쓰는 `renderedPage(for:completion:)`는 유지하고, 새 `renderedPageResult(for:completion:)`가 cache event를 포함한 결과를 돌려준다. Provider의 public behavior는 바꾸지 않았다.
+
+### Render policy 전달
+
+`HwpThumbnailRenderCache`가 `HwpPageImageRenderer.renderFirstPage`를 호출할 때 `request.policy`를 넘기도록 했다. Provider가 만드는 request는 기본 `.coreGraphicsOnly`이므로 Finder Thumbnail 기본 renderer는 그대로 CoreGraphics다. Stage 3 helper는 같은 request 타입에서 `.skiaOptIn`을 명시할 수 있다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+기존 cache key 구성과 larger bucket 재사용 구조는 유지하고, signature equality 조건만 추가했다. `HwpThumbnailProvider` source는 변경하지 않아 Finder Thumbnail reply 생성, fallback tile, error 처리 본문은 무손실이다.
+
+## 검증 결과
+
+| 검증 | 결과 |
+|---|---|
+| `./scripts/check-no-appkit.sh` | 통과: `OK: shared Swift code has no AppKit/UIKit dependencies` |
+| `rg -n "HwpThumbnailRenderSignature\|HwpThumbnailCacheKey\|renderSignature\|coreGraphicsOnly\|skiaOptIn\|cachedPage\|matchedKey\|maximumPixelSize" Sources/ThumbnailExtension Sources/Shared` | 통과 |
+| `xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask258 CODE_SIGNING_ALLOWED=NO build` | 통과: sandbox 밖 재실행에서 `** BUILD SUCCEEDED **` |
+| `git diff --check` | 통과 |
+
+Sandbox 제약:
+
+- 최초 `xcodebuild`는 sandbox 내부에서 Sparkle package fetch가 `Could not resolve host: github.com`로 실패했다.
+- 동일 명령을 네트워크 허용 상태로 재실행했고, Sparkle 2.9.1 resolved 후 build가 통과했다.
+
+## 잔여 위험
+
+| 항목 | 내용 |
+|---|---|
+| provenance constant drift | `rhwp-core.lock` 값을 source constant로 반영했다. core lock 변경 시 signature constant도 함께 갱신해야 한다. |
+| maxDimension 정책 | 현재 signature는 `skia-max-dimension-0`을 고정한다. 실제 maxDimension 전달 정책을 바꾸면 signature version도 바꿔야 한다. |
+| cache event granularity | in-flight join은 별도 event로 분리하지 않았다. Stage 3 helper가 필요로 하면 `inFlightJoin`을 추가할 수 있다. |
+| system Finder cache | 이번 변경은 extension 내부 memory cache 기준이다. Finder/Quick Look 시스템 cache invalidation은 별도 smoke 범위다. |
+
+## 다음 단계 영향
+
+Stage 3는 새 `renderedPageResult(for:)`와 `HwpThumbnailCacheEvent`를 사용해 thumbnail smoke helper를 만들 수 있다. Helper는 같은 파일과 request bucket을 반복 호출해 `miss`, `exactHit`, `largerBucketHit`를 기록하고, policy를 `.coreGraphicsOnly`와 `.skiaOptIn`으로 나눠 backend/fallback/latency를 비교한다.
+
+## 승인 요청
+
+Stage 2 source 반영과 완료 보고를 승인하면 Stage 3 `Thumbnail Skia opt-in diagnostic smoke helper`로 진행한다.

--- a/mydocs/working/task_m020_258_stage3.md
+++ b/mydocs/working/task_m020_258_stage3.md
@@ -1,0 +1,126 @@
+# Task #258 Stage 3 완료 보고서
+
+## 단계 목적
+
+Finder Thumbnail provider 기본 동작을 바꾸지 않고, helper에서만 CoreGraphics와 Skia opt-in thumbnail 렌더 결과를 같은 파일/요청 bucket 기준으로 비교 측정한다. Smoke output에는 backend, fallback, latency, bucket, CacheMiss/CacheHit 성격의 cache event가 남아야 한다.
+
+## 산출물
+
+| 파일 | 내용 |
+|---|---|
+| `scripts/smoke-thumbnail-skia-policy.sh` | thumbnail smoke Swift runner 빌드/실행 wrapper |
+| `scripts/thumbnail_skia_policy_smoke.swift` | CoreGraphics/Skia opt-in thumbnail policy, request bucket, cache event 측정 runner |
+| `mydocs/working/task_m020_258_stage3.md` | Stage 3 변경과 smoke 결과 기록 |
+| `mydocs/orders/20260603.md` | #258 상태를 Stage 3 완료 보고서 승인 대기로 갱신 |
+
+## 구현 내용
+
+### Smoke wrapper
+
+`scripts/smoke-thumbnail-skia-policy.sh`를 추가했다. 기존 Quick Look smoke wrapper와 같은 구조로 `Frameworks/universal/librhwp.a`, `Frameworks/modulemap`, RhwpCoreBridge, Shared renderer, `HwpThumbnailRenderCache`를 Swift runner와 함께 compile한다.
+
+기본 사용법:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+선택적으로 `--request NAME:WIDTHxHEIGHT@SCALE`을 여러 번 넘겨 request preset을 직접 지정할 수 있다.
+
+### Swift runner
+
+`scripts/thumbnail_skia_policy_smoke.swift`는 각 입력 파일에서 다음 policy를 순서대로 측정한다.
+
+- `.coreGraphicsOnly`
+- `.skiaOptIn`
+
+기본 request preset은 다음 순서다.
+
+| Request | maximumSize | scale | 의도 |
+|---|---:|---:|---|
+| `large` | `512x512` | `2` | 첫 render CacheMiss |
+| `large-repeat` | `512x512` | `2` | 같은 key exact CacheHit |
+| `medium-after-large` | `256x256` | `2` | 큰 bucket 재사용 CacheHit |
+| `small-after-large` | `128x128` | `1` | 큰 bucket 재사용 CacheHit |
+
+Runner는 `HwpThumbnailRenderCache.renderedPageResult(for:)`를 호출해 다음 값을 summary/detail 파일에 기록한다.
+
+- policy
+- request size/scale
+- requested bucket
+- matched bucket
+- render signature
+- cache event (`miss`, `exactHit`, `largerBucketHit`)
+- backend
+- fallback
+- pixel size
+- output PNG bytes
+- Skia PNG bytes
+- renderMs
+- elapsed seconds
+
+## Smoke 결과
+
+명령:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+결과:
+
+| File | Policy | large miss | exact hit | larger bucket hit | Backend | Fallback |
+|---|---|---:|---:|---:|---|---|
+| `request.hwp` | `coreGraphicsOnly` | 1 | 1 | 2 | `coreGraphics` | 0 |
+| `request.hwp` | `skiaOptIn` | 1 | 1 | 2 | `skia` | 0 |
+| `KTX.hwp` | `coreGraphicsOnly` | 1 | 1 | 2 | `coreGraphics` | 0 |
+| `KTX.hwp` | `skiaOptIn` | 1 | 1 | 2 | `skia` | 0 |
+
+대표 수치:
+
+| File | Policy | First render ms | First elapsed sec | Output bytes | Skia PNG bytes |
+|---|---|---:|---:|---:|---:|
+| `request.hwp` | `coreGraphicsOnly` | 1180.819 | 1.191673 | 126597 | - |
+| `request.hwp` | `skiaOptIn` | 95.295 | 0.096691 | 120977 | 121702 |
+| `KTX.hwp` | `coreGraphicsOnly` | 64.779 | 0.069169 | 484340 | - |
+| `KTX.hwp` | `skiaOptIn` | 62.633 | 0.064418 | 164259 | 151997 |
+
+Smoke runner stdout에는 `LAYOUT_OVERFLOW` 로그가 출력됐지만 helper 실패는 없었다. `summary.txt` 기준 모든 row의 status는 `OK`이고 fallback은 `-`이다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+제품 provider인 `HwpThumbnailProvider`는 변경하지 않았다. `HwpThumbnailRenderCache`는 Stage 2에서 추가된 `renderedPageResult(for:)`를 helper가 사용하게 했고, 기존 `renderedPage(for:)` API는 유지된다. Finder Thumbnail default는 계속 CoreGraphics다.
+
+## 검증 결과
+
+| 검증 | 결과 |
+|---|---|
+| `./scripts/check-no-appkit.sh` | 통과 |
+| `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-thumbnail-policy samples/basic/request.hwp samples/basic/KTX.hwp` | 통과, 2 files x 2 policies x 4 requests, 실패 0 |
+| `rg -n "Thumbnail Skia\|CacheHit\|CacheMiss\|coreGraphicsOnly\|skiaOptIn\|fallback\|latency\|bucket" scripts mydocs/working/task_m020_258_stage3.md` | 통과 |
+| `xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask258 CODE_SIGNING_ALLOWED=NO build` | 통과: sandbox 밖 재실행에서 `** BUILD SUCCEEDED **` |
+| `git diff --check` | 통과 |
+
+Sandbox 제약:
+
+- `xcodebuild`는 sandbox 내부에서 Swift/clang cache 쓰기 제한으로 실패했다.
+- 같은 명령을 권한 허용 상태로 재실행했고 build가 통과했다.
+
+## 잔여 위험
+
+| 항목 | 내용 |
+|---|---|
+| forced fallback fixture | 이번 helper는 Skia fallback을 강제로 유발하는 fixture를 만들지 않았다. Stage 4에서는 대표 샘플 smoke 결과로 fallback 0 또는 발생 원인을 기록한다. |
+| cache event granularity | `inFlightJoin`은 별도 event로 분리하지 않았다. 현재 helper는 miss, exactHit, largerBucketHit를 측정한다. |
+| output size interpretation | cache hit row의 `renderMs`는 원 render diagnostics 값이고, hit latency는 `elapsedSeconds`로 봐야 한다. |
+| Finder system cache | helper는 extension 내부 cache contract 검증이다. Finder 시스템 cache와 LaunchServices 등록은 이번 scope 밖이다. |
+
+## 다음 단계 영향
+
+Stage 4에서는 이 helper를 대표 샘플 5개로 확장 실행하고, 최소 3개 bucket의 latency/fallback/cache hit-miss를 기록한다. 또한 `mydocs/tech/skia_quicklook_thumbnail_backend.md`에 반복 적용 가능한 Thumbnail gate와 Quick Look/Thumbnail gate 분리 기준을 반영한다.
+
+## 승인 요청
+
+Stage 3 helper 추가와 smoke 결과를 승인하면 Stage 4 `대표 샘플 smoke와 장기 gate 정리`로 진행한다.

--- a/mydocs/working/task_m020_258_stage4.md
+++ b/mydocs/working/task_m020_258_stage4.md
@@ -1,0 +1,105 @@
+# Task #258 Stage 4 완료 보고서
+
+## 단계 목적
+
+대표 HWP/HWPX 샘플과 크기 bucket에서 Thumbnail CoreGraphics/Skia opt-in 결과를 기록하고, 장기 Skia 전환 gate를 반복 가능한 기준으로 정리한다. 이번 단계는 제품 기본값을 바꾸지 않고 문서화와 smoke 기준선 기록만 수행한다.
+
+## 산출물
+
+| 파일 | 내용 |
+|---|---|
+| `mydocs/working/task_m020_258_stage4.md` | Stage 4 대표 smoke 결과와 gate 판단 기록 |
+| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | Thumbnail 반복 smoke gate, Stage 4 기준선, PageLayerTree `displayText` 장기 판단 추가 |
+| `mydocs/orders/20260603.md` | #258 상태를 Stage 4 완료 보고서 승인 대기로 갱신 |
+| `build.noindex/task258-thumbnail-policy-representative/summary.txt` | 대표 샘플 smoke summary 산출물 |
+
+## 대표 smoke 결과
+
+명령:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+```
+
+요청 preset:
+
+| Request | maximumSize | scale | 의도 |
+|---|---:|---:|---|
+| `large` | `512x512` | `2` | 첫 render miss |
+| `large-repeat` | `512x512` | `2` | 같은 key exact hit |
+| `medium-after-large` | `256x256` | `2` | 큰 bucket 재사용 hit |
+| `small-after-large` | `128x128` | `1` | 큰 bucket 재사용 hit |
+
+전체 결과:
+
+| 항목 | 결과 |
+|---|---|
+| 샘플 수 | 5 |
+| row 수 | 5 files x 2 policies x 4 requests = 40 |
+| 실패 row | 0 |
+| fallback | 0 |
+| cache event 패턴 | 각 파일/정책에서 `miss -> exactHit -> largerBucketHit(1024x1024) -> largerBucketHit(1024x1024)` |
+| Skia opt-in backend | 모든 opt-in row `skia` |
+| CoreGraphics backend | 모든 CoreGraphics row `coreGraphics` |
+
+대표 수치:
+
+| File | CoreGraphics first render ms | CoreGraphics output bytes | Skia first render ms | Skia output bytes | Skia PNG bytes |
+|---|---:|---:|---:|---:|---:|
+| `복학원서.hwp` | 1117.887 | 193700 | 57.548 | 155048 | 150336 |
+| `KTX.hwp` | 55.776 | 484340 | 57.876 | 164259 | 151997 |
+| `request.hwp` | 26.741 | 126597 | 61.184 | 120977 | 121702 |
+| `hwpx-01.hwpx` | 32.436 | 198454 | 60.173 | 171054 | 187773 |
+| `hwp-multi-001.hwp` | 28.042 | 196066 | 57.656 | 165485 | 178958 |
+
+stdout에는 일부 샘플의 `LAYOUT_OVERFLOW` 진단 로그가 있었지만 helper 실패는 없었다. `summary.txt` 기준 모든 row의 status는 `OK`이고 fallback은 `-`이다.
+
+## 장기 gate 정리
+
+`mydocs/tech/skia_quicklook_thumbnail_backend.md`의 #258 gate에 다음 반복 기준을 추가했다.
+
+- Thumbnail smoke helper는 `coreGraphicsOnly`와 `skiaOptIn`을 같은 입력/요청 순서로 실행한다.
+- 대표군은 HWP 세로, HWP 가로, HWPX, 다중 페이지 HWP를 포함한다.
+- 통과 기준은 모든 row `OK`, policy별 첫 요청 `miss`, 반복 요청 `exactHit`, 작은 요청 `largerBucketHit`, fallback 미발생 또는 사유 문서화다.
+- render signature가 다른 policy 사이의 cache hit는 허용하지 않는다.
+- 1px 수준의 bitmap pixel rounding 차이는 Stage 4 cache 실패가 아니라 #259 visual gate의 비교 입력으로 본다.
+
+Quick Look 단일 PNG, Quick Look 다중 PDF, Finder Thumbnail은 같은 Shared renderer contract를 쓰되 rollout 판단은 분리한다. Thumbnail smoke가 안정적이어도 다중 페이지 Quick Look PDF가 불안정하면 Thumbnail만 opt-in 또는 first 후보가 될 수 있고, 반대도 가능하다.
+
+## PageLayerTree displayText 판단
+
+`U+F012B -> (인)`, `U+F081C -> 숨김` 같은 표시 문자열 계약은 장기적으로 Swift/CoreGraphics mapping을 계속 늘리는 방식보다 upstream `PageLayerTree`의 `displayText`를 소비하는 방향이 맞다.
+
+이번 #258에서는 Swift `PageLayerTree` renderer를 만들지 않는다. 대신 cache signature와 Skia opt-in smoke를 준비해 PageLayerTree/Skia 경로를 Quick Look/Thumbnail surface별로 검증할 수 있게 했다. `복학원서.hwp` 같은 displayText 민감 샘플은 #259 visual readiness에서 계속 확인해야 한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+제품 source는 변경하지 않았다. Finder Thumbnail provider 기본 policy는 계속 `.coreGraphicsOnly`이며, Stage 4는 smoke 실행과 문서 기준선 갱신만 포함한다. GitHub issue 본문도 이번 단계에서 직접 수정하지 않았다.
+
+## 검증 결과
+
+| 검증 | 결과 |
+|---|---|
+| `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-thumbnail-policy-representative samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp` | 통과, 40 rows 모두 `OK`, 실패 0, fallback 0 |
+| `rg -n "#258|Thumbnail|cache signature|render signature|PageLayerTree|displayText|Quick Look|Finder Thumbnail|skiaOptIn|CoreGraphics" mydocs/working/task_m020_258_stage4.md mydocs/tech/skia_quicklook_thumbnail_backend.md` | 통과 |
+| `git diff --check` | 통과 |
+| `git status --short --branch` | 통과, Stage 4 문서 변경만 확인 |
+
+## 잔여 위험
+
+| 항목 | 내용 |
+|---|---|
+| 성능 통계 | Stage 4는 단일 실행 기준선이다. p50/p95, cold/warm 분리, peak RSS는 #259 readiness에서 측정해야 한다. |
+| visual parity | smoke는 render 성공과 cache event 검증이다. Skia/CoreGraphics/reference visual diff는 #259 범위다. |
+| forced fallback | 이번 대표군에서는 Skia fallback이 발생하지 않았다. fallback 강제 fixture 또는 오류 주입은 별도 follow-up 후보다. |
+| pixel rounding | Skia opt-in 결과에서 긴 변이 CoreGraphics보다 1px 큰 row가 있다. Stage 4 cache 실패는 아니지만 #259 visual gate 입력으로 남긴다. |
+
+## 다음 단계 영향
+
+Stage 5에서는 Stage 1-4 산출물과 검증 결과를 최종 보고서로 묶고, #258 완료 기준을 모두 대응시킨다. 최종 검증에는 `check-no-appkit`, ThumbnailExtension build, 축약 smoke를 다시 포함한다.
+
+## 승인 요청
+
+Stage 4 대표 smoke와 장기 gate 문서화를 승인하면 Stage 5 `최종 보고서와 PR 준비`로 진행한다.

--- a/scripts/smoke-thumbnail-skia-policy.sh
+++ b/scripts/smoke-thumbnail-skia-policy.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0 <output-dir> [--request NAME:WIDTHxHEIGHT@SCALE] <hwp-or-hwpx> [...]
+
+Builds and runs a Finder Thumbnail policy smoke helper for the supplied
+HWP/HWPX inputs. It measures CoreGraphics and Skia opt-in thumbnail rendering,
+then writes summary.txt and per-file detail files with cache hit/miss events.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -lt 2 ]; then
+  usage
+  exit 1
+fi
+
+OUT_DIR="$1"
+shift
+
+RUNNER_ARGS=("$OUT_DIR")
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --request)
+      if [ "$#" -lt 2 ]; then
+        echo "ERROR: --request requires NAME:WIDTHxHEIGHT@SCALE" >&2
+        exit 1
+      fi
+      RUNNER_ARGS+=("--request" "$2")
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "ERROR: unknown option $1" >&2
+      usage
+      exit 1
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
+
+if [ "$#" -lt 1 ]; then
+  usage
+  exit 1
+fi
+RUNNER_ARGS+=("$@")
+
+LIB="$ROOT/Frameworks/universal/librhwp.a"
+MODULEMAP_DIR="$ROOT/Frameworks/modulemap"
+if [ ! -f "$LIB" ]; then
+  echo "ERROR: missing $LIB" >&2
+  echo "Run: $ROOT/scripts/build-rust-macos.sh" >&2
+  exit 1
+fi
+if [ ! -f "$MODULEMAP_DIR/module.modulemap" ]; then
+  echo "ERROR: missing $MODULEMAP_DIR/module.modulemap" >&2
+  echo "Run: $ROOT/scripts/build-rust-macos.sh" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+BIN="$OUT_DIR/thumbnail_skia_policy_smoke"
+SWIFT_MODULE_CACHE="$OUT_DIR/swift-module-cache-thumbnail-skia-policy"
+CLANG_MODULE_CACHE="$OUT_DIR/clang-module-cache-thumbnail-skia-policy"
+rm -rf "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
+mkdir -p "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
+
+swiftc -parse-as-library \
+  -module-cache-path "$SWIFT_MODULE_CACHE" \
+  -Xcc -fmodules-cache-path="$CLANG_MODULE_CACHE" \
+  -I "$MODULEMAP_DIR" \
+  "$ROOT/Sources/RhwpCoreBridge/RhwpDocument.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/PageOverlayImages.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/FontFallback.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/FontResourceRegistry.swift" \
+  "$ROOT/Sources/RhwpCoreBridge/CGTreeRenderer.swift" \
+  "$ROOT/Sources/Shared/HwpPageImageRenderer.swift" \
+  "$ROOT/Sources/Shared/HwpNativePageCompositor.swift" \
+  "$ROOT/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift" \
+  "$ROOT/scripts/thumbnail_skia_policy_smoke.swift" \
+  "$LIB" \
+  -framework CoreGraphics \
+  -framework CoreText \
+  -framework ImageIO \
+  -framework UniformTypeIdentifiers \
+  -framework Security \
+  -framework CoreFoundation \
+  -lc++ \
+  -liconv \
+  -lz \
+  -o "$BIN"
+
+"$BIN" "${RUNNER_ARGS[@]}"

--- a/scripts/thumbnail_skia_policy_smoke.swift
+++ b/scripts/thumbnail_skia_policy_smoke.swift
@@ -1,0 +1,446 @@
+import CoreGraphics
+import Foundation
+
+struct SmokeError: Error, CustomStringConvertible {
+    let description: String
+}
+
+struct Timed<Value> {
+    let value: Value
+    let seconds: Double
+}
+
+struct RequestPreset {
+    let name: String
+    let maximumSize: CGSize
+    let scale: CGFloat
+
+    var display: String {
+        let doubleScale = Double(scale)
+        let scaleString = doubleScale.rounded() == doubleScale
+            ? "\(Int(doubleScale))"
+            : String(format: "%.2f", doubleScale)
+        return "\(name):\(Int(maximumSize.width))x\(Int(maximumSize.height))@\(scaleString)"
+    }
+}
+
+struct RenderMeasurement {
+    let policyName: String
+    let request: RequestPreset
+    let status: String
+    let error: String?
+    let cacheEvent: String?
+    let requestedBucket: String?
+    let matchedBucket: String?
+    let signature: String?
+    let backend: String?
+    let fallback: String?
+    let pageSize: CGSize?
+    let pixelSize: CGSize?
+    let pngBytes: Int?
+    let outputBytes: Int?
+    let renderMs: Double?
+    let elapsedSeconds: Double?
+}
+
+struct FileMeasurement {
+    let fileName: String
+    let filePath: String
+    let fileBytes: Int
+    let coreGraphics: [RenderMeasurement]
+    let skiaOptIn: [RenderMeasurement]
+}
+
+@main
+struct ThumbnailSkiaPolicySmoke {
+    static func main() throws {
+        let parsed = try parseArguments(Array(CommandLine.arguments.dropFirst()))
+        try FileManager.default.createDirectory(at: parsed.outputDir, withIntermediateDirectories: true)
+
+        var measurements: [FileMeasurement] = []
+        for inputURL in parsed.inputs {
+            let measurement = measure(inputURL: inputURL, requests: parsed.requests)
+            measurements.append(measurement)
+            try writeDetail(measurement, outputDir: parsed.outputDir)
+            print("\(measurement.fileName): \(rowSummary(measurement))")
+        }
+
+        try writeSummary(measurements, requests: parsed.requests, outputDir: parsed.outputDir)
+    }
+
+    private struct ParsedArguments {
+        let outputDir: URL
+        let requests: [RequestPreset]
+        let inputs: [URL]
+    }
+
+    private static func parseArguments(_ args: [String]) throws -> ParsedArguments {
+        guard !args.isEmpty else {
+            throw SmokeError(description: usage)
+        }
+
+        let outputDir = absoluteURL(args[0], isDirectory: true)
+        var requests: [RequestPreset] = []
+        var inputs: [URL] = []
+        var index = 1
+        while index < args.count {
+            let arg = args[index]
+            if arg == "--request" {
+                guard index + 1 < args.count else {
+                    throw SmokeError(description: "--request requires NAME:WIDTHxHEIGHT@SCALE")
+                }
+                requests.append(try parseRequest(args[index + 1]))
+                index += 2
+            } else if arg == "--help" || arg == "-h" {
+                throw SmokeError(description: usage)
+            } else if arg.hasPrefix("--") {
+                throw SmokeError(description: "unknown option \(arg)\n\(usage)")
+            } else {
+                inputs.append(absoluteURL(arg))
+                index += 1
+            }
+        }
+
+        guard !inputs.isEmpty else {
+            throw SmokeError(description: usage)
+        }
+        return ParsedArguments(
+            outputDir: outputDir,
+            requests: requests.isEmpty ? defaultRequests : requests,
+            inputs: inputs
+        )
+    }
+
+    private static var usage: String {
+        "usage: thumbnail_skia_policy_smoke <output-dir> [--request NAME:WIDTHxHEIGHT@SCALE] <hwp-or-hwpx> [...]"
+    }
+
+    private static let defaultRequests: [RequestPreset] = [
+        RequestPreset(name: "large", maximumSize: CGSize(width: 512, height: 512), scale: 2),
+        RequestPreset(name: "large-repeat", maximumSize: CGSize(width: 512, height: 512), scale: 2),
+        RequestPreset(name: "medium-after-large", maximumSize: CGSize(width: 256, height: 256), scale: 2),
+        RequestPreset(name: "small-after-large", maximumSize: CGSize(width: 128, height: 128), scale: 1)
+    ]
+
+    private static func parseRequest(_ value: String) throws -> RequestPreset {
+        let nameAndRest = value.split(separator: ":", maxSplits: 1).map(String.init)
+        guard nameAndRest.count == 2 else {
+            throw SmokeError(description: "invalid request '\(value)': expected NAME:WIDTHxHEIGHT@SCALE")
+        }
+
+        let sizeAndScale = nameAndRest[1].split(separator: "@", maxSplits: 1).map(String.init)
+        guard sizeAndScale.count == 2 else {
+            throw SmokeError(description: "invalid request '\(value)': expected NAME:WIDTHxHEIGHT@SCALE")
+        }
+
+        let widthAndHeight = sizeAndScale[0].split(separator: "x", maxSplits: 1).map(String.init)
+        guard
+            widthAndHeight.count == 2,
+            let width = Double(widthAndHeight[0]),
+            let height = Double(widthAndHeight[1]),
+            let scale = Double(sizeAndScale[1]),
+            width > 0,
+            height > 0,
+            scale > 0
+        else {
+            throw SmokeError(description: "invalid request '\(value)': size and scale must be positive numbers")
+        }
+
+        return RequestPreset(
+            name: nameAndRest[0],
+            maximumSize: CGSize(width: width, height: height),
+            scale: CGFloat(scale)
+        )
+    }
+
+    private static func measure(inputURL: URL, requests: [RequestPreset]) -> FileMeasurement {
+        let fileName = inputURL.lastPathComponent
+        let fileBytes = (try? inputURL.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        let coreGraphics = measurePolicy(
+            inputURL: inputURL,
+            requests: requests,
+            policyName: "coreGraphicsOnly",
+            policy: .coreGraphicsOnly
+        )
+        let skiaOptIn = measurePolicy(
+            inputURL: inputURL,
+            requests: requests,
+            policyName: "skiaOptIn",
+            policy: .skiaOptIn
+        )
+        return FileMeasurement(
+            fileName: fileName,
+            filePath: inputURL.path,
+            fileBytes: fileBytes,
+            coreGraphics: coreGraphics,
+            skiaOptIn: skiaOptIn
+        )
+    }
+
+    private static func measurePolicy(
+        inputURL: URL,
+        requests: [RequestPreset],
+        policyName: String,
+        policy: HwpPageRenderPolicy
+    ) -> [RenderMeasurement] {
+        requests.map { request in
+            measureRender(inputURL: inputURL, request: request, policyName: policyName, policy: policy)
+        }
+    }
+
+    private static func measureRender(
+        inputURL: URL,
+        request: RequestPreset,
+        policyName: String,
+        policy: HwpPageRenderPolicy
+    ) -> RenderMeasurement {
+        do {
+            let renderRequest = try HwpThumbnailRenderRequest(
+                fileURL: inputURL,
+                maximumSize: request.maximumSize,
+                scale: request.scale,
+                policy: policy
+            )
+            let timedResult = try timedRender(request: renderRequest)
+            let result = timedResult.value
+            let diagnostics = result.page.diagnostics
+            let outputPNG = try HwpPageImageRenderer.encodePNG(result.page.image)
+            return RenderMeasurement(
+                policyName: policyName,
+                request: request,
+                status: "OK",
+                error: nil,
+                cacheEvent: result.cacheEvent.description,
+                requestedBucket: bucketString(result.requestedKey),
+                matchedBucket: bucketString(result.matchedKey),
+                signature: result.requestedKey.renderSignature.identifier,
+                backend: backendName(diagnostics.backendUsed),
+                fallback: diagnostics.fallbackReason.map(fallbackReasonName) ?? "-",
+                pageSize: diagnostics.pageSize,
+                pixelSize: diagnostics.pixelSize,
+                pngBytes: diagnostics.pngBytes,
+                outputBytes: outputPNG.count,
+                renderMs: diagnostics.durationMs.totalMs,
+                elapsedSeconds: timedResult.seconds
+            )
+        } catch {
+            return RenderMeasurement(
+                policyName: policyName,
+                request: request,
+                status: "FAIL",
+                error: String(describing: error),
+                cacheEvent: nil,
+                requestedBucket: nil,
+                matchedBucket: nil,
+                signature: nil,
+                backend: nil,
+                fallback: nil,
+                pageSize: nil,
+                pixelSize: nil,
+                pngBytes: nil,
+                outputBytes: nil,
+                renderMs: nil,
+                elapsedSeconds: nil
+            )
+        }
+    }
+
+    private static func timedRender(request: HwpThumbnailRenderRequest) throws -> Timed<HwpThumbnailRenderResult> {
+        let semaphore = DispatchSemaphore(value: 0)
+        let start = DispatchTime.now().uptimeNanoseconds
+        var captured: Result<HwpThumbnailRenderResult, Error>?
+
+        HwpThumbnailRenderCache.shared.renderedPageResult(for: request) { result in
+            captured = result
+            semaphore.signal()
+        }
+
+        semaphore.wait()
+        let end = DispatchTime.now().uptimeNanoseconds
+        switch captured {
+        case .success(let result):
+            return Timed(value: result, seconds: Double(end - start) / 1_000_000_000)
+        case .failure(let error):
+            throw error
+        case .none:
+            throw SmokeError(description: "thumbnail render completed without result")
+        }
+    }
+
+    private static func writeSummary(
+        _ measurements: [FileMeasurement],
+        requests: [RequestPreset],
+        outputDir: URL
+    ) throws {
+        var lines: [String] = []
+        lines.append("# Thumbnail Skia Policy Smoke")
+        lines.append("")
+        lines.append("GeneratedAt: \(ISO8601DateFormatter().string(from: Date()))")
+        lines.append("Requests: \(requests.map(\.display).joined(separator: ", "))")
+        lines.append("")
+        lines.append("| File | Policy | Request | Status | Cache | RequestedBucket | MatchedBucket | Backend | Fallback | Pixel | OutputBytes | PNGBytes | RenderMs | Seconds |")
+        lines.append("|------|--------|---------|--------|-------|-----------------|---------------|---------|----------|-------|-------------|----------|----------|---------|")
+
+        for measurement in measurements {
+            for render in measurement.coreGraphics + measurement.skiaOptIn {
+                lines.append(summaryRow(fileName: measurement.fileName, render: render))
+            }
+        }
+
+        let failed = measurements.flatMap { $0.coreGraphics + $0.skiaOptIn }.filter { $0.status == "FAIL" }
+        if !failed.isEmpty {
+            lines.append("")
+            lines.append("## Failures")
+            lines.append("")
+            for render in failed {
+                lines.append("- `\(render.policyName)` `\(render.request.display)`: \(render.error ?? "-")")
+            }
+        }
+
+        try lines.joined(separator: "\n").write(
+            to: outputDir.appendingPathComponent("summary.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    private static func writeDetail(_ measurement: FileMeasurement, outputDir: URL) throws {
+        let baseName = URL(fileURLWithPath: measurement.fileName)
+            .deletingPathExtension()
+            .lastPathComponent
+        let detailURL = outputDir.appendingPathComponent("\(baseName)-thumbnail-skia-policy.txt")
+        var lines: [String] = []
+        lines.append("File: \(measurement.filePath)")
+        lines.append("FileBytes: \(measurement.fileBytes)")
+        appendPolicy(measurement.coreGraphics, name: "CoreGraphics", lines: &lines)
+        appendPolicy(measurement.skiaOptIn, name: "SkiaOptIn", lines: &lines)
+        try lines.joined(separator: "\n").write(to: detailURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func appendPolicy(_ renders: [RenderMeasurement], name: String, lines: inout [String]) {
+        lines.append("")
+        lines.append("[\(name)]")
+        for render in renders {
+            lines.append("")
+            lines.append("Request: \(render.request.display)")
+            lines.append("Status: \(render.status)")
+            if let error = render.error {
+                lines.append("Error: \(error)")
+            }
+            lines.append("CacheEvent: \(render.cacheEvent ?? "-")")
+            lines.append("RequestedBucket: \(render.requestedBucket ?? "-")")
+            lines.append("MatchedBucket: \(render.matchedBucket ?? "-")")
+            lines.append("Signature: \(render.signature ?? "-")")
+            lines.append("Backend: \(render.backend ?? "-")")
+            lines.append("Fallback: \(render.fallback ?? "-")")
+            lines.append("PageSize: \(sizeString(render.pageSize))")
+            lines.append("PixelSize: \(sizeString(render.pixelSize))")
+            lines.append("PNGBytes: \(optionalInt(render.pngBytes))")
+            lines.append("OutputBytes: \(optionalInt(render.outputBytes))")
+            lines.append("RenderMs: \(optionalMilliseconds(render.renderMs))")
+            lines.append("ElapsedSeconds: \(optionalSeconds(render.elapsedSeconds))")
+        }
+    }
+
+    private static func summaryRow(fileName: String, render: RenderMeasurement) -> String {
+        [
+            markdownCell(fileName),
+            render.policyName,
+            markdownCell(render.request.display),
+            render.status,
+            render.cacheEvent ?? "-",
+            render.requestedBucket ?? "-",
+            render.matchedBucket ?? "-",
+            render.backend ?? "-",
+            render.fallback ?? "-",
+            sizeString(render.pixelSize),
+            optionalInt(render.outputBytes),
+            optionalInt(render.pngBytes),
+            optionalMilliseconds(render.renderMs),
+            optionalSeconds(render.elapsedSeconds)
+        ].joined(separator: " | ").wrappedTableRow
+    }
+
+    private static func rowSummary(_ measurement: FileMeasurement) -> String {
+        let renders = measurement.coreGraphics + measurement.skiaOptIn
+        let failed = renders.filter { $0.status == "FAIL" }.count
+        let cacheEvents = renders.map { $0.cacheEvent ?? "fail" }.joined(separator: ",")
+        return "renders=\(renders.count) failed=\(failed) cache=\(cacheEvents)"
+    }
+
+    private static func bucketString(_ key: HwpThumbnailCacheKey) -> String {
+        "\(key.pixelWidth)x\(key.pixelHeight)"
+    }
+
+    private static func backendName(_ backend: HwpPageRenderBackend) -> String {
+        switch backend {
+        case .coreGraphics:
+            return "coreGraphics"
+        case .skia:
+            return "skia"
+        case .embeddedThumbnail:
+            return "embeddedThumbnail"
+        }
+    }
+
+    private static func fallbackReasonName(_ reason: HwpPageRenderFallbackReason) -> String {
+        switch reason {
+        case .ffiUnavailable:
+            return "ffiUnavailable"
+        case .invalidDocumentHandle:
+            return "invalidDocumentHandle"
+        case .invalidPageIndex:
+            return "invalidPageIndex"
+        case .invalidRenderOptions:
+            return "invalidRenderOptions"
+        case .invalidPageSize:
+            return "invalidPageSize"
+        case .skiaRenderFailure:
+            return "skiaRenderFailure"
+        case .pngDecodeFailure:
+            return "pngDecodeFailure"
+        case .memoryTimeoutFallback:
+            return "memoryTimeoutFallback"
+        }
+    }
+
+    private static func absoluteURL(_ path: String, isDirectory: Bool = false) -> URL {
+        let url = URL(fileURLWithPath: path, isDirectory: isDirectory)
+        if path.hasPrefix("/") {
+            return url.standardizedFileURL
+        }
+        return URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+            .appendingPathComponent(path, isDirectory: isDirectory)
+            .standardizedFileURL
+    }
+
+    private static func optionalInt(_ value: Int?) -> String {
+        guard let value else { return "-" }
+        return "\(value)"
+    }
+
+    private static func optionalMilliseconds(_ value: Double?) -> String {
+        guard let value else { return "-" }
+        return String(format: "%.3f", value)
+    }
+
+    private static func optionalSeconds(_ value: Double?) -> String {
+        guard let value else { return "-" }
+        return String(format: "%.6f", value)
+    }
+
+    private static func sizeString(_ size: CGSize?) -> String {
+        guard let size else { return "-" }
+        return "\(Int(size.width))x\(Int(size.height))"
+    }
+
+    private static func markdownCell(_ value: String) -> String {
+        value.replacingOccurrences(of: "|", with: "\\|")
+    }
+}
+
+private extension String {
+    var wrappedTableRow: String {
+        "| \(self) |"
+    }
+}


### PR DESCRIPTION
## 요약

- 대상 타스크: #258 타스크. Finder Thumbnail cache가 backend/render option 변경 뒤 stale thumbnail을 재사용하지 않도록 render signature를 도입했습니다.
- 왜: Skia/PageLayerTree를 opt-in으로 검증하려면 CoreGraphics 결과와 Skia 결과가 같은 file/bucket cache 안에서 섞이지 않아야 합니다.
- 무엇: `HwpThumbnailRenderCache`의 cache key, in-flight key, 큰 bucket 재사용 guard에 render signature를 반영하고, Thumbnail 전용 Skia policy smoke helper를 추가했습니다.
- 리뷰 포인트: Finder Thumbnail 기본 정책은 `coreGraphicsOnly`로 유지했고, Skia는 smoke/helper의 `skiaOptIn` 경로에서만 선택됩니다.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/2565d986f5e8cb0853453ac30584a5da317ecfd6/mydocs/working/task_m020_258_stage1.md)** ([a754400](https://github.com/postmelee/alhangeul-macos/commit/a754400b34d72db8d9ba9542560d376e8efd8668)): Thumbnail cache/provider와 Shared renderer contract를 조사했습니다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/2565d986f5e8cb0853453ac30584a5da317ecfd6/mydocs/working/task_m020_258_stage2.md)** ([bf88b87](https://github.com/postmelee/alhangeul-macos/commit/bf88b87c99ea94e774422c228124b9ad01b610e2)): render signature와 signature-aware cache reuse를 source에 반영했습니다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/2565d986f5e8cb0853453ac30584a5da317ecfd6/mydocs/working/task_m020_258_stage3.md)** ([913c699](https://github.com/postmelee/alhangeul-macos/commit/913c699c48c587f09313372772bafb407e60628f)): Thumbnail Skia opt-in smoke helper를 추가했습니다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/2565d986f5e8cb0853453ac30584a5da317ecfd6/mydocs/working/task_m020_258_stage4.md)** ([ffd6a02](https://github.com/postmelee/alhangeul-macos/commit/ffd6a025d84bb906b8369d7f85491c85c029e040)): 대표 5개 샘플 smoke와 장기 gate 기준을 정리했습니다.
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/2565d986f5e8cb0853453ac30584a5da317ecfd6/mydocs/report/task_m020_258_report.md)** ([2565d98](https://github.com/postmelee/alhangeul-macos/commit/2565d986f5e8cb0853453ac30584a5da317ecfd6)): 최종 보고서와 오늘할일 완료 처리를 작성했습니다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift` | render signature, cache event/result diagnostics, signature-aware reuse 추가 | policy가 다른 결과가 exact hit/in-flight/larger bucket reuse로 섞이지 않는지 |
| `scripts/smoke-thumbnail-skia-policy.sh` | Thumbnail policy smoke wrapper 추가 | `build.noindex/` 아래 산출물 생성과 helper compile 입력 |
| `scripts/thumbnail_skia_policy_smoke.swift` | CoreGraphics/Skia opt-in 측정 runner 추가 | cache event, backend, fallback, latency, bucket 기록 |
| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | #258 반복 smoke gate와 `PageLayerTree displayText` 장기 판단 추가 | Quick Look/Thumbnail rollout gate 분리 기준 |
| `mydocs/report/task_m020_258_report.md` | 전체 단계 결과와 수용 기준 대응 정리 | 남은 리스크와 #259 handoff |

- 수행 계획서: [task_m020_258.md](https://github.com/postmelee/alhangeul-macos/blob/2565d986f5e8cb0853453ac30584a5da317ecfd6/mydocs/plans/task_m020_258.md)
- 구현 계획서: [task_m020_258_impl.md](https://github.com/postmelee/alhangeul-macos/blob/2565d986f5e8cb0853453ac30584a5da317ecfd6/mydocs/plans/task_m020_258_impl.md)
- 최종 보고서: [task_m020_258_report.md](https://github.com/postmelee/alhangeul-macos/blob/2565d986f5e8cb0853453ac30584a5da317ecfd6/mydocs/report/task_m020_258_report.md)

## 핵심 리뷰 포인트

- `HwpThumbnailRenderSignature`가 backend policy, renderer option version, core provenance, max-dimension policy version을 포함하며 cache key와 larger bucket reuse guard에 모두 반영되는지 확인해 주세요.
- `HwpThumbnailProvider`의 제품 기본 경로가 계속 `coreGraphicsOnly`인지 확인해 주세요.
- smoke helper가 Finder 시스템 cache가 아니라 extension 내부 memory cache contract를 검증한다는 범위가 보고서와 문서에 일관되게 남아 있는지 확인해 주세요.

## 검증

- `./scripts/check-no-appkit.sh`
- `xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask258 CODE_SIGNING_ALLOWED=NO build`
- `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task258-final-thumbnail-policy samples/복학원서.hwp samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx`
- `rg -n "#258|Thumbnail|CoreGraphics|skiaOptIn|cache|signature|fallback|latency|hit|miss|PageLayerTree" mydocs/report/task_m020_258_report.md mydocs/orders/20260603.md Sources/ThumbnailExtension scripts`
- `git diff --check`
- `git status --short --branch`

Finder/Quick Look/Thumbnail 설치본 registration smoke는 이번 범위에서 실행하지 않았습니다. 이번 PR은 Finder provider 기본 등록 동작 변경이 아니라 Thumbnail render cache contract와 helper smoke 추가가 범위이며, 수동 `pluginkit`/`qlmanage` 등록도 수행하지 않았습니다.

## 관련 이슈

- 없음

## 후속 이슈 제안

- Issue #259 readiness에서 이번 Thumbnail opt-in diagnostic 결과를 visual/performance/package 판단 입력으로 사용합니다.
- Skia fallback 강제 fixture 또는 오류 주입 smoke가 필요하면 별도 후속 타스크로 분리합니다.
- core update 때 `rhwp-core.lock`과 `HwpThumbnailRenderSignature` source constant drift를 줄이기 위한 generated provenance constant를 검토합니다.

## 남은 리스크

- smoke는 render 성공과 cache event 검증이며, Skia/CoreGraphics/reference visual diff는 Issue #259 readiness 범위입니다.
- helper는 extension 내부 memory cache contract 검증입니다. Finder/LaunchServices 시스템 cache와 설치본 smoke는 이번 task 범위 밖입니다.
- Skia opt-in 결과에서 긴 변이 CoreGraphics보다 1px 큰 row가 있어, Stage 4 cache 실패로 보지는 않지만 Issue #259 visual gate 입력으로 남겼습니다.
- sandbox 내부 `xcodebuild`는 Swift/Xcode cache 디렉터리 쓰기 제한 때문에 실패했고, 같은 명령은 일반 Xcode cache 접근 권한으로 재실행해 통과했습니다.
