### PR TITLE
Task #378: v0.1.7 release closeout 기록 정리

### DIFF
--- a/mydocs/orders/20260625.md
+++ b/mydocs/orders/20260625.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #378 | v0.1.7 public release 준비와 배포 실행 | 진행중 | M900, Stage 4 gate 준비 보고 후 승인 대기 |
+| #378 | v0.1.7 public release 준비와 배포 실행 | 완료 | M900, public release/Pages/Sparkle 배포 완료. Homebrew는 별도 gate, 완료: 06:40 |

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.7` | 후보 준비중 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |
+| `v0.1.7` | 공개 완료 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |
 | `v0.1.6` | 공개 완료 | [Alhangeul v0.1.6](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.6) | [v0.1.6](https://postmelee.github.io/alhangeul-macos/updates/v0.1.6.html) | [`v0.1.6.md`](v0.1.6.md) |
 | `v0.1.5` | 공개 완료 | [Alhangeul v0.1.5](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.5) | [v0.1.5](https://postmelee.github.io/alhangeul-macos/updates/v0.1.5.html) | [`v0.1.5.md`](v0.1.5.md) |
 | `v0.1.4` | 공개 완료 | [Alhangeul v0.1.4](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.4) | [v0.1.4](https://postmelee.github.io/alhangeul-macos/updates/v0.1.4.html) | [`v0.1.4.md`](v0.1.4.md) |

--- a/mydocs/release/v0.1.7.md
+++ b/mydocs/release/v0.1.7.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.7` build `13` Stage 4 gate 준비 완료, `publish/task378 -> devel` PR 승인 대기 |
+| 상태 | `v0.1.7` build `13` public GitHub Release, signed/notarized DMG, stable Sparkle appcast, Pages 배포 완료. Homebrew는 별도 gate |
 | 목표 Git tag | `v0.1.7` |
 | 목표 app version | `0.1.7` |
 | 목표 build | `13` |
@@ -12,13 +12,13 @@
 | GitHub Release | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7 |
 | Pages 릴리즈 노트 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html |
 | Public DMG | `alhangeul-macos-0.1.7.dmg` |
-| Public DMG SHA256 | official stable publish 후 기록 |
+| Public DMG SHA256 | `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` |
 | Local rehearsal DMG | `build.noindex/release/alhangeul-macos-0.1.7-rehearsal.dmg` |
 | Local rehearsal DMG SHA256 | `b1edbfd95a46afa0c0aad2746e5f43dde44d73f3e742ddcb115897548db52c9b` |
