### PR TITLE
Task #385: 문의/제보 페이지 docs-only Pages 반영

### DIFF
--- a/docs/feedback/index.html
+++ b/docs/feedback/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="ko">
+
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#ffffff" />
+  <meta name="description" content="알한글 사용 중 불편한 점, 렌더링 차이, 설치 문제를 이메일이나 GitHub Issue로 제보하는 방법을 안내합니다." />
+  <meta property="og:title" content="알한글 문의 / 제보" />
+  <meta property="og:description" content="GitHub 계정이 없어도 이메일로 알한글 사용 중 불편한 점과 오류를 편하게 제보할 수 있습니다." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://postmelee.github.io/alhangeul-macos/feedback/" />
+  <meta property="og:image" content="https://postmelee.github.io/alhangeul-macos/assets/og-main.png" />
+  <title>알한글 문의 / 제보</title>
+  <link rel="icon" href="../assets/logo-256@2x.png" />
+  <link rel="apple-touch-icon" href="../assets/logo-256@2x.png" />
+  <link rel="stylesheet" href="../styles.css?v=20260626-feedback-note" />
+</head>
+
+<body>
+  <a class="skip-link" href="#main">본문으로 이동</a>
+  <header class="site-header" aria-label="주요 탐색">
+    <div class="site-header-inner">
+      <a class="brand-link" href="../" aria-label="알한글 홈">
+        <img src="../assets/logo-256@2x.png" width="28" height="28" alt="" />
+        <span>알한글</span>
+      </a>
+      <nav class="header-actions" aria-label="주요 링크">
+        <a class="header-link" href="../" aria-label="알한글 홈으로 이동">
+          홈
+        </a>
+        <a class="header-link" href="../updates/" aria-label="업데이트 안내로 이동">
+          업데이트
+        </a>
+        <a class="header-link" href="https://github.com/postmelee/alhangeul-macos" rel="noreferrer"
+          aria-label="GitHub 저장소로 이동">
+          GitHub
+        </a>
+        <a class="header-download-button"
+          href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.7/alhangeul-macos-0.1.7.dmg"
+          aria-label="Mac용 알한글 DMG 다운로드">
+          다운로드
+        </a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main" class="updates-page feedback-page">
+    <section class="updates-hero feedback-hero" aria-labelledby="feedback-title">
+      <h1 id="feedback-title">문의 / 제보</h1>
+      <p>
+        <span>사용 중 불편한 점, 렌더링 차이, 설치 문제를 편하게 알려 주세요.</span>
+      </p>
+    </section>
+
+    <div class="updates-content feedback-content">
+      <aside class="feedback-privacy-note" aria-label="민감한 정보 안내">
+        <span class="feedback-privacy-icon" aria-hidden="true">⚠️</span>
+        <div>
+          <strong>민감한 정보 안내</strong>
+          <span>문서에 주민등록번호, 연락처, 내부 문서 내용이 있으면 원본 대신 설명이나 일부 화면만 보내 주세요.</span>
+        </div>
+      </aside>
+
+      <div class="feedback-card-grid" aria-label="문의와 제보 방법">
+        <article class="feedback-contact-card" aria-labelledby="feedback-email-title">
+          <div class="feedback-card-copy">
+            <h2 id="feedback-email-title">이메일</h2>
+            <p>기본 제보 경로입니다. 앱 버전, macOS 버전, 증상, 가능하면 스크린샷을 함께 보내 주세요.</p>
+          </div>
+          <div class="feedback-card-actions feedback-email-actions">
+            <div class="feedback-email-row">
+              <a class="feedback-email-address"
+                href="mailto:alhangeul.feedback@gmail.com?subject=%5B%EC%95%8C%ED%95%9C%EA%B8%80%20%EB%AC%B8%EC%9D%98%2F%EC%A0%9C%EB%B3%B4%5D&amp;body=%EC%95%B1%20%EB%B2%84%EC%A0%84%3A%0D%0AmacOS%20%EB%B2%84%EC%A0%84%3A%0D%0A%EB%AC%B8%EC%84%9C%20%ED%98%95%EC%8B%9D%28HWP%2FHWPX%29%3A%0D%0A%EC%A6%9D%EC%83%81%3A%0D%0A%EC%9E%AC%ED%98%84%20%EB%B0%A9%EB%B2%95%3A%0D%0A%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7%20%EB%98%90%EB%8A%94%20%EC%B0%B8%EA%B3%A0%20%EC%84%A4%EB%AA%85%3A%0D%0A">alhangeul.feedback@gmail.com</a>
+              <button class="feedback-copy-button" type="button" data-feedback-copy
+                data-copy-text="alhangeul.feedback@gmail.com" data-copy-label="복사" data-copy-success="복사 완료됨"
+                data-copy-fallback="주소 선택됨">
+                복사
+              </button>
+            </div>
+            <a class="feedback-send-button"
+              href="mailto:alhangeul.feedback@gmail.com?subject=%5B%EC%95%8C%ED%95%9C%EA%B8%80%20%EB%AC%B8%EC%9D%98%2F%EC%A0%9C%EB%B3%B4%5D&amp;body=%EC%95%B1%20%EB%B2%84%EC%A0%84%3A%0D%0AmacOS%20%EB%B2%84%EC%A0%84%3A%0D%0A%EB%AC%B8%EC%84%9C%20%ED%98%95%EC%8B%9D%28HWP%2FHWPX%29%3A%0D%0A%EC%A6%9D%EC%83%81%3A%0D%0A%EC%9E%AC%ED%98%84%20%EB%B0%A9%EB%B2%95%3A%0D%0A%EC%8A%A4%ED%81%AC%EB%A6%B0%EC%83%B7%20%EB%98%90%EB%8A%94%20%EC%B0%B8%EA%B3%A0%20%EC%84%A4%EB%AA%85%3A%0D%0A">
+              이메일 보내기
+            </a>
+          </div>
+        </article>
+
+        <article class="feedback-contact-card" aria-labelledby="feedback-issue-title">
+          <div class="feedback-card-copy">
+            <h2 id="feedback-issue-title">GitHub Issue</h2>
+            <p>공개 재현 절차, 샘플 파일, 개발 논의가 필요한 버그는 Issue로 남겨 주세요. 진행 상태를 공개적으로 추적하기에 가장 좋습니다.</p>
+          </div>
+          <div class="feedback-card-actions">
+            <a class="feedback-issue-button" href="https://github.com/postmelee/alhangeul-macos/issues" target="_blank"
+              rel="noreferrer">
+              <svg class="feedback-github-mark" viewBox="0 0 16 16" width="16" height="16" aria-hidden="true">
+                <path
+                  d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82A7.62 7.62 0 0 1 8 3.87c.68 0 1.36.09 2 .26 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8Z" />
+              </svg>
+              GitHub Issue
+            </a>
+          </div>
+        </article>
+      </div>
+    </div>
+  </main>
+
+  <footer class="site-footer">
+    <div class="footer-brand">
+      <img src="../assets/logo-256@2x.png" width="32" height="32" alt="" />
+      <span>알한글</span>
+    </div>
+    <p>Mac을 위한 HWP/HWPX 문서 미리보기 및 편집 앱입니다. 한글 파일이 더 이상 낯선 파일로 남지 않도록 만듭니다.</p>
+    <nav aria-label="푸터 링크">
+      <a href="https://github.com/postmelee/alhangeul-macos/blob/main/LICENSE" rel="noreferrer">MIT License</a>
+    </nav>
+  </footer>
+
+  <script src="../script.js?v=20260626-feedback-copy"></script>
+</body>
+
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,7 +26,7 @@
   <script>
     document.documentElement.classList.add("reveal-ready");
   </script>
