### PR TITLE
Task #351: v0.1.5 release candidate 준비

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -6,15 +6,15 @@ on:
       version:
         description: App version to publish. The workflow must be run from tag v<version>.
         required: true
-        default: "0.1.4"
+        default: "0.1.5"
       previous_release_ref:
         description: Git ref for the previous public release used to draft the release delta checklist.
         required: true
-        default: "v0.1.3"
+        default: "v0.1.4"
       expected_rhwp_tag:
         description: rhwp release tag that must match rhwp-core.lock before publishing.
         required: true
-        default: "v0.7.13"
+        default: "v0.7.15"
       require_latest_rhwp:
         description: Fail if rhwp-core.lock is not pinned to upstream latest release.
         required: true

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -6,15 +6,15 @@ on:
       version:
         description: App version to build as a rehearsal DMG.
         required: true
-        default: "0.1.4"
+        default: "0.1.5"
       previous_release_ref:
         description: Git ref for the previous public release used to draft the release delta checklist.
         required: true
-        default: "v0.1.3"
+        default: "v0.1.4"
       expected_rhwp_tag:
         description: Optional rhwp release tag that must match rhwp-core.lock.
         required: false
-        default: "v0.7.13"
+        default: "v0.7.15"
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -46,15 +46,15 @@
 
 ## 최신 공개 릴리즈
 
-### v0.1.4
+### v0.1.5
 
-`v0.1.4`는 upstream `rhwp v0.7.13` core/studio를 반영해 HWPX 렌더링과 HWP 저장 호환성, 시험지와 공공기관 문서 회귀 수정, viewer/editor 상호작용 개선을 포함하는 patch release입니다. 앱 소유 UTI `com.postmelee.alhangeul.*`, Hancom 계열 UTI 지원, About 창의 bundled `rhwp` provenance 표시, Sparkle 업데이트 확인, signed/notarized universal DMG 배포 기준은 유지합니다.
+`v0.1.5`는 upstream `rhwp v0.7.15` core/studio를 반영해 수식·미주 흐름, HWPX 저장 호환성, 문단 정보 UI 후속 개선을 포함하는 patch release입니다. 앱 소유 UTI `com.postmelee.alhangeul.*`, Hancom 계열 UTI 지원, About 창의 bundled `rhwp` provenance 표시, Sparkle 업데이트 확인, signed/notarized universal DMG 배포 기준은 유지합니다.
 
