### PR TITLE
Task #376: rhwp upstream sync workflow 기준 보강

### DIFF
--- a/.github/workflows/rhwp-upstream-sync-pr.yml
+++ b/.github/workflows/rhwp-upstream-sync-pr.yml
@@ -60,7 +60,12 @@ jobs:
       has_viewer_impact: ${{ steps.impact.outputs.has_viewer_impact }}
       impact_reason_count: ${{ steps.impact.outputs.impact_reason_count }}
       existing_branch: ${{ steps.existing.outputs.branch_exists }}
-      existing_pr_url: ${{ steps.existing.outputs.pr_url }}
+      existing_pr_url: ${{ steps.existing.outputs.open_pr_url }}
+      existing_open_pr_url: ${{ steps.existing.outputs.open_pr_url }}
+      existing_merged_pr_url: ${{ steps.existing.outputs.merged_pr_url }}
+      existing_branch_only: ${{ steps.existing.outputs.branch_only }}
+      existing_cleanup_candidate: ${{ steps.existing.outputs.cleanup_candidate }}
+      existing_blocker_reason: ${{ steps.existing.outputs.blocker_reason }}
       should_build: ${{ steps.decision.outputs.should_build }}
       decision: ${{ steps.decision.outputs.decision }}
 
@@ -266,7 +271,7 @@ jobs:
             branch_exists="true"
           fi
 
-          pr_url="$(gh pr list \
+          open_pr_url="$(gh pr list \
             --repo "$GITHUB_REPOSITORY" \
             --base "$BASE_BRANCH" \
             --head "$branch_name" \
@@ -274,15 +279,39 @@ jobs:
             --json url \
             --jq '.[0].url // ""')"
 
+          merged_pr_url="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base "$BASE_BRANCH" \
+            --head "$branch_name" \
+            --state merged \
+            --json url \
+            --jq '.[0].url // ""')"
+
           exists="false"
-          if [ "$branch_exists" = "true" ] || [ -n "$pr_url" ]; then
+          branch_only="false"
+          cleanup_candidate="false"
+          blocker_reason="none"
+
+          if [ -n "$open_pr_url" ]; then
             exists="true"
+            blocker_reason="open_pr"
+          elif [ "$branch_exists" = "true" ] && [ -z "$merged_pr_url" ]; then
+            exists="true"
+            branch_only="true"
+            blocker_reason="branch_without_pr"
+          elif [ "$branch_exists" = "true" ] && [ -n "$merged_pr_url" ]; then
+            cleanup_candidate="true"
           fi
 
           {
             echo "exists=$exists"
             echo "branch_exists=$branch_exists"
-            echo "pr_url=$pr_url"
+            echo "branch_only=$branch_only"
+            echo "cleanup_candidate=$cleanup_candidate"
+            echo "blocker_reason=$blocker_reason"
+            echo "open_pr_url=$open_pr_url"
+            echo "merged_pr_url=$merged_pr_url"
+            echo "pr_url=$open_pr_url"
           } >> "$GITHUB_OUTPUT"
 
           {
@@ -290,7 +319,11 @@ jobs:
             echo "## Existing full sync PR check"
             echo
             echo "- branch exists: \`$branch_exists\`"
-            echo "- open PR: ${pr_url:-"(none)"}"
+            echo "- open PR: ${open_pr_url:-"(none)"}"
+            echo "- merged PR: ${merged_pr_url:-"(none)"}"
+            echo "- branch-only blocker: \`$branch_only\`"
+            echo "- cleanup candidate: \`$cleanup_candidate\`"
+            echo "- blocker reason: \`$blocker_reason\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Decide full sync execution
@@ -299,6 +332,7 @@ jobs:
         env:
           CURRENT: ${{ steps.resolve.outputs.current }}
           EXISTING: ${{ steps.existing.outputs.exists || 'false' }}
+          EXISTING_REASON: ${{ steps.existing.outputs.blocker_reason || 'none' }}
           DRY_RUN_VALUE: ${{ env.DRY_RUN }}
         run: |
           set -euo pipefail
@@ -328,6 +362,7 @@ jobs:
             echo
             echo "- decision: \`$decision\`"
             echo "- should build/create PR: \`$should_build\`"
+            echo "- existing blocker reason: \`${EXISTING_REASON:-none}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
   build-studio-assets:

--- a/.github/workflows/rhwp-upstream-sync-pr.yml
+++ b/.github/workflows/rhwp-upstream-sync-pr.yml
@@ -68,10 +68,10 @@ jobs:
       GH_TOKEN: ${{ github.token }}
 
     steps:
-      - name: Check out workflow ref
+      - name: Check out base branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.BASE_BRANCH }}
           fetch-depth: 0
 
       - name: Verify helper syntax
@@ -210,6 +210,8 @@ jobs:
             echo "- studio current: \`$studio_current\`"
             echo "- full sync current: \`$current\`"
             echo "- base branch: \`$BASE_BRANCH\`"
+            echo "- repository content ref: \`$BASE_BRANCH\`"
+            echo "- workflow event ref: \`${GITHUB_REF:-unknown}\`"
             echo "- automation branch: \`$branch_name\`"
             echo "- force_pr: \`${FORCE_PR:-false}\`"
             echo "- dry_run: \`${DRY_RUN:-false}\`"
@@ -336,10 +338,10 @@ jobs:
     if: ${{ needs.resolve-target.outputs.should_build == 'true' }}
 
     steps:
-      - name: Check out workflow ref
+      - name: Check out base branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.BASE_BRANCH }}
           fetch-depth: 0
 
       - name: Check out upstream rhwp
@@ -416,10 +418,10 @@ jobs:
     if: ${{ needs.resolve-target.outputs.should_build == 'true' }}
 
     steps:
-      - name: Check out workflow ref
+      - name: Check out base branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ env.BASE_BRANCH }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/mydocs/manual/ci_workflow_guide.md
+++ b/mydocs/manual/ci_workflow_guide.md
@@ -297,9 +297,9 @@ bash scripts/ci/check-rhwp-upstream-release.sh --target-tag <rhwp-tag> --run-com
 - GitHub App token 설정은 repository variable `ALHANGEUL_AUTOMATION_CLIENT_ID`와 repository secret `ALHANGEUL_AUTOMATION_APP_PRIVATE_KEY`가 필요하다.
 - GitHub App 권한은 Contents write, Pull requests write, Issues write, Metadata read로 제한한다.
 - concurrency group은 `rhwp-upstream-sync-pr`, `cancel-in-progress: false`로 두어 schedule과 수동 실행이 같은 branch/PR 생성을 경쟁하지 않게 한다.
-- current 판정은 `rhwp-core.lock`과 `Sources/HostApp/Resources/rhwp-studio/manifest.json`이 모두 target tag/resolved commit과 일치할 때만 true다.
+- current 판정은 `BASE_BRANCH` content의 `rhwp-core.lock`과 `Sources/HostApp/Resources/rhwp-studio/manifest.json`이 모두 target tag/resolved commit과 일치할 때만 true다. schedule workflow file은 default branch에서 실행될 수 있지만, sync 후보 판단에 쓰는 repository content ref는 base branch다.
 - `dry_run=true`이면 target 조회, current 판정, impact 분류까지만 수행하고 build, push, PR 생성을 하지 않는다.
-- 같은 automation branch 또는 open PR이 이미 있으면 새 PR을 만들지 않는다.
+- 같은 target의 open PR이 이미 있으면 새 PR을 만들지 않는다. 원격 automation branch만 있고 관련 PR이 없으면 branch push 후 PR 생성 실패 가능성이 있어 blocker로 둔다. 같은 head의 PR이 이미 merge됐고 branch만 남아 있으면 blocker가 아니라 cleanup 후보로 표시한다.
 - generated PR body에는 `Automation source: rhwp Upstream Sync PR`만 기록하고 issue close keyword를 쓰지 않는다.
 - upstream WASM build는 upstream root의 `.env.docker`를 사용한다. CI에서는 `.env.docker.example` 존재를 확인한 뒤 runner의 `id -u`, `id -g` 값으로 `.env.docker`를 생성해 Docker container user와 bind mount owner를 맞춘다.
 - upstream WASM/studio build는 Ubuntu runner에서 수행하고, native RustBridge/core lock update는 macOS runner에서 수행한다.
