### PR TITLE
Release: v0.1.6 DMG layout polish

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -754,6 +754,12 @@ on run argv
 
     set position of item appName of volumeFolder to {178, 268}
     set position of item "Applications" of volumeFolder to {542, 268}
+    try
+      set position of item ".background" of volumeFolder to {68, 58}
+    end try
+    try
+      set position of item ".fseventsd" of volumeFolder to {652, 58}
+    end try
 
     update volumeFolder without registering applications
     delay 2


### PR DESCRIPTION
## 요약
- v0.1.6 draft DMG smoke 중 Finder 숨김 파일 표시 상태에서 `.background`, `.fseventsd` 아이콘이 설치 안내 문구를 가리는 문제가 확인되었습니다.
- 숨김 폴더 좌표를 명시해 안내 문구와 설치 아이콘 영역을 피하도록 보정했습니다.

## 포함 PR
- #363 Task #360: DMG 숨김 폴더 위치 보정

## 검증
- `bash -n scripts/release.sh`
- `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/release.sh --skip-notarize 0.1.6`
- rehearsal DMG `hdiutil verify` 통과
- rehearsal DMG checksum 확인 통과
- 마운트 후 Finder 좌표 확인: `.background` `95, 58`, `.fseventsd` `679, 58`

## 릴리스 주의
현재 원격 `v0.1.6` tag와 draft signed DMG는 이 보정 전 커밋 기준입니다. 이 PR merge 후 `v0.1.6` tag와 draft DMG를 재생성해야 합니다.