-- GitHub Release: [Alhangeul v0.1.4](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.4)
-- 업데이트 페이지: [알한글 v0.1.4](https://postmelee.github.io/alhangeul-macos/updates/v0.1.4.html)
+- GitHub Release: [Alhangeul v0.1.5](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.5)
+- 업데이트 페이지: [알한글 v0.1.5](https://postmelee.github.io/alhangeul-macos/updates/v0.1.5.html)
 - Homebrew Cask: `brew install --cask postmelee/tap/alhangeul`
-- 포함된 `rhwp`: [`v0.7.13`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.13) (`rhwp-core.lock`, bundled `rhwp-studio` manifest 기준)
-- Sparkle update 기준: short version은 `0.1.4`, build는 `10`입니다.
+- 포함된 `rhwp`: [`v0.7.15`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.15) (`rhwp-core.lock`, bundled `rhwp-studio` manifest 기준)
+- Sparkle update 기준: short version은 `0.1.5`, build는 `11`입니다.
 
 과거 릴리즈 상세와 검증 기록은 `mydocs/release/`의 릴리즈별 문서와 [GitHub Releases](https://github.com/postmelee/alhangeul-macos/releases)에 누적합니다. 사용자용 릴리즈 노트 목록은 [업데이트 페이지](https://postmelee.github.io/alhangeul-macos/updates/)에서 확인할 수 있습니다. README에는 최신 공개 릴리즈 1개만 요약하고, bundled `rhwp` provenance는 한 줄 요약만 표시합니다.
 
@@ -119,7 +119,7 @@ v0.1.x(WebView 첫 배포) -> v0.2(Mac 통합 확장) -> v0.3(변환과 자동�
 ### WKWebView Viewer (MVP 뷰어)
 
 - macOS SwiftUI 기반 HostApp shell과 WKWebView
-- `edwardkim/rhwp` `v0.7.13` snapshot의 `rhwp-studio` viewer 통합
+- `edwardkim/rhwp` `v0.7.15` snapshot의 `rhwp-studio` viewer 통합
 - HWP/HWPX 파일 열기
 - WebView 내부 찾기, 복사, 기본 편집 UI
 - Finder 또는 다른 앱에서 파일 열기 요청 수신

--- a/Sources/HostApp/Info.plist
+++ b/Sources/HostApp/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>12.0</string>
 	<key>LSHasLocalizedDisplayName</key>

--- a/Sources/QLExtension/Info.plist
+++ b/Sources/QLExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>12.0</string>
 	<key>LSHasLocalizedDisplayName</key>

--- a/Sources/ThumbnailExtension/Info.plist
+++ b/Sources/ThumbnailExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.4</string>
+	<string>0.1.5</string>
 	<key>CFBundleVersion</key>
-	<string>10</string>
+	<string>11</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>12.0</string>
 	<key>LSHasLocalizedDisplayName</key>

--- a/docs/index.html
+++ b/docs/index.html
@@ -46,7 +46,7 @@
           GitHub
         </a>
         <a class="header-download-button"
-          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.4/alhangeul-macos-0.1.4.dmg"
+          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.5/alhangeul-macos-0.1.5.dmg"
           aria-label="Mac용 알한글 DMG 다운로드">
           다운로드
         </a>
@@ -203,7 +203,7 @@
         </details>
         <details>
           <summary>다운로드 파일은 어디에서 받을 수 있나요?</summary>
-          <p>상단 다운로드 버튼은 최신 공식 릴리즈의 DMG 파일을 바로 내려받도록 연결됩니다. v0.1.4 공식 DMG도 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다. 파일이 준비되지 않았거나 이전 버전이
+          <p>상단 다운로드 버튼은 최신 공식 릴리즈의 DMG 파일을 바로 내려받도록 연결됩니다. v0.1.5 공식 DMG도 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다. 파일이 준비되지 않았거나 이전 버전이
             필요하면 <a href="https://github.com/postmelee/alhangeul-macos/releases/latest" target="_blank"
               rel="noreferrer">GitHub Releases</a>에서 배포 상태를 확인할 수 있습니다.</p>
           <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>

--- a/docs/updates/index.html
+++ b/docs/updates/index.html
@@ -34,7 +34,7 @@
           GitHub
         </a>
         <a class="header-download-button"
-          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.4/alhangeul-macos-0.1.4.dmg"
+          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.5/alhangeul-macos-0.1.5.dmg"
           aria-label="Mac용 알한글 DMG 다운로드">
           다운로드
         </a>
@@ -48,7 +48,7 @@
       <p>앱에서는 메뉴 막대에서 새 버전을 확인할 수 있고, 웹에서는 Intel Mac과 Apple Silicon Mac을 모두 지원하는 단일 GitHub Release DMG를 직접 받을 수 있습니다.</p>
       <div class="updates-actions" aria-label="업데이트 주요 링크">
         <a class="page-action-button"
-          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.4/alhangeul-macos-0.1.4.dmg">
+          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.5/alhangeul-macos-0.1.5.dmg">
           최신 DMG 다운로드
         </a>
         <a class="page-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"
@@ -73,6 +73,10 @@
       <section class="updates-section" aria-labelledby="release-notes-title">
         <h2 id="release-notes-title">릴리즈 노트</h2>
         <div class="release-note-list">
+          <a href="./v0.1.5.html">
+            알한글 v0.1.5
+            <span>rhwp v0.7.15 반영과 수식/미주, HWPX 저장 호환성 개선</span>
+          </a>
           <a href="./v0.1.4.html">
             알한글 v0.1.4
             <span>Quick Look 특수 기호/텍스트 배경 표시 보정과 rhwp v0.7.13 반영</span>

--- a/docs/updates/v0.1.0.html
+++ b/docs/updates/v0.1.0.html
@@ -44,9 +44,9 @@
 
   <aside class="release-version-notice" aria-label="최신 릴리즈 안내">
     <div class="release-version-notice-inner">
-      <p><strong>이 문서는 이전 버전(v0.1.0)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.4에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
+      <p><strong>이 문서는 이전 버전(v0.1.0)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.5에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
       <div class="release-version-notice-actions">
-        <a class="notice-primary-link" href="./v0.1.4.html">최신 릴리즈 노트</a>
+        <a class="notice-primary-link" href="./v0.1.5.html">최신 릴리즈 노트</a>
         <a class="notice-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"
           rel="noreferrer">GitHub 최신 릴리즈</a>
       </div>

--- a/docs/updates/v0.1.1.html
+++ b/docs/updates/v0.1.1.html
@@ -44,9 +44,9 @@
 
   <aside class="release-version-notice" aria-label="최신 릴리즈 안내">
     <div class="release-version-notice-inner">
-      <p><strong>이 문서는 이전 버전(v0.1.1)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.4에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
+      <p><strong>이 문서는 이전 버전(v0.1.1)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.5에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
       <div class="release-version-notice-actions">
-        <a class="notice-primary-link" href="./v0.1.4.html">최신 릴리즈 노트</a>
+        <a class="notice-primary-link" href="./v0.1.5.html">최신 릴리즈 노트</a>
         <a class="notice-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"
           rel="noreferrer">GitHub 최신 릴리즈</a>
       </div>

--- a/docs/updates/v0.1.2.html
+++ b/docs/updates/v0.1.2.html
@@ -44,9 +44,9 @@
 
   <aside class="release-version-notice" aria-label="최신 릴리즈 안내">
     <div class="release-version-notice-inner">
-      <p><strong>이 문서는 이전 버전(v0.1.2)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.4에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
+      <p><strong>이 문서는 이전 버전(v0.1.2)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.5에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
       <div class="release-version-notice-actions">
-        <a class="notice-primary-link" href="./v0.1.4.html">최신 릴리즈 노트</a>
+        <a class="notice-primary-link" href="./v0.1.5.html">최신 릴리즈 노트</a>
         <a class="notice-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"
           rel="noreferrer">GitHub 최신 릴리즈</a>
       </div>

--- a/docs/updates/v0.1.4.html
+++ b/docs/updates/v0.1.4.html
@@ -42,6 +42,17 @@
     </div>
   </header>
 
+  <aside class="release-version-notice" aria-label="최신 릴리즈 안내">
+    <div class="release-version-notice-inner">
+      <p><strong>이 문서는 이전 버전(v0.1.4)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.5에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
+      <div class="release-version-notice-actions">
+        <a class="notice-primary-link" href="./v0.1.5.html">최신 릴리즈 노트</a>
+        <a class="notice-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"
+          rel="noreferrer">GitHub 최신 릴리즈</a>
+      </div>
+    </div>
+  </aside>
+
   <main id="main" class="updates-page">
     <section class="updates-hero" aria-labelledby="release-title">
       <h1 id="release-title">알한글 v0.1.4</h1>

--- a/docs/updates/v0.1.5.html
+++ b/docs/updates/v0.1.5.html
@@ -5,13 +5,13 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="theme-color" content="#ffffff" />
-  <meta name="description" content="알한글 v0.1.3 릴리즈 노트입니다." />
-  <meta property="og:title" content="알한글 v0.1.3 릴리즈 노트" />
-  <meta property="og:description" content="rhwp v0.7.12를 반영해 HWP/HWPX parser, viewer, WMF/HWP3 처리 개선을 포함한 알한글 패치 릴리즈입니다." />
+  <meta name="description" content="알한글 v0.1.5 릴리즈 노트입니다." />
+  <meta property="og:title" content="알한글 v0.1.5 릴리즈 노트" />
+  <meta property="og:description" content="rhwp v0.7.15를 반영해 수식과 미주 흐름, HWPX 저장 호환성, 문단 정보 UI 후속 개선을 포함한 알한글 패치 릴리즈입니다." />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://postmelee.github.io/alhangeul-macos/updates/v0.1.3.html" />
+  <meta property="og:url" content="https://postmelee.github.io/alhangeul-macos/updates/v0.1.5.html" />
   <meta property="og:image" content="https://postmelee.github.io/alhangeul-macos/assets/og-main.png" />
-  <title>알한글 v0.1.3 릴리즈 노트</title>
+  <title>알한글 v0.1.5 릴리즈 노트</title>
   <link rel="icon" href="../assets/logo-256@2x.png" />
   <link rel="apple-touch-icon" href="../assets/logo-256@2x.png" />
   <link rel="stylesheet" href="../styles.css?v=20260513-release-notice" />
@@ -34,7 +34,7 @@
           GitHub
         </a>
         <a class="header-download-button"
-          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.3/alhangeul-macos-0.1.3.dmg"
+          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.5/alhangeul-macos-0.1.5.dmg"
           aria-label="Mac용 알한글 DMG 다운로드">
           다운로드
         </a>
@@ -42,27 +42,16 @@
     </div>
   </header>
 
-  <aside class="release-version-notice" aria-label="최신 릴리즈 안내">
-    <div class="release-version-notice-inner">
-      <p><strong>이 문서는 이전 버전(v0.1.3)의 릴리즈 노트입니다.</strong> 최신 버전 v0.1.5에서 수정 사항과 최신 설치 파일을 확인하세요.</p>
-      <div class="release-version-notice-actions">
-        <a class="notice-primary-link" href="./v0.1.5.html">최신 릴리즈 노트</a>
-        <a class="notice-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/latest"
-          rel="noreferrer">GitHub 최신 릴리즈</a>
-      </div>
-    </div>
-  </aside>
-
   <main id="main" class="updates-page">
     <section class="updates-hero" aria-labelledby="release-title">
-      <h1 id="release-title">알한글 v0.1.3</h1>
-      <p>업스트림 <code>rhwp v0.7.12</code>를 반영해 HWP/HWPX 문서 열기와 viewer asset 기준을 갱신한 패치 릴리즈입니다.</p>
+      <h1 id="release-title">알한글 v0.1.5</h1>
+      <p><code>rhwp v0.7.15</code>를 반영해 수식과 미주 흐름, HWPX 저장 호환성, 문단 정보 UI 후속 개선을 포함한 패치 릴리즈입니다.</p>
       <div class="updates-actions" aria-label="릴리즈 주요 링크">
         <a class="page-action-button"
-          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.3/alhangeul-macos-0.1.3.dmg">
+          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.5/alhangeul-macos-0.1.5.dmg">
           DMG 다운로드
         </a>
-        <a class="page-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.3"
+        <a class="page-secondary-link" href="https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.5"
           rel="noreferrer">GitHub Release</a>
         <a class="page-secondary-link" href="./">업데이트 목록</a>
       </div>
@@ -72,30 +61,33 @@
       <section class="updates-section" aria-labelledby="release-summary-title">
         <h2 id="release-summary-title">변경 요약</h2>
         <ul>
-          <li><code>rhwp</code> core와 bundled <code>rhwp-studio</code>를 <code>v0.7.12</code> 기준으로 갱신했습니다.</li>
-          <li>업스트림의 HWP/HWPX parser, viewer, WMF, HWP3, 렌더링 관련 수정이 알한글 앱과 Finder 통합 경로에 포함됩니다.</li>
-          <li>앱 본체, Quick Look preview, Finder thumbnail extension의 release version을 <code>0.1.3 (9)</code>로 맞췄습니다.</li>
-          <li>공식 DMG는 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용하는 signed/notarized universal DMG 기준을 유지합니다.</li>
+          <li><code>rhwp</code> core와 bundled <code>rhwp-studio</code>를 <code>v0.7.15</code> 기준으로 갱신했습니다.</li>
+          <li>수식 줄바꿈과 들여쓰기, 강제 줄바꿈 뒤 커서 이동, 미주 안 수식 배치 관련 upstream 보정을 포함했습니다.</li>
+          <li>HWPX 저장/내보내기에서 그림 회전·반전, 대각선 셀 테두리, 0바이트 필드 순서 보존 개선을 포함했습니다.</li>
+          <li>bundled viewer/editor의 문단 정보 대화상자가 왼쪽 여백과 내어쓰기 값을 분리해 다루도록 보강했습니다.</li>
+          <li>앱 본체, Quick Look 미리보기, Finder 썸네일 extension을 <code>0.1.5 (11)</code> 기준 signed/notarized universal DMG로 배포합니다.</li>
         </ul>
       </section>
 
       <section class="updates-section" aria-labelledby="release-rhwp-title">
         <h2 id="release-rhwp-title">포함된 rhwp 변화</h2>
-        <p>v0.1.3은 <a href="https://github.com/edwardkim/rhwp/releases/tag/v0.7.12"
-            rel="noreferrer"><code>rhwp v0.7.12</code></a> 기준의 core와 bundled <code>rhwp-studio</code>를 사용합니다. 앱 내부 provenance 기준 commit은 <code>1899ef9bc2dfd1c6c0c4d18b192d253a2d0a1fb5</code>입니다.</p>
+        <p>v0.1.5는 <a href="https://github.com/edwardkim/rhwp/releases/tag/v0.7.15"
+            rel="noreferrer"><code>rhwp v0.7.15</code></a> 기준의 core와 bundled <code>rhwp-studio</code>를 사용합니다. 앱 내부 provenance 기준 commit은 <code>aa925a5954f0fd26dfcef2166cbce7877c481f44</code>입니다.</p>
         <ul>
-          <li>업스트림 tag 메시지 기준으로 여러 PR의 parser/viewer 결함 수정과 WMF, HWP3, LTO 관련 개선이 포함됩니다.</li>
-          <li>bundled <code>rhwp-studio</code> Web/WASM asset도 같은 <code>v0.7.12</code> commit에서 다시 빌드했습니다.</li>
-          <li>Rust FFI에는 native PNG 렌더링용 <code>rhwp_render_page_png</code> symbol이 추가됐고, 앱 viewer와 Finder extension 경로는 새 bridge artifact 기준으로 검증했습니다.</li>
+          <li>수식 TAC 줄바꿈, 들여쓰기, 강제 줄바꿈 뒤 커서 이동, 미주 안 수식 script 렌더링과 간격 조정이 포함됩니다.</li>
+          <li>HWPX 그림 serialization의 반전/회전/isEmbeded 값, 대각선 셀 테두리, 0바이트 필드 ordering 보존이 보강됩니다.</li>
+          <li>bundled <code>rhwp-studio</code>에는 문단 정보 대화상자의 왼쪽 여백과 내어쓰기 binding 분리, 렌더 sweep 가이드와 폰트 문서 보강이 포함됩니다.</li>
+          <li>upstream browser extension service worker의 문서 fetch 경로 보안 강화가 같은 release에 포함되지만, 알한글 macOS 앱은 별도 브라우저 확장 권한이나 네트워크 경로를 추가하지 않습니다.</li>
         </ul>
       </section>
 
       <section class="updates-section" aria-labelledby="release-app-title">
         <h2 id="release-app-title">알한글 앱 변화</h2>
         <ul>
-          <li>About 창과 내부 provenance 기준이 <code>rhwp v0.7.12</code>를 표시할 수 있도록 bundled manifest를 갱신했습니다.</li>
-          <li>release rehearsal/publish workflow의 기본 입력을 <code>v0.1.3</code>, 직전 공개 릴리즈 <code>v0.1.2</code>, expected <code>rhwp v0.7.12</code> 기준으로 정리했습니다.</li>
-          <li>third-party notices와 release record가 앱 bundle에 포함된 core/studio 기준을 같은 commit으로 가리키도록 맞췄습니다.</li>
+          <li>앱 본체와 Quick Look/Thumbnail extension의 source metadata를 <code>0.1.5 (11)</code>로 맞췄습니다.</li>
+          <li>release rehearsal/publish workflow의 기본 입력을 <code>v0.1.5</code>, 직전 공개 릴리즈 <code>v0.1.4</code>, expected <code>rhwp v0.7.15</code> 기준으로 정리했습니다.</li>
+          <li>About 창과 내부 provenance 정보는 bundled <code>rhwp v0.7.15</code> 기준을 표시합니다.</li>
+          <li>GitHub Release, Pages, Sparkle, Homebrew Cask가 같은 public DMG URL과 checksum을 가리키도록 후속 배포 단계에서 검증합니다.</li>
         </ul>
       </section>
 
@@ -110,7 +102,7 @@
 
       <section class="updates-section" aria-labelledby="release-install-title">
         <h2 id="release-install-title">설치와 업데이트</h2>
-        <p>DMG 파일을 내려받아 앱을 Applications 폴더로 옮긴 뒤, 앱을 한 번 실행합니다. v0.1.3 공식 DMG는 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다.</p>
+        <p>DMG 파일을 내려받아 앱을 Applications 폴더로 옮긴 뒤, 앱을 한 번 실행합니다. v0.1.5 공식 DMG는 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다.</p>
         <p>Homebrew Cask를 사용하는 경우 아래 명령으로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
         <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>
         <p>설치한 앱에서는 메뉴 막대의 <code>알한글 &gt; 업데이트 확인...</code>을 선택해 새 버전을 확인할 수 있습니다.</p>

--- a/mydocs/orders/20260607.md
+++ b/mydocs/orders/20260607.md
@@ -5,3 +5,9 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #348 | rhwp Upstream Sync PR full sync와 PR CI 트리거 구조 확장 | 완료 | 완료: 04:25, PR #350 merge 및 #349 full sync merge 확인 |
+
+## M900 — Release Operations
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #351 | v0.1.5 public release 준비와 배포 실행 | 진행중 | M900, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/plans/task_m900_351.md
+++ b/mydocs/plans/task_m900_351.md
@@ -1,0 +1,188 @@
+# Task M900 #351 수행계획서
+
+## 목적
+
+`v0.1.5` public release를 준비하고, release runbook의 승인 gate에 따라 signed/notarized DMG, GitHub Release, Pages/Sparkle, Homebrew gate까지 실행 가능한 상태로 정렬한다.
+
+확정 후보로 제안된 release identity는 다음과 같다.
+
+| 항목 | 값 |
+|------|----|
+| GitHub Issue | #351 |
+| GitHub milestone | `Release Operations` |
+| 문서 분류 코드 | M900 |
+| release version | `0.1.5` |
+| build | `11` |
+| previous release ref | `v0.1.4` |
+| expected rhwp tag | `v0.7.15` |
+| candidate branch/commit | `origin/devel` / `c20a8639837009bb9ef61c8f84f9f1be0f5f12c5` |
+| 기준 브랜치 | `devel` |
+| 작업 브랜치 | `local/task351` |
+
+## 배경
+
+최신 공개 앱 릴리즈는 `v0.1.4`이고, GitHub Release asset과 Homebrew Cask는 public DMG SHA256 `cf04cb23e9bd072d9852cc404d092824446c7177ffb23a9bf16d1d1438317c6b` 기준으로 공개 완료 상태다.
+
+현재 `devel`은 upstream `rhwp v0.7.15` full sync PR이 merge되어 `rhwp-core.lock`과 bundled `rhwp-studio` manifest가 모두 `v0.7.15` / `aa925a5954f0fd26dfcef2166cbce7877c481f44`를 가리킨다. 반면 앱과 extension plist version은 아직 `0.1.4 (10)`이고, release rehearsal/publish workflow default도 `0.1.4`, `v0.1.3`, `v0.7.13` 기준에 머물러 있다.
+
+또한 `origin/main`에는 `v0.1.4` release record 완료 정리가 들어 있지만, 현재 `devel`의 일부 release record는 후보 준비 상태로 남아 있다. 새 release candidate를 만들기 전에 이 release 기록 차이를 함께 정렬해야 한다.
+
+## 범위
+
+포함:
+
+- HostApp, Quick Look, Thumbnail extension plist version을 `0.1.5 (11)`로 갱신
+- `Release Rehearsal DMG`, `Release Publish DMG` workflow 기본 입력을 `0.1.5`, `v0.1.4`, `v0.7.15` 기준으로 갱신
+- `mydocs/release/v0.1.5.md` release record 초안 작성
+- `docs/updates/v0.1.5.html`, `docs/updates/index.html`, README 최신 공개 릴리즈 요약 정렬
+- `mydocs/release/v0.1.4.md`와 release index의 `v0.1.4` 완료 상태를 `main` 공개 결과와 충돌하지 않게 정리
+- release note 후보와 delta checklist를 실제 사용자-facing 변화 기준으로 보정
+- source preflight, rehearsal, pre-public signed/notarized draft DMG smoke, official stable publish, Pages/Sparkle, Homebrew gate 결과를 release record에 기록
+
+제외:
+
+- upstream `rhwp` 수정
+- unreleased `rhwp` commit pin 적용
+- Developer ID credential, notary credential, Sparkle private key, GitHub token 값 기록
+- public publish, GitHub Release 게시, Pages/Sparkle 갱신, Homebrew tap 반영을 승인 gate 없이 실행
+- 제품 기능 구현 또는 renderer parity 개선 자체
+
+## 설계 방향
+
+릴리즈 실행 순서는 `mydocs/manual/public_release_runbook.md`를 우선한다. 각 위험 구간은 별도 승인 gate로 취급한다.
+
+1. release candidate source를 `0.1.5 (11)`과 `rhwp v0.7.15` provenance 기준으로 정렬한다.
+2. source-level 검증과 release helper dry-run으로 publish 전 결함을 먼저 제거한다.
+3. rehearsal DMG는 public artifact로 사용하지 않고 layout, checksum, delta checklist 확인에만 쓴다.
+4. public publish는 `main` 반영과 `v0.1.5` tag 확정 후, release owner 승인으로만 실행한다.
+5. `draft=true`, `prerelease=false` 실행은 pre-public signed/notarized DMG smoke gate로 보고 stable appcast와 Pages deployment 성공 조건에 포함하지 않는다.
+6. `draft=false`, `prerelease=false` official stable release에서만 Sparkle stable appcast와 Pages deployment를 성공 조건에 포함한다.
+7. Homebrew는 public DMG URL과 SHA256이 확정된 뒤 별도 승인 gate로 진행한다.
+
+## 예상 변경 파일
+
+- `Sources/HostApp/Info.plist`
+- `Sources/QLExtension/Info.plist`
+- `Sources/ThumbnailExtension/Info.plist`
+- `.github/workflows/release-rehearsal.yml`
+- `.github/workflows/release-publish.yml`
+- `README.md`
+- `docs/updates/v0.1.5.html`
+- `docs/updates/index.html`
+- `mydocs/release/index.md`
+- `mydocs/release/v0.1.4.md`
+- `mydocs/release/v0.1.5.md`
+- `mydocs/orders/20260607.md`
+- `mydocs/plans/task_m900_351_impl.md`
+- `mydocs/working/task_m900_351_stage{N}.md`
+- `mydocs/report/task_m900_351_report.md`
+
+public DMG SHA256 확정 후 별도 승인 gate에서 필요하면 다음 파일을 갱신한다.
+
+- `Casks/alhangeul.rb`
+
+## 잠정 단계
+
+1. Stage 1: release context와 source metadata 정렬
+   - app/extension plist, release workflow default, current lock/manifest, `origin/main` release record를 대조한다.
+   - `0.1.5 (11)`, `previous_release_ref=v0.1.4`, `expected_rhwp_tag=v0.7.15` 기준으로 source metadata를 갱신한다.
+2. Stage 2: release communication 작성
+   - `mydocs/release/v0.1.5.md`, Pages release note, updates index, README 최신 요약을 정리한다.
+   - `rhwp v0.7.15` 사용자-facing 변화, 알한글 앱 변화, known limitations를 구분한다.
+   - `v0.1.4` 완료 record 차이를 public 결과 기준으로 정리한다.
+3. Stage 3: source preflight와 rehearsal
+   - lock/provenance, bundled asset, no-AppKit, Debug/Release build, render smoke, release helper dry-run을 수행한다.
+   - 승인 후 local rehearsal DMG 또는 `Release Rehearsal DMG` workflow를 실행하고 delta checklist 초안을 보정한다.
+4. Stage 4: main/tag/pre-public smoke와 official publish gate
+   - `devel` release candidate를 `main`에 반영할 PR 준비 자료를 완성한다.
+   - `v0.1.5` tag 생성 후 별도 승인으로 `Release Publish DMG`를 `draft=true`, `prerelease=false`로 실행해 signed/notarized DMG 설치 smoke를 수행한다.
+   - draft smoke 통과 후 별도 승인으로 `Release Publish DMG`를 `draft=false`, `prerelease=false` official stable 기준으로 실행한다.
+5. Stage 5: post-publish 확인과 Homebrew gate
+   - GitHub Release asset, official stable public DMG SHA256, Pages 다운로드 링크, stable appcast, public 설치본 smoke, Sparkle update smoke를 기록한다.
+   - Homebrew 반영은 public DMG SHA256 확정 후 별도 승인으로 처리한다.
+6. Stage 6: 최종 보고와 cleanup handoff
+   - 최종 release report를 작성하고, PR/merge 후 남은 branch, issue, release record 정리 항목을 확인한다.
+
+## 검증 계획
+
+source preflight:
+
+```bash
+git status --short --branch
+bash scripts/ci/read-rhwp-core-lock.sh rhwp_release_tag
+bash scripts/ci/read-rhwp-core-lock.sh rhwp_commit
+./scripts/build-rust-macos.sh --verify-lock
+scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+./scripts/validate-stage3-render.sh
+```
+
+release helper:
+
+```bash
+./scripts/release.sh --help
+scripts/ci/write-release-delta-checklist.sh v0.1.4 HEAD build.noindex/release/delta-checklist-0.1.5.md
+scripts/ci/write-release-notes.sh 0.1.5 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef build.noindex/release/release-notes-0.1.5.md
+scripts/ci/check-release-notes-template.sh build.noindex/release/release-notes-0.1.5.md
+scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check
+```
+
+rehearsal 승인 후:
+
+```bash
+./scripts/release.sh --skip-notarize 0.1.5
+```
+
+pre-public draft smoke 승인 후:
+
+```bash
+gh workflow run "Release Publish DMG" --ref v0.1.5 \
+  -f version=0.1.5 \
+  -f previous_release_ref=v0.1.4 \
+  -f expected_rhwp_tag=v0.7.15 \
+  -f require_latest_rhwp=true \
+  -f include_rhwp_in_title=true \
+  -f draft=true \
+  -f prerelease=false
+```
+
+official stable publish 승인 후:
+
+```bash
+gh workflow run "Release Publish DMG" --ref v0.1.5 \
+  -f version=0.1.5 \
+  -f previous_release_ref=v0.1.4 \
+  -f expected_rhwp_tag=v0.7.15 \
+  -f require_latest_rhwp=true \
+  -f include_rhwp_in_title=true \
+  -f draft=false \
+  -f prerelease=false
+```
+
+post-publish:
+
+```bash
+gh release view v0.1.5 --repo postmelee/alhangeul-macos --json tagName,name,isDraft,isPrerelease,assets,url
+scripts/smoke-finder-integration.sh --version 0.1.5
+scripts/smoke-sparkle-extension-refresh.sh --expected-version 0.1.5 --expected-build 11
+```
+
+## 리스크
+
+- release workflow 기본 입력이 stale한 상태에서 workflow_dispatch를 실행하면 lock guard에서 실패하거나 잘못된 delta checklist가 생성될 수 있다.
+- `devel`과 `main` 사이의 `v0.1.4` release record 차이를 그대로 두면 새 release record가 이전 release 상태와 충돌할 수 있다.
+- `rhwp v0.7.15`는 security patch와 equation/HWPX fix를 포함하므로 release note에서 앱 viewer, Quick Look, Thumbnail 영향과 한계를 분리해야 한다.
+- public publish는 GitHub Actions release environment secret과 Pages environment 설정에 의존하므로, secret 값은 기록하지 않고 존재와 검증 결과만 남겨야 한다.
+- rehearsal DMG, 개발용 zip, pre-public draft DMG, official stable public DMG의 산출물 계층을 섞으면 Homebrew SHA나 Sparkle enclosure가 잘못될 수 있다.
+- Intel Mac 실기기 smoke, GUI Quick Look preview, Sparkle update smoke를 실행하지 못하면 성공으로 기록하지 않고 미실행 사유를 남겨야 한다.
+
+## 승인 요청 사항
+
+이 수행계획서 기준으로 다음 단계인 구현계획서(`mydocs/plans/task_m900_351_impl.md`) 작성과 Stage 1 release context/source metadata 정렬 진행 승인을 요청한다.

--- a/mydocs/plans/task_m900_351_impl.md
+++ b/mydocs/plans/task_m900_351_impl.md
@@ -1,0 +1,354 @@
+# Task M900 #351 구현계획서
+
+## 개요
+
+이 구현계획서는 `v0.1.5` public release 준비와 배포 실행을 6단계로 나눈다. 확정된 release identity 후보는 `version=0.1.5`, `build=11`, `previous_release_ref=v0.1.4`, `expected_rhwp_tag=v0.7.15`이다.
+
+각 단계는 하이퍼-워터폴 승인 gate를 가진다. Stage 1~2는 release candidate source와 communication 정렬, Stage 3은 source preflight와 rehearsal, Stage 4는 `main` 반영, pre-public signed/notarized DMG smoke, official stable publish gate, Stage 5는 post-publish public surface 확인과 Homebrew gate, Stage 6은 최종 보고와 cleanup handoff다.
+
+pre-public signed/notarized DMG smoke, public publish, GitHub Release 게시, Pages/Sparkle 갱신, Homebrew tap 반영은 이 구현계획 승인만으로 실행하지 않는다. 해당 단계에서 작업지시자의 별도 명시 승인을 받은 뒤 진행한다.
+
+## Stage 1: Release Candidate Source Metadata 정렬
+
+### 목표
+
+`devel`의 release candidate source를 `v0.1.5 (11)`과 `rhwp v0.7.15` 기준으로 맞춘다.
+
+### 변경 파일
+
+- `Sources/HostApp/Info.plist`
+- `Sources/QLExtension/Info.plist`
+- `Sources/ThumbnailExtension/Info.plist`
+- `.github/workflows/release-rehearsal.yml`
+- `.github/workflows/release-publish.yml`
+- `mydocs/working/task_m900_351_stage1.md`
+
+### 작업
+
+1. HostApp, Quick Look, Thumbnail extension의 `CFBundleShortVersionString`을 `0.1.5`로 올린다.
+2. 세 target의 `CFBundleVersion`을 `11`로 올린다.
+3. `Release Rehearsal DMG` workflow default를 `version=0.1.5`, `previous_release_ref=v0.1.4`, `expected_rhwp_tag=v0.7.15`로 갱신한다.
+4. `Release Publish DMG` workflow default를 같은 값으로 갱신한다.
+5. `rhwp-core.lock`과 bundled `rhwp-studio` manifest가 `v0.7.15` / `aa925a5954f0fd26dfcef2166cbce7877c481f44`인지 재확인한다.
+
+### 검증
+
+```bash
+plutil -extract CFBundleShortVersionString raw -o - Sources/HostApp/Info.plist
+plutil -extract CFBundleVersion raw -o - Sources/HostApp/Info.plist
+plutil -extract CFBundleShortVersionString raw -o - Sources/QLExtension/Info.plist
+plutil -extract CFBundleVersion raw -o - Sources/QLExtension/Info.plist
+plutil -extract CFBundleShortVersionString raw -o - Sources/ThumbnailExtension/Info.plist
+plutil -extract CFBundleVersion raw -o - Sources/ThumbnailExtension/Info.plist
+bash scripts/ci/read-rhwp-core-lock.sh rhwp_release_tag
+bash scripts/ci/read-rhwp-core-lock.sh rhwp_commit
+scripts/verify-rhwp-studio-assets.sh
+rg -n "0\\.1\\.4|0\\.1\\.5|v0\\.1\\.3|v0\\.1\\.4|v0\\.7\\.13|v0\\.7\\.15" \
+  .github/workflows/release-rehearsal.yml \
+  .github/workflows/release-publish.yml \
+  Sources/HostApp/Info.plist \
+  Sources/QLExtension/Info.plist \
+  Sources/ThumbnailExtension/Info.plist
+git diff --check
+```
+
+### 단계 산출물
+
+- `mydocs/working/task_m900_351_stage1.md`
+- 단계 커밋: `Task #351 Stage 1: release metadata 정렬`
+
+### 승인 요청
+
+Stage 1 완료보고서 기준으로 Stage 2 진행 승인을 요청한다.
+
+## Stage 2: Release Communication 작성
+
+### 목표
+
+사용자-facing release note와 내부 release record를 `v0.1.5`, `rhwp v0.7.15` 기준으로 정리하고, `devel`에 남아 있는 `v0.1.4` 후보 상태 기록을 public 완료 결과와 충돌하지 않게 보정한다.
+
+### 변경 파일
+
+- `README.md`
+- `docs/updates/v0.1.5.html`
+- `docs/updates/index.html`
+- `mydocs/release/index.md`
+- `mydocs/release/v0.1.4.md`
+- `mydocs/release/v0.1.5.md`
+- `mydocs/working/task_m900_351_stage2.md`
+
+### 작업
+
+1. `mydocs/release/v0.1.5.md`를 작성한다.
+2. 직전 public release `v0.1.4` 대비 변경점을 `rhwp v0.7.15` 반영, 앱 repository 변경, 검증 예정 항목으로 분리한다.
+3. GitHub Release body 후보의 `변경 요약`, `포함된 rhwp 변화`, `알한글 앱 변화` 문구를 사용자-facing 내용으로 보정한다.
+4. Pages `docs/updates/v0.1.5.html`을 기존 update page 구조에 맞춰 추가한다.
+5. `docs/updates/index.html` 최신 항목과 다운로드 경로가 `v0.1.5`를 가리키게 갱신한다.
+6. README 최신 공개 릴리즈 요약을 `v0.1.5` 후보 기준으로 갱신할지 판단하고, 갱신 시 public DMG SHA256 미확정 상태를 명확히 둔다.
+7. `mydocs/release/v0.1.4.md`와 `mydocs/release/index.md`의 `v0.1.4` 상태를 public 완료 결과와 충돌하지 않게 정리한다.
+
+### 검증
+
+```bash
+scripts/ci/write-release-delta-checklist.sh v0.1.4 HEAD build.noindex/release/delta-checklist-0.1.5.md
+scripts/ci/write-release-notes.sh 0.1.5 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef build.noindex/release/release-notes-0.1.5.md
+scripts/ci/check-release-notes-template.sh build.noindex/release/release-notes-0.1.5.md
+scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check
+rg -n "0\\.1\\.5|v0\\.1\\.5|v0\\.7\\.15|변경 요약|포함된 rhwp 변화|알한글 앱 변화|alhangeul-macos-0\\.1\\.5\\.dmg" \
+  README.md docs/updates mydocs/release/v0.1.5.md
+git diff --check
+```
+
+### 단계 산출물
+
+- `mydocs/working/task_m900_351_stage2.md`
+- 단계 커밋: `Task #351 Stage 2: release communication 작성`
+
+### 승인 요청
+
+Stage 2 완료보고서 기준으로 Stage 3 진행 승인을 요청한다.
+
+## Stage 3: Source Preflight와 Rehearsal
+
+### 목표
+
+release candidate source가 빌드와 release helper 기준을 통과하는지 검증하고, 승인 시 rehearsal DMG로 layout/checksum/delta checklist를 확인한다.
+
+### 변경 파일
+
+- `mydocs/release/v0.1.5.md`
+- `mydocs/working/task_m900_351_stage3.md`
+
+rehearsal 산출물은 `build.noindex/` 아래에 생성하며 git에 커밋하지 않는다.
+
+### 작업
+
+1. Rust/core lock, bundled `rhwp-studio`, shared Swift boundary를 검증한다.
+2. `xcodegen generate`, Debug build, render smoke를 실행한다.
+3. 개발용 package 산출물로 Release configuration bundle과 universal app/extension slice 검증을 실행한다.
+4. release helper dry-run과 release note template check를 실행한다.
+5. 작업지시자 승인 후 `Release Rehearsal DMG` workflow 또는 `./scripts/release.sh --skip-notarize 0.1.5`를 실행한다.
+6. rehearsal DMG SHA256, `hdiutil verify`, delta checklist previous/candidate ref를 release record에 기록한다.
+
+### 검증
+
+```bash
+git status --short --branch
+./scripts/build-rust-macos.sh --verify-lock
+scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+./scripts/validate-stage3-render.sh
+./scripts/package-release.sh 0.1.5
+scripts/ci/verify-universal-macos-app.sh build.noindex/release/Alhangeul.app
+./scripts/release.sh --help
+```
+
+승인 후 rehearsal:
+
+```bash
+./scripts/release.sh --skip-notarize 0.1.5
+hdiutil verify build.noindex/release/alhangeul-macos-0.1.5-rehearsal.dmg
+```
+
+### 단계 산출물
+
+- `mydocs/working/task_m900_351_stage3.md`
+- 보정된 `mydocs/release/v0.1.5.md`
+- 단계 커밋: `Task #351 Stage 3: source preflight와 rehearsal 검증`
+
+### 승인 요청
+
+Stage 3 완료보고서 기준으로 Stage 4 진행 승인을 요청한다. Stage 4의 `main` PR, tag 생성, pre-public signed/notarized DMG smoke, official stable publish는 별도 승인 gate다.
+
+## Stage 4: Main/Tag/Pre-public Smoke와 Official Publish Gate
+
+### 목표
+
+검증된 `devel` release candidate를 `main`으로 반영하고, `v0.1.5` tag 생성, pre-public signed/notarized DMG smoke, official stable publish workflow 실행을 승인 gate별로 준비한다.
+
+### 변경 파일
+
+- `mydocs/release/v0.1.5.md`
+- `mydocs/working/task_m900_351_stage4.md`
+
+### 작업
+
+1. `devel` release candidate commit과 포함 PR 범위를 확정한다.
+2. release PR 본문에 release record, 검증 결과, known limitations, publish input을 정리한다.
+3. 작업지시자 승인 후 `devel -> main` release PR을 만들고 merge한다.
+4. 작업지시자 승인 후 `v0.1.5` tag를 정확한 `main` candidate commit에 만든다.
+5. 작업지시자 승인 후 `Release Publish DMG` workflow를 `draft=true`, `prerelease=false`로 실행해 signed/notarized DMG를 생성한다.
+6. maintainer가 draft release asset 또는 Actions artifact DMG를 직접 설치 smoke하고, stable appcast와 Pages deployment가 skip된 것을 확인한다.
+7. draft smoke 통과 후 GitHub Release body, Pages 업데이트 문서, README 최신 요약, 내부 release record를 최종 candidate 기준으로 다시 검토한다.
+8. 작업지시자 별도 승인 후 `Release Publish DMG` workflow를 `draft=false`, `prerelease=false` official stable 기준으로 실행한다.
+9. workflow summary에서 tag/ref 일치, `expected_rhwp_tag`, public DMG, GitHub Release, Pages/Sparkle job 결과를 확인한다.
+
+### 검증
+
+```bash
+git status --short --branch
+git rev-parse HEAD
+gh pr view <release-pr> --repo postmelee/alhangeul-macos --json number,state,mergeCommit,url
+gh release view v0.1.5 --repo postmelee/alhangeul-macos --json tagName,name,isDraft,isPrerelease,assets,url
+```
+
+pre-public draft smoke 승인 입력:
+
+```bash
+gh workflow run "Release Publish DMG" --ref v0.1.5 \
+  -f version=0.1.5 \
+  -f previous_release_ref=v0.1.4 \
+  -f expected_rhwp_tag=v0.7.15 \
+  -f require_latest_rhwp=true \
+  -f include_rhwp_in_title=true \
+  -f draft=true \
+  -f prerelease=false
+```
+
+official stable publish 승인 입력:
+
+```bash
+gh workflow run "Release Publish DMG" --ref v0.1.5 \
+  -f version=0.1.5 \
+  -f previous_release_ref=v0.1.4 \
+  -f expected_rhwp_tag=v0.7.15 \
+  -f require_latest_rhwp=true \
+  -f include_rhwp_in_title=true \
+  -f draft=false \
+  -f prerelease=false
+```
+
+### 단계 산출물
+
+- `mydocs/working/task_m900_351_stage4.md`
+- 보정된 `mydocs/release/v0.1.5.md`
+- 단계 커밋: `Task #351 Stage 4: pre-public smoke와 official publish gate 확인`
+
+### 승인 요청
+
+Stage 4 완료보고서 기준으로 Stage 5 진행 승인을 요청한다.
+
+## Stage 5: Post-publish Public Surface 확인과 Homebrew Gate
+
+### 목표
+
+official stable publish 이후 public artifact와 update surface를 검증하고, Homebrew는 public DMG SHA256 확정 후 별도 승인으로 반영한다.
+
+### 변경 파일
+
+- `Casks/alhangeul.rb` (Homebrew gate 승인 시)
+- `README.md` (Homebrew 안내 공개 조건 충족 시)
+- `docs/updates/index.html` 또는 `docs/updates/v0.1.5.html` (post-publish URL/SHA 보정 필요 시)
+- `mydocs/release/v0.1.5.md`
+- `mydocs/working/task_m900_351_stage5.md`
+
+### 작업
+
+1. GitHub Release URL, official stable public DMG URL, SHA256, size, asset 목록을 확인한다.
+2. Pages `updates/v0.1.5.html`, latest download, stable appcast item, Sparkle EdDSA signature를 확인한다.
+3. release machine에서 가능한 범위의 stapler, `spctl`, universal slice 검증을 반복한다.
+4. Finder Quick Look/Thumbnail smoke와 Sparkle extension refresh smoke를 실행하거나 미실행 사유를 기록한다.
+5. 작업지시자 승인 후 `./scripts/update-cask-sha256.sh 0.1.5`를 실행하고 maintainer tap 반영/검증을 수행한다.
+
+### 검증
+
+```bash
+gh release view v0.1.5 --repo postmelee/alhangeul-macos --json tagName,name,isDraft,isPrerelease,assets,url
+scripts/ci/verify-universal-macos-app.sh build.noindex/release/Alhangeul.app
+xcrun stapler validate build.noindex/release/Alhangeul.app
+xcrun stapler validate build.noindex/release/alhangeul-macos-0.1.5.dmg
+spctl --assess --type execute --verbose build.noindex/release/Alhangeul.app
+spctl --assess --type open --context context:primary-signature --verbose build.noindex/release/alhangeul-macos-0.1.5.dmg
+scripts/smoke-finder-integration.sh --version 0.1.5
+scripts/smoke-sparkle-extension-refresh.sh --expected-version 0.1.5 --expected-build 11
+```
+
+Homebrew 승인 후:
+
+```bash
+./scripts/update-cask-sha256.sh 0.1.5
+brew tap postmelee/tap
+brew style --cask alhangeul
+brew audit --cask alhangeul
+brew install --cask postmelee/tap/alhangeul
+brew uninstall --cask alhangeul
+```
+
+### 단계 산출물
+
+- `mydocs/working/task_m900_351_stage5.md`
+- 보정된 `mydocs/release/v0.1.5.md`
+- 단계 커밋: `Task #351 Stage 5: post-publish 확인과 Homebrew gate 정리`
+
+### 승인 요청
+
+Stage 5 완료보고서 기준으로 Stage 6 진행 승인을 요청한다.
+
+## Stage 6: 최종 보고와 Cleanup Handoff
+
+### 목표
+
+release 실행 결과를 최종 보고서로 정리하고, PR 게시와 merge 후 cleanup 절차로 넘길 상태를 만든다.
+
+### 변경 파일
+
+- `mydocs/release/v0.1.5.md`
+- `mydocs/report/task_m900_351_report.md`
+- `mydocs/orders/20260607.md`
+
+### 작업
+
+1. Stage 1~5 결과와 public artifact 검증 기록을 최종 보고서에 정리한다.
+2. 실행하지 못한 smoke와 미실행 사유, 잔여 위험, 후속 이슈 후보를 기록한다.
+3. 오늘할일 상태를 완료로 갱신한다.
+4. PR 게시 전 최종 diff와 검증 명령을 확인한다.
+
+### 검증
+
+```bash
+git diff --check
+rg -n "0\\.1\\.5|v0\\.1\\.5|v0\\.7\\.15|public DMG|Sparkle|Homebrew|미실행|잔여" \
+  mydocs/release/v0.1.5.md mydocs/report/task_m900_351_report.md
+```
+
+### 단계 산출물
+
+- `mydocs/report/task_m900_351_report.md`
+- 완료 처리된 `mydocs/orders/20260607.md`
+- 단계/최종 커밋: `Task #351 Stage 6 + 최종 보고서: v0.1.5 release 결과 정리`
+
+### 승인 요청
+
+최종 결과보고서 기준으로 PR 게시 단계 진행 승인을 요청한다.
+
+## 전체 승인 Gate
+
+| Gate | 승인 없이 진행 금지 항목 |
+|------|--------------------------|
+| 수행계획 승인 | 구현계획서 작성 이후의 실제 source/release 문서 수정 |
+| 구현계획 승인 | Stage 1 source metadata 수정 |
+| Stage 1 승인 | Stage 2 release communication 작성 |
+| Stage 2 승인 | Stage 3 build/preflight/rehearsal |
+| Stage 3 승인 | `devel -> main` release PR, tag 생성, pre-public signed/notarized DMG smoke, official stable publish |
+| Stage 4 승인 | post-publish smoke, Homebrew gate |
+| Homebrew 별도 승인 | Cask SHA 고정, tap 반영, Homebrew 설치 안내 공개 |
+| Stage 5 승인 | 최종 보고와 PR 게시 준비 |
+
+## 검증/기록 원칙
+
+- 실행하지 않은 smoke는 성공으로 기록하지 않는다.
+- rehearsal DMG, pre-public draft DMG, official stable public DMG SHA256을 섞지 않는다.
+- secret 값은 어떤 문서, commit, PR, shell history에도 기록하지 않는다.
+- public artifact URL, SHA256, workflow run URL, Pages URL, appcast 결과는 `mydocs/release/v0.1.5.md`에 남긴다.
+- GitHub-hosted workflow에서만 생성된 산출물은 workflow summary와 artifact를 기준으로 기록하고, 가능한 검증은 release machine에서 재실행한다.
+
+## 승인 상태
+
+작업지시자가 수행계획서 승인과 함께 구현계획서 작성 및 Stage 1 진행을 지시했으므로, 이 구현계획서 작성 직후 Stage 1 source metadata 정렬까지 진행한다. Stage 1 완료 후에는 Stage 2 진행 승인을 요청한다.

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,8 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.4` | 후보 준비중 | [Alhangeul v0.1.4](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.4) | [v0.1.4](https://postmelee.github.io/alhangeul-macos/updates/v0.1.4.html) | [`v0.1.4.md`](v0.1.4.md) |
+| `v0.1.5` | 후보 준비중 | [Alhangeul v0.1.5](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.5) | [v0.1.5](https://postmelee.github.io/alhangeul-macos/updates/v0.1.5.html) | [`v0.1.5.md`](v0.1.5.md) |
+| `v0.1.4` | 공개 완료 | [Alhangeul v0.1.4](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.4) | [v0.1.4](https://postmelee.github.io/alhangeul-macos/updates/v0.1.4.html) | [`v0.1.4.md`](v0.1.4.md) |
 | `v0.1.3` | 공개 완료 | [Alhangeul v0.1.3](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.3) | [v0.1.3](https://postmelee.github.io/alhangeul-macos/updates/v0.1.3.html) | [`v0.1.3.md`](v0.1.3.md) |
 | `v0.1.2` | 공개 완료 | [Alhangeul v0.1.2](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.2) | [v0.1.2](https://postmelee.github.io/alhangeul-macos/updates/v0.1.2.html) | [`v0.1.2.md`](v0.1.2.md) |
 | `v0.1.1` | 공개 완료 | [Alhangeul v0.1.1](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.1) | [v0.1.1](https://postmelee.github.io/alhangeul-macos/updates/v0.1.1.html) | [`v0.1.1.md`](v0.1.1.md) |

--- a/mydocs/release/v0.1.4.md
+++ b/mydocs/release/v0.1.4.md
@@ -4,174 +4,138 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.4` build `10` source preflight와 local/rehearsal DMG 검증 완료, Stage 4 pre-public signed/notarized DMG smoke 승인 대기 |
-| 목표 Git tag | `v0.1.4` |
-| 목표 app version | `0.1.4` |
-| 목표 build | `10` |
+| 상태 | 완료 |
+| Git tag | `v0.1.4` |
+| Tag commit | `e7ebfd9db97ddfb44139db96dad93189717cbee4` |
+| App version | `0.1.4` |
+| Build | `10` |
 | 직전 public release | `v0.1.3` build `9` |
 | GitHub Release | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.4 |
 | Pages 릴리즈 노트 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.4.html |
-| Public DMG | `alhangeul-macos-0.1.4.dmg` 예정 |
-| Public DMG SHA256 | public workflow 결과 반영 예정 |
-| Local rehearsal DMG | `build.noindex/release/alhangeul-macos-0.1.4-rehearsal.dmg` |
-| Local rehearsal DMG SHA256 | `24d3ce29183b277a79cacc4d051e4f02a81cd9f94eb64f4078edc7da4ec84a56` |
-| Homebrew Cask | public DMG SHA256 확정 후 별도 반영 예정 |
+| Sparkle appcast | https://postmelee.github.io/alhangeul-macos/appcast.xml |
+| Public DMG | `alhangeul-macos-0.1.4.dmg` |
+| Public DMG URL | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.4/alhangeul-macos-0.1.4.dmg |
+| Public DMG SHA256 | `cf04cb23e9bd072d9852cc404d092824446c7177ffb23a9bf16d1d1438317c6b` |
+| Public DMG size | `153214843` bytes |
+| Release workflow | https://github.com/postmelee/alhangeul-macos/actions/runs/26710019767 |
+| Latest docs-only Pages deploy | https://github.com/postmelee/alhangeul-macos/actions/runs/26712466027 |
+| Homebrew Cask | `brew install --cask postmelee/tap/alhangeul` |
+| Homebrew tap commit | `5c3d4ee` |
 | Release 실행 이슈 | [#301](https://github.com/postmelee/alhangeul-macos/issues/301) |
 
-이 문서는 `rhwp v0.7.13` 반영과 `v0.1.4` public release 후보의 source metadata, release communication, 검증 예정 항목을 기록한다. pre-public signed/notarized DMG smoke, official stable GitHub Release, stable Sparkle appcast, Pages 배포, Homebrew Cask 반영 결과는 release workflow와 별도 승인 단계가 끝난 뒤 같은 문서에 보강한다.
+`v0.1.4`는 `rhwp v0.7.13` 반영, Quick Look/Finder thumbnail CoreGraphics 보정, signed/notarized universal DMG 배포, Pages/Sparkle/Homebrew 공개까지 완료한 patch release다.
 
 ## 사용자용 요약
 
-`v0.1.4`는 Quick Look과 Finder 썸네일에서 일부 HWP 문서의 특수 기호 깨짐과 텍스트 배경 표시를 보정하고, `rhwp v0.7.13` core/studio의 문서 호환성 개선을 함께 반영하는 patch release다. 앱 본체, Quick Look preview extension, Finder thumbnail extension은 `0.1.4 (10)` 기준으로 맞춘다.
-
-## 직전 공개 릴리즈 대비 변경점
-
-기준 범위는 `v0.1.3..release-candidate`다. 최종 release tag의 peeled commit은 `main` release PR merge와 `v0.1.4` tag 생성 후 확정한다.
-
-| 영역 | 변경 |
-|------|------|
-| Core/studio | #301: `rhwp` core와 bundled `rhwp-studio`를 `v0.7.13` release tag와 commit `b3e16ef212af81ef37d973ddb86d6816d3804642` 기준으로 유지 |
-| Release metadata | #301: 앱/extension source version을 `0.1.4`, build를 `10`, release workflow default와 helper dry-run 기준을 `v0.1.4`/`v0.7.13`으로 정리 |
-| Release communication | #301: README, Pages v0.1.4 릴리즈 노트, 내부 릴리즈 기록을 `rhwp v0.7.13` 기준으로 정리 |
-
-## GitHub Release 본문 구조 후보
-
-### 변경 요약
-
-- 일부 HWP 양식 문서에서 특수 기호나 서명 표식이 깨진 네모처럼 보이던 문제를 Quick Look과 Finder 썸네일에서 보정했다.
+- Quick Look 미리보기와 Finder 썸네일에서 일부 HWP 문서의 특수 문자, 기호, 서명 표식이 깨진 네모로 보이던 문제를 보정했다.
 - 일부 문서에서 글자 뒤에 의도하지 않은 배경색이나 음영 박스가 보이던 문제를 줄였다.
 - HWPX 렌더링과 HWP 저장 호환성, 표/셀 속성, 메모, 목차 필드, 페이지 번호 처리 관련 `rhwp v0.7.13` 개선을 포함했다.
-- 머리말/꼬리말, 문단 번호, 문단 테두리, 시험 문항 상자처럼 양식 문서에서 자주 눈에 띄는 배치 요소의 회귀 수정을 포함했다.
-- 앱 본체, Quick Look 미리보기, Finder 썸네일 extension을 `0.1.4 (10)` 기준 signed/notarized universal DMG로 배포한다.
+- 앱 본체, Quick Look preview extension, Finder thumbnail extension을 `0.1.4 (10)` signed/notarized universal DMG로 배포했다.
+- GitHub Release, Pages, Sparkle stable appcast, Homebrew Cask가 같은 public DMG URL과 SHA256을 가리키도록 정렬했다.
 
-### 포함된 rhwp 변화
+## 기술 세부
 
-- 포함된 `rhwp` core: [`v0.7.13`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.13) (`b3e16ef212af81ef37d973ddb86d6816d3804642`)
-- bundled `rhwp-studio`: [`v0.7.13`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.13) (`b3e16ef212af81ef37d973ddb86d6816d3804642`)
-- HWPX 문서를 HWP로 내보낼 때 표와 셀 속성, 셀 배경, 메모, 목차 필드, 페이지 번호 같은 문서 구조가 더 안정적으로 보존된다.
-- 배경쪽, 머리말/꼬리말, 문단 번호, 텍스트박스 위치, 문단 테두리, 시험 문항 상자처럼 인쇄 양식에서 눈에 띄는 배치 요소의 렌더링 수정이 포함된다.
-- 페이지 나눔과 이미지/표 배치가 어긋나거나 하단 내용이 넘쳐 보이는 일부 상황을 줄이는 보정이 포함된다.
-- 앱 내부 viewer asset에는 도형 커서 이동, 연속 공백 이동, 브라우저 파일 열기 안내, 중복 다운로드 억제 개선이 포함된다.
-- upstream release는 `exam_social` HWPX -> HWP 저장 시 odd-page header textbox height 잔여 이슈를 follow-up으로 분리했다.
+GitHub Release의 상단 요약과 Pages 문서는 사용자-facing 표현을 유지하고, 구현/검증 세부는 GitHub Release의 `기술 세부`와 이 release record에 분리해 기록한다.
 
-### 알한글 앱 변화
-
-- Quick Look 미리보기와 Finder 썸네일에서 일부 HWP 문서의 특수 문자, 기호, 서명 표식이 깨진 네모로 보이지 않도록 표시를 보정했다.
-- 기본 미리보기 렌더러가 텍스트 배경/음영 값을 더 정확히 해석해, 글자 뒤에 불필요한 배경 박스가 생기는 문제를 줄였다.
-- 앱 본체와 Quick Look/Thumbnail extension을 `0.1.4 (10)`으로 맞추고, GitHub Release, Sparkle 업데이트, Homebrew Cask가 같은 signed/notarized universal DMG를 가리키도록 정렬했다.
-- About 창과 내부 provenance 정보는 bundled `rhwp v0.7.13` 기준을 표시한다.
-
-## 연결된 Issue/PR
-
-| Issue | PR | 상태 | 내용 |
-|-------|----|------|------|
-| [#301](https://github.com/postmelee/alhangeul-macos/issues/301) | 예정 | 진행중 | `rhwp v0.7.13` 기준 `v0.1.4` release candidate 준비와 public release handoff |
-
-## 검증 기준
-
-Stage 3 기준 source-level 검증:
-
-| 영역 | 기준 | 상태 |
-|------|------|------|
-| App/extension version | HostApp, Preview, Thumbnail 모두 `0.1.4 (10)` | Stage 1에서 확인 |
-| Core lock | `rhwp_release_tag=v0.7.13`, commit `b3e16ef212af81ef37d973ddb86d6816d3804642` | Stage 1에서 확인 |
-| Studio asset | bundled manifest `source_release_tag=v0.7.13`, `source_resolved_commit=b3e16ef212af81ef37d973ddb86d6816d3804642` | Stage 1에서 확인 |
-| Release helper | `scripts/ci/write-release-notes.sh 0.1.4 ...` template check | Stage 3에서 재확인 |
-| Pages release note | `docs/updates/v0.1.4.html` | Stage 2에서 확인 |
-| Delta checklist | `scripts/ci/write-release-delta-checklist.sh v0.1.3 HEAD ...` | Stage 3에서 `43438bcc61c9d4d193faeb1dbb0d877b6a71d9de` 기준 재실행 |
-
-Stage 3 local/rehearsal 검증 결과:
-
-| 영역 | 결과 | 비고 |
-|------|------|------|
-| Git 상태 | 통과 | `local/task301`, source 변경 전 clean |
-| Rust bridge lock | 통과 | `./scripts/build-rust-macos.sh --verify-lock` |
-| bundled studio asset | 통과 | source와 Release app bundle 모두 확인 |
-| Shared Swift boundary | 통과 | `./scripts/check-no-appkit.sh` |
-| Xcode project generation | 통과 | `xcodegen generate` |
-| Debug build | 통과 | sandbox DNS 실패 후 네트워크 허용 재실행 성공 |
-| Native renderer smoke | 통과 | `KTX.hwp`, `request.hwp`, `exam_kor.hwp` |
-| Release package build | 통과 | sandbox DNS 실패 후 네트워크 허용 재실행 성공 |
-| Release package universal slice | 통과 | app, Quick Look extension, Thumbnail extension 모두 `x86_64 arm64` |
-| Release package version | 통과 | app, Preview, Thumbnail 모두 `0.1.4 (10)` |
-| Release helper dry-run | 통과 | release notes template check 통과 |
-| Delta checklist | 통과 | `v0.1.3..HEAD`, candidate commit `43438bcc61c9d4d193faeb1dbb0d877b6a71d9de` |
-| Rehearsal DMG 생성 | 통과 | `./scripts/release.sh --skip-notarize 0.1.4` |
-| Rehearsal DMG verify | 통과 | `hdiutil verify build.noindex/release/alhangeul-macos-0.1.4-rehearsal.dmg` |
-
-Stage 4 이후 보강할 검증:
-
-- pre-public signed/notarized draft DMG smoke 확인
-- official stable public DMG, GitHub Release asset, stable Sparkle appcast, Pages deploy 확인
-- public installed app 기준 Finder Quick Look/Thumbnail smoke
-- About 창의 `rhwp v0.7.13 (b3e16ef)` 표시 확인
-- public DMG SHA256, Sparkle EdDSA signature, Homebrew Cask digest 기록
-
-Stage 3 local 산출물:
-
-| 산출물 | SHA256 |
-|--------|--------|
-| `build.noindex/release/alhangeul-macos-0.1.4.zip` | `d4e48e1378d22b333e7c494a4a6beefd5b57511a39d5f9b2d4f35e334ff5bb9b` |
-| `build.noindex/release/alhangeul-macos-0.1.4-rehearsal.dmg` | `24d3ce29183b277a79cacc4d051e4f02a81cd9f94eb64f4078edc7da4ec84a56` |
-
-## Release metadata
-
-| 대상 | 기준 |
+| 항목 | 세부 |
 |------|------|
-| App version | `v0.1.4` |
-| `CFBundleShortVersionString` | `0.1.4` |
-| `CFBundleVersion` | `10` |
-| `rhwp` core repository | `https://github.com/edwardkim/rhwp.git` |
-| rhwp core release tag | `v0.7.13` |
-| rhwp core commit | `b3e16ef212af81ef37d973ddb86d6816d3804642` |
-| bundled rhwp-studio release tag | `v0.7.13` |
-| bundled rhwp-studio commit | `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| 재현 샘플 | `samples/복학원서.hwp` |
+| PUA 보정 | CoreGraphics text path에서 `U+F012B`를 `(인)`으로 표시하고 `U+F081C` filler를 숨김 |
+| text shade/background sentinel | `TextStyle.shadeColor == 0xFFFFFFFF`를 실제 shade가 아닌 no-shade sentinel로 처리 |
+| 구현 경로 | `Sources/RhwpCoreBridge/CGTreeRenderer.swift` |
+| 적용 표면 | Quick Look preview, Finder thumbnail native/CoreGraphics renderer path |
+| 앱 viewer 경로 | HostApp viewer/editor는 WKWebView 기반 bundled `rhwp-studio` 경로를 유지 |
+| 관련 작업 | [#305](https://github.com/postmelee/alhangeul-macos/issues/305), [#307](https://github.com/postmelee/alhangeul-macos/issues/307), [#306](https://github.com/postmelee/alhangeul-macos/pull/306), [#308](https://github.com/postmelee/alhangeul-macos/pull/308) |
+
+## 포함된 rhwp
+
+| 항목 | 값 |
+|------|----|
+| `rhwp` core release tag | [`v0.7.13`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.13) |
+| `rhwp` core commit | `b3e16ef212af81ef37d973ddb86d6816d3804642` |
+| bundled `rhwp-studio` release tag | [`v0.7.13`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.13) |
+| bundled `rhwp-studio` commit | `b3e16ef212af81ef37d973ddb86d6816d3804642` |
 | core lock | `rhwp-core.lock` |
 | studio manifest | `Sources/HostApp/Resources/rhwp-studio/manifest.json` |
-| Third Party notices | `THIRD_PARTY_LICENSES.md`, `Sources/HostApp/Resources/Legal/THIRD_PARTY_LICENSES.md`, `Sources/HostApp/Resources/rhwp-studio/fonts/FONTS.md` |
 
-## Release execution gate
+## 실제 PR 목록
 
-public 배포 전에 다음 조건을 모두 만족해야 한다.
+이번 릴리즈는 public publish 이후 문구/운영 문서 정정까지 포함해 다음 PR로 진행됐다. 향후에는 post-publish 문구 정정과 release record/final report 갱신을 종료 정리 단일 단계로 모아 PR 수를 줄인다.
 
-- [ ] `local/task301` 변경을 `publish/task301` PR로 게시하고 `devel`에 merge
-- [ ] `devel`의 release candidate commit을 `main`에 반영하는 release PR 승인과 merge
-- [ ] `main`의 최종 release commit에 `v0.1.4` tag 생성
-- [ ] `Release Publish DMG` `draft=true`, `prerelease=false` 실행으로 pre-public signed/notarized DMG 생성
-- [ ] maintainer가 draft release asset 또는 Actions artifact DMG를 직접 설치 smoke 통과
-- [ ] GitHub Release body가 `scripts/ci/write-release-notes.sh` template 기준으로 생성됐는지 확인
-- [ ] `Release Publish DMG` `draft=false`, `prerelease=false` official stable publish 실행
-- [ ] public DMG `alhangeul-macos-0.1.4.dmg` SHA256 기록
-- [ ] stable Sparkle appcast의 `sparkle:shortVersionString=0.1.4`, `sparkle:version=10`, EdDSA signature 확인
-- [ ] public Pages `updates/v0.1.4.html`와 `appcast.xml` URL 확인
-- [ ] Homebrew Cask를 public DMG SHA256 기준으로 갱신하고 tap context 검증 후 사용자 설치 명령 공개
+| PR | base | 내용 |
+|----|------|------|
+| [#303](https://github.com/postmelee/alhangeul-macos/pull/303) | `devel` | `v0.1.4` source metadata, release communication, rehearsal 검증 |
+| [#304](https://github.com/postmelee/alhangeul-macos/pull/304) | `main` | 최초 `v0.1.4` release PR |
+| [#306](https://github.com/postmelee/alhangeul-macos/pull/306) | `devel` | #305 CoreGraphics PUA 표시 최소 보정 |
+| [#308](https://github.com/postmelee/alhangeul-macos/pull/308) | `devel` | #307 CoreGraphics text shade sentinel 보정 |
+| [#309](https://github.com/postmelee/alhangeul-macos/pull/309) | `main` | public publish 전 bugfix refresh |
+| [#310](https://github.com/postmelee/alhangeul-macos/pull/310) | `devel` | Homebrew Cask source를 `v0.1.4` public DMG 기준으로 갱신 |
+| [#311](https://github.com/postmelee/alhangeul-macos/pull/311) | `main` | Homebrew Cask source main sync |
+| [#312](https://github.com/postmelee/alhangeul-macos/pull/312) | `devel` | 이전 릴리즈 안내 banner 자동화 |
+| [#313](https://github.com/postmelee/alhangeul-macos/pull/313) | `main` | 이전 릴리즈 안내 자동화 main 반영 |
+| [#314](https://github.com/postmelee/alhangeul-macos/pull/314) | `devel` | Docs-only Pages XML tool 설치 보강 |
+| [#315](https://github.com/postmelee/alhangeul-macos/pull/315) | `main` | Docs-only Pages XML tool main 반영 |
+| [#316](https://github.com/postmelee/alhangeul-macos/pull/316) | `devel` | v0.1.4 Pages/GitHub Release 사용자 문구 보정 |
+| [#317](https://github.com/postmelee/alhangeul-macos/pull/317) | `main` | 사용자 문구 보정 main 반영 |
+| [#318](https://github.com/postmelee/alhangeul-macos/pull/318) | `devel` | GitHub Release 기술 세부 규칙 문서화 |
+| [#319](https://github.com/postmelee/alhangeul-macos/pull/319) | `main` | 기술 세부 규칙 main 반영 |
+| [#320](https://github.com/postmelee/alhangeul-macos/pull/320) | `devel` | release note heading을 `변경 요약`으로 정리 |
+| [#321](https://github.com/postmelee/alhangeul-macos/pull/321) | `main` | `변경 요약` heading main 반영 |
 
-## 알려진 제한 사항과 후속 이슈
+## 검증 결과
 
-- Quick Look preview와 Finder thumbnail은 native renderer 경로를 사용하고, 앱 viewer/editor는 WKWebView 기반 `rhwp-studio` 경로를 사용한다.
-- 일부 문서에서는 글꼴, 배치, 페이지 표현이 원본 한글 프로그램과 다르게 보일 수 있다.
-- HWPX 문서는 현재 직접 저장이 제한되어 HWP export 경로를 사용한다.
-- public DMG SHA256, appcast EdDSA signature, notarization result, Homebrew Cask digest는 Stage 2 source commit에 미리 단정하지 않는다.
-- upstream `rhwp v0.7.13`은 `exam_social` HWPX -> HWP 저장 시 odd-page header textbox height 잔여 이슈를 follow-up으로 분리했다.
+| 영역 | 결과 | 근거 |
+|------|------|------|
+| Source preflight | 통과 | Stage 3에서 version/build, `rhwp-core.lock`, bundled manifest, release helper dry-run 확인 |
+| Local rehearsal DMG | 통과 | `./scripts/release.sh --skip-notarize 0.1.4`, `hdiutil verify` 통과 |
+| Public Release workflow | 통과 | `Release Publish DMG` run `26710019767` success |
+| GitHub Release 상태 | 통과 | public, non-prerelease, `v0.1.4` tag |
+| Public DMG checksum | 통과 | `cf04cb23e9bd072d9852cc404d092824446c7177ffb23a9bf16d1d1438317c6b` |
+| Public DMG signing/notarization | 통과 | workflow와 설치본 검증에서 staple/Gatekeeper accepted 확인 |
+| App/extension version | 통과 | mounted app 기준 `0.1.4 (10)` |
+| Universal slice | 통과 | app/Quick Look/Thumbnail bundle `x86_64 arm64` |
+| Pages | 통과 | `updates/v0.1.4.html` 접근 가능, `변경 요약` heading 확인 |
+| Sparkle appcast | 통과 | `sparkle:shortVersionString=0.1.4`, `sparkle:version=10`, EdDSA signature 존재 |
+| Homebrew Cask | 통과 | `brew style`, `brew audit`, `brew audit --new`, install/uninstall smoke 통과 |
+| Public installed smoke | 통과 | 작업지시자가 public signed/notarized DMG 설치 후 Quick Look/Finder smoke 확인 |
 
-## Release communication checklist
+Sparkle public appcast의 최신 item은 다음 값을 제공한다.
 
-- [x] `CFBundleShortVersionString`을 `0.1.4`로 증가
-- [x] `CFBundleVersion`을 직전 public build `9`보다 큰 `10`으로 증가
-- [x] release rehearsal/publish workflow default version을 `0.1.4`로 정리
-- [x] release workflow `previous_release_ref`를 `v0.1.3`으로 정리
-- [x] release workflow `expected_rhwp_tag`를 `v0.7.13`으로 정리
-- [x] README release 요약 갱신
-- [x] `docs/updates/v0.1.4.html` 추가
-- [x] `docs/updates/index.html`에 v0.1.4 항목 추가
-- [x] `docs/index.html` 최신 다운로드 link 갱신
-- [x] local/rehearsal DMG 생성과 `hdiutil verify` 확인
-- [x] local/rehearsal app/preview/thumbnail universal slice 확인
-- [ ] installed candidate 기준 Finder Quick Look/Thumbnail smoke 확인
-- [ ] About 창의 `rhwp v0.7.13 (b3e16ef)` 표시 확인
-- [ ] public DMG 생성
-- [ ] Homebrew Cask `postmelee/tap/alhangeul` 공개와 install/uninstall smoke 확인
-- [ ] public DMG 안의 app/extension version이 `0.1.4 (10)`인지 확인
-- [ ] public DMG SHA256 기록
-- [ ] public GitHub Release URL과 latest 상태 확인
-- [ ] public `https://postmelee.github.io/alhangeul-macos/appcast.xml` stable item과 Sparkle EdDSA signature 확인
+| 항목 | 값 |
+|------|----|
+| title | `Alhangeul v0.1.4` |
+| release notes | https://postmelee.github.io/alhangeul-macos/updates/v0.1.4.html |
+| `sparkle:version` | `10` |
+| `sparkle:shortVersionString` | `0.1.4` |
+| enclosure URL | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.4/alhangeul-macos-0.1.4.dmg |
+| enclosure length | `153214843` |
+| `sparkle:minimumSystemVersion` | `12.0` |
+
+## Stage별 요약
+
+| Stage | 결과 |
+|-------|------|
+| Stage 1 | version/build, release workflow default, `rhwp v0.7.13` provenance 정렬 |
+| Stage 2 | README, Pages, release record, GitHub Release body 후보 작성 |
+| Stage 3 | source preflight, Debug/Release build, native renderer smoke, local rehearsal DMG 검증 |
+| Stage 4 | `devel -> main`, tag 생성, draft signed/notarized DMG 생성, public 설치 smoke |
+| Stage 5 | official publish, GitHub Release/Pages/Sparkle/Homebrew public surface 검증 |
+| 종료 정리 | GitHub Release 기술 세부 보강, release record와 최종 보고서 완료 상태 정리, post-publish 문구 정정 PR 축소 규칙 문서화 |
+
+## 잔여 한계와 후속 판단
+
+| 항목 | 상태 |
+|------|------|
+| Quick Look/Thumbnail renderer 경로 | native/CoreGraphics 경로를 사용하므로 앱 viewer의 WKWebView/rhwp-studio 경로와 표시 차이가 남을 수 있다. |
+| PUA 보정 | 확인된 `복학원서.hwp` codepoint 두 개에 대한 최소 보정이다. 장기적으로는 PageLayerTree display text 소비 경로 전환이 더 적절하다. |
+| text shade sentinel | `0xFFFFFFFF`를 no-shade sentinel로 처리한다. 실제 흰색 shade 문서가 있을 가능성은 낮지만 이론적 잔여 리스크로 남긴다. |
+| 렌더링 fidelity | 일부 문서에서는 글꼴, 배치, 페이지 표현이 원본 한글 프로그램과 다르게 보일 수 있다. |
+| HWPX 직접 저장 | 현재 직접 저장이 제한되어 HWP export 경로를 사용한다. |
+| Intel Mac 실기기 smoke | universal slice와 Gatekeeper 검증은 통과했지만 별도 Intel 실기기 수동 smoke는 수행하지 않았다. |
+
+## 종료 처리
+
+- GitHub Release v0.1.4 본문은 사용자-facing 요약을 유지하고 하단에 `기술 세부` section을 추가했다.
+- 이 release record는 public 결과 기준으로 갱신했다.
+- 최종 보고서는 `mydocs/report/task_m900_301_report.md`에 작성했다.
+- 종료 정리 PR이 `main`에 merge된 뒤 #301 issue close와 `publish/task301` 로컬/원격 브랜치 정리를 수행한다.

--- a/mydocs/release/v0.1.5.md
+++ b/mydocs/release/v0.1.5.md
@@ -1,0 +1,166 @@
+# 알한글 v0.1.5 릴리즈 기록
+
+## 상태
+
+| 항목 | 값 |
+|------|----|
+| 상태 | `v0.1.5` build `11` source metadata 정렬 완료, release communication 후보 작성 중 |
+| 목표 Git tag | `v0.1.5` |
+| 목표 app version | `0.1.5` |
+| 목표 build | `11` |
+| 직전 public release | `v0.1.4` build `10` |
+| GitHub Release | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.5 |
+| Pages 릴리즈 노트 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.5.html |
+| Public DMG | `alhangeul-macos-0.1.5.dmg` 예정 |
+| Public DMG SHA256 | public workflow 결과 반영 예정 |
+| Homebrew Cask | public DMG SHA256 확정 후 별도 반영 예정 |
+| Release 실행 이슈 | [#351](https://github.com/postmelee/alhangeul-macos/issues/351) |
+
+이 문서는 `rhwp v0.7.15` 반영과 `v0.1.5` public release 후보의 source metadata, release communication, 검증 예정 항목을 기록한다. pre-public signed/notarized DMG smoke, official stable GitHub Release, stable Sparkle appcast, Pages 배포, Homebrew Cask 반영 결과는 release workflow와 별도 승인 단계가 끝난 뒤 같은 문서에 보강한다.
+
+## 사용자용 요약
+
+`v0.1.5`는 `rhwp v0.7.15` core/studio를 반영해 수식과 미주 흐름, HWPX 저장 호환성, 문단 정보 UI 후속 개선을 포함하는 patch release다. 앱 본체, Quick Look preview extension, Finder thumbnail extension은 `0.1.5 (11)` 기준으로 맞춘다.
+
+## 직전 공개 릴리즈 대비 변경점
+
+기준 범위는 `v0.1.4..release-candidate`다. 최종 release tag의 peeled commit은 `main` release PR merge와 `v0.1.5` tag 생성 후 확정한다.
+
+| 영역 | 변경 |
+|------|------|
+| Core/studio | #348/#349: `rhwp` core와 bundled `rhwp-studio`를 `v0.7.15` release tag와 commit `aa925a5954f0fd26dfcef2166cbce7877c481f44` 기준으로 갱신 |
+| Release metadata | #351: 앱/extension source version을 `0.1.5`, build를 `11`, release workflow default와 helper dry-run 기준을 `v0.1.5`/`v0.7.15`로 정리 |
+| Release communication | #351: README, Pages v0.1.5 릴리즈 노트, 내부 릴리즈 기록을 `rhwp v0.7.15` 기준으로 정리 |
+
+## GitHub Release 본문 구조 후보
+
+### 변경 요약
+
+- `rhwp` core와 bundled `rhwp-studio`를 `v0.7.15` 기준으로 갱신했다.
+- 수식 TAC 줄바꿈과 들여쓰기, 강제 줄바꿈 뒤 커서 이동, 미주 안 수식 배치 관련 upstream 보정을 포함했다.
+- HWPX 저장/내보내기에서 그림 회전·반전, 대각선 셀 테두리, 0바이트 필드 순서 보존 개선을 포함했다.
+- bundled viewer/editor의 문단 정보 대화상자가 왼쪽 여백과 내어쓰기 값을 분리해 다루도록 보강했다.
+- 앱 본체, Quick Look 미리보기, Finder 썸네일 extension을 `0.1.5 (11)` 기준 signed/notarized universal DMG로 배포한다.
+
+### 포함된 rhwp 변화
+
+- 포함된 `rhwp` core: [`v0.7.15`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.15) (`aa925a5954f0fd26dfcef2166cbce7877c481f44`)
+- bundled `rhwp-studio`: [`v0.7.15`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.15) (`aa925a5954f0fd26dfcef2166cbce7877c481f44`)
+- 수식 TAC-only line wrapping과 indent, 강제 줄바꿈 뒤 cursor movement, 미주 안 수식 script 렌더링/간격/위첨자 정렬 보정이 포함된다.
+- HWPX picture serialization의 flip/rotation/isEmbeded, 대각선 셀 테두리 `hh:slash`/`hh:backSlash`, zero-length field ordering 보존이 보강된다.
+- `rhwp-studio` 문단 정보 대화상자는 왼쪽 여백과 내어쓰기 binding을 분리한다.
+- upstream release에는 browser extension service worker document fetch path 보안 강화가 포함되지만, 알한글 macOS 앱은 별도 브라우저 확장 권한이나 네트워크 경로를 추가하지 않는다.
+
+### 알한글 앱 변화
+
+- 앱 본체와 Quick Look/Thumbnail extension의 source metadata를 `0.1.5 (11)`로 맞췄다.
+- release rehearsal/publish workflow의 기본 입력을 `v0.1.5`, 직전 공개 릴리즈 `v0.1.4`, expected `rhwp v0.7.15` 기준으로 정리했다.
+- About 창과 내부 provenance 정보는 bundled `rhwp v0.7.15` 기준을 표시한다.
+- README, Pages 업데이트 목록, Pages 홈 다운로드 링크, 내부 release index가 최신 후보 `v0.1.5`를 가리키도록 정리했다.
+- GitHub Release, Pages, Sparkle, Homebrew Cask가 같은 public DMG URL과 checksum을 가리키는지는 public publish 단계에서 검증한다.
+
+## 연결된 Issue/PR
+
+| Issue | PR | 상태 | 내용 |
+|-------|----|------|------|
+| [#348](https://github.com/postmelee/alhangeul-macos/issues/348) | [#349](https://github.com/postmelee/alhangeul-macos/pull/349) | merge 완료 | `rhwp v0.7.15` core/studio sync |
+| [#351](https://github.com/postmelee/alhangeul-macos/issues/351) | 예정 | 진행중 | `v0.1.5` release candidate 준비와 public release handoff |
+
+## 검증 기준
+
+Stage 3 기준 source-level 검증:
+
+| 영역 | 기준 | 상태 |
+|------|------|------|
+| App/extension version | HostApp, Preview, Thumbnail 모두 `0.1.5 (11)` | Stage 1에서 확인 |
+| Core lock | `rhwp_release_tag=v0.7.15`, commit `aa925a5954f0fd26dfcef2166cbce7877c481f44` | Stage 1에서 확인 |
+| Studio asset | bundled manifest `source_release_tag=v0.7.15`, `source_resolved_commit=aa925a5954f0fd26dfcef2166cbce7877c481f44` | Stage 1에서 확인 |
+| Release helper | `scripts/ci/write-release-notes.sh 0.1.5 ...` template check | Stage 2 dry-run, Stage 3 재확인 |
+| Pages release note | `docs/updates/v0.1.5.html` | Stage 2에서 확인 |
+| Delta checklist | `scripts/ci/write-release-delta-checklist.sh v0.1.4 HEAD ...` | Stage 2 dry-run, Stage 3 재확인 |
+
+Stage 3 이후 보강할 검증:
+
+- Rust bridge lock verify
+- bundled studio asset verify
+- Shared Swift boundary `scripts/check-no-appkit.sh`
+- Xcode project generation
+- Debug build
+- Release package build
+- local/rehearsal DMG 생성과 `hdiutil verify`
+- release package universal slice 확인
+- release package version 확인
+- native renderer smoke
+- HostApp viewer smoke
+
+Stage 4 이후 보강할 검증:
+
+- pre-public signed/notarized draft DMG smoke 확인
+- official stable public DMG, GitHub Release asset, stable Sparkle appcast, Pages deploy 확인
+- public installed app 기준 Finder Quick Look/Thumbnail smoke
+- About 창의 `rhwp v0.7.15 (aa925a5)` 표시 확인
+- public DMG SHA256, Sparkle EdDSA signature, Homebrew Cask digest 기록
+
+## Release metadata
+
+| 대상 | 기준 |
+|------|------|
+| App version | `v0.1.5` |
+| `CFBundleShortVersionString` | `0.1.5` |
+| `CFBundleVersion` | `11` |
+| `rhwp` core repository | `https://github.com/edwardkim/rhwp.git` |
+| rhwp core release tag | `v0.7.15` |
+| rhwp core commit | `aa925a5954f0fd26dfcef2166cbce7877c481f44` |
+| bundled rhwp-studio release tag | `v0.7.15` |
+| bundled rhwp-studio commit | `aa925a5954f0fd26dfcef2166cbce7877c481f44` |
+| core lock | `rhwp-core.lock` |
+| studio manifest | `Sources/HostApp/Resources/rhwp-studio/manifest.json` |
+| Third Party notices | `THIRD_PARTY_LICENSES.md`, `Sources/HostApp/Resources/Legal/THIRD_PARTY_LICENSES.md`, `Sources/HostApp/Resources/rhwp-studio/fonts/FONTS.md` |
+
+## Release execution gate
+
+public 배포 전에 다음 조건을 모두 만족해야 한다.
+
+- [ ] `local/task351` 변경을 `publish/task351` PR로 게시하고 `devel`에 merge
+- [ ] `devel`의 release candidate commit을 `main`에 반영하는 release PR 승인과 merge
+- [ ] `main`의 최종 release commit에 `v0.1.5` tag 생성
+- [ ] `Release Publish DMG` `draft=true`, `prerelease=false` 실행으로 pre-public signed/notarized DMG 생성
+- [ ] maintainer가 draft release asset 또는 Actions artifact DMG를 직접 설치 smoke 통과
+- [ ] GitHub Release body가 `scripts/ci/write-release-notes.sh` template 기준으로 생성됐는지 확인
+- [ ] `Release Publish DMG` `draft=false`, `prerelease=false` official stable publish 실행
+- [ ] public DMG `alhangeul-macos-0.1.5.dmg` SHA256 기록
+- [ ] stable Sparkle appcast의 `sparkle:shortVersionString=0.1.5`, `sparkle:version=11`, EdDSA signature 확인
+- [ ] public Pages `updates/v0.1.5.html`와 `appcast.xml` URL 확인
+- [ ] Homebrew Cask를 public DMG SHA256 기준으로 갱신하고 tap context 검증 후 사용자 설치 명령 공개
+
+## 알려진 제한 사항과 후속 이슈
+
+- Quick Look preview와 Finder thumbnail은 native renderer 경로를 사용하고, 앱 viewer/editor는 WKWebView 기반 `rhwp-studio` 경로를 사용한다.
+- 일부 문서에서는 글꼴, 배치, 페이지 표현이 원본 한글 프로그램과 다르게 보일 수 있다.
+- HWPX 문서는 현재 직접 저장이 제한되어 HWP export 경로를 사용한다.
+- public DMG SHA256, appcast EdDSA signature, notarization result, Homebrew Cask digest는 Stage 2 source commit에 미리 단정하지 않는다.
+- upstream browser extension 보안 강화는 같은 `rhwp v0.7.15` package에 포함된 변화이며, 알한글 macOS 앱의 신규 네트워크 기능이나 브라우저 확장 배포를 뜻하지 않는다.
+
+## Release communication checklist
+
+- [x] `CFBundleShortVersionString`을 `0.1.5`로 증가
+- [x] `CFBundleVersion`을 직전 public build `10`보다 큰 `11`로 증가
+- [x] release rehearsal/publish workflow default version을 `0.1.5`로 정리
+- [x] release workflow `previous_release_ref`를 `v0.1.4`로 정리
+- [x] release workflow `expected_rhwp_tag`를 `v0.7.15`로 정리
+- [x] README release 요약 갱신
+- [x] `docs/updates/v0.1.5.html` 추가
+- [x] `docs/updates/index.html`에 v0.1.5 항목 추가
+- [x] `docs/index.html` 최신 다운로드 link 갱신
+- [x] `mydocs/release/index.md`에 v0.1.5 후보와 v0.1.4 공개 완료 상태 반영
+- [x] `mydocs/release/v0.1.4.md`를 공개 완료 기록으로 정리
+- [ ] local/rehearsal DMG 생성과 `hdiutil verify` 확인
+- [ ] local/rehearsal app/preview/thumbnail universal slice 확인
+- [ ] installed candidate 기준 Finder Quick Look/Thumbnail smoke 확인
+- [ ] About 창의 `rhwp v0.7.15 (aa925a5)` 표시 확인
+- [ ] public DMG 생성
+- [ ] Homebrew Cask `postmelee/tap/alhangeul` 공개와 install/uninstall smoke 확인
+- [ ] public DMG 안의 app/extension version이 `0.1.5 (11)`인지 확인
+- [ ] public DMG SHA256 기록
+- [ ] public GitHub Release URL과 latest 상태 확인
+- [ ] public `https://postmelee.github.io/alhangeul-macos/appcast.xml` stable item과 Sparkle EdDSA signature 확인

--- a/mydocs/release/v0.1.5.md
+++ b/mydocs/release/v0.1.5.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.5` build `11` source metadata 정렬 완료, release communication 후보 작성 중 |
+| 상태 | `v0.1.5` build `11` source preflight와 local/rehearsal DMG 검증 완료, Stage 4 승인 대기 |
 | 목표 Git tag | `v0.1.5` |
 | 목표 app version | `0.1.5` |
 | 목표 build | `11` |
@@ -13,6 +13,10 @@
 | Pages 릴리즈 노트 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.5.html |
 | Public DMG | `alhangeul-macos-0.1.5.dmg` 예정 |
 | Public DMG SHA256 | public workflow 결과 반영 예정 |
+| Local package zip | `build.noindex/release/alhangeul-macos-0.1.5.zip` |
+| Local package zip SHA256 | `9f2420b9a6ffc6edadd10252e488d038b3f59c4397c25ad74b22eff283f706f3` |
+| Local rehearsal DMG | `build.noindex/release/alhangeul-macos-0.1.5-rehearsal.dmg` |
+| Local rehearsal DMG SHA256 | `190a171e0ee66079507aabe2f0b7939f1b43274a1dd85677b3ce1cad01a1078b` |
 | Homebrew Cask | public DMG SHA256 확정 후 별도 반영 예정 |
 | Release 실행 이슈 | [#351](https://github.com/postmelee/alhangeul-macos/issues/351) |
 
@@ -75,26 +79,40 @@ Stage 3 기준 source-level 검증:
 | App/extension version | HostApp, Preview, Thumbnail 모두 `0.1.5 (11)` | Stage 1에서 확인 |
 | Core lock | `rhwp_release_tag=v0.7.15`, commit `aa925a5954f0fd26dfcef2166cbce7877c481f44` | Stage 1에서 확인 |
 | Studio asset | bundled manifest `source_release_tag=v0.7.15`, `source_resolved_commit=aa925a5954f0fd26dfcef2166cbce7877c481f44` | Stage 1에서 확인 |
-| Release helper | `scripts/ci/write-release-notes.sh 0.1.5 ...` template check | Stage 2 dry-run, Stage 3 재확인 |
+| Release helper | `scripts/ci/write-release-notes.sh 0.1.5 ...` template check | Stage 2 dry-run, Stage 3 확인 |
 | Pages release note | `docs/updates/v0.1.5.html` | Stage 2에서 확인 |
-| Delta checklist | `scripts/ci/write-release-delta-checklist.sh v0.1.4 HEAD ...` | Stage 2 dry-run, Stage 3 재확인 |
+| Delta checklist | `scripts/ci/write-release-delta-checklist.sh v0.1.4 HEAD ...` | Stage 2 dry-run, Stage 3 확인 |
 
-Stage 3 이후 보강할 검증:
+Stage 3 local/rehearsal 검증 결과:
 
-- Rust bridge lock verify
-- bundled studio asset verify
-- Shared Swift boundary `scripts/check-no-appkit.sh`
-- Xcode project generation
-- Debug build
-- Release package build
-- local/rehearsal DMG 생성과 `hdiutil verify`
-- release package universal slice 확인
-- release package version 확인
-- native renderer smoke
-- HostApp viewer smoke
+| 영역 | 결과 | 비고 |
+|------|------|------|
+| Git 상태 | 통과 | `local/task351`, source 변경 전 clean |
+| Rust bridge strict lock verify | 실패 | `Frameworks/universal/librhwp.a` byte hash/size mismatch. lock은 수정하지 않음 |
+| Rust bridge source/header/ABI verify | 통과 | `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/build-rust-macos.sh --verify-lock` |
+| bundled studio asset | 통과 | source와 Release app bundle 모두 확인 |
+| Shared Swift boundary | 통과 | `./scripts/check-no-appkit.sh` |
+| Xcode project generation | 통과 | `xcodegen generate` |
+| Debug build | 통과 | sandbox DNS 실패 후 네트워크 허용 재실행 성공 |
+| Native renderer smoke | 통과 | `KTX.hwp`, `request.hwp`, `exam_kor.hwp` |
+| Release package build | 통과 | staticlib byte hash skip + sandbox DNS 실패 후 네트워크 허용 재실행 성공 |
+| Release package universal slice | 통과 | app, Quick Look extension, Thumbnail extension 모두 `x86_64 arm64` |
+| Release package version | 통과 | app, Preview, Thumbnail 모두 `0.1.5 (11)` |
+| Release helper dry-run | 통과 | release notes template check 통과 |
+| Delta checklist | 통과 | `v0.1.4..HEAD`, candidate commit `b6b85829dbfc7f6f0d3557d41d082e56e26532fa` |
+| Rehearsal DMG 생성 | 통과 | `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/release.sh --skip-notarize 0.1.5` |
+| Rehearsal DMG verify | 통과 | `hdiutil verify build.noindex/release/alhangeul-macos-0.1.5-rehearsal.dmg` |
+
+Stage 3 local 산출물:
+
+| 산출물 | 크기 | SHA256 |
+|--------|------|--------|
+| `build.noindex/release/alhangeul-macos-0.1.5.zip` | `153730298` bytes | `9f2420b9a6ffc6edadd10252e488d038b3f59c4397c25ad74b22eff283f706f3` |
+| `build.noindex/release/alhangeul-macos-0.1.5-rehearsal.dmg` | `153229477` bytes | `190a171e0ee66079507aabe2f0b7939f1b43274a1dd85677b3ce1cad01a1078b` |
 
 Stage 4 이후 보강할 검증:
 
+- HostApp viewer smoke
 - pre-public signed/notarized draft DMG smoke 확인
 - official stable public DMG, GitHub Release asset, stable Sparkle appcast, Pages deploy 확인
 - public installed app 기준 Finder Quick Look/Thumbnail smoke
@@ -154,8 +172,8 @@ public 배포 전에 다음 조건을 모두 만족해야 한다.
 - [x] `docs/index.html` 최신 다운로드 link 갱신
 - [x] `mydocs/release/index.md`에 v0.1.5 후보와 v0.1.4 공개 완료 상태 반영
 - [x] `mydocs/release/v0.1.4.md`를 공개 완료 기록으로 정리
-- [ ] local/rehearsal DMG 생성과 `hdiutil verify` 확인
-- [ ] local/rehearsal app/preview/thumbnail universal slice 확인
+- [x] local/rehearsal DMG 생성과 `hdiutil verify` 확인
+- [x] local/rehearsal app/preview/thumbnail universal slice 확인
 - [ ] installed candidate 기준 Finder Quick Look/Thumbnail smoke 확인
 - [ ] About 창의 `rhwp v0.7.15 (aa925a5)` 표시 확인
 - [ ] public DMG 생성

--- a/mydocs/working/task_m900_351_stage1.md
+++ b/mydocs/working/task_m900_351_stage1.md
@@ -1,0 +1,52 @@
+# Task M900 #351 Stage 1 완료보고서
+
+## 단계 요약
+
+`v0.1.5` public release candidate의 source metadata를 확정 후보값에 맞춰 정렬했다.
+
+| 항목 | 결과 |
+|------|------|
+| App version | `0.1.5` |
+| Build | `11` |
+| Previous release ref | `v0.1.4` |
+| Expected rhwp tag | `v0.7.15` |
+| rhwp commit | `aa925a5954f0fd26dfcef2166cbce7877c481f44` |
+
+## 변경 내용
+
+| 파일 | 변경 |
+|------|------|
+| `Sources/HostApp/Info.plist` | `CFBundleShortVersionString=0.1.5`, `CFBundleVersion=11` |
+| `Sources/QLExtension/Info.plist` | `CFBundleShortVersionString=0.1.5`, `CFBundleVersion=11` |
+| `Sources/ThumbnailExtension/Info.plist` | `CFBundleShortVersionString=0.1.5`, `CFBundleVersion=11` |
+| `.github/workflows/release-rehearsal.yml` | default `version=0.1.5`, `previous_release_ref=v0.1.4`, `expected_rhwp_tag=v0.7.15` |
+| `.github/workflows/release-publish.yml` | default `version=0.1.5`, `previous_release_ref=v0.1.4`, `expected_rhwp_tag=v0.7.15` |
+
+`rhwp-core.lock`과 bundled `rhwp-studio` manifest는 이미 `v0.7.15` / `aa925a5954f0fd26dfcef2166cbce7877c481f44` 기준이라 수정하지 않았다.
+
+## 검증 결과
+
+| 검증 | 결과 | 비고 |
+|------|------|------|
+| HostApp version/build 추출 | 통과 | `0.1.5`, `11` |
+| Quick Look extension version/build 추출 | 통과 | `0.1.5`, `11` |
+| Thumbnail extension version/build 추출 | 통과 | `0.1.5`, `11` |
+| `bash scripts/ci/read-rhwp-core-lock.sh rhwp_release_tag` | 통과 | `v0.7.15` |
+| `bash scripts/ci/read-rhwp-core-lock.sh rhwp_commit` | 통과 | `aa925a5954f0fd26dfcef2166cbce7877c481f44` |
+| `scripts/verify-rhwp-studio-assets.sh` | 통과 | bundled asset entrypoint hash 검증 |
+| `plutil -lint` | 통과 | HostApp, Quick Look, Thumbnail plist 모두 OK |
+| workflow YAML parse | 통과 | `release-rehearsal.yml`, `release-publish.yml` parse 성공 |
+| stale release defaults 검색 | 통과 | 변경 대상 파일에서 `v0.1.3`, `v0.7.13`, plist `0.1.4` 잔존 없음. `v0.1.4`는 의도된 `previous_release_ref`로만 남음 |
+| `git diff --check` | 통과 | whitespace 오류 없음 |
+
+## 남은 위험
+
+- `include_rhwp_in_title` 기본값은 이번 단계에서 바꾸지 않았다. `rhwp v0.7.15` 반영이 release title의 중심 표현인지 여부는 Stage 2 release communication에서 본문과 함께 다시 판단한다.
+- Stage 1은 metadata 정렬 단계다. Debug/Release build, Rust bridge strict verify, render smoke, rehearsal DMG는 Stage 3에서 실행한다.
+- public publish, GitHub Release, Pages/Sparkle, Homebrew는 아직 실행하지 않았다.
+
+## 다음 단계 요청
+
+Stage 2에서는 `mydocs/release/v0.1.5.md`, Pages release note, updates index, README 최신 요약 등 release communication을 작성하고, `devel`에 남아 있는 `v0.1.4` release record 후보 상태를 public 완료 결과와 충돌하지 않게 정리한다.
+
+Stage 2 진행 승인을 요청한다.

--- a/mydocs/working/task_m900_351_stage2.md
+++ b/mydocs/working/task_m900_351_stage2.md
@@ -1,0 +1,64 @@
+# Task M900 #351 Stage 2 완료 보고서
+
+## 단계 목표
+
+`v0.1.5` public release 후보의 사용자-facing release communication과 내부 release record를 `rhwp v0.7.15` 기준으로 정리했다. `devel`에 남아 있던 `v0.1.4` 후보 상태 기록은 public 완료 결과와 충돌하지 않도록 보정했다.
+
+## 변경 요약
+
+| 파일 | 변경 |
+|------|------|
+| `README.md` | 최신 공개 릴리즈 요약을 `v0.1.5`, `rhwp v0.7.15`, build `11` 기준으로 갱신 |
+| `docs/index.html` | 홈 화면 다운로드 버튼과 FAQ의 최신 DMG 문구를 `v0.1.5`로 갱신 |
+| `docs/updates/v0.1.5.html` | Pages 사용자용 릴리즈 노트 신규 작성 |
+| `docs/updates/index.html` | 최신 DMG 링크와 릴리즈 노트 목록에 `v0.1.5` 추가 |
+| `docs/updates/v0.1.0.html` ~ `docs/updates/v0.1.4.html` | 이전 릴리즈 안내 배너가 최신 `v0.1.5` 페이지를 가리키도록 자동 정규화 |
+| `mydocs/release/index.md` | `v0.1.5` 후보 항목 추가, `v0.1.4` 상태를 공개 완료로 보정 |
+| `mydocs/release/v0.1.4.md` | `main`의 public 완료 기록 기준으로 release record 보정 |
+| `mydocs/release/v0.1.5.md` | release decision record, GitHub Release body 후보, 검증 gate, 후속 항목 신규 작성 |
+
+## Release body 후보
+
+`mydocs/release/v0.1.5.md`에 GitHub Release 본문 후보를 다음 구조로 작성했다.
+
+- `변경 요약`: `rhwp v0.7.15` 반영, 수식/미주 흐름, HWPX 저장 호환성, 문단 정보 UI, `0.1.5 (11)` universal DMG 기준
+- `포함된 rhwp 변화`: core/studio tag와 commit, 수식 TAC/커서 이동/미주 수식, HWPX picture/diagonal border/field ordering, `rhwp-studio` 문단 정보 UI
+- `알한글 앱 변화`: source metadata, workflow default, About provenance, README/Pages/release index 정렬, public publish 단계의 checksum 검증 보류
+
+upstream browser extension 보안 강화는 같은 `rhwp v0.7.15` package에 포함된 변화로만 기록했다. 알한글 macOS 앱의 신규 브라우저 확장 권한이나 네트워크 기능으로 오해되지 않도록 Pages와 release record에 제한 문구를 함께 넣었다.
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| `scripts/ci/write-release-delta-checklist.sh v0.1.4 HEAD build.noindex/release/delta-checklist-0.1.5.md` | 통과 |
+| `scripts/ci/write-release-notes.sh 0.1.5 <64hex> build.noindex/release/release-notes-0.1.5.md` | 통과 |
+| `scripts/ci/check-release-notes-template.sh build.noindex/release/release-notes-0.1.5.md` | 통과 |
+| `scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check` | 통과 |
+| `rg -n "v0\\.1\\.5|0\\.1\\.5|v0\\.7\\.15|변경 요약|포함된 rhwp 변화|알한글 앱 변화|alhangeul-macos-0\\.1\\.5\\.dmg" ...` | 통과 |
+| `rg -n "최신 버전 v0\\.1\\.5|href=\"\\./v0\\.1\\.5\\.html\"" docs/updates/v0.1.0.html ... docs/updates/v0.1.4.html` | 통과 |
+| `git diff --check` | 통과 |
+
+`write-release-notes.sh` 최초 dry-run은 SHA256 자리표시자 길이 입력 오류로 실패했고, 64자리 hex 자리표시자로 즉시 재실행해 통과했다. 이는 source 변경이나 release helper 결함이 아니라 검증 명령 입력값 문제다.
+
+## 산출물
+
+- `docs/updates/v0.1.5.html`
+- `mydocs/release/v0.1.5.md`
+- `mydocs/working/task_m900_351_stage2.md`
+- 검증 dry-run 산출물:
+  - `build.noindex/release/delta-checklist-0.1.5.md`
+  - `build.noindex/release/release-notes-0.1.5.md`
+
+`build.noindex/` 산출물은 git에 포함하지 않는다.
+
+## 후속 단계로 넘길 항목
+
+- Stage 3에서 `v0.1.4..HEAD` delta checklist를 Stage 2 commit 포함 상태로 다시 생성한다.
+- Stage 3에서 source preflight, Debug/Release build, release package, local/rehearsal DMG 검증을 수행한다.
+- public DMG SHA256, Sparkle EdDSA signature, notarization 결과, Homebrew Cask digest는 Stage 4/5 public publish 이후에만 기록한다.
+- `Casks/alhangeul.rb`는 public DMG SHA256 확정 전에는 변경하지 않는다.
+
+## 다음 승인 요청
+
+Stage 3: Source Preflight와 Rehearsal 진행 승인을 요청한다.

--- a/mydocs/working/task_m900_351_stage3.md
+++ b/mydocs/working/task_m900_351_stage3.md
@@ -1,0 +1,82 @@
+# Task M900 #351 Stage 3 완료 보고서
+
+## 단계 목표
+
+`v0.1.5` release candidate source가 Rust/core provenance, bundled asset, Swift boundary, Debug/Release build, native render smoke, release package, rehearsal DMG 기준을 통과하는지 검증했다.
+
+## 실행 결과 요약
+
+| 영역 | 결과 | 비고 |
+|------|------|------|
+| Git 상태 | 통과 | `local/task351`, 시작/종료 시 source 변경 외 작업 트리 clean |
+| Rust bridge strict verify | 실패 | `Frameworks/universal/librhwp.a` byte hash/size mismatch |
+| Rust bridge source/header/ABI verify | 통과 | `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1` 사용, lock은 수정하지 않음 |
+| bundled `rhwp-studio` asset | 통과 | source와 Release app bundle 모두 확인 |
+| Shared Swift boundary | 통과 | AppKit/UIKit 직접 의존 없음 |
+| Xcode project generation | 통과 | `xcodegen generate` |
+| Debug build | 통과 | Sparkle package resolve 때문에 네트워크 허용 재실행 |
+| Native renderer smoke | 통과 | `KTX.hwp`, `request.hwp`, `exam_kor.hwp` |
+| Release package | 통과 | Sparkle package resolve 때문에 네트워크 허용 재실행 |
+| Universal slice | 통과 | app, Quick Look extension, Thumbnail extension 모두 `x86_64 arm64` |
+| Release package version | 통과 | app, Preview, Thumbnail 모두 `0.1.5 (11)` |
+| Rehearsal DMG | 통과 | unsigned, non-notarized local rehearsal artifact |
+| Release helper dry-run | 통과 | release notes template check 통과 |
+| Delta checklist | 통과 | `v0.1.4..HEAD`, candidate `b6b85829dbfc7f6f0d3557d41d082e56e26532fa` |
+
+## 주요 명령
+
+| 명령 | 결과 |
+|------|------|
+| `./scripts/build-rust-macos.sh --verify-lock` | 실패: `librhwp.a` byte hash/size mismatch |
+| `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/build-rust-macos.sh --verify-lock` | 통과 |
+| `scripts/verify-rhwp-studio-assets.sh` | 통과 |
+| `./scripts/check-no-appkit.sh` | 통과 |
+| `xcodegen generate` | 통과 |
+| `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData CODE_SIGNING_ALLOWED=NO build` | 통과 |
+| `./scripts/validate-stage3-render.sh` | 통과 |
+| `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/package-release.sh 0.1.5` | 통과 |
+| `scripts/ci/verify-universal-macos-app.sh build.noindex/release/Alhangeul.app` | 통과 |
+| `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/release.sh --skip-notarize 0.1.5` | 통과 |
+| `hdiutil verify build.noindex/release/alhangeul-macos-0.1.5-rehearsal.dmg` | 통과 |
+| `scripts/ci/write-release-delta-checklist.sh v0.1.4 HEAD build.noindex/release/delta-checklist-0.1.5.md` | 통과 |
+| `scripts/ci/write-release-notes.sh 0.1.5 <64hex> build.noindex/release/release-notes-0.1.5.md` | 통과 |
+| `scripts/ci/check-release-notes-template.sh build.noindex/release/release-notes-0.1.5.md` | 통과 |
+| `scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check` | 통과 |
+| `git diff --check` | 통과 |
+
+## 산출물
+
+| 산출물 | 크기 | SHA256 |
+|--------|------|--------|
+| `build.noindex/release/alhangeul-macos-0.1.5.zip` | `153730298` bytes | `9f2420b9a6ffc6edadd10252e488d038b3f59c4397c25ad74b22eff283f706f3` |
+| `build.noindex/release/alhangeul-macos-0.1.5-rehearsal.dmg` | `153229477` bytes | `190a171e0ee66079507aabe2f0b7939f1b43274a1dd85677b3ce1cad01a1078b` |
+| `build.noindex/release/delta-checklist-0.1.5.md` | git 제외 | release delta checklist draft |
+| `build.noindex/release/release-notes-0.1.5.md` | git 제외 | GitHub Release body template dry-run |
+
+`build.noindex/` 산출물은 git에 포함하지 않는다.
+
+## 특이 사항
+
+`./scripts/build-rust-macos.sh --verify-lock`의 strict staticlib byte hash 검증은 실패했다.
+
+| 항목 | 값 |
+|------|----|
+| expected sha256 | `6049b39c078a4c59a4efe0e39c71fc557cf178aa02fe847f7d0c21902aeff62f` |
+| actual sha256 | `e2b328dc3f4dfc1fdd5cc250ab988724dd9b1795a07814774c7a843117608bc5` |
+| expected size | `200925744` |
+| actual size | `200888664` |
+
+스크립트 안내와 `build_run_guide.md` 정책에 따라 이 값만으로 `rhwp-core.lock`을 갱신하지 않았다. 대신 `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`을 사용해 source provenance, `Cargo.lock`, generated header, FFI symbol set 검증을 유지했고 해당 검증은 통과했다. Stage 4/CI에서 GitHub-hosted release workflow가 같은 정책으로 통과하는지 별도 확인해야 한다.
+
+Debug build, Release package, rehearsal DMG 최초 시도는 sandbox DNS 제한으로 Sparkle package resolve에 실패했고, 네트워크 허용 재실행에서 통과했다.
+
+## 후속 단계로 넘길 항목
+
+- Stage 4에서 `devel -> main` release PR 범위와 candidate commit을 확정한다.
+- Stage 4에서 `v0.1.5` tag 생성과 pre-public signed/notarized draft DMG는 별도 승인 후 진행한다.
+- Stage 4/5에서 public DMG SHA256, notarization/staple/Gatekeeper, Sparkle appcast, Pages deploy, Homebrew Cask digest를 확정한다.
+- HostApp viewer smoke와 public 설치본 Finder Quick Look/Thumbnail smoke는 signed/notarized draft 또는 public DMG 기준으로 분리해 확인한다.
+
+## 다음 승인 요청
+
+Stage 4: Main/Tag/Pre-public Smoke와 Official Publish Gate 진행 승인을 요청한다.


### PR DESCRIPTION
## 요약

Related: #351

`v0.1.5` public release candidate source와 release communication을 `rhwp v0.7.15` 기준으로 정렬합니다.

## 포함 범위

- 앱/Quick Look/Thumbnail extension version을 `0.1.5 (11)`로 정렬
- release rehearsal/publish workflow default를 `version=0.1.5`, `previous_release_ref=v0.1.4`, `expected_rhwp_tag=v0.7.15`로 갱신
- README, Pages 업데이트 문서, release record를 `v0.1.5` 기준으로 갱신
- `v0.1.4` 내부 release record를 public 완료 결과와 충돌하지 않게 보정
- Stage 3 source preflight, Release package, local rehearsal DMG 검증 결과 기록

## 검증

- `scripts/verify-rhwp-studio-assets.sh`
- `./scripts/check-no-appkit.sh`
- `xcodegen generate`
- `xcodebuild -project Alhangeul.xcodeproj -scheme HostApp -configuration Debug -derivedDataPath build.noindex/DerivedData CODE_SIGNING_ALLOWED=NO build`
- `./scripts/validate-stage3-render.sh`
- `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/package-release.sh 0.1.5`
- `scripts/ci/verify-universal-macos-app.sh build.noindex/release/Alhangeul.app`
- `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/release.sh --skip-notarize 0.1.5`
- `hdiutil verify build.noindex/release/alhangeul-macos-0.1.5-rehearsal.dmg`
- `scripts/ci/check-release-notes-template.sh build.noindex/release/release-notes-0.1.5.md`
- `scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check`
- `git diff --check`

## 검증 메모

로컬 strict staticlib byte hash 검증은 `Frameworks/universal/librhwp.a` hash/size mismatch로 실패했습니다. `rhwp-core.lock`은 수정하지 않았고, 문서화된 정책에 따라 staticlib byte hash만 제외한 `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1` 검증으로 source provenance, `Cargo.lock`, generated header, FFI symbol set 검증을 유지했습니다.

## 다음 gate

이 PR이 `devel`에 반영된 뒤 `devel -> main` release PR, `v0.1.5` tag, pre-public signed/notarized draft DMG smoke는 각각 별도 승인 gate로 진행합니다.