@@ -318,7 +318,7 @@ workflow가 만드는 주요 산출물:
 - `Sync rhwp upstream <tag>` PR
 - `RustBridge/Cargo.toml`, `RustBridge/Cargo.lock`, `rhwp-core.lock`
 - `Sources/HostApp/Resources/rhwp-studio/**` asset과 manifest 변경
-- workflow summary의 target, current 판정, impact detection, existing PR, created/skipped 상태
+- workflow summary의 target, base branch content ref, workflow event ref, current 판정, impact detection, existing PR/branch blocker, cleanup 후보, created/skipped 상태
 
 이 workflow는 public release workflow가 아니다. signed/notarized DMG, GitHub Release, Sparkle appcast, Homebrew Cask 반영은 자동으로 수행하지 않으며, 별도 작업 승인과 보호 workflow를 거친다. 실제 schedule 활성화, GitHub App token, `gh pr create`, assignee/reviewer 지정, PR CI 자동 trigger는 workflow가 default branch에 merge된 뒤 GitHub-hosted runner에서 최종 확인한다.
 

--- a/mydocs/manual/core_dependency_operation_guide.md
+++ b/mydocs/manual/core_dependency_operation_guide.md
@@ -93,7 +93,8 @@ xcodebuild -project Alhangeul.xcodeproj \
 `rhwp-core.lock`은 Rust bridge가 링크하는 core 기준이고, `Sources/HostApp/Resources/rhwp-studio/manifest.json`은 WKWebView viewer asset의 source release와 resolved commit 기준이다. 두 provenance는 release note와 검증에서 함께 확인하지만, 자동 sync PR은 public release 결정을 대신하지 않는다.
 
 - `.github/workflows/rhwp-upstream-check.yml`은 read-only 감시 workflow로 upstream latest release와 `rhwp-core.lock`을 비교한다.
-- `.github/workflows/rhwp-upstream-sync-pr.yml`은 upstream target release를 `devel` 대상 `automation/rhwp-<tag>-full-sync` branch에 반영하는 full sync 후보 PR을 만든다.
+- `.github/workflows/rhwp-upstream-sync-pr.yml`은 upstream target release를 `devel` 대상 `automation/rhwp-<tag>-full-sync` branch에 반영하는 full sync 후보 PR을 만든다. current 판정은 `devel` content의 core lock과 bundled studio manifest 기준으로 수행한다.
+- sync workflow는 같은 target의 open PR 또는 PR 없는 branch-only 상태를 중복 생성 blocker로 취급한다. merge 완료 PR의 head branch가 남아 있으면 blocker가 아니라 cleanup 후보로 표시하며, 실제 원격 branch 삭제는 별도 승인 또는 merge 후 cleanup 절차에서 수행한다.
 - sync workflow는 `scripts/update-rhwp-core.sh --check --channel stable --tag <tag>`로 target release compatibility를 먼저 조회하고, 실제 PR 생성 단계에서는 `scripts/update-rhwp-core.sh --channel stable --tag <tag>`와 `scripts/build-rust-macos.sh --update-lock`로 `RustBridge/Cargo.toml`, `RustBridge/Cargo.lock`, `rhwp-core.lock`을 갱신한다.
 - sync workflow는 같은 target commit에서 upstream WASM/studio asset을 빌드하고 `scripts/sync-rhwp-studio.sh`로 bundled `rhwp-studio` manifest와 asset을 갱신한다. 이때 upstream root `Cargo.lock`의 sha256은 manifest의 `source_cargo_lock_sha256`에 기록해 studio/WASM dependency graph provenance로 검토한다.
 - full sync 변경 PR은 PR CI에서 `scripts/verify-rhwp-studio-assets.sh`, HostApp build, Rust/core provenance verify, release helper dry-run을 확인한다.

--- a/mydocs/orders/20260624.md
+++ b/mydocs/orders/20260624.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #370 | upstream Cargo.lock 기반 provenance와 locked build 검증 보강 | 완료 | M040, 최종보고서 작성 완료: 02:34 |
 | #371 | HWP 3.0 파일이 HostApp 열기 검증에서 차단되는 문제 수정 | 완료 | 완료: 02:30 |
-| #376 | rhwp Upstream Sync PR workflow 기준 브랜치와 automation branch 정리 보강 | 진행중 | M040, 구현계획서 작성 후 승인 대기 |
+| #376 | rhwp Upstream Sync PR workflow 기준 브랜치와 automation branch 정리 보강 | 완료 | M040, 최종보고서 작성 완료: 23:40 |

--- a/mydocs/orders/20260624.md
+++ b/mydocs/orders/20260624.md
@@ -6,3 +6,4 @@
 |------|--------|------|------|
 | #370 | upstream Cargo.lock 기반 provenance와 locked build 검증 보강 | 완료 | M040, 최종보고서 작성 완료: 02:34 |
 | #371 | HWP 3.0 파일이 HostApp 열기 검증에서 차단되는 문제 수정 | 완료 | 완료: 02:30 |
+| #376 | rhwp Upstream Sync PR workflow 기준 브랜치와 automation branch 정리 보강 | 진행중 | M040, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260624.md
+++ b/mydocs/orders/20260624.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #370 | upstream Cargo.lock 기반 provenance와 locked build 검증 보강 | 완료 | M040, 최종보고서 작성 완료: 02:34 |
 | #371 | HWP 3.0 파일이 HostApp 열기 검증에서 차단되는 문제 수정 | 완료 | 완료: 02:30 |
