### PR TITLE
Task #351: release note 링크와 앱 변화 규칙 보강

### DIFF
--- a/mydocs/manual/public_release_runbook.md
+++ b/mydocs/manual/public_release_runbook.md
@@ -212,7 +212,8 @@ signed/notarized DMG smoke는 public publish 전에 통과해야 하는 blocking
 사용자-facing release note 최종 확인:
 
 - `변경 요약`은 특정 샘플 문서명이나 issue 번호가 아니라 사용자가 보는 증상과 개선 결과로 일반화되어 있다.
-- `알한글 앱 변화`는 HostApp, Quick Look preview, Finder thumbnail, 설치, 업데이트처럼 앱 저장소가 소유한 사용자-visible 변화를 먼저 설명한다.
+- `알한글 앱 변화`는 HostApp, Quick Look preview, Finder thumbnail, 설치, 업데이트처럼 앱 저장소가 소유한 사용자-visible 변화를 먼저 설명한다. 앱 자체 신규 기능이 크지 않으면 1~2개 bullet로 짧게 쓰고, source metadata, workflow default, README/Pages 정렬, 단순 version bump를 사용자-facing 변화처럼 나열하지 않는다.
+- GitHub Release body에는 `mydocs/release/v<version>.md` 같은 실제 조회 가능한 상세 문서를 GitHub blob URL로 링크한다.
 - 구현 용어는 사용자 용어로 번역되어 있다. 예를 들어 PUA는 특수 문자/기호 표시, shade sentinel은 텍스트 배경/음영 표시처럼 설명한다.
 - GitHub Release에 샘플 파일명, PUA, sentinel, CoreGraphics, PR/Issue 같은 개발자/검증자용 정보가 필요하면 `기술 세부` 또는 `검증 세부` section으로 분리되어 있고, 요약보다 뒤에 있다.
 - Pages 업데이트 문서에는 기술 세부 section을 두지 않고, 해당 정보는 GitHub Release의 기술 세부 또는 내부 release record로 연결된다.

--- a/mydocs/manual/release_distribution_guide.md
+++ b/mydocs/manual/release_distribution_guide.md
@@ -134,6 +134,8 @@
 - [ ] release note에 `rhwp-core.lock`, `rhwp-studio` manifest, third-party notices 기준 기록
 - [ ] release note에 렌더링 경로, 알려진 한계, 수동 확인 항목 기록
 - [ ] release note의 주요 변경 사항이 `변경 요약`, `포함된 rhwp 변화`, `알한글 앱 변화`로 구분되어 있고 release owner가 실제 사용자-facing 내용으로 보정했는지 확인
+- [ ] GitHub Release note에 `mydocs/release/v<version>.md` 등 실제 조회 가능한 상세 문서가 GitHub blob URL로 링크되어 있는지 확인
+- [ ] `알한글 앱 변화`가 source metadata, workflow default, README/Pages 정렬, 단순 version bump 같은 운영 항목을 사용자-facing 변화처럼 나열하지 않는지 확인
 - [ ] release note template 필수 섹션 검증
 - [ ] 서명/공증 검증 완료
 - [ ] GitHub Release note 작성

--- a/mydocs/manual/release_github_pages_sparkle_guide.md
+++ b/mydocs/manual/release_github_pages_sparkle_guide.md
@@ -18,6 +18,7 @@
 - 릴리즈 상세 기록 `mydocs/release/v<version>.md`가 현재 release candidate 기준으로 갱신되었는가
 - 직전 public release 대비 delta checklist가 생성되고 release owner가 보정했는가
 - GitHub Release body의 `이번 버전의 주요 변경 사항`에 `변경 요약`, `포함된 rhwp 변화`, `알한글 앱 변화`가 실제 사용자-facing 내용으로 보정되었는가
