### PR TITLE
Task #360: DMG 숨김 폴더 위치 보정

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -754,6 +754,12 @@ on run argv
 
     set position of item appName of volumeFolder to {178, 268}
     set position of item "Applications" of volumeFolder to {542, 268}
+    try
+      set position of item ".background" of volumeFolder to {68, 58}
+    end try
+    try
+      set position of item ".fseventsd" of volumeFolder to {652, 58}
+    end try
 
     update volumeFolder without registering applications
     delay 2


### PR DESCRIPTION
## 요약
- Finder 숨김 파일 표시가 켜진 상태에서도 DMG의 `.background`, `.fseventsd` 아이콘이 설치 안내 문구를 가리지 않도록 위치를 명시했습니다.
- 숨김 항목이 없거나 Finder가 노출하지 않는 환경에서도 실패하지 않도록 AppleScript `try` 블록으로 처리했습니다.

## 검증
- `bash -n scripts/release.sh`
- `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/release.sh --skip-notarize 0.1.6`
- rehearsal DMG `hdiutil verify` 통과
- `shasum -a 256 -c alhangeul-macos-0.1.6-rehearsal.dmg.sha256` 통과
- 마운트 후 Finder 좌표 확인: `.background` `95, 58`, `.fseventsd` `679, 58`

## 릴리스 주의
기존 `v0.1.6` tag와 draft signed DMG는 이 수정 전 산출물입니다. 이 PR merge 후에는 tag/draft DMG 재생성이 필요합니다.