### PR TITLE
Task #378: Homebrew Cask v0.1.7 배포 정리

### DIFF
--- a/Casks/alhangeul.rb
+++ b/Casks/alhangeul.rb
@@ -1,6 +1,6 @@
 cask "alhangeul" do
-  version "0.1.6"
-  sha256 "87e37549a569813a3e22606f497ce837b350243cf3fed2ccd286af3ab8b02b9a"
+  version "0.1.7"
+  sha256 "332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d"
 
   url "https://github.com/postmelee/alhangeul-macos/releases/download/v#{version}/alhangeul-macos-#{version}.dmg"
   name "알한글"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
 - GitHub Release: [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7)
 - 업데이트 페이지: [알한글 v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html)
-- Homebrew Cask: public DMG SHA256 확정 후 별도 배포 단계에서 반영
+- Homebrew Cask: `brew install --cask postmelee/tap/alhangeul`
 - 포함된 `rhwp`: [`v0.7.17`](https://github.com/edwardkim/rhwp/releases/tag/v0.7.17) (`rhwp-core.lock`, bundled `rhwp-studio` manifest 기준)
 - Sparkle update 기준: short version은 `0.1.7`, build는 `13`입니다.
 
@@ -178,7 +178,13 @@ WKWebView 경로는 native macOS shell이 충분히 안정화될 때까지 fallb
 
 공개 배포 기준은 Developer ID로 서명하고 Apple notarization을 통과한 DMG입니다. GitHub Release에는 `alhangeul-macos-<version>.dmg`와 checksum을 함께 공개합니다. `v0.1.1`부터 공식 DMG는 앱 본체와 Quick Look/Thumbnail extension 실행 파일이 `arm64 + x86_64` slice를 포함하는 단일 universal DMG 기준으로 검증합니다. Intel Mac과 Apple Silicon Mac 모두 같은 파일을 받으며, 아키텍처별 DMG는 따로 제공하지 않습니다.
 
-Homebrew Cask는 public DMG SHA256 확정 후 별도 배포 단계에서 반영합니다. 최신 버전 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.
+Homebrew Cask를 사용하는 경우 아래 명령으로 같은 signed/notarized universal DMG를 설치할 수 있습니다.
+
+```bash
+brew install --cask postmelee/tap/alhangeul
+```
+
+Homebrew가 untrusted tap 정책으로 설치를 거부하면 `brew trust --cask postmelee/tap/alhangeul`을 한 번 실행한 뒤 다시 설치하세요.
 
 설치 후에는 `Alhangeul.app`을 한 번 실행하세요. macOS가 Quick Look 및 Thumbnail extension을 발견하고 등록한 뒤 Finder에서 `.hwp`, `.hwpx` preview와 thumbnail을 사용할 수 있습니다.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -206,7 +206,9 @@
           <p>상단 다운로드 버튼은 최신 공식 릴리즈의 DMG 파일을 바로 내려받도록 연결됩니다. v0.1.7 공식 DMG도 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다. 파일이 준비되지 않았거나 이전 버전이
             필요하면 <a href="https://github.com/postmelee/alhangeul-macos/releases/latest" target="_blank"
               rel="noreferrer">GitHub Releases</a>에서 배포 상태를 확인할 수 있습니다.</p>
-          <p>Homebrew Cask는 별도 배포 단계에서 최신 DMG 기준으로 반영합니다. 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.</p>
+          <p>Homebrew Cask를 사용하는 경우 아래 명령으로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
+          <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>
+          <p>Homebrew가 untrusted tap 정책으로 설치를 거부하면 <code>brew trust --cask postmelee/tap/alhangeul</code>을 한 번 실행한 뒤 다시 설치하세요.</p>
         </details>
         <details>
           <summary>앱 업데이트는 어떻게 확인하나요?</summary>

--- a/docs/updates/index.html
+++ b/docs/updates/index.html
@@ -66,7 +66,9 @@
 
       <section class="updates-section" aria-labelledby="homebrew-title">
         <h2 id="homebrew-title">Homebrew Cask</h2>
-        <p>Homebrew Cask는 GitHub Release DMG 공개 뒤 별도 배포 단계에서 반영합니다. 최신 v0.1.7이 필요하면 위 DMG 다운로드를 사용하세요.</p>
+        <p>Homebrew Cask를 사용하는 경우 아래 명령으로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
+        <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>
+        <p>Homebrew가 untrusted tap 정책으로 설치를 거부하면 <code>brew trust --cask postmelee/tap/alhangeul</code>을 한 번 실행한 뒤 다시 설치하세요.</p>
       </section>
 
       <section class="updates-section" aria-labelledby="release-notes-title">

--- a/docs/updates/v0.1.7.html
+++ b/docs/updates/v0.1.7.html
@@ -105,7 +105,9 @@
       <section class="updates-section" aria-labelledby="release-install-title">
         <h2 id="release-install-title">설치와 업데이트</h2>
         <p>DMG 파일을 내려받아 앱을 Applications 폴더로 옮긴 뒤, 앱을 한 번 실행합니다. v0.1.7 공식 DMG는 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다.</p>
-        <p>Homebrew Cask 반영은 별도 배포 단계에서 진행합니다. 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.</p>
+        <p>Homebrew Cask를 사용하는 경우 아래 명령으로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
+        <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>
+        <p>Homebrew가 untrusted tap 정책으로 설치를 거부하면 <code>brew trust --cask postmelee/tap/alhangeul</code>을 한 번 실행한 뒤 다시 설치하세요.</p>
         <p>설치한 앱에서는 메뉴 막대의 <code>알한글 &gt; 업데이트 확인...</code>을 선택해 새 버전을 확인할 수 있습니다.</p>
       </section>
     </div>

--- a/mydocs/orders/20260625.md
+++ b/mydocs/orders/20260625.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #378 | v0.1.7 public release 준비와 배포 실행 | 완료 | M900, public release/Pages/Sparkle 배포 완료. Homebrew는 별도 gate, 완료: 06:40 |
+| #378 | v0.1.7 public release 준비와 배포 실행 | 완료 | M900, public release/Pages/Sparkle/Homebrew 배포 완료, 완료: 07:09 |

--- a/mydocs/release/v0.1.7.md
+++ b/mydocs/release/v0.1.7.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.7` build `13` public GitHub Release, signed/notarized DMG, stable Sparkle appcast, Pages 배포 완료. Homebrew는 별도 gate |
+| 상태 | `v0.1.7` build `13` public GitHub Release, signed/notarized DMG, stable Sparkle appcast, Pages, Homebrew Cask 배포 완료 |
 | 목표 Git tag | `v0.1.7` |
 | 목표 app version | `0.1.7` |
 | 목표 build | `13` |
@@ -15,10 +15,10 @@
 | Public DMG SHA256 | `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` |
 | Local rehearsal DMG | `build.noindex/release/alhangeul-macos-0.1.7-rehearsal.dmg` |
 | Local rehearsal DMG SHA256 | `b1edbfd95a46afa0c0aad2746e5f43dde44d73f3e742ddcb115897548db52c9b` |
-| Homebrew Cask | 별도 승인 gate 미진행. public 안내는 GitHub Release DMG 직접 설치 유지 |
+| Homebrew Cask | `brew install --cask postmelee/tap/alhangeul` |
 | Release 실행 이슈 | [#378](https://github.com/postmelee/alhangeul-macos/issues/378) |
 
-이 문서는 `rhwp v0.7.17` 반영과 `v0.1.7` public release의 source metadata, release communication, 검증 결과를 기록한다. pre-public signed/notarized DMG smoke, official stable GitHub Release, stable Sparkle appcast, Pages 배포는 승인 gate에 따라 완료했다. Homebrew Cask 반영은 별도 승인 gate로 남긴다.
+이 문서는 `rhwp v0.7.17` 반영과 `v0.1.7` public release의 source metadata, release communication, 검증 결과를 기록한다. pre-public signed/notarized DMG smoke, official stable GitHub Release, stable Sparkle appcast, Pages 배포, Homebrew Cask 반영은 각각 승인 gate에 따라 완료했다.
 
 ## 사용자용 요약
 
@@ -164,7 +164,12 @@ Stage 3 local rehearsal 산출물은 notarization과 Developer ID signing을 건
 | Sparkle appcast | 통과 | `sparkle:shortVersionString=0.1.7`, `sparkle:version=13`, length `156747415`, EdDSA signature 포함 |
 | Pages release note | 통과 | `https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html`이 v0.1.7 DMG와 `rhwp v0.7.17` 안내 반영 |
 | Pages updates index | 통과 | `https://postmelee.github.io/alhangeul-macos/updates/`가 v0.1.7 최신 항목과 DMG link 반영 |
-| Homebrew Cask | 미진행 | public DMG SHA256은 확정됐지만 Homebrew tap 반영은 별도 승인 gate로 남김 |
+| Homebrew Cask source | 통과 | `Casks/alhangeul.rb` version `0.1.7`, SHA256 `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` |
+| Homebrew tap | 통과 | `postmelee/homebrew-tap` main commit `f1567d507f69e8b58164a879f008e754eda4b35e` |
+| Homebrew style/audit | 통과 | `brew style --cask alhangeul`, `brew audit --cask alhangeul` |
+| Homebrew install/uninstall smoke | 통과 | 임시 appdir `/private/tmp/alhangeul-homebrew-smoke-apps` 설치, `0.1.7 (13)`/codesign/Gatekeeper 확인, `brew uninstall --cask alhangeul` 제거 확인 |
+| Homebrew `--new` audit | 통과 | maintainer tap 기준 참고 검증으로 실행 |
+| GitHub Release Homebrew 안내 | 통과 | release body를 `brew install --cask postmelee/tap/alhangeul` 안내로 갱신하고 body validator 통과 |
 
 ## Public artifacts
 
@@ -174,6 +179,8 @@ Stage 3 local rehearsal 산출물은 notarization과 Developer ID signing을 건
 | `alhangeul-macos-0.1.7.dmg` official stable asset | `156747415` | `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` | public GitHub Release, Sparkle appcast, Pages download |
 
 official stable run은 build signed/notarized DMG job과 GitHub Pages deploy job이 모두 성공했다. workflow summary 기준 stable appcast와 Pages artifact가 생성/배포됐고, public appcast 확인 결과 enclosure는 official stable DMG URL, length `156747415`, EdDSA signature `aKW+9nPDHi5nhiVR1VGPWIxxgSE0eVNIttyZFnIirFp7xYX4Z00oKj2lpCvUxkSZohkpkam/w/Sk5SqoL0r9Cw==`를 포함한다.
+
+Homebrew 6.0.3 검증 환경은 `postmelee/tap`을 untrusted tap으로 차단했다. smoke는 `brew trust --cask postmelee/tap/alhangeul`을 선행한 뒤 진행했으며, public 안내에도 untrusted tap 차단 시 같은 보조 명령을 안내한다.
 
 ## Release metadata
 
@@ -205,7 +212,7 @@ public 배포 기준 조건은 다음과 같이 처리했다.
 - [x] public DMG `alhangeul-macos-0.1.7.dmg` SHA256 기록
 - [x] stable Sparkle appcast의 `sparkle:shortVersionString=0.1.7`, `sparkle:version=13`, EdDSA signature 확인
 - [x] public Pages `updates/v0.1.7.html`와 `appcast.xml` URL 확인
-- [ ] Homebrew Cask를 public DMG SHA256 기준으로 갱신하고 tap context 검증 후 사용자 설치 명령 공개. 이번 public publish 승인 범위 밖의 별도 gate로 남김
+- [x] Homebrew Cask를 public DMG SHA256 기준으로 갱신하고 tap context 검증 후 사용자 설치 명령 공개
 
 ## 알려진 제한 사항과 후속 이슈
 
@@ -214,7 +221,6 @@ public 배포 기준 조건은 다음과 같이 처리했다.
 - HWPX 문서는 현재 직접 저장이 제한되어 HWP export 경로를 사용한다.
 - HWP 3.0 열기 보강은 `HWP Document File V3.` prefix를 가진 확인된 문서가 앱에서 차단되지 않도록 하는 변경이며, 모든 HWP 3.x 변형의 렌더링 품질을 보장하지는 않는다.
 - `rhwp-studio` asset을 upstream dist로 다시 동기화하면 HWP 3.0 URL byte guard 보강이 사라질 수 있으므로 다음 Studio sync 작업에서 다시 확인해야 한다.
-- Homebrew Cask digest와 tap smoke는 별도 gate에서 확정한다.
 
 ## Release communication checklist
 

--- a/mydocs/report/task_m900_378_report.md
+++ b/mydocs/report/task_m900_378_report.md
@@ -2,7 +2,7 @@
 
 ## 개요
 
-`v0.1.7` public release 준비, `devel -> main` 반영, `v0.1.7` tag 생성, pre-public signed/notarized DMG smoke, official stable GitHub Release 게시, Sparkle appcast와 Pages 배포를 완료했다. Homebrew Cask 반영은 별도 승인 gate로 남겼다.
+`v0.1.7` public release 준비, `devel -> main` 반영, `v0.1.7` tag 생성, pre-public signed/notarized DMG smoke, official stable GitHub Release 게시, Sparkle appcast와 Pages 배포, Homebrew Cask 반영과 smoke를 완료했다.
 
 | 항목 | 값 |
 |------|----|
@@ -13,7 +13,7 @@
 | rhwp | `v0.7.17` / `03351190ec35436e58cbfee0aa9278a8fdc04a59` |
 | Tag commit | `876d2667c2bff60e8599af8bccb45c4cab19099f` |
 | Public DMG SHA256 | `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` |
-| Homebrew Cask | 별도 gate 미진행 |
+| Homebrew Cask | `brew install --cask postmelee/tap/alhangeul` |
 
 ## 반영 PR
 
@@ -32,6 +32,16 @@
 - Sparkle appcast는 `sparkle:version=13`, `sparkle:shortVersionString=0.1.7`, public DMG URL, length `156747415`, EdDSA signature를 포함한다.
 - GitHub Pages 배포 job이 성공했고, `updates/v0.1.7.html`과 updates index가 v0.1.7 public DMG를 가리킨다.
 
+## Homebrew
+
+- repository Cask source `Casks/alhangeul.rb`를 `0.1.7`과 public DMG SHA256으로 갱신했다.
+- `postmelee/homebrew-tap` main commit `f1567d507f69e8b58164a879f008e754eda4b35e`에 같은 Cask를 반영했다.
+- `brew style --cask alhangeul`, `brew audit --cask alhangeul`, `brew audit --cask --new alhangeul`이 통과했다.
+- 임시 appdir `/private/tmp/alhangeul-homebrew-smoke-apps` 기준으로 `brew install --cask --appdir=... postmelee/tap/alhangeul`과 `brew uninstall --cask alhangeul` smoke를 완료했다.
+- Homebrew 설치본은 `0.1.7 (13)`였고, `codesign --verify --deep --strict`와 `spctl --assess --type execute`가 통과했다.
+- 검증 환경의 Homebrew 6.0.3은 `postmelee/tap`을 untrusted tap으로 차단해 `brew trust --cask postmelee/tap/alhangeul`을 선행했다. README, Pages, GitHub Release 본문에 같은 보조 명령을 안내한다.
+- GitHub Release body는 Homebrew 설치 명령으로 직접 갱신했고 `scripts/validate-github-body.sh`를 통과했다.
+
 ## 주요 검증
 
 | 검증 | 결과 |
@@ -44,9 +54,11 @@
 | public `.dmg.sha256` 내용 | 통과 |
 | public appcast stable item | 통과 |
 | Pages v0.1.7 release note와 updates index | 통과 |
+| Homebrew Cask source/tap/style/audit | 통과 |
+| Homebrew install/uninstall smoke | 통과 |
+| GitHub Release Homebrew 안내 갱신 | 통과 |
 
 ## 남은 항목
 
-- Homebrew Cask 반영과 tap smoke는 별도 승인 gate에서 진행한다.
 - 기존 public 설치본에서 Sparkle update를 실제로 시작하는 smoke는 별도 수동 검증이 필요하다.
-- Issue #378 close와 branch cleanup은 이 closeout 기록 반영 후 수행한다.
+- Issue #378 close와 branch cleanup은 이 최종 기록 반영 후 수행한다.

--- a/mydocs/working/task_m900_378_stage5.md
+++ b/mydocs/working/task_m900_378_stage5.md
@@ -2,7 +2,7 @@
 
 ## 단계 요약
 
-`v0.1.7` official stable publish를 완료하고 public GitHub Release, DMG asset, Sparkle appcast, Pages 업데이트 표면을 확인했다. Homebrew Cask 반영은 이번 승인 범위 밖의 별도 gate로 남겼다.
+`v0.1.7` official stable publish를 완료하고 public GitHub Release, DMG asset, Sparkle appcast, Pages 업데이트 표면을 확인했다. 이후 Homebrew Cask 반영과 tap smoke까지 같은 release closeout 흐름에서 완료했다.
 
 | 항목 | 값 |
 |------|----|
@@ -40,10 +40,9 @@
 
 | 항목 | 사유 |
 |------|------|
-| Homebrew Cask 갱신과 tap smoke | 별도 승인 gate. public SHA256은 확정됐지만 이번 지시는 GitHub Release/Pages/Sparkle 공개 배포까지로 처리 |
 | Sparkle old-version update smoke | 기존 public 설치본에서 업데이트를 시작하는 별도 수동 검증이 필요함. 이번에는 stable appcast public surface 확인까지만 수행 |
 | official stable DMG 재다운로드 후 로컬 Finder smoke | pre-public draft DMG는 작업지시자가 직접 smoke 완료. official stable DMG는 workflow의 signing/notarization/public artifact 검증과 public surface 확인으로 기록 |
 
 ## 다음 단계
 
-Stage 6에서는 release record의 남은 pre-public 기록을 실제 결과로 보정하고 최종 보고서를 작성한다. Homebrew를 이번 릴리즈에 이어서 공개할 경우 별도 승인 후 public DMG SHA256 `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` 기준으로 Cask와 tap 검증을 진행한다.
+Stage 6에서는 release record의 남은 pre-public 기록을 실제 결과로 보정하고 최종 보고서를 작성한다. Homebrew는 public DMG SHA256 `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` 기준으로 Cask와 tap 검증까지 완료했다.


### PR DESCRIPTION
## 요약

- repository Cask source를 v0.1.7 public DMG SHA256으로 갱신했습니다.
- README, Pages, release record, 최종 보고서의 Homebrew 안내를 공개 설치 명령으로 갱신했습니다.
- GitHub Release body도 `brew install --cask postmelee/tap/alhangeul` 안내로 갱신했습니다.

## 외부 tap 반영

- `postmelee/homebrew-tap` main commit: `f1567d507f69e8b58164a879f008e754eda4b35e`

## 검증

- `brew style --cask alhangeul`
- `brew audit --cask alhangeul`
- `brew audit --cask --new alhangeul`
- `brew install --cask --appdir=/private/tmp/alhangeul-homebrew-smoke-apps postmelee/tap/alhangeul`
- installed app `0.1.7 (13)` 확인
- `codesign --verify --deep --strict --verbose=2 /private/tmp/alhangeul-homebrew-smoke-apps/Alhangeul.app`
- `spctl --assess --type execute --verbose=4 /private/tmp/alhangeul-homebrew-smoke-apps/Alhangeul.app`
- `brew uninstall --cask alhangeul`
- `scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check`
- `./scripts/update-cask-sha256.sh --dry-run 0.1.7 build.noindex/release/homebrew-v0.1.7/alhangeul-macos-0.1.7.dmg.sha256`
- `git diff --check`