+- GitHub Release body에 `mydocs/release/v<version>.md` 같은 실제 조회 가능한 상세 문서가 GitHub blob URL로 링크되어 있는가
 - 마지막 release candidate 변경, bugfix PR, draft signed/notarized DMG smoke 이후 official stable publish 전에 GitHub Release body와 Pages 업데이트 문서를 다시 검토했는가
 - `변경 요약`과 `알한글 앱 변화`가 특정 검증 샘플명, issue 번호, 내부 구현 용어가 아니라 사용자가 보는 증상과 개선 결과 중심으로 쓰였는가
 - GitHub Release title이 기본형 `Alhangeul v<version>`을 쓰는가, 또는 upstream `rhwp` 반영 중심 release라서 `(rhwp vX.Y.Z)` 병기 조건을 충족하는가
@@ -117,6 +118,7 @@ Release note에 포함할 내용:
 
 - Pages 업데이트 문서는 사용자용 안내 표면이다. 주요 변경, hero, 설치 안내에는 샘플 파일명, issue 번호, PR 번호, `PUA`, `sentinel`, `CoreGraphics` 같은 구현/검증 용어를 쓰지 않고 증상과 개선 결과로 일반화한다.
 - GitHub Release는 사용자와 개발자가 모두 보는 public 표면이다. `요약`과 `이번 버전의 주요 변경 사항`은 Pages와 같은 사용자-facing 표현을 쓰고, 샘플 파일명, 구현 용어, 관련 PR/Issue, 검증 fixture는 `기술 세부` 또는 `검증 세부` 같은 별도 section에만 둔다.
+- GitHub Release에는 `## 상세 문서` section을 두고 `mydocs/release/v<version>.md`, 필요 시 `mydocs/release/index.md`, Pages 릴리즈 노트처럼 실제 조회 가능한 문서를 링크한다. 저장소 문서는 plain code path만 쓰지 않고 `https://github.com/postmelee/alhangeul-macos/blob/main/...` 형식의 GitHub blob URL로 연결한다.
 - 내부 `mydocs/release/v<version>.md`는 release decision record다. 샘플 파일명, 재현 조건, 구현 용어, 검증 명령, workflow run, PR/Issue, SHA256, provenance를 가장 자세히 남긴다.
 - GitHub Release의 기술 세부 section은 사용자 요약보다 뒤에 둔다. 기술 세부가 없더라도 release body는 유효하지만, 앱 자체 렌더링 bugfix처럼 재현 샘플과 구현 경계가 중요한 release는 기술 세부를 두는 편을 우선한다.
 
@@ -133,7 +135,7 @@ public publish 이후 GitHub Release, Pages 업데이트 문서, release record,
 
 - `### 변경 요약`: 이번 릴리즈에서 달라진 점을 3~5개 bullet로 쓴다. `rhwp` 반영과 앱 자체 변경을 합쳐 사용자가 체감할 결과 중심으로 요약한다.
 - `### 포함된 rhwp 변화`: upstream `rhwp` core 또는 bundled `rhwp-studio` 변경 중 문서 열기, 렌더링, HWP/HWPX 호환성, viewer/editor 동작에 실제로 영향을 주는 내용을 적는다. upstream release note 전체를 복제하지 않는다.
-- `### 알한글 앱 변화`: HostApp, Quick Look, Finder thumbnail, 저장/공유/PDF/인쇄, 설치, 업데이트, About, DMG, Homebrew, Pages/Sparkle 등 앱 저장소가 소유한 변화를 적는다.
+- `### 알한글 앱 변화`: HostApp, Quick Look, Finder thumbnail, 저장/공유/PDF/인쇄, 설치, 업데이트처럼 앱 저장소가 소유하고 사용자가 체감하는 변화를 적는다. 앱 자체 신규 기능이나 동작 변화가 크지 않으면 "이번 릴리즈의 앱 자체 신규 기능은 크지 않으며, 핵심 변화는 bundled `rhwp` 문서 처리 개선을 앱/Quick Look/Finder 썸네일 경로에 반영한 것"처럼 1~2개 bullet로 짧게 쓴다. source metadata, workflow default, README/Pages 정렬, 단순 version bump, checksum 정렬은 사용자-facing 앱 변화로 쓰지 않는다.
 
 `rhwp` 버전이 직전 public release와 같으면 `포함된 rhwp 변화` heading은 유지하고 "이번 릴리즈에서 bundled `rhwp` core와 `rhwp-studio` 버전 변경은 없습니다."처럼 짧게 쓴다. upstream `rhwp` 반영이 release의 중심 사용자-facing 변화라면 title 병기 여부와 별개로 upstream release 링크, bundled tag/commit, 앱에서 확인한 영향을 함께 기록한다.
 

