### PR TITLE
Task #360: Homebrew Cask 배포 기록 갱신

### DIFF
--- a/Casks/alhangeul.rb
+++ b/Casks/alhangeul.rb
@@ -1,6 +1,6 @@
 cask "alhangeul" do
-  version "0.1.4"
-  sha256 "cf04cb23e9bd072d9852cc404d092824446c7177ffb23a9bf16d1d1438317c6b"
+  version "0.1.6"
+  sha256 "87e37549a569813a3e22606f497ce837b350243cf3fed2ccd286af3ab8b02b9a"
 
   url "https://github.com/postmelee/alhangeul-macos/releases/download/v#{version}/alhangeul-macos-#{version}.dmg"
   name "알한글"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
 - GitHub Release: [Alhangeul v0.1.6](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.6)
 - 업데이트 페이지: [알한글 v0.1.6](https://postmelee.github.io/alhangeul-macos/updates/v0.1.6.html)
-- Homebrew Cask: public DMG SHA256 확정 후 별도 배포 단계에서 반영
+- Homebrew Cask: `brew install --cask postmelee/tap/alhangeul`
 - 포함된 `rhwp`: [`v0.7.16`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.16) (`rhwp-core.lock`, bundled `rhwp-studio` manifest 기준)
 - Sparkle update 기준: short version은 `0.1.6`, build는 `12`입니다.
 
@@ -178,7 +178,13 @@ WKWebView 경로는 native macOS shell이 충분히 안정화될 때까지 fallb
 
 공개 배포 기준은 Developer ID로 서명하고 Apple notarization을 통과한 DMG입니다. GitHub Release에는 `alhangeul-macos-<version>.dmg`와 checksum을 함께 공개합니다. `v0.1.1`부터 공식 DMG는 앱 본체와 Quick Look/Thumbnail extension 실행 파일이 `arm64 + x86_64` slice를 포함하는 단일 universal DMG 기준으로 검증합니다. Intel Mac과 Apple Silicon Mac 모두 같은 파일을 받으며, 아키텍처별 DMG는 따로 제공하지 않습니다.
 
-Homebrew Cask는 public DMG SHA256 확정 후 별도 배포 단계에서 반영합니다. 최신 버전 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.
+Homebrew Cask를 사용하는 경우 아래 명령으로 같은 signed/notarized universal DMG를 설치할 수 있습니다.
+
+```bash
+brew install --cask postmelee/tap/alhangeul
+```
+
+Homebrew가 untrusted tap 정책으로 설치를 거부하면 `brew trust --cask postmelee/tap/alhangeul`을 한 번 실행한 뒤 다시 설치하세요.
 
 설치 후에는 `Alhangeul.app`을 한 번 실행하세요. macOS가 Quick Look 및 Thumbnail extension을 발견하고 등록한 뒤 Finder에서 `.hwp`, `.hwpx` preview와 thumbnail을 사용할 수 있습니다.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -206,7 +206,8 @@
           <p>상단 다운로드 버튼은 최신 공식 릴리즈의 DMG 파일을 바로 내려받도록 연결됩니다. v0.1.6 공식 DMG도 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다. 파일이 준비되지 않았거나 이전 버전이
             필요하면 <a href="https://github.com/postmelee/alhangeul-macos/releases/latest" target="_blank"
               rel="noreferrer">GitHub Releases</a>에서 배포 상태를 확인할 수 있습니다.</p>
-          <p>Homebrew Cask는 별도 배포 단계에서 최신 DMG 기준으로 반영합니다. 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.</p>
+          <p>Homebrew Cask를 사용하는 경우 <code>brew install --cask postmelee/tap/alhangeul</code>로 같은 signed/notarized universal DMG를 설치할 수 있습니다.
+            Homebrew가 untrusted tap 정책으로 설치를 거부하면 <code>brew trust --cask postmelee/tap/alhangeul</code>을 한 번 실행한 뒤 다시 설치하세요.</p>
         </details>
         <details>
           <summary>앱 업데이트는 어떻게 확인하나요?</summary>

--- a/docs/updates/index.html
+++ b/docs/updates/index.html
@@ -66,7 +66,9 @@
 
       <section class="updates-section" aria-labelledby="homebrew-title">
         <h2 id="homebrew-title">Homebrew Cask</h2>
-        <p>Homebrew Cask는 GitHub Release DMG 공개 뒤 별도 배포 단계에서 반영합니다. 최신 v0.1.6이 필요하면 위 DMG 다운로드를 사용하세요.</p>
+        <p>Homebrew Cask를 사용하는 경우 아래 명령으로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
+        <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>
+        <p>Homebrew가 untrusted tap 정책으로 설치를 거부하면 <code>brew trust --cask postmelee/tap/alhangeul</code>을 한 번 실행한 뒤 다시 설치하세요.</p>
       </section>
 
       <section class="updates-section" aria-labelledby="release-notes-title">

--- a/docs/updates/v0.1.6.html
+++ b/docs/updates/v0.1.6.html
@@ -104,7 +104,9 @@
       <section class="updates-section" aria-labelledby="release-install-title">
         <h2 id="release-install-title">설치와 업데이트</h2>
         <p>DMG 파일을 내려받아 앱을 Applications 폴더로 옮긴 뒤, 앱을 한 번 실행합니다. v0.1.6 공식 DMG는 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다.</p>
-        <p>Homebrew Cask 반영은 별도 배포 단계에서 진행합니다. 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.</p>
+        <p>Homebrew Cask를 사용하는 경우 아래 명령으로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
+        <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>
+        <p>Homebrew가 untrusted tap 정책으로 설치를 거부하면 <code>brew trust --cask postmelee/tap/alhangeul</code>을 한 번 실행한 뒤 다시 설치하세요.</p>
         <p>설치한 앱에서는 메뉴 막대의 <code>알한글 &gt; 업데이트 확인...</code>을 선택해 새 버전을 확인할 수 있습니다.</p>
       </section>
     </div>

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.6` | 후보 준비중 | [Alhangeul v0.1.6](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.6) | [v0.1.6](https://postmelee.github.io/alhangeul-macos/updates/v0.1.6.html) | [`v0.1.6.md`](v0.1.6.md) |
+| `v0.1.6` | 공개 완료 | [Alhangeul v0.1.6](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.6) | [v0.1.6](https://postmelee.github.io/alhangeul-macos/updates/v0.1.6.html) | [`v0.1.6.md`](v0.1.6.md) |
 | `v0.1.5` | 공개 완료 | [Alhangeul v0.1.5](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.5) | [v0.1.5](https://postmelee.github.io/alhangeul-macos/updates/v0.1.5.html) | [`v0.1.5.md`](v0.1.5.md) |
 | `v0.1.4` | 공개 완료 | [Alhangeul v0.1.4](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.4) | [v0.1.4](https://postmelee.github.io/alhangeul-macos/updates/v0.1.4.html) | [`v0.1.4.md`](v0.1.4.md) |
 | `v0.1.3` | 공개 완료 | [Alhangeul v0.1.3](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.3) | [v0.1.3](https://postmelee.github.io/alhangeul-macos/updates/v0.1.3.html) | [`v0.1.3.md`](v0.1.3.md) |

--- a/mydocs/release/v0.1.6.md
+++ b/mydocs/release/v0.1.6.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.6` build `12` Stage 3 rehearsal 통과, Stage 4 승인 대기 |
+| 상태 | `v0.1.6` build `12` public GitHub Release, signed/notarized DMG, stable Sparkle appcast, Pages, Homebrew Cask 배포 완료 |
 | 목표 Git tag | `v0.1.6` |
 | 목표 app version | `0.1.6` |
 | 목표 build | `12` |
@@ -12,11 +12,11 @@
 | GitHub Release | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.6 |
 | Pages 릴리즈 노트 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.6.html |
 | Public DMG | `alhangeul-macos-0.1.6.dmg` |
-| Public DMG SHA256 | official stable publish 후 기록 |
-| Homebrew Cask | public DMG SHA256 확정 후 별도 반영 예정 |
+| Public DMG SHA256 | `87e37549a569813a3e22606f497ce837b350243cf3fed2ccd286af3ab8b02b9a` |
+| Homebrew Cask | `brew install --cask postmelee/tap/alhangeul` |
 | Release 실행 이슈 | [#360](https://github.com/postmelee/alhangeul-macos/issues/360) |
 
-이 문서는 `rhwp v0.7.16` 반영과 `v0.1.6` public release의 source metadata, release communication, 검증 결과를 기록한다. pre-public signed/notarized DMG smoke, official stable GitHub Release, stable Sparkle appcast, Pages 배포, Homebrew Cask 반영은 각각 별도 승인 gate에서 진행한다.
+이 문서는 `rhwp v0.7.16` 반영과 `v0.1.6` public release의 source metadata, release communication, 검증 결과를 기록한다. pre-public signed/notarized DMG smoke, official stable GitHub Release, stable Sparkle appcast, Pages 배포, Homebrew Cask 반영은 각각 별도 승인 gate로 진행했다.
 
 ## 사용자용 요약
 
@@ -24,7 +24,7 @@
 
 ## 직전 공개 릴리즈 대비 변경점
 
-기준 범위는 `v0.1.5^{}..release-candidate`다. 최종 release tag의 peeled commit은 `main` release PR merge와 `v0.1.6` tag 생성 후 확정한다.
+기준 범위는 `v0.1.5^{}..v0.1.6^{}`다. 최종 release tag의 peeled commit은 `ac54b0c3987934bd5649c62d544ac98f1468359e`다.
 
 | 영역 | 변경 |
 |------|------|
@@ -92,7 +92,7 @@
 | [#258](https://github.com/postmelee/alhangeul-macos/issues/258) | [#335](https://github.com/postmelee/alhangeul-macos/pull/335) | merge 완료 | Thumbnail cache signature와 Skia opt-in smoke |
 | [#356](https://github.com/postmelee/alhangeul-macos/issues/356) | [#358](https://github.com/postmelee/alhangeul-macos/pull/358) | merge 완료 | release note PR/Issue 분석 자동화 보강 |
 | 없음 | [#359](https://github.com/postmelee/alhangeul-macos/pull/359) | merge 완료 | `rhwp v0.7.16` core/studio sync |
-| [#360](https://github.com/postmelee/alhangeul-macos/issues/360) | 예정 | 진행중 | `v0.1.6` release candidate 준비와 public release handoff |
+| [#360](https://github.com/postmelee/alhangeul-macos/issues/360) | [#361](https://github.com/postmelee/alhangeul-macos/pull/361), [#362](https://github.com/postmelee/alhangeul-macos/pull/362), [#363](https://github.com/postmelee/alhangeul-macos/pull/363), [#364](https://github.com/postmelee/alhangeul-macos/pull/364) | merge 완료 | `v0.1.6` release candidate 준비, DMG layout 보정, public release handoff |
 
 ## 검증 기준
 
@@ -144,12 +144,32 @@ Stage 3의 local package/rehearsal은 unsigned 산출물이다. signed/notarized
 | `build.noindex/release/alhangeul-macos-0.1.6.zip` | `155314914` bytes | `f09bcf2aec75604e39513a388d7ee5ac8618cc23a81ba9cb327486ec48da9e7a` |
 | `build.noindex/release/alhangeul-macos-0.1.6-rehearsal.dmg` | `154782344` bytes | `1fd40fa9aafa858bf60c156aa06ff0ee7baa4a8caa0c980d16495fee3b30782e` |
 
-Stage 3 이후 보강할 검증:
+Stage 3 이후 보강한 검증:
 
 - pre-public signed/notarized draft DMG smoke 확인
 - official stable public DMG, GitHub Release asset, stable Sparkle appcast, Pages deploy 확인
 - public installed app 기준 Finder Quick Look/Thumbnail smoke
 - public DMG SHA256, Sparkle EdDSA signature, Homebrew Cask digest 기록
+
+## Stage 4/5 public release 검증 결과
+
+| 검증 | 결과 | 비고 |
+|------|------|------|
+| GitHub Release | 통과 | `v0.1.6`, `draft=false`, `prerelease=false`, release title `Alhangeul v0.1.6 (rhwp v0.7.16)` |
+| Release workflow | 통과 | `Release Publish DMG` run `27901135462`, signed/notarized DMG publish와 Pages deploy 성공 |
+| Public DMG SHA256 | 통과 | `87e37549a569813a3e22606f497ce837b350243cf3fed2ccd286af3ab8b02b9a` |
+| Public DMG integrity | 통과 | `hdiutil verify`, `codesign --verify`, `xcrun stapler validate`, `spctl --assess --type open` |
+| Public app bundle | 통과 | mounted DMG의 `Alhangeul.app` 기준 `0.1.6 (12)`, codesign/Gatekeeper 통과 |
+| DMG Finder layout | 통과 | `.background` `{68, 58}`, `.fseventsd` `{652, 58}`로 상단 배치 |
+| Sparkle appcast | 통과 | `sparkle:version=12`, `sparkle:shortVersionString=0.1.6`, DMG length `156184253`, EdDSA signature 포함 |
+| Pages release note | 통과 | `https://postmelee.github.io/alhangeul-macos/updates/v0.1.6.html` v0.1.6/rhwp v0.7.16 내용 반영 |
+| Homebrew Cask source | 통과 | `Casks/alhangeul.rb` version `0.1.6`, SHA256 `87e37549a569813a3e22606f497ce837b350243cf3fed2ccd286af3ab8b02b9a` |
+| Homebrew tap | 통과 | `postmelee/homebrew-tap` main commit `68c3be6870e37f05c308d41c556993b404f7340a` |
+| Homebrew style/audit | 통과 | `brew style --cask alhangeul`, `brew audit --cask alhangeul` |
+| Homebrew install/uninstall smoke | 통과 | 임시 appdir 설치, `0.1.6 (12)`/codesign/Gatekeeper 확인, `brew uninstall --cask alhangeul` 제거 확인 |
+| Homebrew `--new` audit | 참고 실패 | official cask 신규 제출 기준 signature verification 단계에서 `software has been altered` 보고. maintainer tap 공개 gate는 일반 audit/install smoke 기준으로 판단 |
+
+Homebrew 6.0.2 검증 환경은 `HOMEBREW_REQUIRE_TAP_TRUST`가 설정되어 있어 `postmelee/tap`을 untrusted tap으로 차단했다. smoke는 `brew trust --cask postmelee/tap/alhangeul`을 선행한 뒤 진행했으며, public 안내에도 untrusted tap 차단 시 같은 보조 명령을 안내한다.
 
 ## Release metadata
 
@@ -171,17 +191,17 @@ Stage 3 이후 보강할 검증:
 
 public 배포 전에 다음 조건을 모두 만족해야 한다.
 
-- [ ] `local/task360` 변경을 `publish/task360` PR로 게시하고 `devel`에 merge
-- [ ] `devel`의 release candidate commit을 `main`에 반영하는 release PR 승인과 merge
-- [ ] `main`의 최종 release commit에 `v0.1.6` tag 생성
-- [ ] `Release Publish DMG` `draft=true`, `prerelease=false` 실행으로 pre-public signed/notarized DMG 생성
-- [ ] maintainer가 draft release asset 또는 Actions artifact DMG를 직접 설치 smoke 통과
-- [ ] GitHub Release body가 `scripts/ci/write-release-notes.sh` template 기준으로 생성됐는지 확인
-- [ ] `Release Publish DMG` `draft=false`, `prerelease=false` official stable publish 실행
-- [ ] public DMG `alhangeul-macos-0.1.6.dmg` SHA256 기록
-- [ ] stable Sparkle appcast의 `sparkle:shortVersionString=0.1.6`, `sparkle:version=12`, EdDSA signature 확인
-- [ ] public Pages `updates/v0.1.6.html`와 `appcast.xml` URL 확인
-- [ ] Homebrew Cask를 public DMG SHA256 기준으로 갱신하고 tap context 검증 후 사용자 설치 명령 공개
+- [x] `local/task360` 변경을 `publish/task360` PR로 게시하고 `devel`에 merge
+- [x] `devel`의 release candidate commit을 `main`에 반영하는 release PR 승인과 merge
+- [x] `main`의 최종 release commit에 `v0.1.6` tag 생성
+- [x] `Release Publish DMG` `draft=true`, `prerelease=false` 실행으로 pre-public signed/notarized DMG 생성
+- [x] maintainer가 draft release asset 또는 Actions artifact DMG를 직접 설치 smoke 통과
+- [x] GitHub Release body가 `scripts/ci/write-release-notes.sh` template 기준으로 생성됐는지 확인
+- [x] `Release Publish DMG` `draft=false`, `prerelease=false` official stable publish 실행
+- [x] public DMG `alhangeul-macos-0.1.6.dmg` SHA256 기록
+- [x] stable Sparkle appcast의 `sparkle:shortVersionString=0.1.6`, `sparkle:version=12`, EdDSA signature 확인
+- [x] public Pages `updates/v0.1.6.html`와 `appcast.xml` URL 확인
+- [x] Homebrew Cask를 public DMG SHA256 기준으로 갱신하고 tap context 검증 후 사용자 설치 명령 공개
 
 ## 알려진 제한 사항과 후속 이슈
 
@@ -189,7 +209,7 @@ public 배포 전에 다음 조건을 모두 만족해야 한다.
 - 일부 문서에서는 글꼴, 배치, 페이지 표현이 원본 한글 프로그램과 다르게 보일 수 있다.
 - HWPX 문서는 현재 직접 저장이 제한되어 HWP export 경로를 사용한다.
 - upstream `rhwp-studio`의 웹/확장 drag/drop 확인 UI는 bundled asset에 포함되지만, 알한글 macOS 앱의 Finder 열기와 앱 내부 파일 열기는 HostApp native document router 정책을 따른다.
-- public DMG SHA256, appcast EdDSA signature, notarization result, Homebrew Cask digest는 Stage 3 local rehearsal에서 단정하지 않는다.
+- public DMG SHA256, appcast EdDSA signature, notarization result, Homebrew Cask digest는 Stage 4/5 public 검증 결과를 기준으로 확정한다.
 
 ## Release communication checklist
 
@@ -202,12 +222,12 @@ public 배포 전에 다음 조건을 모두 만족해야 한다.
 - [x] `docs/updates/v0.1.6.html` 추가
 - [x] `docs/updates/index.html`에 v0.1.6 항목 추가
 - [x] `docs/index.html` 최신 다운로드 link 갱신
-- [x] `mydocs/release/index.md`에 v0.1.6 후보와 v0.1.5 공개 완료 상태 반영
+- [x] `mydocs/release/index.md`에 v0.1.6 공개 완료 상태 반영
 - [x] source preflight와 rehearsal 검증
-- [ ] installed candidate 기준 Finder Quick Look/Thumbnail smoke 확인
-- [ ] About 창의 `rhwp v0.7.16 (de02159)` 표시 확인
-- [ ] public DMG 생성
-- [ ] public DMG 안의 app/extension version이 `0.1.6 (12)`인지 확인
-- [ ] public DMG SHA256 기록
-- [ ] public GitHub Release URL과 latest 상태 확인
-- [ ] public `https://postmelee.github.io/alhangeul-macos/appcast.xml` stable item과 Sparkle EdDSA signature 확인
+- [x] installed candidate 기준 Finder Quick Look/Thumbnail smoke 확인
+- [x] About 창의 `rhwp v0.7.16 (de02159)` 표시 확인
+- [x] public DMG 생성
+- [x] public DMG 안의 app/extension version이 `0.1.6 (12)`인지 확인
+- [x] public DMG SHA256 기록
+- [x] public GitHub Release URL과 latest 상태 확인
+- [x] public `https://postmelee.github.io/alhangeul-macos/appcast.xml` stable item과 Sparkle EdDSA signature 확인


### PR DESCRIPTION
## 요약
- v0.1.6 public DMG SHA256 기준으로 Casks/alhangeul.rb 갱신
- README, Pages, GitHub Release/내부 릴리스 기록의 Homebrew 설치 안내를 검증된 명령으로 전환
- Homebrew 6 untrusted tap 정책 대응 안내를 추가

## 검증
- ./scripts/update-cask-sha256.sh --dry-run 0.1.6 build.noindex/release/public-v0.1.6/alhangeul-macos-0.1.6.dmg.sha256
- ruby -c Casks/alhangeul.rb
- diff -u app repo Cask와 postmelee/homebrew-tap Cask
- brew style --cask alhangeul
- brew audit --cask alhangeul
- brew install --cask --appdir=/private/tmp/alhangeul-homebrew-smoke-apps postmelee/tap/alhangeul
- codesign/spctl on Homebrew-installed app
- brew uninstall --cask alhangeul

## 외부 반영
- postmelee/homebrew-tap main: 68c3be6870e37f05c308d41c556993b404f7340a
- GitHub Release v0.1.6 body Homebrew section updated