-  <link rel="stylesheet" href="./styles.css?v=20260510-reveal" />
+  <link rel="stylesheet" href="./styles.css?v=20260626-feedback-page" />
 </head>
 
 <body>
@@ -40,6 +40,9 @@
       <nav class="header-actions" aria-label="주요 링크">
         <a class="header-link" href="./updates/" aria-label="업데이트 안내로 이동">
           업데이트
+        </a>
+        <a class="header-link" href="./feedback/" aria-label="문의와 제보 안내로 이동">
+          문의/제보
         </a>
         <a class="header-link" href="https://github.com/postmelee/alhangeul-macos" rel="noreferrer"
           aria-label="GitHub 저장소로 이동">
@@ -206,9 +209,7 @@
           <p>상단 다운로드 버튼은 최신 공식 릴리즈의 DMG 파일을 바로 내려받도록 연결됩니다. v0.1.7 공식 DMG도 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다. 파일이 준비되지 않았거나 이전 버전이
             필요하면 <a href="https://github.com/postmelee/alhangeul-macos/releases/latest" target="_blank"
               rel="noreferrer">GitHub Releases</a>에서 배포 상태를 확인할 수 있습니다.</p>
-          <p>Homebrew Cask를 사용하는 경우 아래 명령으로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
-          <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>
-          <p>Homebrew가 untrusted tap 정책으로 설치를 거부하면 <code>brew trust --cask postmelee/tap/alhangeul</code>을 한 번 실행한 뒤 다시 설치하세요.</p>
+          <p>Homebrew Cask는 별도 배포 단계에서 최신 DMG 기준으로 반영합니다. 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.</p>
         </details>
         <details>
           <summary>앱 업데이트는 어떻게 확인하나요?</summary>