--- a/mydocs/release/v0.1.5.md
+++ b/mydocs/release/v0.1.5.md
@@ -40,27 +40,24 @@
 
 ### 변경 요약
 
-- `rhwp v0.7.15`를 반영해 수식, 미주, HWPX 저장/내보내기 호환성 관련 개선을 포함했다.
-- 앱 화면, Finder Quick Look 미리보기, Finder 썸네일은 같은 `rhwp v0.7.15` 기반 문서 처리 개선을 사용한다.
-- HWPX 저장/내보내기에서 그림 회전·반전, 대각선 셀 테두리, 빈 필드 순서 보존 관련 호환성을 보강했다.
-- bundled viewer/editor의 문단 정보 대화상자가 왼쪽 여백과 내어쓰기 값을 더 분명히 구분하도록 개선했다.
-- 공식 DMG는 Intel Mac과 Apple Silicon Mac을 모두 지원하는 signed/notarized universal DMG다.
+- `rhwp v0.7.15`를 반영해 수식, 미주, HWPX 저장/내보내기 호환성 관련 개선을 포함했습니다.
+- 앱 화면, Finder Quick Look 미리보기, Finder 썸네일은 같은 `rhwp v0.7.15` 기반 문서 처리 개선을 사용합니다.
+- HWPX 저장/내보내기에서 그림 회전·반전, 대각선 셀 테두리, 빈 필드 순서 보존 관련 호환성을 보강했습니다.
+- bundled viewer/editor의 문단 정보 대화상자가 왼쪽 여백과 내어쓰기 값을 더 분명히 구분하도록 개선했습니다.
+- 공식 DMG는 Intel Mac과 Apple Silicon Mac을 모두 지원하는 signed/notarized universal DMG입니다.
 
 ### 포함된 rhwp 변화
 
 - 포함된 `rhwp` core: [`v0.7.15`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.15) (`aa925a5954f0fd26dfcef2166cbce7877c481f44`)
 - bundled `rhwp-studio`: [`v0.7.15`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.15) (`aa925a5954f0fd26dfcef2166cbce7877c481f44`)
-- 수식 TAC-only line wrapping과 indent, 강제 줄바꿈 뒤 cursor movement, 미주 안 수식 script 렌더링/간격/위첨자 정렬 보정이 포함된다.
-- HWPX picture serialization의 flip/rotation/isEmbeded, 대각선 셀 테두리 `hh:slash`/`hh:backSlash`, zero-length field ordering 보존이 보강된다.
-- `rhwp-studio` 문단 정보 대화상자는 왼쪽 여백과 내어쓰기 binding을 분리한다.
-- upstream release에는 browser extension service worker document fetch path 보안 강화가 포함되지만, 알한글 macOS 앱은 별도 브라우저 확장 권한이나 네트워크 경로를 추가하지 않는다.
+- 수식 TAC-only line wrapping과 indent, 강제 줄바꿈 뒤 cursor movement, 미주 안 수식 script 렌더링/간격/위첨자 정렬 보정이 포함됩니다.
+- HWPX picture serialization의 flip/rotation/isEmbeded, 대각선 셀 테두리 `hh:slash`/`hh:backSlash`, zero-length field ordering 보존이 보강됩니다.
+- `rhwp-studio` 문단 정보 대화상자는 왼쪽 여백과 내어쓰기 binding을 분리합니다.
+- upstream release에는 browser extension service worker document fetch path 보안 강화가 포함되지만, 알한글 macOS 앱은 별도 브라우저 확장 권한이나 네트워크 경로를 추가하지 않습니다.
 
 ### 알한글 앱 변화
 