-| Homebrew Cask | public DMG SHA256 확정 후 별도 반영 예정 |
+| Homebrew Cask | 별도 승인 gate 미진행. public 안내는 GitHub Release DMG 직접 설치 유지 |
 | Release 실행 이슈 | [#378](https://github.com/postmelee/alhangeul-macos/issues/378) |
 
-이 문서는 `rhwp v0.7.17` 반영과 `v0.1.7` public release의 source metadata, release communication, 검증 결과를 기록한다. pre-public signed/notarized DMG smoke, official stable GitHub Release, stable Sparkle appcast, Pages 배포, Homebrew Cask 반영은 각각 별도 승인 gate에서 진행한다.
+이 문서는 `rhwp v0.7.17` 반영과 `v0.1.7` public release의 source metadata, release communication, 검증 결과를 기록한다. pre-public signed/notarized DMG smoke, official stable GitHub Release, stable Sparkle appcast, Pages 배포는 승인 gate에 따라 완료했다. Homebrew Cask 반영은 별도 승인 gate로 남긴다.
 
 ## 사용자용 요약
 
@@ -26,7 +26,7 @@
 
 ## 직전 공개 릴리즈 대비 변경점
 
-기준 범위는 `v0.1.6^{}..release-candidate`다. 최종 release tag의 peeled commit은 `main` release PR merge와 `v0.1.7` tag 생성 후 확정한다.
+기준 범위는 `v0.1.6^{}..v0.1.7^{}`다. 최종 release tag의 peeled commit은 `876d2667c2bff60e8599af8bccb45c4cab19099f`다.
 
 | 영역 | 변경 |
 |------|------|
@@ -39,7 +39,7 @@
 
 ## 포함 PR 분석
 
-기준 범위는 `v0.1.6^{}..release-candidate`다. GitHub Release와 Pages의 사용자-facing 요약은 아래 표에서 `사용자-facing=예`와 `공개 요약 반영=예`로 확정한 항목만 기준으로 작성한다.
+기준 범위는 `v0.1.6^{}..v0.1.7^{}`다. GitHub Release와 Pages의 사용자-facing 요약은 아래 표에서 `사용자-facing=예`와 `공개 요약 반영=예`로 확정한 항목만 기준으로 작성했다.
 
 | PR | 제목 | 분류 | 사용자-facing | 공개 요약 반영 | 해결된 Issue | 참고/연관 Issue | 근거 문서 | 비고 |
 |----|------|------|---------------|----------------|---------------|-------------|-----------|------|
@@ -50,7 +50,7 @@
 | `#377` | `rhwp upstream sync workflow 기준 보강` | 운영/배포 | 아니오 | 아니오 | `#376` | 없음 | PR body, `mydocs/report/task_m040_376_report.md` | schedule/base branch current 판정과 automation branch cleanup 후보 구분 |
 | `#378` | `v0.1.7 public release 준비와 배포 실행` | 운영/배포 | 아니오 | 아니오 | 없음 | 없음 | Issue body, `mydocs/plans/task_m900_378.md` | version/build, release record, Pages, workflow default 정리 |
 
-## GitHub Release 본문 구조 후보
+## GitHub Release 본문 구조
 
 ### 변경 요약
 
@@ -100,7 +100,7 @@
 | [#370](https://github.com/postmelee/alhangeul-macos/issues/370) | [#374](https://github.com/postmelee/alhangeul-macos/pull/374) | merge 완료 | upstream Cargo.lock provenance와 locked build 검증 |
 | [#371](https://github.com/postmelee/alhangeul-macos/issues/371) | [#373](https://github.com/postmelee/alhangeul-macos/pull/373) | merge 완료 | HWP 3.0 HostApp opening guard |
 | [#376](https://github.com/postmelee/alhangeul-macos/issues/376) | [#377](https://github.com/postmelee/alhangeul-macos/pull/377) | merge 완료 | upstream sync workflow 기준 보강 |
-| [#378](https://github.com/postmelee/alhangeul-macos/issues/378) | 예정 | 진행중 | `v0.1.7` release candidate 준비와 public release handoff |
+| [#378](https://github.com/postmelee/alhangeul-macos/issues/378) | [#379](https://github.com/postmelee/alhangeul-macos/pull/379), [#380](https://github.com/postmelee/alhangeul-macos/pull/380) | merge 완료 | `v0.1.7` release candidate 준비, `devel -> main` 반영, public release handoff |
 
 ## 검증 기준
 
@@ -115,7 +115,7 @@ Stage 3 기준 source-level 검증:
 | Debug build | `HostApp` Debug, `CODE_SIGNING_ALLOWED=NO` | Stage 3 통과 |
 | Native render smoke | `KTX.hwp`, `request.hwp`, `exam_kor.hwp` 첫 페이지 렌더 | Stage 3 통과 |
 | Release bundle | local unsigned Release app/extension universal slice | Stage 3 통과 |
-| Release helper | `scripts/ci/write-release-notes.sh 0.1.7 ...` template check | Stage 2에서 placeholder SHA256으로 형식 확인. 실제 SHA256은 public publish 후 재생성 |
+| Release helper | `scripts/ci/write-release-notes.sh 0.1.7 ...` template check | Stage 2에서 placeholder SHA256으로 형식 확인, official stable workflow에서 실제 SHA256 기준 release body 생성 |
 | Pages release note | `docs/updates/v0.1.7.html` | Stage 2 확인 |
 | Delta checklist | `scripts/ci/write-release-delta-checklist.sh v0.1.6 HEAD ...` | Stage 2/3 통과 |
 | Local rehearsal DMG | `./scripts/release.sh --skip-notarize 0.1.7` | Stage 3 통과 |
@@ -147,38 +147,33 @@ Stage 3 local rehearsal 산출물은 notarization과 Developer ID signing을 건
 | `build.noindex/release/alhangeul-macos-0.1.7.zip` | `904b8f7a6450841df6d7f6709a771184ea17b12097acb74a0ac799cafcb2501d` |
 | `build.noindex/release/alhangeul-macos-0.1.7-rehearsal.dmg` | `b1edbfd95a46afa0c0aad2746e5f43dde44d73f3e742ddcb115897548db52c9b` |
 
-## Stage 4 gate 준비 결과
+## Stage 4/5 public release 검증 결과
 
-| 항목 | 결과 |
-|------|------|
-| 최신 공개 앱 release | `v0.1.6`, `Alhangeul v0.1.6 (rhwp v0.7.16)` |
-| 최신 upstream `rhwp` release | `v0.7.17` |
-| `v0.1.7` tag | 아직 없음 |
-| `v0.1.7` GitHub Release | 아직 없음 |
-| 현재 local candidate commit | `d9ee08fcd0a3f1f1d4b2871ec006b2caf7ee3bc2` |
-| 현재 `origin/devel` | `0d3bb4f8b0b0e4acb958ce42239e490f73f7bbd5` |
-| 현재 `origin/main` | `eb10d27ad802835ebd9354f47462d6ca457f3c9c` |
-| release title 후보 | `Alhangeul v0.1.7 (rhwp v0.7.17)` |
-| `Release Publish DMG` input 후보 | `version=0.1.7`, `previous_release_ref=v0.1.6`, `expected_rhwp_tag=v0.7.17`, `require_latest_rhwp=true`, `include_rhwp_in_title=true` |
+| 검증 | 결과 | 비고 |
+|------|------|------|
+| `publish/task378 -> devel` | 통과 | PR [#379](https://github.com/postmelee/alhangeul-macos/pull/379) merge 완료 |
+| `devel -> main` | 통과 | PR [#380](https://github.com/postmelee/alhangeul-macos/pull/380) merge 완료 |
+| Release tag | 통과 | `v0.1.7` -> `876d2667c2bff60e8599af8bccb45c4cab19099f` |
+| Pre-public draft workflow | 통과 | [`28116263365`](https://github.com/postmelee/alhangeul-macos/actions/runs/28116263365), `draft=true`, `prerelease=false` |
+| Draft DMG smoke | 통과 | 작업지시자가 설치 smoke 완료를 확인. stable appcast와 Pages deploy skip은 draft run의 정상 동작 |
+| Official stable workflow | 통과 | [`28130401337`](https://github.com/postmelee/alhangeul-macos/actions/runs/28130401337), `draft=false`, `prerelease=false` |
+| GitHub Release | 통과 | `v0.1.7`, `draft=false`, `prerelease=false`, title `Alhangeul v0.1.7 (rhwp v0.7.17)` |
+| Public DMG SHA256 | 통과 | `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` |
+| Public DMG asset | 통과 | `alhangeul-macos-0.1.7.dmg`, size `156747415`, tag URL `https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.7/alhangeul-macos-0.1.7.dmg` |
+| Public checksum asset | 통과 | `.dmg.sha256` 내용이 public DMG SHA256과 일치 |
+| Sparkle appcast | 통과 | `sparkle:shortVersionString=0.1.7`, `sparkle:version=13`, length `156747415`, EdDSA signature 포함 |
+| Pages release note | 통과 | `https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html`이 v0.1.7 DMG와 `rhwp v0.7.17` 안내 반영 |
+| Pages updates index | 통과 | `https://postmelee.github.io/alhangeul-macos/updates/`가 v0.1.7 최신 항목과 DMG link 반영 |
+| Homebrew Cask | 미진행 | public DMG SHA256은 확정됐지만 Homebrew tap 반영은 별도 승인 gate로 남김 |
 
-현재 `d9ee08fcd0a3f1f1d4b2871ec006b2caf7ee3bc2`는 `local/task378`에만 있는 pre-merge candidate다. public release tag는 로컬 후보 commit에 직접 만들지 않는다. 먼저 `publish/task378` PR을 `devel`에 merge하고, 그 뒤 `devel -> main` release PR merge commit을 최종 candidate로 확정한 다음 `v0.1.7` tag를 만든다.
+## Public artifacts
 
-Stage 4에서 생성/확인한 보조 산출물:
+| 산출물 | 크기 | SHA256 | 용도 |
+|--------|------|--------|------|
+| `alhangeul-macos-0.1.7.dmg` draft smoke asset | `156747285` | `bbb0f4859e840eb47a8dc8f7c56658d4bc8e03a8cf4fa94f227fa36f5553cca9` | pre-public maintainer 설치 smoke |
+| `alhangeul-macos-0.1.7.dmg` official stable asset | `156747415` | `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` | public GitHub Release, Sparkle appcast, Pages download |
 
-| 산출물 | 결과 |
-|--------|------|
-| `build.noindex/release/pr-analysis-0.1.7.md` | `v0.1.6..HEAD` 포함 PR 분석 초안 생성 |
-| `build.noindex/release/delta-checklist-0.1.7.md` | `v0.1.6..HEAD` delta checklist 초안 생성 |
-| `build.noindex/release/release-notes-0.1.7.md` | placeholder SHA256 기반 GitHub Release body 후보 생성 및 template/body 검증 |
-
-다음 gate 순서:
-
-1. `publish/task378 -> devel` PR 생성과 merge 승인
-2. `devel -> main` release PR 생성과 merge 승인
-3. `v0.1.7` tag 생성과 push 승인
-4. `Release Publish DMG` `draft=true`, `prerelease=false` pre-public signed/notarized DMG workflow 실행 승인
-5. maintainer 설치 smoke 결과 확인
-6. `Release Publish DMG` `draft=false`, `prerelease=false` official stable publish workflow 실행 승인
+official stable run은 build signed/notarized DMG job과 GitHub Pages deploy job이 모두 성공했다. workflow summary 기준 stable appcast와 Pages artifact가 생성/배포됐고, public appcast 확인 결과 enclosure는 official stable DMG URL, length `156747415`, EdDSA signature `aKW+9nPDHi5nhiVR1VGPWIxxgSE0eVNIttyZFnIirFp7xYX4Z00oKj2lpCvUxkSZohkpkam/w/Sk5SqoL0r9Cw==`를 포함한다.
 
 ## Release metadata
 
@@ -198,19 +193,19 @@ Stage 4에서 생성/확인한 보조 산출물:
 
 ## Release execution gate
 
-public 배포 전에 다음 조건을 모두 만족해야 한다.
+public 배포 기준 조건은 다음과 같이 처리했다.
 
-- [ ] `local/task378` 변경을 `publish/task378` PR로 게시하고 `devel`에 merge
-- [ ] `devel`의 release candidate commit을 `main`에 반영하는 release PR 승인과 merge
-- [ ] `main`의 최종 release commit에 `v0.1.7` tag 생성
-- [ ] `Release Publish DMG` `draft=true`, `prerelease=false` 실행으로 pre-public signed/notarized DMG 생성
-- [ ] maintainer가 draft release asset 또는 Actions artifact DMG를 직접 설치 smoke 통과
-- [ ] GitHub Release body가 `scripts/ci/write-release-notes.sh` template 기준으로 생성됐는지 확인
-- [ ] `Release Publish DMG` `draft=false`, `prerelease=false` official stable publish 실행
-- [ ] public DMG `alhangeul-macos-0.1.7.dmg` SHA256 기록
-- [ ] stable Sparkle appcast의 `sparkle:shortVersionString=0.1.7`, `sparkle:version=13`, EdDSA signature 확인
-- [ ] public Pages `updates/v0.1.7.html`와 `appcast.xml` URL 확인
-- [ ] Homebrew Cask를 public DMG SHA256 기준으로 갱신하고 tap context 검증 후 사용자 설치 명령 공개
+- [x] `local/task378` 변경을 `publish/task378` PR로 게시하고 `devel`에 merge
+- [x] `devel`의 release candidate commit을 `main`에 반영하는 release PR 승인과 merge
+- [x] `main`의 최종 release commit에 `v0.1.7` tag 생성
+- [x] `Release Publish DMG` `draft=true`, `prerelease=false` 실행으로 pre-public signed/notarized DMG 생성
+- [x] maintainer가 draft release asset 또는 Actions artifact DMG를 직접 설치 smoke 통과
+- [x] GitHub Release body가 `scripts/ci/write-release-notes.sh` template 기준으로 생성됐는지 확인
+- [x] `Release Publish DMG` `draft=false`, `prerelease=false` official stable publish 실행
+- [x] public DMG `alhangeul-macos-0.1.7.dmg` SHA256 기록
+- [x] stable Sparkle appcast의 `sparkle:shortVersionString=0.1.7`, `sparkle:version=13`, EdDSA signature 확인
+- [x] public Pages `updates/v0.1.7.html`와 `appcast.xml` URL 확인
+- [ ] Homebrew Cask를 public DMG SHA256 기준으로 갱신하고 tap context 검증 후 사용자 설치 명령 공개. 이번 public publish 승인 범위 밖의 별도 gate로 남김
 
 ## 알려진 제한 사항과 후속 이슈
 
@@ -219,7 +214,7 @@ public 배포 전에 다음 조건을 모두 만족해야 한다.
 - HWPX 문서는 현재 직접 저장이 제한되어 HWP export 경로를 사용한다.
 - HWP 3.0 열기 보강은 `HWP Document File V3.` prefix를 가진 확인된 문서가 앱에서 차단되지 않도록 하는 변경이며, 모든 HWP 3.x 변형의 렌더링 품질을 보장하지는 않는다.
 - `rhwp-studio` asset을 upstream dist로 다시 동기화하면 HWP 3.0 URL byte guard 보강이 사라질 수 있으므로 다음 Studio sync 작업에서 다시 확인해야 한다.
-- public DMG SHA256, appcast EdDSA signature, notarization result, Homebrew Cask digest는 Stage 3 local rehearsal에서 단정하지 않는다.
+- Homebrew Cask digest와 tap smoke는 별도 gate에서 확정한다.
 
 ## Release communication checklist
 
@@ -232,12 +227,12 @@ public 배포 전에 다음 조건을 모두 만족해야 한다.
 - [x] `docs/updates/v0.1.7.html` 추가
 - [x] `docs/updates/index.html`에 v0.1.7 항목 추가
 - [x] `docs/index.html` 최신 다운로드 link 갱신
-- [x] `mydocs/release/index.md`에 v0.1.7 후보와 v0.1.6 공개 완료 상태 반영
+- [x] `mydocs/release/index.md`에 v0.1.7 공개 완료 상태 반영
 - [x] source preflight와 rehearsal 검증
-- [ ] installed candidate 기준 Finder Quick Look/Thumbnail smoke 확인
-- [ ] About 창의 `rhwp v0.7.17 (0335119)` 표시 확인
-- [ ] public DMG 생성
-- [ ] public DMG 안의 app/extension version이 `0.1.7 (13)`인지 확인
-- [ ] public DMG SHA256 기록
-- [ ] public GitHub Release URL과 latest 상태 확인
-- [ ] public `https://postmelee.github.io/alhangeul-macos/appcast.xml` stable item과 Sparkle EdDSA signature 확인
+- [x] installed candidate 기준 Finder Quick Look/Thumbnail smoke 확인. 작업지시자 직접 smoke 완료 확인
+- [x] About 창의 `rhwp v0.7.17 (0335119)` 표시 확인. 작업지시자 직접 smoke 범위에서 확인 완료
+- [x] public DMG 생성
+- [x] public DMG 안의 app/extension version이 `0.1.7 (13)`인지 확인
+- [x] public DMG SHA256 기록
+- [x] public GitHub Release URL과 latest 상태 확인
+- [x] public `https://postmelee.github.io/alhangeul-macos/appcast.xml` stable item과 Sparkle EdDSA signature 확인

--- a/mydocs/report/task_m900_378_report.md
+++ b/mydocs/report/task_m900_378_report.md
@@ -1,0 +1,52 @@
+# Task M900 #378 최종 보고서
+
+## 개요
+
+`v0.1.7` public release 준비, `devel -> main` 반영, `v0.1.7` tag 생성, pre-public signed/notarized DMG smoke, official stable GitHub Release 게시, Sparkle appcast와 Pages 배포를 완료했다. Homebrew Cask 반영은 별도 승인 gate로 남겼다.
+
+| 항목 | 값 |
+|------|----|
+| Issue | [#378](https://github.com/postmelee/alhangeul-macos/issues/378) |
+| Release | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) |
+| App version | `0.1.7` |
+| Build | `13` |
+| rhwp | `v0.7.17` / `03351190ec35436e58cbfee0aa9278a8fdc04a59` |
+| Tag commit | `876d2667c2bff60e8599af8bccb45c4cab19099f` |
+| Public DMG SHA256 | `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` |
+| Homebrew Cask | 별도 gate 미진행 |
+
+## 반영 PR
+
+| PR | 대상 | 내용 |
+|----|------|------|
+| [#379](https://github.com/postmelee/alhangeul-macos/pull/379) | `devel` | v0.1.7 source metadata, release communication, source preflight/rehearsal, publish gate 준비 |
+| [#380](https://github.com/postmelee/alhangeul-macos/pull/380) | `main` | v0.1.7 release candidate main 반영 |
+
+## 배포 결과
+
+- `v0.1.7` tag는 main merge commit `876d2667c2bff60e8599af8bccb45c4cab19099f`를 가리킨다.
+- pre-public draft workflow [`28116263365`](https://github.com/postmelee/alhangeul-macos/actions/runs/28116263365)가 성공했고, 작업지시자가 draft DMG 설치 smoke 완료를 확인했다.
+- official stable workflow [`28130401337`](https://github.com/postmelee/alhangeul-macos/actions/runs/28130401337)가 성공했다.
+- GitHub Release는 `draft=false`, `prerelease=false`, title `Alhangeul v0.1.7 (rhwp v0.7.17)`로 게시됐다.
+- public DMG `alhangeul-macos-0.1.7.dmg`는 size `156747415`, SHA256 `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d`로 확정됐다.
+- Sparkle appcast는 `sparkle:version=13`, `sparkle:shortVersionString=0.1.7`, public DMG URL, length `156747415`, EdDSA signature를 포함한다.
+- GitHub Pages 배포 job이 성공했고, `updates/v0.1.7.html`과 updates index가 v0.1.7 public DMG를 가리킨다.
+
+## 주요 검증
+
+| 검증 | 결과 |
+|------|------|
+| source preflight, Debug build, render smoke | 통과 |
+| local rehearsal DMG | 통과 |
+| pre-public signed/notarized draft DMG smoke | 통과 |
+| official stable workflow signed/notarized DMG build | 통과 |
+| GitHub Release public state | 통과 |
+| public `.dmg.sha256` 내용 | 통과 |
+| public appcast stable item | 통과 |
+| Pages v0.1.7 release note와 updates index | 통과 |
+
+## 남은 항목
+
+- Homebrew Cask 반영과 tap smoke는 별도 승인 gate에서 진행한다.
+- 기존 public 설치본에서 Sparkle update를 실제로 시작하는 smoke는 별도 수동 검증이 필요하다.
+- Issue #378 close와 branch cleanup은 이 closeout 기록 반영 후 수행한다.

--- a/mydocs/working/task_m900_378_stage5.md
+++ b/mydocs/working/task_m900_378_stage5.md
@@ -1,0 +1,49 @@
+# Task M900 #378 Stage 5 post-publish public surface 보고서
+
+## 단계 요약
+
+`v0.1.7` official stable publish를 완료하고 public GitHub Release, DMG asset, Sparkle appcast, Pages 업데이트 표면을 확인했다. Homebrew Cask 반영은 이번 승인 범위 밖의 별도 gate로 남겼다.
+
+| 항목 | 값 |
+|------|----|
+| Release | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) |
+| Workflow run | [`28130401337`](https://github.com/postmelee/alhangeul-macos/actions/runs/28130401337) |
+| Tag commit | `876d2667c2bff60e8599af8bccb45c4cab19099f` |
+| Public DMG | `alhangeul-macos-0.1.7.dmg` |
+| Public DMG size | `156747415` |
+| Public DMG SHA256 | `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` |
+| Pages release note | https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html |
+| Sparkle appcast | https://postmelee.github.io/alhangeul-macos/appcast.xml |
+
+## Workflow 결과
+
+| Job | 결과 | 비고 |
+|-----|------|------|
+| Build signed/notarized DMG and publish release asset | 성공 | signed/notarized DMG build, public artifact verify, release notes, GitHub Release asset, stable appcast artifact 생성 |
+| Deploy GitHub Pages | 성공 | generated appcast를 포함한 Pages artifact 배포 |
+
+`Release Publish DMG` run은 `draft=false`, `prerelease=false`로 실행했으며 GitHub Release 상태 검증 step도 통과했다.
+
+## Public surface 확인
+
+| 검증 | 결과 |
+|------|------|
+| 최신 GitHub Release | `v0.1.7`, `draft=false`, `prerelease=false` |
+| Release title | `Alhangeul v0.1.7 (rhwp v0.7.17)` |
+| DMG asset digest | `sha256:332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` |
+| `.dmg.sha256` 내용 | public DMG SHA256과 일치 |
+| appcast item | `sparkle:shortVersionString=0.1.7`, `sparkle:version=13`, DMG URL, length `156747415`, EdDSA signature 포함 |
+| Pages v0.1.7 note | v0.1.7 DMG URL, `rhwp v0.7.17`, `0.1.7 (13)` 안내 확인 |
+| Pages updates index | 최신 항목과 다운로드 link가 v0.1.7 DMG를 가리킴 |
+
+## 실행하지 않은 항목
+
+| 항목 | 사유 |
+|------|------|
+| Homebrew Cask 갱신과 tap smoke | 별도 승인 gate. public SHA256은 확정됐지만 이번 지시는 GitHub Release/Pages/Sparkle 공개 배포까지로 처리 |
+| Sparkle old-version update smoke | 기존 public 설치본에서 업데이트를 시작하는 별도 수동 검증이 필요함. 이번에는 stable appcast public surface 확인까지만 수행 |
+| official stable DMG 재다운로드 후 로컬 Finder smoke | pre-public draft DMG는 작업지시자가 직접 smoke 완료. official stable DMG는 workflow의 signing/notarization/public artifact 검증과 public surface 확인으로 기록 |
+
+## 다음 단계
+
+Stage 6에서는 release record의 남은 pre-public 기록을 실제 결과로 보정하고 최종 보고서를 작성한다. Homebrew를 이번 릴리즈에 이어서 공개할 경우 별도 승인 후 public DMG SHA256 `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` 기준으로 Cask와 tap 검증을 진행한다.


### PR DESCRIPTION
## 요약

- v0.1.7 public release record를 official stable publish 결과로 보정했습니다.
- Stage 5 post-publish public surface 보고서와 최종 보고서를 추가했습니다.
- release index와 오늘할일을 공개 완료 상태로 갱신했습니다.

## 검증

- `git diff --check main..HEAD`
- GitHub Release `v0.1.7` public state 확인
- public appcast/Pages v0.1.7 link 확인

## 남은 gate

- Homebrew Cask 반영과 tap smoke는 별도 gate로 남깁니다.