@@ -224,12 +225,14 @@
         </details>
         <details>
           <summary>오류는 어디에 제보하면 되나요?</summary>
-          <p>미리보기, 썸네일, 공유 등 알한글 저장소가 다루는 기능의 오류는 <a
-              href="https://github.com/postmelee/alhangeul-macos/issues" target="_blank" rel="noreferrer">알한글 GitHub
-              Issues</a>에 제보해 주세요. 편집 화면은 <a href="https://github.com/edwardkim/rhwp" target="_blank"
+          <p>공개 추적이나 재현 논의가 필요한 오류는 <a href="https://github.com/postmelee/alhangeul-macos/issues"
+              target="_blank" rel="noreferrer">알한글 GitHub Issues</a>에 남겨 주세요.</p>
+          <p>GitHub을 사용하지 않는다면 <a href="mailto:alhangeul.feedback@gmail.com">alhangeul.feedback@gmail.com</a>으로
+            제보해 주세요. 앱 버전, macOS 버전, 증상, 스크린샷을 함께 보내면 확인에 도움이 됩니다.</p>
+          <p>편집 화면은 <a href="https://github.com/edwardkim/rhwp" target="_blank"
               rel="noreferrer"><code>rhwp-studio</code></a>를 WebView로 사용하므로, 렌더링과 편집 엔진 자체의 오류는 <a
               href="https://github.com/edwardkim/rhwp/issues" target="_blank" rel="noreferrer">rhwp upstream</a>에 제보하는
-            것이 가장 정확합니다. 알한글은 upstream 업데이트가 반영되면 macOS 앱에 맞춰 가져옵니다.</p>
+            것이 가장 정확합니다.</p>
         </details>
       </div>
       <p class="faq-credit">
@@ -252,7 +255,7 @@
   </footer>
 
   <noscript>FAQ 아코디언은 JavaScript 없이도 브라우저 기본 동작으로 열고 닫을 수 있습니다.</noscript>
-  <script src="./script.js?v=20260510-reveal-video"></script>
+  <script src="./script.js?v=20260626-feedback-copy"></script>
 </body>
 
 </html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,6 +1,7 @@
 const faqItems = document.querySelectorAll(".faq-list details");
 const featureSteps = Array.from(document.querySelectorAll("[data-feature-step]"));
 const featureVideos = Array.from(document.querySelectorAll("[data-feature-video]"));