-| #376 | rhwp Upstream Sync PR workflow 기준 브랜치와 automation branch 정리 보강 | 진행중 | M040, 수행계획서 작성 후 승인 대기 |
+| #376 | rhwp Upstream Sync PR workflow 기준 브랜치와 automation branch 정리 보강 | 진행중 | M040, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/plans/task_m040_376.md
+++ b/mydocs/plans/task_m040_376.md
@@ -1,0 +1,97 @@
+# Task M040 #376 수행계획서
+
+## 타스크
+
+- GitHub Issue: #376
+- 마일스톤: M040 (`v0.4`)
+- 제목: rhwp Upstream Sync PR workflow의 base branch 기준과 automation branch 정리 보강
+- 브랜치: `local/task376`
+- 기준 브랜치: `devel`
+- 시작 기준 커밋: `093e75e`
+
+## 목적
+
+`rhwp Upstream Sync PR` workflow가 upstream sync 필요 여부를 PR base인 `devel` 기준으로 판단하게 보정한다. 이미 `devel`에 merge된 upstream sync가 `main`의 stale한 provenance 때문에 계속 필요하다고 판정되거나, merge 완료된 automation branch가 새 판단을 막는 상태를 줄여 다음 public release 준비 전에 자동화 상태를 명확히 한다.
+
+## 배경
+
+현재 workflow는 `BASE_BRANCH=devel`로 full sync PR을 만들지만, schedule 실행은 GitHub Actions 기본 동작에 따라 default branch인 `main`의 workflow ref를 checkout한다. `resolve-target` job은 checkout된 파일의 `rhwp-core.lock`과 `Sources/HostApp/Resources/rhwp-studio/manifest.json`을 읽기 때문에, `devel`에는 최신 sync가 merge되어 있어도 `main`이 아직 같은 provenance를 포함하지 않으면 `current=false`가 될 수 있다.
+
+2026-06-24 schedule run은 upstream latest `v0.7.17`을 감지했고, #369가 `devel`에 merge된 뒤였지만 `main` checkout 기준으로 current를 false로 판단했다. 이후 `automation/rhwp-v0.7.17-full-sync` 원격 브랜치가 남아 있어 `decision=existing_automation_pr`, `should_build=false`가 되었고 build/PR 생성 job은 skipped 되었다. 이 동작은 실제 중복 PR을 막는 효과는 있지만, workflow summary가 stale 상태를 반복하고 automation branch 정리 시 다음 schedule에서 불필요한 build가 재시도될 수 있다.
+
+## 범위
+
+포함:
+
+- `.github/workflows/rhwp-upstream-sync-pr.yml`의 current 판정 기준을 `devel`의 lock/manifest 상태와 일치시키는 방식 검토 및 반영
+- existing automation branch/PR 확인 로직이 열린 PR, merge 완료 PR, 단순 잔존 branch를 구분하도록 보강
+- merge 완료된 `automation/rhwp-v*-full-sync` branch가 sync 판단을 계속 막지 않게 하는 정리 또는 skip 기준 확정
+- `ci_workflow_guide.md`와 core dependency 운영 문서의 upstream sync workflow 설명을 실제 기준에 맞게 보정
+- 남아 있는 `automation/rhwp-v0.7.16-full-sync`, `automation/rhwp-v0.7.17-full-sync` 원격 브랜치 정리 필요 여부 보고
+
+제외:
+
+- upstream `edwardkim/rhwp` 저장소 수정
+- 새 upstream release sync 또는 bundled `rhwp-studio` asset 갱신
+- public release publish, signing, notarization, Pages/Sparkle, Homebrew 작업
+- 이미 merge된 #359, #369 PR 내용 변경
+- 자동으로 GitHub Issue를 close하거나 release branch를 정리하는 작업
+
+## 설계 방향
+
+우선 current 판정의 source of truth를 PR base branch와 맞춘다. schedule workflow 자체는 default branch에서 실행될 수밖에 없으므로, workflow definition은 default branch에서 읽되 repository content 판정은 `BASE_BRANCH` ref 기준으로 수행하는 방향을 우선 검토한다. 구체적으로 `actions/checkout`의 `ref`를 `BASE_BRANCH`로 바꾸거나, 별도 `git fetch origin "$BASE_BRANCH"` 후 `origin/$BASE_BRANCH`의 파일을 읽는 방식의 안정성을 비교한다.
+
+automation branch 존재 여부는 "열린 sync 후보가 이미 있다"와 "merge된 후보 branch가 남아 있다"를 분리한다. 열린 PR이 있으면 기존처럼 새 PR을 만들지 않는다. 반면 같은 branch가 존재하더라도 관련 PR이 merge 완료되어 있고 base branch가 target provenance를 이미 포함한다면 current 판정이 우선되어야 하며, 단순 잔존 branch 때문에 stale 상태가 반복되어서는 안 된다.
+
+branch cleanup은 destructive remote 작업이므로 구현 단계에서 자동 삭제와 수동 정리의 경계를 명확히 둔다. 안전한 기본값은 workflow가 merged branch를 blocker로 취급하지 않게 만드는 것이다. 실제 원격 branch 삭제는 작업지시자 승인 또는 merge 후 cleanup 절차에서 수행한다.
+
+## 예상 변경 파일
+
+- `.github/workflows/rhwp-upstream-sync-pr.yml`
+- `mydocs/manual/ci_workflow_guide.md`
+- `mydocs/manual/core_dependency_operation_guide.md`
+- `mydocs/plans/task_m040_376_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m040_376_stage{N}.md`
+- `mydocs/report/task_m040_376_report.md`
+- `mydocs/orders/20260624.md`
+
+## 잠정 단계(3~6단계)
+
+1. 현행 workflow 재현과 판정 기준 확정
+   - 최신 schedule run #28075879933의 로그와 현재 `main`/`devel` provenance 차이를 정리한다.
+   - `resolve-target` job이 어떤 ref의 lock/manifest를 읽어야 하는지 확정한다.
+2. base branch 기준 current 판정 보강
+   - workflow가 `BASE_BRANCH=devel`의 repository content로 current/core_current/studio_current를 계산하도록 수정한다.
+   - manual dispatch의 `target_tag`, `dry_run`, `force_pr` 입력 의미가 바뀌지 않는지 확인한다.
+3. existing automation branch/PR 판단 보강
+   - 열린 PR이 있을 때만 중복 방지 blocker로 처리하고, merge 완료 branch는 current 판정 또는 명시 cleanup 대상으로 분리한다.
+   - 필요한 경우 workflow summary에 branch exists, open PR, merged PR 상태를 구분해 표시한다.
+4. 문서와 운영 정리
+   - CI workflow/core dependency 문서에 base branch 기준 판정과 automation branch cleanup 기준을 반영한다.
+   - 현재 남은 automation branch 정리 권고와 실행 승인 필요 여부를 최종 보고서에 남긴다.
+5. 검증과 보고
+   - workflow YAML parse, helper syntax, 관련 문자열 검색, `git diff --check`를 수행한다.
+   - 실제 GitHub-hosted schedule run 확인이 필요한 항목은 PR 이후 검증 항목으로 분리한다.
+
+## 검증 계획
+
+- `git status --short --branch`
+- `git diff --check`
+- `ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml")'`
+- `bash -n scripts/ci/check-rhwp-upstream-release.sh scripts/ci/detect-rhwp-studio-impact.sh scripts/ci/read-rhwp-core-lock.sh scripts/ci/write-rhwp-full-sync-pr-body.sh`
+- `scripts/ci/detect-rhwp-studio-impact.sh --help`
+- `scripts/ci/read-rhwp-core-lock.sh --help`
+- `scripts/ci/write-rhwp-full-sync-pr-body.sh --help`
+- `rg -n "BASE_BRANCH|current_core_tag|current_studio_tag|existing_automation_pr|automation/rhwp|rhwp Upstream Sync PR" .github/workflows/rhwp-upstream-sync-pr.yml mydocs/manual`
+
+## 리스크
+
+- schedule workflow는 default branch의 workflow file을 사용하므로, base branch checkout 방식만 바꾸면 workflow 변경 검증과 content 판정 ref가 분리될 수 있다.
+- `actions/checkout` ref를 `devel`로 직접 바꾸면 default branch에만 있는 새 workflow 변경이 schedule에 반영되기 전까지 테스트가 헷갈릴 수 있다.
+- merge 완료 branch를 자동 삭제하도록 만들면 권한, branch protection, audit trail 문제가 생길 수 있다.
+- existing branch blocker를 너무 느슨하게 만들면 같은 target tag의 중복 PR 생성 가능성이 생긴다.
+- GitHub-hosted schedule 동작은 로컬에서 완전히 재현하기 어렵기 때문에, PR merge 후 첫 schedule run 확인이 별도 운영 확인으로 남을 수 있다.
+
+## 승인 요청 사항
+
+이 수행계획서 기준으로 구현 계획서 작성 단계 진행 승인을 요청한다.

