### PR TITLE
Task #351: v0.1.5 release note public 문구 보정

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
 - GitHub Release: [Alhangeul v0.1.5](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.5)
 - 업데이트 페이지: [알한글 v0.1.5](https://postmelee.github.io/alhangeul-macos/updates/v0.1.5.html)
-- Homebrew Cask: `brew install --cask postmelee/tap/alhangeul`
+- Homebrew Cask: public DMG SHA256 확정 후 별도 배포 단계에서 반영
 - 포함된 `rhwp`: [`v0.7.15`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.15) (`rhwp-core.lock`, bundled `rhwp-studio` manifest 기준)
 - Sparkle update 기준: short version은 `0.1.5`, build는 `11`입니다.
 
@@ -178,11 +178,7 @@ WKWebView 경로는 native macOS shell이 충분히 안정화될 때까지 fallb
 
 공개 배포 기준은 Developer ID로 서명하고 Apple notarization을 통과한 DMG입니다. GitHub Release에는 `alhangeul-macos-<version>.dmg`와 checksum을 함께 공개합니다. `v0.1.1`부터 공식 DMG는 앱 본체와 Quick Look/Thumbnail extension 실행 파일이 `arm64 + x86_64` slice를 포함하는 단일 universal DMG 기준으로 검증합니다. Intel Mac과 Apple Silicon Mac 모두 같은 파일을 받으며, 아키텍처별 DMG는 따로 제공하지 않습니다.
 
-Homebrew Cask로 설치할 수도 있습니다.
-
-```bash
-brew install --cask postmelee/tap/alhangeul
-```
+Homebrew Cask는 public DMG SHA256 확정 후 별도 배포 단계에서 반영합니다. 최신 버전 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.
 
 설치 후에는 `Alhangeul.app`을 한 번 실행하세요. macOS가 Quick Look 및 Thumbnail extension을 발견하고 등록한 뒤 Finder에서 `.hwp`, `.hwpx` preview와 thumbnail을 사용할 수 있습니다.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -206,7 +206,7 @@
           <p>상단 다운로드 버튼은 최신 공식 릴리즈의 DMG 파일을 바로 내려받도록 연결됩니다. v0.1.5 공식 DMG도 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다. 파일이 준비되지 않았거나 이전 버전이
             필요하면 <a href="https://github.com/postmelee/alhangeul-macos/releases/latest" target="_blank"
               rel="noreferrer">GitHub Releases</a>에서 배포 상태를 확인할 수 있습니다.</p>
-          <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>
+          <p>Homebrew Cask는 별도 배포 단계에서 최신 DMG 기준으로 반영합니다. 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.</p>
         </details>
         <details>
           <summary>앱 업데이트는 어떻게 확인하나요?</summary>

--- a/docs/updates/index.html
+++ b/docs/updates/index.html
@@ -66,8 +66,7 @@
 
       <section class="updates-section" aria-labelledby="homebrew-title">
         <h2 id="homebrew-title">Homebrew Cask</h2>
-        <p>Homebrew를 사용하는 경우 maintainer tap에서 최신 public DMG 기준 Cask를 설치할 수 있습니다.</p>
-        <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>
+        <p>Homebrew Cask는 GitHub Release DMG 공개 뒤 별도 배포 단계에서 반영합니다. 최신 v0.1.5가 필요하면 위 DMG 다운로드를 사용하세요.</p>
       </section>
 
       <section class="updates-section" aria-labelledby="release-notes-title">

--- a/docs/updates/v0.1.5.html
+++ b/docs/updates/v0.1.5.html
@@ -65,7 +65,7 @@
           <li>수식 줄바꿈과 들여쓰기, 강제 줄바꿈 뒤 커서 이동, 미주 안 수식 배치 관련 upstream 보정을 포함했습니다.</li>
           <li>HWPX 저장/내보내기에서 그림 회전·반전, 대각선 셀 테두리, 0바이트 필드 순서 보존 개선을 포함했습니다.</li>
           <li>bundled viewer/editor의 문단 정보 대화상자가 왼쪽 여백과 내어쓰기 값을 분리해 다루도록 보강했습니다.</li>
-          <li>앱 본체, Quick Look 미리보기, Finder 썸네일 extension을 <code>0.1.5 (11)</code> 기준 signed/notarized universal DMG로 배포합니다.</li>
+          <li>공식 DMG는 Intel Mac과 Apple Silicon Mac을 모두 지원하는 signed/notarized universal DMG입니다.</li>
         </ul>
       </section>
 
@@ -84,10 +84,9 @@
       <section class="updates-section" aria-labelledby="release-app-title">
         <h2 id="release-app-title">알한글 앱 변화</h2>
         <ul>
-          <li>앱 본체와 Quick Look/Thumbnail extension의 source metadata를 <code>0.1.5 (11)</code>로 맞췄습니다.</li>
-          <li>release rehearsal/publish workflow의 기본 입력을 <code>v0.1.5</code>, 직전 공개 릴리즈 <code>v0.1.4</code>, expected <code>rhwp v0.7.15</code> 기준으로 정리했습니다.</li>
-          <li>About 창과 내부 provenance 정보는 bundled <code>rhwp v0.7.15</code> 기준을 표시합니다.</li>
-          <li>GitHub Release, Pages, Sparkle, Homebrew Cask가 같은 public DMG URL과 checksum을 가리키도록 후속 배포 단계에서 검증합니다.</li>
+          <li>이번 릴리즈의 앱 자체 신규 기능은 크지 않습니다. 핵심 변화는 <code>rhwp v0.7.15</code> 문서 처리 개선을 앱 화면, Quick Look 미리보기, Finder 썸네일 경로에 반영한 것입니다.</li>
+          <li>About 창에서 bundled <code>rhwp v0.7.15</code> 기준을 확인할 수 있습니다.</li>
+          <li>설치본은 <code>0.1.5 (11)</code> signed/notarized universal DMG로 배포됩니다.</li>
         </ul>
       </section>
 
@@ -103,8 +102,7 @@
       <section class="updates-section" aria-labelledby="release-install-title">
         <h2 id="release-install-title">설치와 업데이트</h2>
         <p>DMG 파일을 내려받아 앱을 Applications 폴더로 옮긴 뒤, 앱을 한 번 실행합니다. v0.1.5 공식 DMG는 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다.</p>
-        <p>Homebrew Cask를 사용하는 경우 아래 명령으로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
-        <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>
+        <p>Homebrew Cask 반영은 별도 배포 단계에서 진행합니다. 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.</p>
         <p>설치한 앱에서는 메뉴 막대의 <code>알한글 &gt; 업데이트 확인...</code>을 선택해 새 버전을 확인할 수 있습니다.</p>
       </section>
     </div>

--- a/mydocs/release/v0.1.5.md
+++ b/mydocs/release/v0.1.5.md
@@ -4,15 +4,15 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.5` build `11` source preflight와 local/rehearsal DMG 검증 완료, Stage 4 승인 대기 |
+| 상태 | `v0.1.5` build `11` public GitHub Release와 Pages/Sparkle 배포 완료, Homebrew Cask 별도 반영 대기 |
 | 목표 Git tag | `v0.1.5` |
 | 목표 app version | `0.1.5` |
 | 목표 build | `11` |
 | 직전 public release | `v0.1.4` build `10` |
 | GitHub Release | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.5 |
 | Pages 릴리즈 노트 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.5.html |
-| Public DMG | `alhangeul-macos-0.1.5.dmg` 예정 |
-| Public DMG SHA256 | public workflow 결과 반영 예정 |
+| Public DMG | `alhangeul-macos-0.1.5.dmg` |
+| Public DMG SHA256 | `d347c13b80aeaa006776db7ae2b00f8a2d11836c94757165f4bb87a331dd585b` |
 | Local package zip | `build.noindex/release/alhangeul-macos-0.1.5.zip` |
 | Local package zip SHA256 | `9f2420b9a6ffc6edadd10252e488d038b3f59c4397c25ad74b22eff283f706f3` |
 | Local rehearsal DMG | `build.noindex/release/alhangeul-macos-0.1.5-rehearsal.dmg` |
@@ -20,11 +20,11 @@
 | Homebrew Cask | public DMG SHA256 확정 후 별도 반영 예정 |
 | Release 실행 이슈 | [#351](https://github.com/postmelee/alhangeul-macos/issues/351) |
 
-이 문서는 `rhwp v0.7.15` 반영과 `v0.1.5` public release 후보의 source metadata, release communication, 검증 예정 항목을 기록한다. pre-public signed/notarized DMG smoke, official stable GitHub Release, stable Sparkle appcast, Pages 배포, Homebrew Cask 반영 결과는 release workflow와 별도 승인 단계가 끝난 뒤 같은 문서에 보강한다.
+이 문서는 `rhwp v0.7.15` 반영과 `v0.1.5` public release의 source metadata, release communication, 검증 결과를 기록한다. pre-public signed/notarized DMG smoke, official stable GitHub Release, stable Sparkle appcast, Pages 배포는 완료됐다. Homebrew Cask 반영은 별도 승인 단계에서 진행한다.
 
 ## 사용자용 요약
 
-`v0.1.5`는 `rhwp v0.7.15` core/studio를 반영해 수식과 미주 흐름, HWPX 저장 호환성, 문단 정보 UI 후속 개선을 포함하는 patch release다. 앱 본체, Quick Look preview extension, Finder thumbnail extension은 `0.1.5 (11)` 기준으로 맞춘다.
+`v0.1.5`는 `rhwp v0.7.15` core/studio를 반영해 수식과 미주 흐름, HWPX 저장/내보내기 호환성, 문단 정보 UI 후속 개선을 포함하는 patch release다. 앱 화면, Quick Look preview extension, Finder thumbnail extension은 같은 bundled `rhwp v0.7.15` 기준 문서 처리 개선을 사용한다.
 
 ## 직전 공개 릴리즈 대비 변경점
 
@@ -40,11 +40,11 @@
 
 ### 변경 요약
 
-- `rhwp` core와 bundled `rhwp-studio`를 `v0.7.15` 기준으로 갱신했다.
-- 수식 TAC 줄바꿈과 들여쓰기, 강제 줄바꿈 뒤 커서 이동, 미주 안 수식 배치 관련 upstream 보정을 포함했다.
-- HWPX 저장/내보내기에서 그림 회전·반전, 대각선 셀 테두리, 0바이트 필드 순서 보존 개선을 포함했다.
-- bundled viewer/editor의 문단 정보 대화상자가 왼쪽 여백과 내어쓰기 값을 분리해 다루도록 보강했다.
-- 앱 본체, Quick Look 미리보기, Finder 썸네일 extension을 `0.1.5 (11)` 기준 signed/notarized universal DMG로 배포한다.
+- `rhwp v0.7.15`를 반영해 수식, 미주, HWPX 저장/내보내기 호환성 관련 개선을 포함했다.
+- 앱 화면, Finder Quick Look 미리보기, Finder 썸네일은 같은 `rhwp v0.7.15` 기반 문서 처리 개선을 사용한다.
+- HWPX 저장/내보내기에서 그림 회전·반전, 대각선 셀 테두리, 빈 필드 순서 보존 관련 호환성을 보강했다.
+- bundled viewer/editor의 문단 정보 대화상자가 왼쪽 여백과 내어쓰기 값을 더 분명히 구분하도록 개선했다.
+- 공식 DMG는 Intel Mac과 Apple Silicon Mac을 모두 지원하는 signed/notarized universal DMG다.
 
 ### 포함된 rhwp 변화
 
@@ -57,11 +57,10 @@
 
 ### 알한글 앱 변화
 
-- 앱 본체와 Quick Look/Thumbnail extension의 source metadata를 `0.1.5 (11)`로 맞췄다.
-- release rehearsal/publish workflow의 기본 입력을 `v0.1.5`, 직전 공개 릴리즈 `v0.1.4`, expected `rhwp v0.7.15` 기준으로 정리했다.
+- 이번 릴리즈의 앱 자체 신규 기능은 크지 않다. 핵심 변화는 `rhwp v0.7.15` 문서 처리 개선을 앱 화면, Quick Look 미리보기, Finder 썸네일 경로에 반영한 것이다.
 - About 창과 내부 provenance 정보는 bundled `rhwp v0.7.15` 기준을 표시한다.
-- README, Pages 업데이트 목록, Pages 홈 다운로드 링크, 내부 release index가 최신 후보 `v0.1.5`를 가리키도록 정리했다.
-- GitHub Release, Pages, Sparkle, Homebrew Cask가 같은 public DMG URL과 checksum을 가리키는지는 public publish 단계에서 검증한다.
+- 설치본은 `0.1.5 (11)` signed/notarized universal DMG로 배포한다.
+- Homebrew Cask는 public DMG SHA256 기준으로 별도 배포 단계에서 반영한다.
 
 ## 연결된 Issue/PR
 


### PR DESCRIPTION
## 요약

- v0.1.5 public Release body 직접 보정 결과와 같은 사용자-facing 문구로 Pages/README를 정렬합니다.
- v0.1.5 Pages의 알한글 앱 변화 section에서 내부 workflow/source metadata 설명을 제거하고, 사용자에게 보이는 변화만 짧게 남깁니다.
- Homebrew Cask는 아직 별도 배포 단계 전이므로 public 안내에서 최신 v0.1.5 설치 경로로 단정하지 않습니다.

## 검증

- gh release view v0.1.5 --json body
- scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check
- scripts/ci/prepare-pages-artifact.sh --docs-dir docs --appcast build.noindex/public-appcast-v0.1.5.xml --output-dir build.noindex/release/pages-artifact-check
- xmllint --noout build.noindex/public-appcast-v0.1.5.xml