+const feedbackCopyButtons = Array.from(document.querySelectorAll("[data-feedback-copy]"));
 const revealGroups = Array.from(document.querySelectorAll("[data-reveal-group]"));
 const prefersReducedMotionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
 
@@ -16,6 +17,88 @@ faqItems.forEach((item) => {
         otherItem.removeAttribute("open");
       }
     });
+  });
+});
+
+const copyTextWithTextarea = (text) => {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.width = "1px";
+  textarea.style.height = "1px";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  const didCopy = document.execCommand("copy");
+  textarea.remove();
+
+  if (!didCopy) {
+    throw new Error("Copy command failed");
+  }
+};
+
+const copyText = async (text) => {
+  if (navigator.clipboard && window.isSecureContext) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return;
+    } catch {
+      copyTextWithTextarea(text);
+      return;
+    }
+  }
+
+  copyTextWithTextarea(text);
+};
+
+const selectFallbackEmail = (button) => {
+  const emailAddress = button.closest(".feedback-email-row")?.querySelector(".feedback-email-address");
+  if (!emailAddress || !window.getSelection || !document.createRange) return false;
+
+  const range = document.createRange();
+  range.selectNodeContents(emailAddress);
+
+  const selection = window.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return true;
+};
+
+feedbackCopyButtons.forEach((button) => {
+  const defaultLabel = button.dataset.copyLabel || button.textContent.trim();
+  const successLabel = button.dataset.copySuccess || "복사됨";
+  const fallbackLabel = button.dataset.copyFallback || "주소 선택됨";
+  let resetTimer;
+
+  button.addEventListener("click", async () => {
+    const text = button.dataset.copyText;
+    if (!text) return;
+
+    try {
+      await copyText(text);
+      button.textContent = successLabel;
+      button.classList.add("is-copied");
+      button.classList.remove("is-selected");
+      window.clearTimeout(resetTimer);
+      resetTimer = window.setTimeout(() => {
+        button.textContent = defaultLabel;
+        button.classList.remove("is-copied");
+      }, 1600);
+    } catch {
+      const didSelect = selectFallbackEmail(button);
+      button.textContent = didSelect ? fallbackLabel : defaultLabel;
+      button.classList.toggle("is-selected", didSelect);
+      window.clearTimeout(resetTimer);
+      resetTimer = window.setTimeout(() => {
+        button.textContent = defaultLabel;
+        button.classList.remove("is-selected");
+      }, 1600);
+    }
   });
 });
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -37,18 +37,25 @@
 html {
   background: var(--bg);
   color: var(--text);
-  overflow-x: hidden;
+  overflow-x: clip;
   scroll-behavior: smooth;
 }
 
 body {
+  display: flex;
+  flex-direction: column;
   margin: 0;
+  min-height: 100svh;
   min-width: 320px;
-  overflow-x: hidden;
+  overflow-x: clip;
   background: var(--bg);
   color: var(--text);
   font-size: 17px;
   line-height: 1.47;
+}
+
+body > main {
+  flex: 1 0 auto;
 }
 
 a {
@@ -618,6 +625,246 @@ video {
   }
 }
 