-- 이번 릴리즈의 앱 자체 신규 기능은 크지 않다. 핵심 변화는 `rhwp v0.7.15` 문서 처리 개선을 앱 화면, Quick Look 미리보기, Finder 썸네일 경로에 반영한 것이다.
-- About 창과 내부 provenance 정보는 bundled `rhwp v0.7.15` 기준을 표시한다.
-- 설치본은 `0.1.5 (11)` signed/notarized universal DMG로 배포한다.
-- Homebrew Cask는 public DMG SHA256 기준으로 별도 배포 단계에서 반영한다.
+- 이번 릴리즈의 앱 자체 신규 기능은 크지 않습니다. 핵심 변화는 `rhwp v0.7.15` 문서 처리 개선을 앱 화면, Quick Look 미리보기, Finder 썸네일 경로에 반영한 것입니다.
 
 ## 연결된 Issue/PR
 

--- a/scripts/ci/check-release-notes-template.sh
+++ b/scripts/ci/check-release-notes-template.sh
@@ -27,6 +27,7 @@ required_headings=(
   "## 지원 환경과 아키텍처"
   "## 설치 후 첫 실행과 Quick Look/Thumbnail 활성화 안내"
   "## 업데이트 확인 방법"
+  "## 상세 문서"
   "## 이번 버전의 주요 변경 사항"
   "### 변경 요약"
   "### 포함된 rhwp 변화"
@@ -49,6 +50,28 @@ for heading in "${required_headings[@]}"; do
 done
 
 if [ "$missing_count" -ne 0 ]; then
+  exit 1
+fi
+
+forbidden_texts=(
+  "Release owner는"
+  "release owner가 보정"
+  "보정합니다"
+  "초안"
+  "HostApp, Quick Look, Finder thumbnail, 저장/다른 이름 저장, PDF/인쇄/공유, 설치, 업데이트, About, DMG, Homebrew, Pages/Sparkle 변경"
+  "문서 전용 변경과 설치본 smoke가 필요한 변경은 release delta checklist에서 구분합니다"
+  "Homebrew Cask는 public DMG URL/SHA256과 tap context 검증을 통과했습니다"
+)
+
+for forbidden_text in "${forbidden_texts[@]}"; do
+  if grep -Fq "$forbidden_text" "$RELEASE_NOTES_FILE"; then
+    echo "ERROR: release notes contain placeholder or unverified public wording: $forbidden_text" >&2
+    exit 1
+  fi
+done
+
+if ! grep -Eq '\[`mydocs/release/v[0-9]+\.[0-9]+\.[0-9]+[^`]*\.md`\]\(https://github.com/[^)]*/blob/[^)]*/mydocs/release/v[0-9]+\.[0-9]+\.[0-9]+[^)]*\.md\)' "$RELEASE_NOTES_FILE"; then
+  echo "ERROR: release notes must link to the public mydocs/release/v<version>.md document" >&2
   exit 1
 fi
 

--- a/scripts/ci/write-release-notes.sh
+++ b/scripts/ci/write-release-notes.sh
@@ -29,6 +29,10 @@ DMG_URL="https://github.com/$REPOSITORY/releases/download/$TAG_NAME/$DMG_NAME"
 PAGES_RELEASE_NOTES_URL="https://postmelee.github.io/alhangeul-macos/updates/$TAG_NAME.html"
 APPCAST_URL="https://postmelee.github.io/alhangeul-macos/appcast.xml"
 RELEASE_DETAIL_DOC="mydocs/release/$TAG_NAME.md"
+RELEASE_INDEX_DOC="mydocs/release/index.md"
+SOURCE_DOC_BASE_URL="https://github.com/$REPOSITORY/blob/main"
+RELEASE_DETAIL_DOC_URL="$SOURCE_DOC_BASE_URL/$RELEASE_DETAIL_DOC"
+RELEASE_INDEX_DOC_URL="$SOURCE_DOC_BASE_URL/$RELEASE_INDEX_DOC"
 CORE_LOCK="rhwp-core.lock"
 
 if ! [[ "$VERSION" =~ ^[0-9]+[.][0-9]+[.][0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
@@ -48,9 +52,24 @@ STUDIO_MANIFEST="Sources/HostApp/Resources/rhwp-studio/manifest.json"
 THIRD_PARTY_NOTICES="THIRD_PARTY_LICENSES.md"
 FONT_NOTICES="Sources/HostApp/Resources/rhwp-studio/fonts/FONTS.md"
 
-for required_file in "$ROOT/$STUDIO_MANIFEST" "$ROOT/$THIRD_PARTY_NOTICES" "$ROOT/$FONT_NOTICES"; do
+for required_file in "$ROOT/$RELEASE_DETAIL_DOC" "$ROOT/$STUDIO_MANIFEST" "$ROOT/$THIRD_PARTY_NOTICES" "$ROOT/$FONT_NOTICES"; do
   if [ ! -f "$required_file" ]; then
     echo "ERROR: required release provenance file is missing: ${required_file#$ROOT/}" >&2
+    exit 1
+  fi
+done
+
+RELEASE_CHANGE_SECTIONS="$(
+  awk '
+    /^## GitHub Release 본문 구조 후보$/ { in_section = 1; next }
+    in_section && /^## / { exit }
+    in_section { print }
+  ' "$ROOT/$RELEASE_DETAIL_DOC" | sed '/./,$!d'
+)"
+
+for required_release_section in "### 변경 요약" "### 포함된 rhwp 변화" "### 알한글 앱 변화"; do
+  if ! grep -Fq "$required_release_section" <<<"$RELEASE_CHANGE_SECTIONS"; then
+    echo "ERROR: $RELEASE_DETAIL_DOC must contain $required_release_section under '## GitHub Release 본문 구조 후보'" >&2
     exit 1
   fi
 done
@@ -67,7 +86,7 @@ cat > "$OUTPUT_FILE" <<EOF
 
 - macOS 12 이상에서 HWP/HWPX 문서를 Finder Quick Look, Finder thumbnail, 알한글 앱으로 확인할 수 있습니다.
 - 공식 DMG는 Intel Mac과 Apple Silicon Mac을 모두 지원하는 단일 universal DMG입니다.
-- 이번 릴리스의 상세 변경과 검증 기록은 \`$RELEASE_DETAIL_DOC\`와 release delta checklist를 기준으로 관리합니다.
+- 이번 릴리스의 상세 변경과 검증 기록은 [\`$RELEASE_DETAIL_DOC\`]($RELEASE_DETAIL_DOC_URL)와 release delta checklist를 기준으로 관리합니다.
 - 설치, 첫 실행, 업데이트 확인, 알려진 제한 사항을 먼저 확인한 뒤 DMG를 내려받으세요.
 
 ## 설치 방법
@@ -98,26 +117,15 @@ cat > "$OUTPUT_FILE" <<EOF
 - 업데이트 feed: \`$APPCAST_URL\`
 - 버전별 Pages 릴리즈 노트: $PAGES_RELEASE_NOTES_URL
 
+## 상세 문서
+
+- 릴리즈 상세 기록: [\`$RELEASE_DETAIL_DOC\`]($RELEASE_DETAIL_DOC_URL)
+- 릴리즈 기록 index: [\`$RELEASE_INDEX_DOC\`]($RELEASE_INDEX_DOC_URL)
+- 사용자용 Pages 릴리즈 노트: $PAGES_RELEASE_NOTES_URL
+
 ## 이번 버전의 주요 변경 사항
 
-### 변경 요약
-
-- Release owner는 직전 공개 릴리즈 대비 사용자가 체감할 변경을 3~5개 bullet로 보정합니다.
-- \`rhwp\` 반영과 알한글 앱 자체 변경이 함께 만든 결과를 먼저 씁니다.
-- 자동 생성된 release delta checklist는 초안이며, 이 섹션의 사용자-facing 요약을 대체하지 않습니다.
-
-### 포함된 rhwp 변화
-
-- 포함된 \`rhwp\` core: [\`$RHWP_TAG\`]($RHWP_RELEASE_URL) (\`$RHWP_COMMIT\`)
-- bundled \`rhwp-studio\`: [\`$STUDIO_TAG\`]($STUDIO_RELEASE_URL) (\`$STUDIO_COMMIT\`)
-- Upstream \`rhwp\` 또는 bundled \`rhwp-studio\` 변경 중 문서 열기, 렌더링, HWP/HWPX 호환성, viewer/editor 동작에 영향을 주는 내용을 release owner가 보정합니다.
-- 직전 public release와 bundled \`rhwp\` 버전이 같으면 "이번 릴리즈에서 bundled \`rhwp\` core와 \`rhwp-studio\` 버전 변경은 없습니다."라고 짧게 적습니다.
-
-### 알한글 앱 변화
-
-- HostApp, Quick Look, Finder thumbnail, 저장/다른 이름 저장, PDF/인쇄/공유, 설치, 업데이트, About, DMG, Homebrew, Pages/Sparkle 변경을 release owner가 보정합니다.
-- 연결된 Issue/PR과 기여자는 \`$RELEASE_DETAIL_DOC\`의 릴리즈 상세 기록을 기준으로 확인합니다.
-- 문서 전용 변경과 설치본 smoke가 필요한 변경은 release delta checklist에서 구분합니다.
+$RELEASE_CHANGE_SECTIONS
 
 ## 다운로드 산출물과 SHA256
 
@@ -130,9 +138,9 @@ cat > "$OUTPUT_FILE" <<EOF
 
 ## Homebrew Cask
 
-- Homebrew Cask는 public DMG URL/SHA256과 tap context 검증을 통과했습니다.
-- 설치 명령: \`brew install --cask postmelee/tap/alhangeul\`
-- Homebrew Cask도 아키텍처별 URL을 나누지 않고 같은 public universal DMG URL과 SHA256을 사용합니다.
+- Homebrew Cask 반영은 별도 배포 단계에서 진행합니다.
+- Homebrew Cask 반영 전에는 위 GitHub Release DMG를 직접 내려받아 설치하세요.
+- Cask를 공개한 뒤에는 GitHub Release, Pages, README의 설치 명령과 SHA256 안내를 같은 값으로 맞춥니다.
 
 ## Release metadata
 
@@ -151,15 +159,15 @@ cat > "$OUTPUT_FILE" <<EOF
 - release publish workflow에서 서명, 공증, staple, Gatekeeper assessment, checksum 검증을 통과한 public DMG만 배포합니다.
 - \`hdiutil verify\`, SHA256 대조, app bundle signing/notarization/staple 검증 결과를 최종 확인합니다.
 - \`Alhangeul.app\`, \`AlhangeulPreview.appex\`, \`AlhangeulThumbnail.appex\`의 실행 파일이 \`arm64 + x86_64\` universal인지 확인합니다.
-- Finder Quick Look preview, Finder thumbnail, 앱 실행, 문서 열기, 창 resize/확대, Sparkle 수동 업데이트 확인 smoke 결과는 \`$RELEASE_DETAIL_DOC\`에 기록합니다.
-- 실행하지 않은 수동 확인 항목은 성공으로 쓰지 않고 #188 final smoke 또는 후속 확인으로 분리합니다.
+- Finder Quick Look preview, Finder thumbnail, 앱 실행, 문서 열기, 창 resize/확대, Sparkle 수동 업데이트 확인 smoke 결과는 [\`$RELEASE_DETAIL_DOC\`]($RELEASE_DETAIL_DOC_URL)에 기록합니다.
+- 실행하지 않은 수동 확인 항목은 성공으로 쓰지 않고 릴리즈 상세 기록의 미실행 또는 후속 확인 항목으로 분리합니다.
 
 ## 릴리즈 delta 기반 추가 확인 항목
 
 - 기준 범위는 직전 공개 release tag부터 현재 release candidate commit까지입니다.
-- merged PR, 연결된 Issue, commit range, 변경 파일 목록을 수집한 뒤 영향 영역별 smoke 항목을 보정합니다.
+- merged PR, 연결된 Issue, commit range, 변경 파일 목록을 수집한 뒤 영향 영역별 smoke 항목을 릴리즈 상세 기록에 정리합니다.
 - 영향 영역 후보: HostApp viewer, Quick Look preview, Finder thumbnail, 저장/다른 이름 저장, PDF/인쇄/공유, Sparkle/appcast/Pages, DMG/signing/notarization, Homebrew Cask, rhwp core/viewer asset provenance, 문서 전용 변경.
-- 자동 생성된 checklist는 초안이며 release owner가 누락/과잉 항목을 보정합니다.
+- 자동 생성된 checklist는 보조 자료이며 public 사용자-facing 요약을 대체하지 않습니다.
 
 ## 알려진 제한 사항과 후속 이슈
 
@@ -169,7 +177,7 @@ cat > "$OUTPUT_FILE" <<EOF
 - Quick Look/Thumbnail smoke 통과는 extension 등록과 기본 렌더 성공 확인이며, 모든 문서가 앱 화면과 같은 시각 결과로 보인다는 보장은 아닙니다.
 - 손상·대용량·미지원 문서 fallback은 복구가 아니라 앱과 extension이 raw error, hang, crash로 끝나지 않게 하는 안전장치입니다.
 - native renderer의 style, image effect/fill, text layout, RawSvg/OLE 등 parity 개선은 v0.5 이후 Swift native viewer 범위에서 계속 다룹니다.
-- 후속 이슈는 \`$RELEASE_DETAIL_DOC\`와 GitHub Issue 상태를 기준으로 관리합니다.
+- 후속 이슈는 [\`$RELEASE_DETAIL_DOC\`]($RELEASE_DETAIL_DOC_URL)와 GitHub Issue 상태를 기준으로 관리합니다.
 
 ## Third Party notices
 


### PR DESCRIPTION
## 요약

- GitHub Release body에 실제 조회 가능한 릴리즈 상세 문서 링크를 포함하도록 release notes generator를 보강합니다.
- `mydocs/release/v<version>.md`의 `GitHub Release 본문 구조 후보`를 주요 변경 section 원천으로 사용해 placeholder가 public body로 나가지 않게 합니다.
- `알한글 앱 변화`가 source metadata, workflow default, 단순 version bump 같은 운영 항목을 나열하지 않도록 매뉴얼과 template check를 보강합니다.
- v0.1.5 release record 후보 문구를 현재 public body 기준으로 줄이고 정리합니다.

## 검증

- `bash -n scripts/ci/write-release-notes.sh scripts/ci/check-release-notes-template.sh`
- `scripts/ci/write-release-notes.sh 0.1.5 d347c13b80aeaa006776db7ae2b00f8a2d11836c94757165f4bb87a331dd585b build.noindex/release-notes-v0.1.5-generated-check.md`
- `scripts/ci/check-release-notes-template.sh build.noindex/release-notes-v0.1.5-generated-check.md`
- `git diff --check`