--- a/mydocs/plans/task_m040_376_impl.md
+++ b/mydocs/plans/task_m040_376_impl.md
@@ -1,0 +1,199 @@
+# Task #376 구현 계획서
+
+본 문서는 [`task_m040_376.md`](task_m040_376.md) 수행계획서를 단계별 실행 단위로 분해한 것이다. 각 단계 완료 후 [`task-stage-report`](../skills/task-stage-report/SKILL.md) skill로 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 환경
+
+- Worktree: `/Users/melee/Documents/projects/rhwp-mac`
+- Branch: `local/task376`
+- 기준 브랜치: `devel`
+- 기준 이슈: [#376](https://github.com/postmelee/alhangeul-macos/issues/376)
+- 마일스톤: M040 (`v0.4`)
+- 범위: `rhwp Upstream Sync PR` workflow의 base branch 기준 판정과 automation branch blocker 정리
+
+## 구현 원칙
+
+- workflow schedule은 GitHub default branch의 workflow file로 실행되지만, upstream sync 후보의 source of truth는 `BASE_BRANCH=devel`의 repository content로 둔다.
+- `rhwp-core.lock`과 bundled `rhwp-studio` manifest의 current 판정은 PR base branch의 파일을 읽어 계산한다.
+- 열린 sync PR은 계속 중복 생성 blocker로 취급한다.
+- merge 완료 PR의 head branch가 원격에 남아 있는 경우는 opened PR blocker와 구분한다.
+- 원격 branch 삭제는 destructive 작업이므로 이번 구현에서는 자동 삭제보다 blocker 오판 방지와 문서화에 집중한다. 실제 삭제는 작업지시자 승인 또는 merge 후 cleanup 절차에서 수행한다.
+- public release publish, signing/notarization, Pages/Sparkle, Homebrew 작업은 이번 task에서 실행하지 않는다.
+
+## Stage 1 — 현행 workflow 판정 재현과 설계 확정
+
+### 목표
+
+- `main` checkout 기준 current 판정과 `devel` base branch 기준 current 판정 차이를 작업 문서에 고정한다.
+- Stage 2~3에서 바꿀 checkout 기준과 existing branch 판단 규칙을 확정한다.
+
+### 변경 파일과 작업
+
+| 파일 | 작업 | 비고 |
+|------|------|------|
+| `mydocs/plans/task_m040_376_impl.md` | 구현계획서 작성 | 현재 단계 산출물 |
+| `mydocs/working/task_m040_376_stage1.md` | Stage 1 완료보고서 작성 | 현행 run 로그와 설계 결정 기록 |
+
+### 확인할 자료
+
+- Issue #376 본문
+- `mydocs/plans/task_m040_376.md`
+- `.github/workflows/rhwp-upstream-sync-pr.yml`
+- 최신 schedule run `28075879933`의 `resolve-target` job 로그
+- PR #359, #369 상태와 head branch 존재 여부
+- `mydocs/manual/ci_workflow_guide.md`
+- `mydocs/manual/core_dependency_operation_guide.md`
+
+### 설계 결정 기준
+
+- `resolve-target` job의 `current_core_tag`, `current_core_commit`, `current_studio_tag`, `current_studio_commit`은 `BASE_BRANCH` content 기준이어야 한다.
+- workflow helper syntax 검증도 base branch checkout 후 실행해 실제 sync PR 생성에 사용할 scripts와 맞춘다.
+- `build-studio-assets`와 `create-full-sync-pr` job의 repository checkout도 base branch 기준으로 맞춘다. `create-full-sync-pr`는 어차피 `git switch -c "$branch_name" "origin/$BASE_BRANCH"`로 PR branch를 만들므로 checkout ref와 실제 변경 base가 어긋나지 않게 한다.
+- existing automation check는 open PR, merged PR, branch-only 상태를 분리한다.
+- branch-only 상태는 이전 run이 branch push 후 PR 생성 전에 실패했을 가능성이 있으므로 계속 blocker로 취급한다.
+- merged PR head branch는 blocker로 취급하지 않는 방향을 우선한다. 단, base branch가 current가 아니면 같은 target을 다시 생성할 위험이 있으므로 Stage 3에서 조건을 명확히 한다.
+
+### 단계 검증
+
+```bash
+git status --short --branch
+git diff --check
+rg -n "github.ref|BASE_BRANCH|current_core_tag|current_studio_tag|existing_automation_pr|branch_exists|gh pr list" .github/workflows/rhwp-upstream-sync-pr.yml
+```
+
+### 커밋 메시지
+
+```text
+Task #376 Stage 1: upstream sync workflow 판정 기준 조사
+```
+
+## Stage 2 — base branch 기준 checkout과 current 판정 보강
+
+### 목표
+
+- schedule/manual dispatch 모두에서 sync 필요 여부를 `BASE_BRANCH=devel` content 기준으로 계산하게 한다.
+- target release 조회, compatibility check, impact detection 입력이 같은 base branch scripts와 lock/manifest를 사용하게 한다.
+
+### 변경 파일과 작업
+
+| 파일 | 작업 | 비고 |
+|------|------|------|
+| `.github/workflows/rhwp-upstream-sync-pr.yml` | checkout ref와 summary 문구 보강 | `resolve-target`, `build-studio-assets`, `create-full-sync-pr` 중심 |
+| `mydocs/working/task_m040_376_stage2.md` | Stage 2 완료보고서 작성 | checkout 기준과 로컬 검증 결과 기록 |
+
+### 반영 기준
+
+- `resolve-target`의 checkout step은 `ref: ${{ env.BASE_BRANCH }}` 또는 동등하게 base branch content를 읽는 방식으로 수정한다.
+- helper syntax 검증은 base branch checkout 후 실행한다.
+- `build-studio-assets` checkout도 `BASE_BRANCH` 기준으로 맞춰 `scripts/update-rhwp-core.sh`, `scripts/sync-rhwp-studio.sh`, 검증 helper가 PR base와 같은 버전을 쓰게 한다.
+- `create-full-sync-pr` checkout도 `BASE_BRANCH` 기준으로 맞추되, `persist-credentials: false`와 GitHub App token 사용 구조는 유지한다.
+- workflow summary에는 workflow ref와 base branch를 구분해, schedule은 default branch workflow로 실행되지만 판정 content는 base branch라는 점이 드러나게 한다.
+- `workflow_dispatch`의 `target_tag`, `dry_run`, `force_pr` 입력 의미는 유지한다.
+
+### 단계 검증
+
+```bash
+ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml")'
+git diff --check
+rg -n "ref:.*BASE_BRANCH|workflow ref|base branch|current core tag|full sync current" .github/workflows/rhwp-upstream-sync-pr.yml
+```
+
+### 커밋 메시지
+
+```text
+Task #376 Stage 2: sync workflow base branch 판정 적용
+```
+
+## Stage 3 — existing automation branch와 PR blocker 판단 보강
+
+### 목표
+
+- 같은 target automation branch가 남아 있어도 열린 PR과 merge 완료 PR을 구분한다.
+- merge 완료 head branch가 남아 있는 상태를 workflow가 stale blocker로 오판하지 않게 한다.
+
+### 변경 파일과 작업
+
+| 파일 | 작업 | 비고 |
+|------|------|------|
+| `.github/workflows/rhwp-upstream-sync-pr.yml` | existing check output과 decision logic 보강 | open/merged/branch-only 상태 구분 |
+| `mydocs/working/task_m040_376_stage3.md` | Stage 3 완료보고서 작성 | blocker matrix와 검증 결과 기록 |
+
+### 반영 기준
+
+- `Check existing automation PR` step은 다음 상태를 output과 summary에 구분해 남긴다.
+  - `open_pr_url`: 같은 base/head의 열린 PR
+  - `merged_pr_url` 또는 merged 상태: 같은 base/head의 merge 완료 PR
+  - `branch_exists`: 원격 automation branch 존재 여부
+  - `exists` 또는 blocker 값: 새 PR 생성을 막아야 하는지 여부
+- 열린 PR이 있으면 기존처럼 `decision=existing_automation_pr`로 둔다.
+- 원격 branch만 있고 PR이 없으면 branch push 후 PR 생성 실패 가능성이 있으므로 blocker로 유지한다.
+- merge 완료 PR이 있고 branch만 남은 경우는 blocker로 보지 않는다. 이 경우 base branch current 판정이 true이면 `decision=current`로 끝나고, current가 false이면 새 sync 필요 상태로 이어질 수 있으므로 Stage 2의 base branch current 판정이 먼저 정확해야 한다.
+- summary에는 merge 완료 branch가 남아 있어도 blocker가 아니라 cleanup 후보라는 점을 명확히 표시한다.
+
+### 단계 검증
+
+```bash
+ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml")'
+git diff --check
+rg -n "open_pr|merged_pr|branch_exists|existing_automation_pr|branch_only|cleanup" .github/workflows/rhwp-upstream-sync-pr.yml
+```
+
+가능하면 `gh pr list` 명령의 `--jq` 표현은 로컬에서 read-only로 dry 확인한다.
+
+```bash
+gh pr list --repo postmelee/alhangeul-macos --base devel --head automation/rhwp-v0.7.17-full-sync --state all --json url,state,mergedAt --jq '.[0] // {}'
+```
+
+### 커밋 메시지
+
+```text
+Task #376 Stage 3: merged automation branch blocker 구분
+```
+
+## Stage 4 — 문서 정리와 최종 검증
+
+### 목표
+
+- CI/core 운영 문서가 base branch 기준 판정과 automation branch lifecycle을 정확히 설명하게 한다.
+- 현재 남아 있는 remote automation branch 정리 권고를 최종 보고서에 남긴다.
+
+### 변경 파일과 작업
+
+| 파일 | 작업 | 비고 |
+|------|------|------|
+| `mydocs/manual/ci_workflow_guide.md` | upstream sync workflow 기준 보강 | base branch 판정, blocker 기준 |
+| `mydocs/manual/core_dependency_operation_guide.md` | full sync provenance 설명 보강 | base branch 기준과 cleanup 경계 |
+| `mydocs/report/task_m040_376_report.md` | 최종 결과보고서 작성 | 검증 결과와 남은 운영 확인 기록 |
+| `mydocs/orders/20260624.md` | 작업 상태 완료 처리 | 최종 보고 단계 |
+
+### 반영 기준
+
+- `ci_workflow_guide.md`의 유지 조건에 "current 판정은 base branch content 기준"을 명시한다.
+- 같은 automation branch 또는 open PR 문구는 열린 PR, branch-only blocker, merged branch cleanup 후보를 구분하는 문구로 바꾼다.
+- `core_dependency_operation_guide.md`에는 full sync 후보 PR이 `devel` 기준 provenance로 판단된다는 점을 짧게 보강한다.
+- 원격 branch 삭제는 자동 수행하지 않는다. 최종 보고서에서 `automation/rhwp-v0.7.16-full-sync`, `automation/rhwp-v0.7.17-full-sync` 삭제 권고와 승인 필요성을 분리해 기록한다.
+
+### 최종 검증
+
+```bash
+git status --short --branch
+git diff --check
+ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml")'
+bash -n scripts/ci/check-rhwp-upstream-release.sh scripts/ci/detect-rhwp-studio-impact.sh scripts/ci/read-rhwp-core-lock.sh scripts/ci/write-rhwp-full-sync-pr-body.sh
+scripts/ci/detect-rhwp-studio-impact.sh --help
+scripts/ci/read-rhwp-core-lock.sh --help
+scripts/ci/write-rhwp-full-sync-pr-body.sh --help
+rg -n "BASE_BRANCH|current_core_tag|current_studio_tag|existing_automation_pr|automation/rhwp|rhwp Upstream Sync PR|base branch" .github/workflows/rhwp-upstream-sync-pr.yml mydocs/manual
+```
+
+GitHub-hosted schedule run은 로컬에서 완전 재현할 수 없으므로, PR merge 이후 첫 `rhwp Upstream Sync PR` schedule run에서 `current=true` 또는 기대 decision을 확인하는 항목을 최종 보고서에 남긴다.
+
+### 커밋 메시지
+
+```text
+Task #376 Stage 4 + 최종 보고서: upstream sync workflow 기준 정리
+```
+
+## 승인 요청 사항
+
+이 구현계획서 승인 후 Stage 1 현행 workflow 판정 재현과 설계 확정 작업을 시작한다.

--- a/mydocs/report/task_m040_376_report.md
+++ b/mydocs/report/task_m040_376_report.md
@@ -1,0 +1,106 @@
+# Task M040 #376 최종 결과보고서
+
+## 개요
+
+- GitHub Issue: #376
+- 마일스톤: M040 (`v0.4`)
+- 브랜치: `local/task376`
+- 기준 브랜치: `devel`
+- 작업 범위: `rhwp Upstream Sync PR` workflow의 base branch 기준 current 판정과 automation branch blocker 구분 보강
+
+## 최종 결과
+
+`rhwp Upstream Sync PR` workflow가 upstream sync 필요 여부를 `BASE_BRANCH=devel` content 기준으로 판단하도록 수정했다. schedule workflow file은 GitHub default branch에서 실행될 수 있지만, 실제 current 판정에 쓰는 `rhwp-core.lock`과 bundled `rhwp-studio` manifest는 base branch checkout에서 읽는다.
+
+또한 existing automation branch 확인 로직을 열린 PR, branch-only, merge 완료 PR head branch 잔존 상태로 구분했다. 열린 PR과 branch-only 상태는 계속 중복 PR 생성 blocker로 유지하고, merge 완료 PR의 head branch가 남은 경우는 blocker가 아니라 cleanup 후보로 표시한다.
+
+## 변경 파일
+
+| 파일 | 변경 |
+|------|------|
+| `.github/workflows/rhwp-upstream-sync-pr.yml` | checkout 기준을 `env.BASE_BRANCH`로 변경, workflow event ref와 repository content ref summary 추가, existing branch/PR blocker 세분화 |
+| `mydocs/manual/ci_workflow_guide.md` | upstream sync workflow의 base branch current 판정, branch-only blocker, merged branch cleanup 후보 기준 문서화 |
+| `mydocs/manual/core_dependency_operation_guide.md` | full sync 후보 PR의 `devel` 기준 provenance 판정과 cleanup 경계 보강 |
+| `mydocs/working/task_m040_376_stage1.md` | 현행 run과 설계 결정 기록 |
+| `mydocs/working/task_m040_376_stage2.md` | base branch checkout 적용 결과 기록 |
+| `mydocs/working/task_m040_376_stage3.md` | merged automation branch blocker 구분 결과 기록 |
+| `mydocs/report/task_m040_376_report.md` | 최종 결과보고서 |
+| `mydocs/orders/20260624.md` | 오늘할일 완료 처리 |
+
+## 단계별 요약
+
+### Stage 1
+
+최신 schedule run `28075879933`이 `main` 기준 `v0.7.16`을 읽어 `CURRENT=false`, `EXISTING=true`로 판단한 사실을 확인했다. 같은 시점 `origin/devel`은 core/studio 모두 `v0.7.17`이므로, base branch 기준이면 current가 true가 되어야 한다는 설계를 확정했다.
+
+### Stage 2
+
+`resolve-target`, `build-studio-assets`, `create-full-sync-pr` job의 repository checkout을 `github.ref`에서 `env.BASE_BRANCH`로 바꿨다. workflow summary에는 `repository content ref`와 `workflow event ref`를 나누어 표시하도록 했다.
+
+### Stage 3
+
+existing automation check를 `open_pr_url`, `merged_pr_url`, `branch_only`, `cleanup_candidate`, `blocker_reason`으로 세분화했다. 현재 남아 있는 `automation/rhwp-v0.7.17-full-sync`는 open PR이 없고 merge 완료 PR #369가 있으므로 cleanup 후보로 분류되는 상태다.
+
+### Stage 4
+
+CI/core 운영 문서에 새 기준을 반영하고 최종 검증을 수행했다.
+
+## 검증 결과
+
+```text
+$ git status --short --branch
+## local/task376
+ M mydocs/manual/ci_workflow_guide.md
+ M mydocs/manual/core_dependency_operation_guide.md
+```
+
+위 상태는 최종 보고서 작성 전 문서 변경만 남은 시점의 상태다.
+
+```text
+$ git diff --check
+```
+
+출력 없음. 통과.
+
+```text
+$ ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml")'
+Ignoring ffi-1.13.1 because its extensions are not built. Try: gem pristine ffi --version 1.13.1
+```
+
+exit code 0. YAML parse는 통과했다. `ffi` 경고는 로컬 Ruby gem 환경 경고다.
+
+```text
+$ bash -n scripts/ci/check-rhwp-upstream-release.sh scripts/ci/detect-rhwp-studio-impact.sh scripts/ci/read-rhwp-core-lock.sh scripts/ci/write-rhwp-full-sync-pr-body.sh
+```
+
+출력 없음. 통과.
+
+```text
+$ scripts/ci/detect-rhwp-studio-impact.sh --help
+$ scripts/ci/read-rhwp-core-lock.sh --help
+$ scripts/ci/write-rhwp-full-sync-pr-body.sh --help
+```
+
+세 helper 모두 usage 출력을 반환하고 exit code 0으로 완료했다.
+
+```text
+$ rg -n "BASE_BRANCH|current_core_tag|current_studio_tag|existing_automation_pr|automation/rhwp|rhwp Upstream Sync PR|base branch" .github/workflows/rhwp-upstream-sync-pr.yml mydocs/manual
+```
+
+workflow와 운영 문서에서 base branch current 판정, automation branch, existing blocker 관련 항목이 확인됐다.
+
+## 남은 운영 확인
+
+- GitHub-hosted schedule 동작은 로컬에서 완전 재현할 수 없다. 이 변경이 `devel`에 merge된 뒤 첫 `rhwp Upstream Sync PR` schedule run에서 `repository content ref`가 `devel`로 표시되고, `v0.7.17` 기준 current 판정이 기대대로 정리되는지 확인해야 한다.
+- 현재 원격에는 `automation/rhwp-v0.7.16-full-sync`, `automation/rhwp-v0.7.17-full-sync` branch가 남아 있다. 둘 다 merge 완료 PR의 head branch이므로 cleanup 후보지만, 원격 branch 삭제는 destructive 작업이므로 별도 승인 또는 merge 후 cleanup 절차에서 수행해야 한다.
+- 이번 작업은 public release publish, signing/notarization, Pages/Sparkle, Homebrew 작업을 실행하지 않았다.
+
+## PR 전 확인 사항
+
+- PR base는 `devel`이다.
+- PR body에는 #376을 해결하는 내부 workflow 수정이며 public release 작업이 아님을 명시한다.
+- PR merge 후 schedule run 확인과 automation branch cleanup 승인 여부를 후속 운영 항목으로 남긴다.
+
+## 결론
+
+#376의 핵심 문제였던 `main` checkout 기준 stale current 판정과 merge 완료 automation branch blocker 오판을 workflow와 문서에서 보강했다. 최종 검증은 통과했으며, 다음 단계는 작업지시자 승인 후 `publish/task376` push와 `devel` 대상 PR 생성이다.

--- a/mydocs/working/task_m040_376_stage1.md
+++ b/mydocs/working/task_m040_376_stage1.md
@@ -1,0 +1,154 @@
+# Task M040 #376 Stage 1 완료보고서
+
+## 단계 목적
+
+`rhwp Upstream Sync PR` workflow의 현행 판정 경로를 재확인하고, Stage 2~3에서 적용할 base branch 기준 current 판정과 automation branch blocker 구분 설계를 확정했다. 이번 단계에서는 workflow source를 수정하지 않고 조사 결과와 설계 결정을 문서화했다.
+
+## 산출물
+
+| 파일 | 요약 |
+|------|------|
+| `mydocs/working/task_m040_376_stage1.md` | 현행 run, branch provenance, automation branch/PR 상태, Stage 2~3 설계 결정 기록 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 코드와 운영 매뉴얼 본문은 변경하지 않았다.
+- Stage 1 산출물은 신규 완료보고서 1개다.
+
+## 조사 결과
+
+### 최신 workflow run 상태
+
+- 최신 `rhwp Upstream Sync PR` schedule run: `28075879933`
+- 실행 시각: 2026-06-24T04:48:46Z
+- event: `schedule`
+- headBranch/headSha: `main` / `eb10d27ad802835ebd9354f47462d6ca457f3c9c`
+- 결론: workflow 전체 `success`
+- job 결론:
+  - `Resolve rhwp full sync target`: `success`
+  - `Build upstream rhwp-studio assets`: `skipped`
+  - `Create rhwp full sync PR candidate`: `skipped`
+
+로그 발췌:
+
+```text
+current_tag=v0.7.16
+current_commit=de02159ab4d2c5d165d6e25568bad3f8af5ef6cb
+target_tag=v0.7.17
+target_commit=03351190ec35436e58cbfee0aa9278a8fdc04a59
+has_viewer_impact=true
+impact_reason_count=129
+CURRENT: false
+EXISTING: true
+DRY_RUN_VALUE: false
+```
+
+이 run은 target이 `v0.7.17`임을 감지했지만, current를 `v0.7.16`으로 읽었다. 이후 `EXISTING=true` 때문에 build/PR 생성 job은 실행되지 않았다.
+
+### `main`과 `devel` provenance 차이
+
+원격 ref 비교 결과:
+
+| ref | commit | core tag | core commit | studio tag | studio commit |
+|-----|--------|----------|-------------|------------|---------------|
+| `origin/main` | `eb10d27ad802835ebd9354f47462d6ca457f3c9c` | `v0.7.16` | `de02159ab4d2c5d165d6e25568bad3f8af5ef6cb` | `v0.7.16` | `de02159ab4d2c5d165d6e25568bad3f8af5ef6cb` |
+| `origin/devel` | `093e75e2083997fc9f16475e65a575415830474d` | `v0.7.17` | `03351190ec35436e58cbfee0aa9278a8fdc04a59` | `v0.7.17` | `03351190ec35436e58cbfee0aa9278a8fdc04a59` |
+
+upstream latest release는 `v0.7.17`이며, `origin/devel`의 core/studio provenance는 이미 target과 일치한다. 따라서 current 판정은 `devel` 기준이면 true가 되어야 한다.
+
+### workflow의 현행 checkout/판정 경로
+
+`rg` 확인 결과:
+
+```text
+32:  BASE_BRANCH: devel
+74:          ref: ${{ github.ref }}
+145:          current_core_tag="$(scripts/ci/read-rhwp-core-lock.sh rhwp_release_tag)"
+147:          current_studio_tag="$(manifest_field "$manifest_path" source_release_tag)"
+276:          if [ "$branch_exists" = "true" ] || [ -n "$pr_url" ]; then
+312:            decision="existing_automation_pr"
+342:          ref: ${{ github.ref }}
+422:          ref: ${{ github.ref }}
+524:          git fetch --prune origin "$BASE_BRANCH"
+525:          git switch -c "$branch_name" "origin/$BASE_BRANCH"
+```
+
+`resolve-target`, `build-studio-assets`, `create-full-sync-pr`의 checkout은 모두 `github.ref` 기준이다. schedule run에서 `github.ref`는 default branch인 `main`이므로, current 판정이 `main`의 stale한 lock/manifest를 읽는다. 반면 실제 PR branch 생성은 `origin/$BASE_BRANCH`에서 이루어진다. 이 불일치가 이번 문제의 핵심이다.
+
+### automation branch와 PR 상태
+
+남아 있는 원격 automation branch:
+
+```text
+automation/rhwp-v0.7.16-full-sync -> 3f200c94f27c6465f430d17ac4e21e83476f4fbd
+automation/rhwp-v0.7.17-full-sync -> 56096a106af39d58a938d651e3d66a4958198c77
+```
+
+관련 PR:
+
+| PR | branch | state | mergedAt |
+|----|--------|-------|----------|
+| #359 | `automation/rhwp-v0.7.16-full-sync` | `MERGED` | 2026-06-20T16:18:20Z |
+| #369 | `automation/rhwp-v0.7.17-full-sync` | `MERGED` | 2026-06-23T17:50:02Z |
+
+현재 workflow는 `branch_exists=true`만으로 `exists=true`를 만들기 때문에 merge 완료 PR의 head branch도 새 PR 생성 blocker가 된다. 이 동작은 중복 PR 방지에는 보수적이지만, merge 완료 branch와 열린 PR을 구분하지 못해 stale summary와 branch cleanup 혼선을 만든다.
+
+## 설계 결정
+
+1. Stage 2에서는 repository content current 판정 기준을 `BASE_BRANCH=devel`로 맞춘다.
+   - `resolve-target` job은 `BASE_BRANCH` ref의 `rhwp-core.lock`과 bundled `rhwp-studio` manifest를 읽어야 한다.
+   - helper syntax 검증과 impact detection도 같은 base branch checkout에서 실행한다.
+   - `build-studio-assets`, `create-full-sync-pr` checkout도 base branch 기준으로 맞춰 실제 PR 생성 base와 사용 script 버전이 어긋나지 않게 한다.
+
+2. Stage 3에서는 existing check의 blocker 기준을 세분화한다.
+   - 열린 PR은 계속 blocker로 둔다.
+   - branch-only 상태는 PR 생성 전 실패 가능성이 있으므로 blocker로 둔다.
+   - merge 완료 PR의 head branch가 남은 상태는 blocker가 아니라 cleanup 후보로 표시한다.
+   - `branch_exists`, `open_pr_url`, `merged_pr_url`, blocker 여부를 summary와 output에서 구분한다.
+
+3. 원격 branch 삭제는 이번 구현에서 자동 수행하지 않는다.
+   - 원격 삭제는 destructive 작업이므로 최종 보고서에서 권고와 승인 필요성을 분리한다.
+   - workflow는 먼저 merge 완료 branch를 blocker로 오판하지 않게 해야 한다.
+
+## 검증 결과
+
+```text
+$ git status --short --branch
+## local/task376
+```
+
+```text
+$ git diff --check
+```
+
+출력 없음. 통과.
+
+```text
+$ rg -n "github.ref|BASE_BRANCH|current_core_tag|current_studio_tag|existing_automation_pr|branch_exists|gh pr list" .github/workflows/rhwp-upstream-sync-pr.yml
+32:  BASE_BRANCH: devel
+74:          ref: ${{ github.ref }}
+145:          current_core_tag="$(scripts/ci/read-rhwp-core-lock.sh rhwp_release_tag)"
+147:          current_studio_tag="$(manifest_field "$manifest_path" source_release_tag)"
+276:          if [ "$branch_exists" = "true" ] || [ -n "$pr_url" ]; then
+312:            decision="existing_automation_pr"
+342:          ref: ${{ github.ref }}
+422:          ref: ${{ github.ref }}
+524:          git fetch --prune origin "$BASE_BRANCH"
+525:          git switch -c "$branch_name" "origin/$BASE_BRANCH"
+```
+
+Stage 1의 계획 검증 명령은 실패 없이 완료됐다.
+
+## 잔여 위험
+
+- schedule workflow는 default branch의 workflow file로 실행되므로, Stage 2 수정이 default branch에 merge되기 전까지 실제 schedule 동작은 기존 구조를 유지한다.
+- `actions/checkout`을 `BASE_BRANCH`로 바꾸면 workflow file의 실행 ref와 repository content ref가 의도적으로 분리된다. summary에 이를 명시해야 운영자가 혼동하지 않는다.
+- branch-only 상태를 blocker로 유지하더라도, 이미 merge된 PR branch cleanup은 별도 승인 또는 merge cleanup 절차가 필요하다.
+
+## 다음 단계 영향
+
+Stage 2에서는 `.github/workflows/rhwp-upstream-sync-pr.yml`의 checkout 기준과 summary를 먼저 수정한다. Stage 3의 blocker 세분화는 Stage 2의 base branch current 판정이 정확하다는 전제 위에서 적용한다.
+
+## 승인 요청
+
+Stage 1 결과를 승인하고 Stage 2 `sync workflow base branch 판정 적용` 단계로 진행할지 승인 요청한다.

--- a/mydocs/working/task_m040_376_stage2.md
+++ b/mydocs/working/task_m040_376_stage2.md
@@ -1,0 +1,87 @@
+# Task M040 #376 Stage 2 완료보고서
+
+## 단계 목적
+
+`rhwp Upstream Sync PR` workflow가 schedule/manual dispatch에서 repository content를 `BASE_BRANCH=devel` 기준으로 checkout하고, 그 checkout의 `rhwp-core.lock`과 bundled `rhwp-studio` manifest로 current 판정을 수행하도록 수정했다. 이번 단계는 checkout/current 판정 기준 보정에 한정하고, existing automation branch/PR blocker 세분화는 Stage 3으로 남겼다.
+
+## 산출물
+
+| 파일 | 요약 |
+|------|------|
+| `.github/workflows/rhwp-upstream-sync-pr.yml` | `resolve-target`, `build-studio-assets`, `create-full-sync-pr` job checkout을 `github.ref`에서 `env.BASE_BRANCH`로 변경하고 summary에 workflow event ref와 repository content ref를 분리 표시 |
+| `mydocs/working/task_m040_376_stage2.md` | Stage 2 변경 내용과 검증 결과 기록 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- workflow YAML의 checkout step 3곳과 summary 출력 2줄만 변경했다.
+- `target_tag`, `dry_run`, `force_pr`, GitHub App token, PR 생성, artifact 흐름은 변경하지 않았다.
+- existing automation branch/PR 판단 로직은 Stage 3 범위로 유지해 이번 커밋에서는 변경하지 않았다.
+
+## 변경 내용
+
+### base branch checkout 적용
+
+다음 세 job의 checkout 기준을 `github.ref`에서 `env.BASE_BRANCH`로 바꿨다.
+
+- `resolve-target`
+- `build-studio-assets`
+- `create-full-sync-pr`
+
+변경 전 schedule run은 default branch `main`의 repository content를 읽어 current 판정을 수행했다. 변경 후에는 workflow file 자체는 default branch에서 실행되더라도, lock/manifest와 helper script는 `BASE_BRANCH=devel` checkout에서 읽는다.
+
+### summary 가시성 보강
+
+`resolve-target` summary에 다음 항목을 추가했다.
+
+```text
+- repository content ref: `$BASE_BRANCH`
+- workflow event ref: `${GITHUB_REF:-unknown}`
+```
+
+이로써 workflow가 어떤 event ref로 실행되었고 어떤 branch content를 current 판정에 사용했는지 구분할 수 있다.
+
+## 검증 결과
+
+```text
+$ ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml")'
+Ignoring ffi-1.13.1 because its extensions are not built. Try: gem pristine ffi --version 1.13.1
+```
+
+exit code 0. YAML parse는 통과했다. `ffi` 경고는 로컬 Ruby gem 환경 경고로, YAML parse 실패는 아니다.
+
+```text
+$ git diff --check
+```
+
+출력 없음. 통과.
+
+```text
+$ rg -n "ref:.*BASE_BRANCH|workflow event ref|repository content ref|base branch|current core tag|full sync current|Check out base branch|github.ref" .github/workflows/rhwp-upstream-sync-pr.yml
+71:      - name: Check out base branch
+74:          ref: ${{ env.BASE_BRANCH }}
+202:            echo "- current core tag: \`$current_core_tag\`"
+211:            echo "- full sync current: \`$current\`"
+212:            echo "- base branch: \`$BASE_BRANCH\`"
+213:            echo "- repository content ref: \`$BASE_BRANCH\`"
+214:            echo "- workflow event ref: \`${GITHUB_REF:-unknown}\`"
+341:      - name: Check out base branch
+344:          ref: ${{ env.BASE_BRANCH }}
+421:      - name: Check out base branch
+424:          ref: ${{ env.BASE_BRANCH }}
+```
+
+계획서 Stage 2의 검증 명령은 실패 없이 완료됐다.
+
+## 잔여 위험
+
+- GitHub Actions schedule은 계속 default branch의 workflow file을 실행한다. 이번 수정은 실행된 workflow가 checkout하는 repository content를 `BASE_BRANCH`로 맞추는 방식이다.
+- `env.BASE_BRANCH` expression은 GitHub-hosted runner에서 최종 확인이 필요하다. 로컬 YAML parse는 문법만 검증한다.
+- 기존 `Check existing automation PR` step은 아직 `branch_exists=true`만으로 blocker를 만들 수 있다. merge 완료 branch blocker 구분은 Stage 3에서 처리한다.
+
+## 다음 단계 영향
+
+Stage 3에서는 existing automation branch/PR check를 열린 PR, branch-only, merge 완료 PR로 분리한다. Stage 2에서 current 판정이 base branch 기준으로 바뀌었으므로, merge 완료 branch가 남아 있어도 base branch가 이미 current이면 `decision=current`로 종료될 수 있는 기반이 마련됐다.
+
+## 승인 요청
+
+Stage 2 결과를 승인하고 Stage 3 `merged automation branch blocker 구분` 단계로 진행할지 승인 요청한다.

--- a/mydocs/working/task_m040_376_stage3.md
+++ b/mydocs/working/task_m040_376_stage3.md
@@ -1,0 +1,127 @@
+# Task M040 #376 Stage 3 완료보고서
+
+## 단계 목적
+
+`rhwp Upstream Sync PR` workflow의 existing automation branch/PR 확인 로직을 보강해 열린 PR, branch-only 상태, merge 완료 PR head branch 잔존 상태를 구분했다. merge 완료 PR의 head branch가 원격에 남아 있는 경우는 새 sync PR 생성을 막는 blocker가 아니라 cleanup 후보로 표시하게 했다.
+
+## 산출물
+
+| 파일 | 요약 |
+|------|------|
+| `.github/workflows/rhwp-upstream-sync-pr.yml` | existing check output과 decision summary를 open/merged/branch-only/cleanup 상태로 세분화 |
+| `mydocs/working/task_m040_376_stage3.md` | Stage 3 변경 내용과 검증 결과 기록 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- workflow YAML의 `Check existing automation PR` step과 `Decide full sync execution` summary만 변경했다.
+- Stage 2에서 적용한 base branch checkout 구조는 유지했다.
+- upstream checkout/build, PR 생성 token, sync script 실행, artifact 흐름은 변경하지 않았다.
+
+## 변경 내용
+
+### job output 세분화
+
+`resolve-target` job output에 다음 값을 추가했다.
+
+- `existing_open_pr_url`
+- `existing_merged_pr_url`
+- `existing_branch_only`
+- `existing_cleanup_candidate`
+- `existing_blocker_reason`
+
+기존 `existing_pr_url`은 호환성을 위해 open PR URL을 가리키도록 유지했다.
+
+### blocker 판단 matrix
+
+| 상태 | workflow 판단 | 이유 |
+|------|---------------|------|
+| open PR 존재 | blocker | 이미 리뷰 가능한 sync 후보가 있으므로 중복 PR 생성 금지 |
+| 원격 branch 존재, 관련 PR 없음 | blocker | branch push 후 PR 생성 전에 실패했을 수 있어 보수적으로 중복 생성 금지 |
+| 원격 branch 존재, merged PR 존재, open PR 없음 | cleanup 후보 | 이미 merge된 후보의 head branch 잔존 상태이므로 새 PR blocker로 보지 않음 |
+| branch 없음, PR 없음 | blocker 아님 | 새 sync PR 생성 가능 |
+
+### summary 가시성 보강
+
+`Existing full sync PR check` summary에 다음 항목을 추가했다.
+
+```text
+- merged PR: ...
+- branch-only blocker: ...
+- cleanup candidate: ...
+- blocker reason: ...
+```
+
+`rhwp full sync decision` summary에는 `existing blocker reason`을 추가했다.
+
+## 현재 원격 상태 확인
+
+`automation/rhwp-v0.7.17-full-sync` 기준 read-only 조회:
+
+```text
+$ gh pr list --repo postmelee/alhangeul-macos --base devel --head automation/rhwp-v0.7.17-full-sync --state open --json url,state,mergedAt --jq '.[0] // {}'
+{}
+```
+
+```text
+$ gh pr list --repo postmelee/alhangeul-macos --base devel --head automation/rhwp-v0.7.17-full-sync --state merged --json url,state,mergedAt --jq '.[0] // {}'
+{"mergedAt":"2026-06-23T17:50:02Z","state":"MERGED","url":"https://github.com/postmelee/alhangeul-macos/pull/369"}
+```
+
+따라서 현재 `v0.7.17` branch는 Stage 3 기준으로 cleanup 후보이며 open PR blocker가 아니다.
+
+## 검증 결과
+
+```text
+$ ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml")'
+Ignoring ffi-1.13.1 because its extensions are not built. Try: gem pristine ffi --version 1.13.1
+```
+
+exit code 0. YAML parse는 통과했다. `ffi` 경고는 로컬 Ruby gem 환경 경고다.
+
+```text
+$ git diff --check
+```
+
+출력 없음. 통과.
+
+```text
+$ rg -n "open_pr|merged_pr|branch_exists|existing_automation_pr|branch_only|cleanup|blocker_reason|EXISTING_REASON" .github/workflows/rhwp-upstream-sync-pr.yml
+62:      existing_branch: ${{ steps.existing.outputs.branch_exists }}
+63:      existing_pr_url: ${{ steps.existing.outputs.open_pr_url }}
+64:      existing_open_pr_url: ${{ steps.existing.outputs.open_pr_url }}
+65:      existing_merged_pr_url: ${{ steps.existing.outputs.merged_pr_url }}
+66:      existing_branch_only: ${{ steps.existing.outputs.branch_only }}
+67:      existing_cleanup_candidate: ${{ steps.existing.outputs.cleanup_candidate }}
+68:      existing_blocker_reason: ${{ steps.existing.outputs.blocker_reason }}
+274:          open_pr_url="$(gh pr list \
+282:          merged_pr_url="$(gh pr list \
+291:          branch_only="false"
+292:          cleanup_candidate="false"
+293:          blocker_reason="none"
+295:          if [ -n "$open_pr_url" ]; then
+297:            blocker_reason="open_pr"
+298:          elif [ "$branch_exists" = "true" ] && [ -z "$merged_pr_url" ]; then
+300:            branch_only="true"
+301:            blocker_reason="branch_without_pr"
+302:          elif [ "$branch_exists" = "true" ] && [ -n "$merged_pr_url" ]; then
+303:            cleanup_candidate="true"
+335:          EXISTING_REASON: ${{ steps.existing.outputs.blocker_reason || 'none' }}
+348:            decision="existing_automation_pr"
+365:            echo "- existing blocker reason: \`${EXISTING_REASON:-none}\`"
+```
+
+계획서 Stage 3의 검증 명령과 `gh pr list` read-only 확인은 실패 없이 완료됐다.
+
+## 잔여 위험
+
+- branch-only 상태는 계속 blocker로 유지했다. 실제로 branch-only가 오래 남아 있으면 수동 확인 후 cleanup이 필요할 수 있다.
+- merge 완료 branch를 blocker로 보지 않게 했으므로, Stage 2의 base branch current 판정이 정확해야 중복 PR 위험이 낮다.
+- `gh pr list --state merged` 동작은 로컬 gh에서 확인했지만, 최종 GitHub-hosted runner 동작은 PR merge 후 workflow run에서 확인해야 한다.
+
+## 다음 단계 영향
+
+Stage 4에서는 `ci_workflow_guide.md`와 `core_dependency_operation_guide.md`에 base branch current 판정, open PR/branch-only/merged branch cleanup 후보 기준을 반영한다. 최종 보고서에는 남아 있는 `automation/rhwp-v0.7.16-full-sync`, `automation/rhwp-v0.7.17-full-sync` 삭제 권고와 별도 승인 필요성을 기록한다.
+
+## 승인 요청
+
+Stage 3 결과를 승인하고 Stage 4 `문서 정리와 최종 검증` 단계로 진행할지 승인 요청한다.


### PR DESCRIPTION
## 요약

- `rhwp Upstream Sync PR` workflow가 schedule 실행 ref가 아니라 `BASE_BRANCH=devel`의 `rhwp-core.lock`과 studio manifest 기준으로 current 상태를 판정하도록 수정했습니다.
- 기존 automation branch 확인을 open PR, branch-only blocker, merged PR cleanup 후보로 구분해 merge 완료 head branch가 중복 PR 생성을 막지 않도록 했습니다.
- CI/core dependency 운영 문서와 최종 결과보고서를 갱신했습니다.

## 검증

- `git diff --check`
- `ruby -e 'require "psych"; Psych.parse_file(".github/workflows/rhwp-upstream-sync-pr.yml")'`
- `bash -n scripts/ci/check-rhwp-upstream-release.sh scripts/ci/detect-rhwp-studio-impact.sh scripts/ci/read-rhwp-core-lock.sh scripts/ci/write-rhwp-full-sync-pr-body.sh`
- 관련 helper script `--help` 실행 확인

Closes #376