+.feedback-section {
+  width: 100%;
+  min-height: calc(100svh - var(--header-height));
+  scroll-margin-top: var(--header-height);
+  padding: 88px 20px 96px;
+  background: #ffffff;
+}
+
+.feedback-inner {
+  width: min(760px, 100%);
+  margin: 0 auto;
+}
+
+.feedback-heading {
+  width: 100%;
+  margin: 0;
+  text-align: center;
+}
+
+.feedback-methods {
+  display: grid;
+  gap: 34px;
+  margin-top: 42px;
+}
+
+.feedback-method {
+  padding: 0;
+  text-align: left;
+}
+
+.feedback-method h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: 22px;
+  line-height: 1.25;
+  font-weight: 650;
+  letter-spacing: 0;
+}
+
+.feedback-method p {
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-size: 17px;
+  line-height: 1.65;
+  word-break: keep-all;
+}
+
+.feedback-email-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.feedback-email-address {
+  min-width: 0;
+  max-width: 100%;
+  color: #3a3a40;
+  font-weight: 600;
+  font-size: 17px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+
+.feedback-email-address:hover {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.feedback-copy-button,
+.feedback-send-button,
+.feedback-issue-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 34px;
+  border-radius: 999px;
+  padding: 0 13px;
+  font-size: 14px;
+  line-height: 1;
+  font-weight: 600;
+}
+
+.feedback-copy-button {
+  border: 1px solid var(--border);
+  background: #ffffff;
+  color: var(--accent);
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.feedback-copy-button:hover {
+  border-color: rgba(0, 102, 204, 0.44);
+  color: var(--accent-hover);
+}
+
+.feedback-copy-button.is-copied {
+  border-color: var(--accent);
+  background: var(--accent);
+  color: #ffffff;
+}
+
+.feedback-copy-button.is-selected {
+  border-color: rgba(0, 102, 204, 0.44);
+  background: rgba(0, 102, 204, 0.06);
+  color: var(--accent);
+}
+
+.feedback-send-button,
+.feedback-issue-button {
+  gap: 8px;
+  min-height: 42px;
+  border: 1px solid var(--accent);
+  background: var(--accent);
+  padding: 0 20px;
+  color: #ffffff;
+  font-size: 15px;
+}
+
+.feedback-send-button:hover,
+.feedback-issue-button:hover {
+  border-color: var(--accent-hover);
+  background: var(--accent-hover);
+  color: #ffffff;
+}
+
+.feedback-github-mark {
+  flex: 0 0 auto;
+  fill: currentColor;
+}
+
+.feedback-note {
+  width: min(640px, 100%);
+  margin: 30px 0 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.62;
+  text-align: left;
+  word-break: keep-all;
+}
+
+.feedback-hero p {
+  width: min(1040px, 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.feedback-hero p span {
+  display: block;
+  width: fit-content;
+  max-width: 100%;
+  margin-inline: auto;
+  text-align: center;
+}
+
+.feedback-privacy-note {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  border: 1px solid rgba(0, 102, 204, 0.18);
+  border-radius: 8px;
+  background: rgba(0, 102, 204, 0.06);
+  padding: 16px 18px;
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1.55;
+  word-break: keep-all;
+}
+
+.feedback-privacy-icon {
+  flex: 0 0 auto;
+  font-size: 18px;
+  line-height: 1.4;
+}
+
+.feedback-privacy-note div {
+  min-width: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+}
+
+.feedback-privacy-note strong {
+  color: var(--text);
+  font-weight: 650;
+}
+
+.feedback-card-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.feedback-contact-card {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 24px;
+}
+
+.feedback-card-actions {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 14px;
+  margin-top: auto;
+}
+
+.feedback-card-actions .feedback-email-row {
+  margin-top: 0;
+}
+
+.feedback-contact-card h2 {
+  margin: 0;
+  color: var(--text);
+  font-size: 26px;
+  line-height: 1.18;
+  letter-spacing: 0;
+}
+
+.feedback-card-copy p {
+  margin: 12px 0 0;
+  color: var(--muted);
+  font-size: 17px;
+  line-height: 1.65;
+  word-break: keep-all;
+}
+
+.feedback-contact-card .feedback-send-button,
+.feedback-contact-card .feedback-issue-button {
+  align-self: flex-start;
+}
+
 .faq-section {
   width: 100%;
   padding: 80px 20px 56px;
@@ -904,6 +1151,24 @@ video {
   text-decoration: underline;
 }
 
+.updates-section .feedback-issue-button {
+  color: var(--accent);
+}
+
+.updates-section .feedback-issue-button:hover {
+  color: var(--accent-hover);
+  text-decoration: none;
+}
+
+.updates-section .feedback-email-address {
+  color: #3a3a40;
+}
+
+.updates-section .feedback-email-address:hover {
+  color: var(--accent);
+  text-decoration: none;
+}
+
 .updates-section code {
   font: inherit;
   font-weight: 600;
@@ -987,6 +1252,7 @@ video {
 }
 
 .site-footer {
+  flex: 0 0 auto;
   width: 100%;
   display: grid;
   grid-template-columns: minmax(160px, 1fr) minmax(0, max-content) minmax(160px, 1fr);
@@ -1212,12 +1478,17 @@ video {
   .faq-list {
     grid-template-columns: 1fr;
   }
+
+  .feedback-card-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 
 @media (max-width: 520px) {
   .site-header-inner {
     width: min(100% - 24px, var(--content-width));
+    gap: 12px;
   }
 
   .brand-link span {
@@ -1225,18 +1496,18 @@ video {
   }
 
   .header-actions {
-    gap: 12px;
+    gap: 8px;
   }
 
   .header-link,
   .github-link {
-    font-size: 13px;
+    font-size: 12px;
   }
 
   .header-download-button {
     min-height: 30px;
-    padding: 0 12px;
-    font-size: 13px;
+    padding: 0 10px;
+    font-size: 12px;
   }
 
   .release-version-notice-inner {
@@ -1278,12 +1549,14 @@ video {
   .demo-section,
   .app-intro-section,
   .features-section,
+  .feedback-section,
   .faq-section {
     padding-left: 14px;
     padding-right: 14px;
   }
 
   .features-section,
+  .feedback-section,
   .faq-section {
     padding-top: 72px;
   }
@@ -1376,12 +1649,62 @@ video {
     line-height: 1.42;
   }
 
+  .feedback-section {
+    padding: 72px 20px 80px;
+  }
+
+  .feedback-methods {
+    margin-top: 30px;
+    gap: 30px;
+  }
+
+  .feedback-method {
+    padding: 0;
+  }
+
+  .feedback-method h3 {
+    font-size: 21px;
+  }
+
+  .feedback-method p {
+    font-size: 15px;
+    line-height: 1.58;
+  }
+
+  .feedback-contact-card {
+    padding: 20px;
+  }
+
+  .feedback-contact-card h2 {
+    font-size: 24px;
+  }
+
+  .feedback-card-copy p {
+    font-size: 15px;
+    line-height: 1.58;
+  }
+
+  .feedback-email-address {
+    font-size: 14px;
+  }
+
+  .feedback-note {
+    margin-top: 20px;
+    font-size: 13px;
+  }
+
   .reveal-ready [data-reveal-item] {
     transform: translateY(18px);
   }
 
   .site-footer nav {
     flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 380px) {
+  .brand-link span {
+    display: none;
   }
 }
 

--- a/docs/updates/index.html
+++ b/docs/updates/index.html
@@ -14,7 +14,7 @@
   <title>알한글 업데이트</title>
   <link rel="icon" href="../assets/logo-256@2x.png" />
   <link rel="apple-touch-icon" href="../assets/logo-256@2x.png" />
-  <link rel="stylesheet" href="../styles.css?v=20260510-reveal" />
+  <link rel="stylesheet" href="../styles.css?v=20260626-feedback-page" />
 </head>
 
 <body>
@@ -28,6 +28,9 @@
       <nav class="header-actions" aria-label="주요 링크">
         <a class="header-link" href="../" aria-label="알한글 홈으로 이동">
           홈
+        </a>
+        <a class="header-link" href="../feedback/" aria-label="문의와 제보 안내로 이동">
+          문의/제보
         </a>
         <a class="header-link" href="https://github.com/postmelee/alhangeul-macos" rel="noreferrer"
           aria-label="GitHub 저장소로 이동">
@@ -66,9 +69,7 @@
 
       <section class="updates-section" aria-labelledby="homebrew-title">
         <h2 id="homebrew-title">Homebrew Cask</h2>
-        <p>Homebrew Cask를 사용하는 경우 아래 명령으로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
-        <pre class="code-panel"><code>brew install --cask postmelee/tap/alhangeul</code></pre>
-        <p>Homebrew가 untrusted tap 정책으로 설치를 거부하면 <code>brew trust --cask postmelee/tap/alhangeul</code>을 한 번 실행한 뒤 다시 설치하세요.</p>
+        <p>Homebrew Cask는 GitHub Release DMG 공개 뒤 별도 배포 단계에서 반영합니다. 최신 v0.1.7이 필요하면 위 DMG 다운로드를 사용하세요.</p>
       </section>
 
       <section class="updates-section" aria-labelledby="release-notes-title">


### PR DESCRIPTION
## 요약

- 대상 타스크: #385
- 왜: 문의/제보 페이지를 릴리즈 전체 준비와 분리해 GitHub Pages에 먼저 공개합니다.
- 무엇: #384 변경 중 `docs/**`만 `main` 기준 브랜치에 선반영했습니다.
- 리뷰 포인트: PR diff가 `docs/**`로만 제한되는지, `/feedback/` 페이지와 헤더 링크가 공개 Pages 배포 대상에 포함되는지 확인해 주세요.

## PR base

- base: `main`

## 변경 내역

- `docs/feedback/index.html`: 문의/제보 별도 페이지, 민감한 정보 안내, 이메일/GitHub Issue 카드 추가
- `docs/index.html`: 홈 헤더 `문의/제보` 링크와 FAQ 오류 제보 답변 갱신
- `docs/updates/index.html`: 업데이트 페이지 헤더 `문의/제보` 링크 추가
- `docs/styles.css`: feedback page, 카드, CTA, 복사 버튼, footer flex layout 스타일 추가
- `docs/script.js`: 이메일 주소 복사와 fallback 선택 동작 추가

## docs-only 제한

이 PR은 `main` 대상 Pages 선반영 PR이므로 `docs/**`만 포함합니다.

제외한 항목:

- 앱 코드
- release 설정
- `project.yml`
- Swift/Rust 코드
- `mydocs/**` 작업 문서
- release tag, GitHub Release, DMG, Homebrew, appcast publish 작업

## 검증

- `git diff --check origin/main...HEAD`
- `git diff --name-only origin/main...HEAD`
  - `docs/feedback/index.html`
  - `docs/index.html`
  - `docs/script.js`
  - `docs/styles.css`
  - `docs/updates/index.html`
- `curl -I http://127.0.0.1:8767/feedback/`
  - `HTTP/1.0 200 OK`
- `scripts/ci/prepare-pages-artifact.sh --docs-dir docs --appcast build.noindex/task385/appcast.xml --output-dir build.noindex/task385/pages-artifact`
  - `Prepared Pages artifact at .../build.noindex/task385/pages-artifact`
- `test -f build.noindex/task385/pages-artifact/feedback/index.html`
- `xmllint --noout build.noindex/task385/pages-artifact/appcast.xml`
- `scripts/validate-github-body.sh build.noindex/task385/pr-body.md`

## 배포 확인 계획

이 PR merge 후 `Docs-only Pages Deploy` workflow가 `main`의 `docs/**` push로 실행되는지 확인합니다. 자동 실행이 없거나 재실행이 필요하면 `main` ref로 수동 실행합니다.

확인 URL:

- `https://postmelee.github.io/alhangeul-macos/feedback/`
- `https://postmelee.github.io/alhangeul-macos/`
- `https://postmelee.github.io/alhangeul-macos/updates/`

## 관련 이슈

Closes #385

## 후속 이슈 제안

- 없음

## 남은 리스크

- GitHub Pages CDN 반영에 몇 분 지연이 있을 수 있습니다.
- Pages workflow는 public `appcast.xml` fetch와 release asset gate에 의존하므로, 일시적인 GitHub API 또는 네트워크 실패 시 workflow 재실행이 필요할 수 있습니다.
- 이 docs 변경은 추후 release PR에서 이미 `main`에 선반영된 변경으로 보일 수 있습니다.
