### PR TITLE
Task #388: Thumbnail render signature core metadata 정합화

### DIFF
--- a/Alhangeul.xcodeproj/project.pbxproj
+++ b/Alhangeul.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		227BB0B9C6B7D7C6811A4C36 /* BuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA73996BDEAF04DE10497E23 /* BuildInfo.swift */; };
 		2CBAC0F13FA5A5C4486D4452 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2612A2057C62E35A5E751E7 /* Foundation.framework */; };
 		2DC3A5C591A43ED5139D6D7C /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2612A2057C62E35A5E751E7 /* Foundation.framework */; };
+		3009365CCC313802FEA32EA8 /* RhwpCoreBuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7582723794D9CFE90ED759 /* RhwpCoreBuildInfo.swift */; };
 		302DEA2AC6D48AB95F3A7C00 /* ApplicationServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B85C87F3CD3C8EFD709842FF /* ApplicationServices.framework */; };
 		307CE14735FB510DD719EC5F /* Rhwp.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F5AFC8EC56882BF138E698C /* Rhwp.xcframework */; };
 		308D4855D7022391FEF9CCD8 /* ExtensionSystemRegistrationRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62E51D4DC8276BF1D36E5FEC /* ExtensionSystemRegistrationRefresher.swift */; };
@@ -50,6 +51,7 @@
 		55993B1F9BBFFBBA62397829 /* LaunchMaintenanceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64C25EF462BA350A75A155D /* LaunchMaintenanceService.swift */; };
 		58FEED15D7979CC23FADA9D9 /* FontResourceRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2D57719DF9672E7C311D7 /* FontResourceRegistry.swift */; };
 		59DC1D6F67C3F459AC4A8ADC /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B49CA0DEC91C628C9B92B7A1 /* CoreFoundation.framework */; };
+		5C02265DAB27BE08F8FF4D8C /* RhwpCoreBuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7582723794D9CFE90ED759 /* RhwpCoreBuildInfo.swift */; };
 		5D0E58974DAD8BEA1E040E5A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D0ED3A363318BCA70DEA5C4C /* Assets.xcassets */; };
 		5E071C1C500CDB5723E42680 /* sample.hwpx in Resources */ = {isa = PBXBuildFile; fileRef = E4F2FDC67F5328E229845401 /* sample.hwpx */; };
 		6180BA787D50DD6F44AB68AF /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2612A2057C62E35A5E751E7 /* Foundation.framework */; };
@@ -111,6 +113,7 @@
 		DBD45292114D646A364B0B87 /* HwpPageImageRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B5C316C5FBCECA08C309CF9 /* HwpPageImageRenderer.swift */; };
 		DBF2603BA09D093A91E230C9 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0E931CF12C8BE40BCE94DC51 /* libc++.tbd */; };
 		DE194623702B252806CF09DF /* RhwpStudioDocumentPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BED1B65658BC71151FB7AC /* RhwpStudioDocumentPayload.swift */; };
+		E209FF4CC62FC20D4DC368AD /* RhwpCoreBuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7582723794D9CFE90ED759 /* RhwpCoreBuildInfo.swift */; };
 		E31F1F5AF648803FDDC2E893 /* DocumentSavePanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CD083E83BB7DFA8089562B5 /* DocumentSavePanel.swift */; };
 		E7AA85F51DE595BC11D36345 /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = A5315FE25D0AB65823C1D91A /* libz.tbd */; };
 		E7E737D711C9523AF943BB70 /* ThumbnailExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 3F33B7AA294D0DC689399E16 /* ThumbnailExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -237,6 +240,7 @@
 		E72EEE01C9016462E4E5956E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		EA2088B1914C461BF4EC8023 /* HostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostApp.swift; sourceTree = "<group>"; };
 		EC5D4F52776B873F6AB20372 /* DocumentFileActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentFileActions.swift; sourceTree = "<group>"; };
+		ED7582723794D9CFE90ED759 /* RhwpCoreBuildInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RhwpCoreBuildInfo.swift; sourceTree = "<group>"; };
 		F64C25EF462BA350A75A155D /* LaunchMaintenanceService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchMaintenanceService.swift; sourceTree = "<group>"; };
 		F6870F9FC321B27386359E2E /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		F6DA732CC42A781180AA2F88 /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
@@ -414,6 +418,7 @@
 				DEC2D57719DF9672E7C311D7 /* FontResourceRegistry.swift */,
 				77B27A9A00D195F9031B6311 /* PageOverlayImages.swift */,
 				6A01160D544F0F71CA0C3501 /* RenderTree.swift */,
+				ED7582723794D9CFE90ED759 /* RhwpCoreBuildInfo.swift */,
 				423B5D870B909D2D5D87F3D6 /* RhwpDocument.swift */,
 			);
 			name = RhwpCoreBridge;
@@ -692,6 +697,7 @@
 				09D138398C713C14EB0266D1 /* RecentDocumentStore.swift in Sources */,
 				44CDAB1946DFA27A7CADCF6D /* RecentDocumentThumbnailRefresher.swift in Sources */,
 				D8932BD515CBB96629CADD55 /* RenderTree.swift in Sources */,
+				3009365CCC313802FEA32EA8 /* RhwpCoreBuildInfo.swift in Sources */,
 				90F97E295C84EDBABCA218F6 /* RhwpDocument.swift in Sources */,
 				9E7FC8AC6078A6BD9975CD4E /* RhwpProvenance.swift in Sources */,
 				DE194623702B252806CF09DF /* RhwpStudioDocumentPayload.swift in Sources */,
@@ -722,6 +728,7 @@
 				539DFB38A0293062B5A01ED9 /* HwpThumbnailRenderCache.swift in Sources */,
 				7561FA65463CDF9CC5BED398 /* PageOverlayImages.swift in Sources */,
 				6475910A39D8217C7E004CB8 /* RenderTree.swift in Sources */,
+				E209FF4CC62FC20D4DC368AD /* RhwpCoreBuildInfo.swift in Sources */,
 				477B4C8AC6A0370182751D8F /* RhwpDocument.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -740,6 +747,7 @@
 				41C5D25E1060BEF211833C8A /* HwpPreviewProvider.swift in Sources */,
 				F853A92E67C1E05F3C1C8722 /* PageOverlayImages.swift in Sources */,
 				748E5560ED13294F03F1B627 /* RenderTree.swift in Sources */,
+				5C02265DAB27BE08F8FF4D8C /* RhwpCoreBuildInfo.swift in Sources */,
 				BCE95338397154D9AC1C61C6 /* RhwpDocument.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift
+++ b/Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift
@@ -1,0 +1,5 @@
+enum RhwpCoreBuildInfo {
+    static let releaseTag = "v0.7.17"
+    static let commit = "03351190ec35436e58cbfee0aa9278a8fdc04a59"
+    static let enabledFeatures = "native-skia"
+}

--- a/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift
+++ b/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift
@@ -48,9 +48,9 @@ struct HwpThumbnailRenderRequest {
 
 struct HwpThumbnailRenderSignature: Hashable {
     private static let rendererOptionVersion = "thumbnail-renderer-v1"
-    private static let coreReleaseTag = "v0.7.13"
-    private static let coreCommit = "b3e16ef212af81ef37d973ddb86d6816d3804642"
-    private static let coreEnabledFeatures = "native-skia"
+    private static let coreReleaseTag = RhwpCoreBuildInfo.releaseTag
+    private static let coreCommit = RhwpCoreBuildInfo.commit
+    private static let coreEnabledFeatures = RhwpCoreBuildInfo.enabledFeatures
     private static let maxDimensionPolicyVersion = "skia-max-dimension-0"
 
     let backendPolicy: String

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 진행중 | Stage 3 완료보고서 승인 대기 |
+| #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 진행중 | 구현계획서 작성 후 승인 대기 |
+| #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 진행중 | Stage 1 완료보고서 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 진행중 | Stage 1 완료보고서 승인 대기 |
+| #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 진행중 | Stage 2 완료보고서 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 6월 29일
+
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 진행중 | 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 진행중 | 수행계획서 작성 후 승인 대기 |
+| #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 진행중 | 구현계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 진행중 | Stage 2 완료보고서 승인 대기 |
+| #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 진행중 | Stage 3 완료보고서 승인 대기 |

--- a/mydocs/plans/task_m020_388.md
+++ b/mydocs/plans/task_m020_388.md
@@ -1,0 +1,93 @@
+# Task M020 #388 수행계획서
+
+## 목적
+
+Thumbnail render cache key에 포함되는 `HwpThumbnailRenderSignature`가 현재 bundled `rhwp` core provenance를 정확히 반영하도록 정리한다.
+
+현재 release-critical Swift 코드에는 `rhwp v0.7.13`과 commit `b3e16ef212af81ef37d973ddb86d6816d3804642`가 하드코딩되어 있지만, `rhwp-core.lock`은 `v0.7.17`과 commit `03351190ec35436e58cbfee0aa9278a8fdc04a59`를 가리킨다. 이 불일치를 제거하고, 이후 core pin 변경 시 같은 문제가 반복되지 않도록 검증 흐름을 둔다.
+
+## 배경
+
+Finder thumbnail cache는 file path, modification time, file size, pixel bucket, render signature를 함께 사용한다. 이 중 render signature는 renderer option, backend policy, core release tag, core commit, enabled features, maxDimension policy version을 포함한다.
+
+현재 `HwpThumbnailRenderSignature`의 core metadata가 stale 상태이면 core 변경 후에도 같은 signature로 cache reuse가 일어날 수 있다. 특히 larger bucket reuse도 render signature 동일성을 전제로 하므로, signature가 source of truth와 맞지 않으면 stale thumbnail 방지 효과가 약해진다.
+
+## 범위
+
+포함:
+
+- `rhwp-core.lock`의 `rhwp_release_tag`, `rhwp_commit`, `rhwp_enabled_features`를 Swift에서 참조할 수 있는 build info로 연결한다.
+- `HwpThumbnailRenderSignature`의 core metadata 하드코딩을 제거하고 build info를 참조하도록 수정한다.
+- lock 파일과 Swift build info가 불일치할 때 실패하는 검증 스크립트 또는 기존 build script hook을 추가한다.
+- release-critical Swift 코드에서 오래된 `v0.7.13` / `b3e16ef` 문자열이 사라졌는지 확인한다.
+- ThumbnailExtension compile 검증과 signature smoke 확인을 수행한다.
+
+제외:
+
+- `rhwp` core dependency update
+- Skia default 전환
+- Thumbnail render policy 변경
+- Finder/Quick Look extension release package 등록 smoke
+- P1 이후 readiness 재측정
+
+## 설계 방향
+
+`rhwp-core.lock`을 source of truth로 둔다. Swift 쪽에는 `RhwpCoreBuildInfo` 성격의 작은 generated source 또는 동등한 constant 파일을 두고, 생성/검증 스크립트가 lock과의 정합성을 확인한다.
+
+검증은 단순 문자열 치환에 머물지 않고 다음을 보장해야 한다.
+
+- lock의 release tag, commit, enabled features가 Swift build info와 일치한다.
+- `HwpThumbnailRenderSignature.identifier`가 build info 값을 포함한다.
+- core metadata가 바뀌면 thumbnail render signature도 바뀐다.
+- maxDimension policy version과 backend policy는 기존 cache 분리 의도를 유지한다.
+
+생성 source를 둘 위치는 단계 1에서 기존 target 포함 범위와 XcodeGen 설정을 확인해 결정한다. `Sources/RhwpCoreBridge`에는 AppKit/UIKit 의존을 넣지 않는 규칙을 유지하고, 공통 build info가 여러 target에서 필요하면 platform-neutral 파일로 둔다.
+
+## 예상 변경 파일
+
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- `Sources/RhwpCoreBridge` 또는 `Sources/Shared` 하위 build info source 후보
+- `scripts/` 하위 lock/build info 생성 또는 검증 스크립트 후보
+- `project.yml` 필요 여부 확인
+- `mydocs/working/task_m020_388_stage*.md`
+- `mydocs/report/task_m020_388_report.md`
+
+## 잠정 단계
+
+1. Stage 1: 현재 target source 포함 범위, lock parser 재사용 가능성, build info 파일 위치 후보를 조사한다.
+2. Stage 2: `RhwpCoreBuildInfo` 생성/검증 흐름과 Thumbnail signature 참조 구조를 구현한다.
+3. Stage 3: build script 또는 standalone verification command에 lock/build info 정합성 검사를 연결한다.
+4. Stage 4: ThumbnailExtension build, signature smoke, old metadata 검색, diff 검증을 수행한다.
+5. Stage 5: 결과와 후속 이슈 #390 입력 사항을 최종 보고서로 정리한다.
+
+## 검증 계획
+
+```bash
+rg -n "v0\\.7\\.13|b3e16ef|coreReleaseTag|coreCommit|RhwpCoreBuildInfo" Sources scripts mydocs
+./scripts/build-rust-macos.sh --verify-lock
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task388 CODE_SIGNING_ALLOWED=NO build
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task388-thumbnail-signature \
+  samples/basic/KTX.hwp samples/basic/request.hwp
+git diff --check
+```
+
+필요 시 추가:
+
+```bash
+swiftc 또는 별도 script로 HwpThumbnailRenderSignature.identifier smoke 확인
+```
+
+## 리스크
+
+- generated Swift 파일을 target에 포함하는 방식이 XcodeGen source glob과 충돌하면 project.yml 조정이 필요할 수 있다.
+- `scripts/build-rust-macos.sh --verify-lock`는 local staticlib byte hash 차이에 민감할 수 있다. 이 경우 source provenance, generated header, FFI symbol 검증과 staticlib hash 검증 실패를 분리해 해석해야 한다.
+- build info를 ThumbnailExtension 전용 위치에 두면 후속 Quick Look/Shared 경로에서 재사용성이 낮아질 수 있다.
+- 검증 스크립트가 lock parser를 중복 구현하면 core lock format 변경 시 유지보수 비용이 생긴다. 가능하면 기존 `scripts/ci/read-rhwp-core-lock.sh` 또는 build script의 parsing 흐름을 재사용한다.
+
+## 승인 요청 사항
+
+- 기준 브랜치는 `devel`, 작업 브랜치는 `local/task388`로 진행한다.
+- 이 작업은 #387 추적 이슈의 P0 하위 이슈 #388로 진행한다.
+- 수행계획서 승인 후 Stage 1 구현 계획서를 작성하고, 코드/스크립트 변경은 그 다음 단계에서 수행한다.

--- a/mydocs/plans/task_m020_388_impl.md
+++ b/mydocs/plans/task_m020_388_impl.md
@@ -1,0 +1,219 @@
+# Task M020 #388 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_388.md`
+
+## 작업 개요
+
+- 이슈: #388 Thumbnail render signature를 `rhwp-core.lock` 기준으로 생성/검증
+- 추적 이슈: #387 Preview/Thumbnail Skia readiness 후속 개선 추적
+- 마일스톤: `v0.2.x Skia Quick Look/Thumbnail Backend`
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task388`
+- 목표: `HwpThumbnailRenderSignature`의 core metadata가 `rhwp-core.lock`과 일치하도록 만들고, 이후 core pin 변경 시 불일치를 검증으로 잡는다.
+
+## 구현 원칙
+
+- `rhwp-core.lock`을 source of truth로 둔다.
+- release-critical Swift 코드에 core release tag와 commit을 직접 중복 하드코딩하지 않는다.
+- Thumbnail cache key의 기존 분리 의도는 유지한다.
+  - backend policy
+  - renderer option version
+  - core release tag
+  - core commit
+  - core enabled features
+  - maxDimension policy version
+- `Sources/RhwpCoreBridge`에는 AppKit/UIKit 의존을 넣지 않는다.
+- Xcode project 원본은 `project.yml`이며, `Alhangeul.xcodeproj`는 직접 수정하지 않는다.
+- generated file을 추가하는 경우 생성 명령, 검증 명령, target 포함 범위를 함께 정리한다.
+
+## Stage 1. build info 위치와 lock parser 재사용 경로 조사
+
+목표:
+
+- `RhwpCoreBuildInfo` 성격의 Swift source를 어디에 둘지 결정한다.
+- 기존 script와 XcodeGen source inclusion 구조에서 lock parser를 재사용할 수 있는지 확인한다.
+- 검증 흐름을 build script에 넣을지 standalone script로 둘지 판단한다.
+
+대상:
+
+- `project.yml`
+- `rhwp-core.lock`
+- `scripts/build-rust-macos.sh`
+- `scripts/ci/read-rhwp-core-lock.sh`
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- `Sources/Shared`
+- `Sources/RhwpCoreBridge`
+
+작업:
+
+1. `project.yml`의 `ThumbnailExtension`, `QLExtension`, `HostApp` source inclusion 구조를 확인한다.
+2. `scripts/build-rust-macos.sh`의 lock parsing과 verify flow를 조사한다.
+3. `scripts/ci/read-rhwp-core-lock.sh`를 local 검증 script에서 재사용할 수 있는지 확인한다.
+4. build info source 위치 후보를 비교한다.
+   - `Sources/RhwpCoreBridge`
+   - `Sources/Shared`
+   - `Sources/ThumbnailExtension`
+5. Stage 1 완료보고서에 선택안과 Stage 2 구현 방향을 기록한다.
+
+검증:
+
+```bash
+rg -n "sources:|Sources/Shared|Sources/RhwpCoreBridge|ThumbnailExtension|QLExtension|HostApp" project.yml
+rg -n "rhwp_release_tag|rhwp_commit|rhwp_enabled_features|read-rhwp-core-lock|verify-lock|LOCK_FILE" \
+  rhwp-core.lock scripts/build-rust-macos.sh scripts/ci/read-rhwp-core-lock.sh
+rg -n "HwpThumbnailRenderSignature|coreReleaseTag|coreCommit|coreEnabledFeatures" \
+  Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift
+git diff --check -- mydocs/plans/task_m020_388_impl.md mydocs/working/task_m020_388_stage1.md
+```
+
+완료 조건:
+
+- build info 파일 위치와 생성/검증 책임이 문서화되어 있다.
+- Stage 2에서 수정할 파일 목록이 확정되어 있다.
+- AppKit/UIKit 금지 경계와 XcodeGen 원본 경계에 어긋나지 않는다.
+
+커밋:
+
+```text
+Task #388 Stage 1: Thumbnail core build info 경로 조사
+```
+
+## Stage 2. RhwpCoreBuildInfo와 Thumbnail signature refactor
+
+목표:
+
+- `HwpThumbnailRenderSignature`가 stale hardcoded core metadata 대신 current build info를 참조하도록 수정한다.
+- `v0.7.13` / `b3e16ef` 하드코딩을 release-critical Swift 코드에서 제거한다.
+
+대상:
+
+- Stage 1에서 확정한 build info Swift source
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- 필요 시 `project.yml`
+- `mydocs/working/task_m020_388_stage2.md`
+
+작업:
+
+1. `RhwpCoreBuildInfo` 또는 동등한 타입을 추가한다.
+2. current lock 기준 값을 build info에 반영한다.
+   - `releaseTag = "v0.7.17"`
+   - `commit = "03351190ec35436e58cbfee0aa9278a8fdc04a59"`
+   - `enabledFeatures = "native-skia"`
+3. `HwpThumbnailRenderSignature`의 default core metadata를 build info 참조로 바꾼다.
+4. `identifier`가 기존 필드 순서와 cache 분리 의미를 유지하는지 확인한다.
+5. Stage 2 완료보고서에 변경 구조와 cache key 영향 범위를 기록한다.
+
+검증:
+
+```bash
+rg -n "v0\\.7\\.13|b3e16ef" Sources
+rg -n "RhwpCoreBuildInfo|coreReleaseTag|coreCommit|coreEnabledFeatures|identifier" \
+  Sources mydocs/working/task_m020_388_stage2.md
+git diff --check
+```
+
+완료 조건:
+
+- `Sources` 아래 release-critical 코드에 stale core metadata가 남아 있지 않다.
+- `HwpThumbnailRenderSignature`가 current build info 값을 참조한다.
+- cache key 구조와 larger bucket reuse 조건은 기존 의도대로 유지된다.
+
+커밋:
+
+```text
+Task #388 Stage 2: Thumbnail render signature core metadata 정합화
+```
+
+## Stage 3. rhwp-core.lock과 build info 정합성 검증 추가
+
+목표:
+
+- `rhwp-core.lock`과 Swift build info가 다르면 명시적으로 실패하는 검증 경로를 추가한다.
+- core pin 변경 후 build info 갱신 누락을 조기에 발견한다.
+
+대상:
+
+- `scripts/` 하위 신규 또는 기존 검증 script
+- 필요 시 `scripts/build-rust-macos.sh`
+- 필요 시 `scripts/ci/read-rhwp-core-lock.sh`
+- `mydocs/working/task_m020_388_stage3.md`
+
+작업:
+
+1. Stage 1 결론에 따라 standalone verification command 또는 build script hook을 구현한다.
+2. 검증 대상 값을 lock에서 읽는다.
+   - `rhwp_release_tag`
+   - `rhwp_commit`
+   - `rhwp_enabled_features`
+3. Swift build info source에서 같은 값을 확인한다.
+4. mismatch 발생 시 어떤 파일을 갱신해야 하는지 에러 메시지에 남긴다.
+5. Stage 3 완료보고서에 실행 명령과 failure mode를 기록한다.
+
+검증:
+
+```bash
+신규 또는 갱신된 lock/build info 검증 명령
+./scripts/build-rust-macos.sh --verify-lock
+git diff --check
+```
+
+완료 조건:
+
+- 검증 명령이 현재 `rhwp-core.lock`과 build info의 일치 상태에서 통과한다.
+- mismatch를 만들지 않고도 검증 대상과 failure mode가 코드/문서에서 확인 가능하다.
+- 기존 `build-rust-macos.sh --verify-lock` 의미와 충돌하지 않는다.
+
+커밋:
+
+```text
+Task #388 Stage 3: core lock build info 검증 추가
+```
+
+## Stage 4. build, smoke, 최종 정리
+
+목표:
+
+- ThumbnailExtension compile과 thumbnail signature smoke를 통해 변경이 실제 target에서 동작하는지 확인한다.
+- #390 readiness 재측정으로 넘길 기준 상태를 정리한다.
+
+대상:
+
+- `mydocs/working/task_m020_388_stage4.md`
+- `mydocs/report/task_m020_388_report.md`
+- `mydocs/orders/20260629.md`
+
+작업:
+
+1. AppKit/UIKit boundary 검사를 실행한다.
+2. 필요 시 Xcode project를 재생성한다.
+3. `ThumbnailExtension` Debug build를 실행한다.
+4. thumbnail policy smoke를 실행하고 signature 값이 current lock 기준을 포함하는지 확인한다.
+5. 오래된 core metadata 검색 결과를 기록한다.
+6. 최종 보고서와 오늘할일 완료 처리를 준비한다.
+
+검증:
+
+```bash
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task388 CODE_SIGNING_ALLOWED=NO build
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task388-thumbnail-signature \
+  samples/basic/KTX.hwp samples/basic/request.hwp
+rg -n "v0\\.7\\.13|b3e16ef" Sources scripts mydocs
+git diff --check
+git status --short
+```
+
+완료 조건:
+
+- `ThumbnailExtension` Debug build가 성공한다.
+- smoke output 또는 보고서에 current lock 기준 signature가 기록된다.
+- stale core metadata 검색 결과가 release-critical source에 남아 있지 않음으로 정리된다.
+- 최종 보고서가 #390 readiness 재측정의 입력 상태를 명확히 남긴다.
+
+커밋:
+
+```text
+Task #388 Stage 4: Thumbnail signature 검증과 최종 보고서 정리
+```

--- a/mydocs/report/task_m020_388_report.md
+++ b/mydocs/report/task_m020_388_report.md
@@ -1,0 +1,76 @@
+# Task #388 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | #388 Thumbnail render signature를 `rhwp-core.lock` 기준으로 생성/검증 |
+| 추적 이슈 | #387 Preview/Thumbnail Skia readiness 후속 개선 추적 |
+| 마일스톤 | v0.2.x Skia Quick Look/Thumbnail Backend |
+| 단계 수 | 4 |
+| 작업 브랜치 | `local/task388` |
+
+`HwpThumbnailRenderSignature`가 stale `rhwp v0.7.13` metadata 대신 current `rhwp-core.lock` 기준 `v0.7.17`, `03351190ec35436e58cbfee0aa9278a8fdc04a59`, `native-skia`를 사용하도록 정리했다. 이후 core pin 변경 시 Swift build info 갱신 누락을 잡는 standalone verification command도 추가했다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift` | `rhwp-core.lock` 기준 release tag, resolved commit, enabled features를 Swift target에서 참조할 platform-neutral build info로 추가 |
+| `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift` | `HwpThumbnailRenderSignature`의 core metadata 기본값을 `RhwpCoreBuildInfo` 참조로 변경 |
+| `scripts/verify-rhwp-core-build-info.sh` | lock/build info mismatch를 실패시키는 검증 명령 추가 |
+| `scripts/check-no-appkit.sh` | `RhwpCoreBuildInfo.swift`도 AppKit/UIKit 금지 검사 대상에 포함 |
+| `scripts/smoke-thumbnail-skia-policy.sh` | smoke compile source list에 `RhwpCoreBuildInfo.swift` 포함 |
+| `Alhangeul.xcodeproj/project.pbxproj` | XcodeGen 생성 결과로 `RhwpCoreBuildInfo.swift` target source phase 포함 |
+| `mydocs/plans/task_m020_388.md` | 수행계획서 |
+| `mydocs/plans/task_m020_388_impl.md` | 구현계획서 |
+| `mydocs/working/task_m020_388_stage1.md` | build info 위치와 lock parser 조사 보고 |
+| `mydocs/working/task_m020_388_stage2.md` | signature refactor 보고 |
+| `mydocs/working/task_m020_388_stage3.md` | lock/build info 검증 추가 보고 |
+| `mydocs/working/task_m020_388_stage4.md` | build/smoke 최종 검증 보고 |
+| `mydocs/orders/20260629.md` | 오늘할일 완료 처리 |
+
+## 변경 전·후 정량 비교
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| Thumbnail signature core tag | `v0.7.13` 하드코딩 | `RhwpCoreBuildInfo.releaseTag = "v0.7.17"` |
+| Thumbnail signature core commit | `b3e16ef212af81ef37d973ddb86d6816d3804642` 하드코딩 | `RhwpCoreBuildInfo.commit = "03351190ec35436e58cbfee0aa9278a8fdc04a59"` |
+| enabled features | `native-skia` 하드코딩 | `RhwpCoreBuildInfo.enabledFeatures` 참조 |
+| build info source | 없음 | `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift`, 5 lines |
+| lock/build info 검증 | 없음 | `scripts/verify-rhwp-core-build-info.sh`, 83 lines |
+| stale metadata 검색 | release-critical Swift source에 존재 | `Sources`와 `scripts`에서 stale 문자열 없음 |
+
+## 단계 요약
+
+| Stage | 커밋 | 요약 |
+|------|------|------|
+| Stage 1 | `d3151c7` | build info 위치를 `Sources/RhwpCoreBridge`로 정하고 기존 lock parser 재사용 경로 확인 |
+| Stage 2 | `36643d9` | `RhwpCoreBuildInfo` 추가와 Thumbnail signature core metadata refactor |
+| Stage 3 | `6756ba1` | lock/build info standalone verification command 추가 |
+| Stage 4 | 이번 커밋 | XcodeGen, ThumbnailExtension build, thumbnail smoke, 최종 보고 정리 |
+
+## 검증 결과
+
+| 수용 기준 | 결과 | 근거 |
+|-----------|------|------|
+| lock과 Swift build info 일치 검증 | OK | `./scripts/verify-rhwp-core-build-info.sh` 통과 |
+| AppKit/UIKit boundary 유지 | OK | `./scripts/check-no-appkit.sh` 통과 |
+| Xcode project 생성 | OK | `xcodegen generate` 통과 |
+| ThumbnailExtension Debug build | OK | `xcodebuild ... ThumbnailExtension ... build`에서 `BUILD SUCCEEDED` |
+| thumbnail signature smoke | OK | `KTX.hwp`, `request.hwp` 모두 `renders=8 failed=0` |
+| signature current lock metadata 포함 | OK | smoke output에 `v0.7.17`, `03351190ec35436e58cbfee0aa9278a8fdc04a59`, `native-skia` 포함 |
+| stale metadata 제거 | OK | `rg -n "v0\\.7\\.13\|b3e16ef" Sources scripts` 결과 없음 |
+| whitespace 점검 | OK | `git diff --check` 통과 |
+
+## 잔여 위험과 후속 작업
+
+| 항목 | 상태 | 처리 |
+|------|------|------|
+| local strict static archive byte hash mismatch | 잔여 | #394 `build-rust-macos verify-lock strict 실패 UX 개선과 portable verify 분리`로 등록 |
+| #390 readiness 재측정 | 후속 | 이번 작업의 signature 정합화 결과를 입력으로 사용 |
+| `RhwpCoreBuildInfo` 갱신 자동화 | 제한적 수동 | 현재는 검증으로 누락을 잡는다. future core pin update에서 생성 자동화 필요성이 커지면 별도 작업으로 분리 |
+
+## 작업지시자 승인 요청
+
+Task #388의 구현과 검증은 완료했다. PR 게시 단계 진입 여부를 승인해 달라.

--- a/mydocs/working/task_m020_388_stage1.md
+++ b/mydocs/working/task_m020_388_stage1.md
@@ -1,0 +1,161 @@
+# Task M020 #388 Stage 1 완료보고서
+
+## 단계 목적
+
+`HwpThumbnailRenderSignature`의 core metadata를 `rhwp-core.lock` 기준으로 정합화하기 전에, build info source 위치와 lock parser 재사용 경로를 결정한다.
+
+이번 단계는 코드 변경 없이 다음 항목을 조사했다.
+
+- `project.yml`의 target source inclusion 구조
+- `scripts/build-rust-macos.sh`와 `scripts/ci/read-rhwp-core-lock.sh`의 lock parsing/verify 흐름
+- `HwpThumbnailRenderSignature`의 stale metadata 위치
+- smoke script의 수동 `swiftc` source list 영향
+
+## 산출물
+
+- `mydocs/working/task_m020_388_stage1.md`
+  - Stage 1 조사 결과와 Stage 2 구현 방향을 기록했다.
+- `mydocs/orders/20260629.md`
+  - #388 비고를 `Stage 1 완료보고서 승인 대기`로 갱신했다.
+
+제품 Swift/Rust source는 수정하지 않았다.
+
+## 조사 결과
+
+### target source inclusion
+
+`project.yml` 기준으로 `HostApp`, `QLExtension`, `ThumbnailExtension` 모두 `Sources/Shared`와 `Sources/RhwpCoreBridge`를 포함한다.
+
+- `HostApp`: `Sources/HostApp`, `Sources/Shared`, `Sources/RhwpCoreBridge`
+- `QLExtension`: `Sources/QLExtension`, `Sources/Shared`, `Sources/RhwpCoreBridge`
+- `ThumbnailExtension`: `Sources/ThumbnailExtension`, `Sources/Shared`, `Sources/RhwpCoreBridge`
+
+따라서 build info source는 `Sources/RhwpCoreBridge` 또는 `Sources/Shared`에 두면 Xcode target에는 자동 포함된다. `Sources/ThumbnailExtension`에 두면 이번 문제는 가장 좁게 해결되지만, 후속 Quick Look/Shared 진단에서 같은 core metadata를 재사용하기 어렵다.
+
+### build info 위치 후보
+
+선택안:
+
+- `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift`
+
+이유:
+
+- core provenance는 RustBridge와 Swift FFI wrapper의 경계 정보라 `RhwpCoreBridge` 책임에 가깝다.
+- `HostApp`, `QLExtension`, `ThumbnailExtension`이 모두 `Sources/RhwpCoreBridge`를 포함한다.
+- 파일 내용은 `Foundation`조차 필요 없는 constant enum으로 둘 수 있어 AppKit/UIKit 금지 규칙과 충돌하지 않는다.
+- 후속 P1/P2/P3 작업에서 Quick Look/Shared 진단에도 같은 값을 재사용할 수 있다.
+
+대안과 보류 이유:
+
+- `Sources/Shared`: Quick Look/Thumbnail helper와 가깝지만, core provenance 책임은 Shared helper보다 bridge 경계에 더 가깝다.
+- `Sources/ThumbnailExtension`: 변경 범위는 가장 작지만, 같은 metadata를 다른 surface가 재사용하기 어렵고 후속 중복 하드코딩 가능성이 남는다.
+
+### lock parser 재사용
+
+`scripts/build-rust-macos.sh`는 내부 `lock_scalar` 함수로 `rhwp-core.lock`을 읽고, `--verify-lock`에서 repo, ref kind, release tag, commit, enabled features, artifact metadata를 검증한다. 다만 이 함수는 스크립트 내부 함수라 별도 script가 직접 source해서 쓰기에는 적합하지 않다.
+
+`scripts/ci/read-rhwp-core-lock.sh`는 top-level scalar 하나를 안정적으로 읽는 작은 helper이며, 현재 task에 필요한 세 값을 모두 읽을 수 있다.
+
+- `rhwp_release_tag`
+- `rhwp_commit`
+- `rhwp_enabled_features`
+
+Stage 3에서는 이 helper를 재사용하는 standalone 검증 script를 두는 편이 적절하다. `build-rust-macos.sh --verify-lock`에 바로 끼우면 Rust bridge build/lock 검증과 Swift build info 검증의 책임이 섞인다. 후속으로 필요하면 build script에서 standalone script를 호출하는 hook을 별도 검토할 수 있다.
+
+### 현재 stale metadata 위치
+
+`Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`의 `HwpThumbnailRenderSignature`에 다음 값이 직접 하드코딩되어 있다.
+
+- `coreReleaseTag = "v0.7.13"`
+- `coreCommit = "b3e16ef212af81ef37d973ddb86d6816d3804642"`
+- `coreEnabledFeatures = "native-skia"`
+
+현재 `rhwp-core.lock`은 다음 값이다.
+
+- `rhwp_release_tag = "v0.7.17"`
+- `rhwp_commit = "03351190ec35436e58cbfee0aa9278a8fdc04a59"`
+- `rhwp_enabled_features = "native-skia"`
+
+Stage 2에서는 `RhwpCoreBuildInfo`를 추가하고 `HwpThumbnailRenderSignature`의 default 값을 이 타입으로 교체한다.
+
+### smoke script 영향
+
+XcodeGen target은 폴더 단위 inclusion을 쓰지만, 일부 smoke script는 `swiftc` 입력 파일을 직접 나열한다. `RhwpCoreBuildInfo.swift`를 `Sources/RhwpCoreBridge`에 추가하면 적어도 다음 script는 compile list 보정이 필요하다.
+
+- `scripts/smoke-thumbnail-skia-policy.sh`
+
+Thumbnail signature가 새 build info 타입을 직접 참조하기 때문이다.
+
+Quick Look/preview smoke script는 현재 `HwpThumbnailRenderCache.swift`를 컴파일하지 않으므로 Stage 2 변경만으로는 직접 영향이 없다. 다만 `RhwpCoreBuildInfo`를 후속 Quick Look 진단에서 재사용하면 해당 script들도 같은 방식으로 compile list 보정이 필요하다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+해당 없음. 이번 단계는 신규 조사 보고서 작성과 오늘할일 비고 갱신만 수행했다.
+
+## 검증 결과
+
+### target source inclusion 확인
+
+```text
+project.yml:28:      - path: Sources/Shared
+project.yml:29:      - path: Sources/RhwpCoreBridge
+project.yml:69:      - path: Sources/Shared
+project.yml:70:      - path: Sources/RhwpCoreBridge
+project.yml:102:      - path: Sources/ThumbnailExtension
+project.yml:103:      - path: Sources/Shared
+project.yml:104:      - path: Sources/RhwpCoreBridge
+```
+
+### lock parser와 current lock 확인
+
+```text
+scripts/ci/read-rhwp-core-lock.sh:6:LOCK_FILE="$ROOT/rhwp-core.lock"
+scripts/build-rust-macos.sh:11:LOCK_FILE="$ROOT/rhwp-core.lock"
+scripts/build-rust-macos.sh:518:    expected_release_tag="$(lock_scalar rhwp_release_tag)"
+scripts/build-rust-macos.sh:530:  expected_commit="$(lock_scalar rhwp_commit)"
+scripts/build-rust-macos.sh:546:  expected_enabled_features="$(lock_scalar rhwp_enabled_features)"
+rhwp-core.lock:4:rhwp_release_tag = "v0.7.17"
+rhwp-core.lock:5:rhwp_commit = "03351190ec35436e58cbfee0aa9278a8fdc04a59"
+rhwp-core.lock:6:rhwp_enabled_features = "native-skia"
+```
+
+### stale metadata 확인
+
+```text
+Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift:51:    private static let coreReleaseTag = "v0.7.13"
+Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift:52:    private static let coreCommit = "b3e16ef212af81ef37d973ddb86d6816d3804642"
+Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift:53:    private static let coreEnabledFeatures = "native-skia"
+```
+
+### diff 검증
+
+```text
+git diff --check: 통과
+```
+
+## 잔여 위험
+
+- `RhwpCoreBuildInfo.swift`를 `Sources/RhwpCoreBridge`에 추가하면 `scripts/check-no-appkit.sh`의 hardcoded 검사 파일 목록에도 포함할지 Stage 2에서 판단해야 한다.
+- `scripts/smoke-thumbnail-skia-policy.sh`는 `swiftc` 파일 목록을 직접 관리하므로 Stage 2에서 새 source를 누락하면 Xcode build는 통과해도 smoke compile은 실패할 수 있다.
+- lock/build info 검증 script가 Swift source를 단순 문자열 검색으로 검사하면 형식 변화에 취약할 수 있다. Stage 3에서는 에러 메시지와 검사 범위를 좁혀 유지보수 비용을 줄여야 한다.
+
+## 다음 단계 영향
+
+Stage 2 구현 방향:
+
+1. `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift`를 추가한다.
+2. `HwpThumbnailRenderSignature`의 `coreReleaseTag`, `coreCommit`, `coreEnabledFeatures` 기본값을 `RhwpCoreBuildInfo` 참조로 바꾼다.
+3. `scripts/smoke-thumbnail-skia-policy.sh`의 `swiftc` source list에 `RhwpCoreBuildInfo.swift`를 추가한다.
+4. 필요하면 `scripts/check-no-appkit.sh` 검사 목록에도 새 파일을 추가한다.
+
+Stage 3 구현 방향:
+
+1. `scripts/ci/read-rhwp-core-lock.sh`를 호출하는 standalone 검증 script를 추가한다.
+2. Swift build info source와 lock 값의 일치 여부를 검사한다.
+3. mismatch 시 build info 갱신 대상 파일과 lock key를 명확히 출력한다.
+
+## 승인 요청
+
+Stage 1 결과에 따라 Stage 2로 진행해도 되는지 승인 요청한다.
+
+Stage 2에서는 `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift` 추가, `HwpThumbnailRenderSignature` 참조 변경, 관련 smoke/check script source list 보정을 수행한다.

--- a/mydocs/working/task_m020_388_stage2.md
+++ b/mydocs/working/task_m020_388_stage2.md
@@ -1,0 +1,130 @@
+# Task M020 #388 Stage 2 완료보고서
+
+## 단계 목적
+
+`HwpThumbnailRenderSignature`가 stale hardcoded core metadata 대신 current `rhwp-core.lock` 기준 build info를 참조하도록 수정한다.
+
+Stage 1 결론에 따라 build info source는 `Sources/RhwpCoreBridge`에 두고, Thumbnail signature와 관련 smoke/check script source list를 보정했다.
+
+## 산출물
+
+- `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift`
+  - `rhwp-core.lock`의 current core metadata를 Swift constant로 노출한다.
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+  - `HwpThumbnailRenderSignature`의 core release tag, commit, enabled features 기본값을 `RhwpCoreBuildInfo` 참조로 변경했다.
+- `scripts/check-no-appkit.sh`
+  - 새 `RhwpCoreBuildInfo.swift`를 AppKit/UIKit 금지 검사 목록에 포함했다.
+- `scripts/smoke-thumbnail-skia-policy.sh`
+  - 수동 `swiftc` compile list에 `RhwpCoreBuildInfo.swift`를 추가했다.
+- `mydocs/working/task_m020_388_stage2.md`
+  - Stage 2 결과와 검증을 기록했다.
+- `mydocs/orders/20260629.md`
+  - #388 비고를 `Stage 2 완료보고서 승인 대기`로 갱신했다.
+
+## 변경 내용
+
+### RhwpCoreBuildInfo 추가
+
+`Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift`를 추가했다.
+
+현재 값:
+
+```swift
+enum RhwpCoreBuildInfo {
+    static let releaseTag = "v0.7.17"
+    static let commit = "03351190ec35436e58cbfee0aa9278a8fdc04a59"
+    static let enabledFeatures = "native-skia"
+}
+```
+
+이 파일은 AppKit/UIKit 또는 Foundation 의존이 없고, `RhwpCoreBridge` target source에 포함된다.
+
+### Thumbnail signature refactor
+
+`HwpThumbnailRenderSignature`의 기존 하드코딩을 다음 참조로 변경했다.
+
+```swift
+private static let coreReleaseTag = RhwpCoreBuildInfo.releaseTag
+private static let coreCommit = RhwpCoreBuildInfo.commit
+private static let coreEnabledFeatures = RhwpCoreBuildInfo.enabledFeatures
+```
+
+`identifier` 필드 순서와 cache key 구조는 바꾸지 않았다. 따라서 backend policy, renderer option version, core metadata, maxDimension policy version을 함께 분리하는 기존 cache 의미가 유지된다.
+
+### smoke/check script 보정
+
+`scripts/smoke-thumbnail-skia-policy.sh`는 `swiftc` 파일 목록을 직접 나열하므로 `RhwpCoreBuildInfo.swift`를 추가했다. 그렇지 않으면 Xcode target build는 통과하더라도 smoke helper compile에서 `RhwpCoreBuildInfo` symbol을 찾지 못할 수 있다.
+
+`scripts/check-no-appkit.sh`도 hardcoded 검사 파일 목록을 사용하므로 새 bridge source를 검사 대상에 넣었다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+기존 제품 동작의 render policy나 cache key 필드 구성은 바꾸지 않았다.
+
+변경된 의미는 `HwpThumbnailRenderSignature`의 기본 core metadata source가 stale literal에서 `RhwpCoreBuildInfo`로 바뀐 것이다. 이로 인해 현재 default signature는 `v0.7.17`, `03351190ec35436e58cbfee0aa9278a8fdc04a59`, `native-skia` 기준을 사용한다.
+
+## 검증 결과
+
+### stale metadata 검색
+
+```text
+rg -n "v0\.7\.13|b3e16ef" Sources
+결과: 매치 없음
+```
+
+### build info 참조 확인
+
+```text
+Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift:1:enum RhwpCoreBuildInfo {
+Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift:51:    private static let coreReleaseTag = RhwpCoreBuildInfo.releaseTag
+Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift:52:    private static let coreCommit = RhwpCoreBuildInfo.commit
+Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift:53:    private static let coreEnabledFeatures = RhwpCoreBuildInfo.enabledFeatures
+scripts/check-no-appkit.sh:7:  "$ROOT/Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift"
+scripts/smoke-thumbnail-skia-policy.sh:86:  "$ROOT/Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift" \
+```
+
+### AppKit/UIKit boundary
+
+```text
+scripts/check-no-appkit.sh
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+### Thumbnail smoke compile/run
+
+```text
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task388-stage2-smoke samples/basic/KTX.hwp
+KTX.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+```
+
+명령 중 `DVTFilePathFSEvents`와 `DARWIN_USER_CACHE_DIR` 관련 xcodebuild 경고가 출력됐지만, smoke helper는 exit 0으로 완료됐다.
+
+### diff 검증
+
+```text
+git diff --check
+결과: 통과
+```
+
+## 잔여 위험
+
+- `RhwpCoreBuildInfo.swift` 값은 아직 사람이 갱신해야 하는 constant다. Stage 3에서 `rhwp-core.lock`과 이 파일의 정합성 검증을 추가해야 core pin 변경 시 누락을 잡을 수 있다.
+- 다른 수동 `swiftc` script가 후속 단계에서 `HwpThumbnailRenderCache.swift` 또는 `RhwpCoreBuildInfo`를 함께 쓰게 되면 compile list 보정이 추가로 필요할 수 있다.
+- `RhwpCoreBuildInfo`가 source of truth가 아니라 lock mirror라는 점을 문서/검증에서 명확히 유지해야 한다.
+
+## 다음 단계 영향
+
+Stage 3에서는 lock/build info 정합성 검증 script를 추가한다.
+
+권장 방향:
+
+1. `scripts/ci/read-rhwp-core-lock.sh`로 `rhwp_release_tag`, `rhwp_commit`, `rhwp_enabled_features`를 읽는다.
+2. `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift`에서 대응하는 literal 값을 확인한다.
+3. mismatch 시 lock key, Swift field, 기대값, 실제값을 출력하고 실패한다.
+4. 현재 Stage 2 상태에서는 검증이 통과해야 한다.
+
+## 승인 요청
+
+Stage 2 결과에 따라 Stage 3로 진행해도 되는지 승인 요청한다.
+
+Stage 3에서는 `rhwp-core.lock`과 `RhwpCoreBuildInfo.swift`의 정합성 검증 경로를 추가한다.

--- a/mydocs/working/task_m020_388_stage3.md
+++ b/mydocs/working/task_m020_388_stage3.md
@@ -1,0 +1,49 @@
+# Task #388 Stage 3 완료 보고서
+
+## 단계 목적
+
+`rhwp-core.lock`과 `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift`의 core metadata가 어긋났을 때 독립 검증 명령으로 즉시 실패하도록 한다. core pin 변경 후 Thumbnail render signature의 build info 갱신 누락을 조기에 발견하는 것이 목적이다.
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `scripts/verify-rhwp-core-build-info.sh` | 신규 검증 스크립트, 83 lines |
+| `mydocs/orders/20260629.md` | #388 상태 메모를 Stage 3 완료보고서 승인 대기로 갱신 |
+
+## 변경 내용
+
+- `scripts/ci/read-rhwp-core-lock.sh`를 재사용해 `rhwp_release_tag`, `rhwp_commit`, `rhwp_enabled_features`를 읽는다.
+- `RhwpCoreBuildInfo.releaseTag`, `RhwpCoreBuildInfo.commit`, `RhwpCoreBuildInfo.enabledFeatures` 값을 Swift source에서 읽어 lock 값과 비교한다.
+- mismatch 시 어떤 `RhwpCoreBuildInfo` key가 다른지, lock key와 기대값/실제값, 갱신 대상 파일을 stderr에 출력하고 실패한다.
+- `--help`와 잘못된 인자 입력 경로를 제공해 로컬 검증 명령의 사용 범위를 명확히 했다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+문서 본문 변환 작업은 없다. Swift/Rust runtime 동작은 변경하지 않고, lock metadata와 Swift build info source의 정합성 검증 스크립트만 추가했다.
+
+## 검증 결과
+
+| 명령 | 결과 | 메모 |
+|------|------|------|
+| `./scripts/verify-rhwp-core-build-info.sh` | 통과 | `OK: RhwpCoreBuildInfo matches rhwp-core.lock` |
+| `./scripts/verify-rhwp-core-build-info.sh --help` | 통과 | Usage와 검증 대상 설명 출력 |
+| `CARGO_NET_OFFLINE=true ./scripts/build-rust-macos.sh --verify-lock` | 참고 실패 | 로컬 Cargo git cache에 `rhwp v0.7.17` checkout이 없어 offline checkout 불가 |
+| `./scripts/build-rust-macos.sh --verify-lock` | 참고 실패 | 네트워크 fetch와 build는 완료했으나 `Frameworks/universal/librhwp.a` byte hash/size가 로컬 toolchain 산출물과 불일치 |
+| `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/build-rust-macos.sh --verify-lock` | 통과 | static archive byte hash/size만 제외하고 source provenance, Cargo.lock, generated header, FFI symbols 검증 유지. `Verified: rhwp-core.lock` |
+| `git diff --check` | 통과 | whitespace error 없음 |
+
+strict `--verify-lock`의 static archive hash mismatch는 `mydocs/manual/build_run_guide.md`와 `mydocs/manual/core_dependency_operation_guide.md`에 문서화된 Rust static archive byte reproducibility 차이다. Stage 3 범위에서는 `rhwp-core.lock`을 갱신하지 않았고, 문서화된 정책 env로 source/header/ABI 중심 검증을 유지했다.
+
+## 잔여 위험
+
+- `verify-rhwp-core-build-info.sh`는 Swift 파일을 `awk`로 읽는다. 현재 `RhwpCoreBuildInfo`가 단순한 `static let` string literal 구조이므로 충분하지만, 향후 computed property나 multi-line literal로 바뀌면 스크립트도 함께 갱신해야 한다.
+- local strict staticlib byte hash mismatch는 기존 정책에 따라 분리 기록했다. 이 값 자체를 다시 release gate로 쓰려면 toolchain/runner/build path 고정 또는 기준 lock 재생성 정책이 먼저 필요하다.
+
+## 다음 단계 영향
+
+Stage 4에서는 기존 Thumbnail render signature smoke와 build 검증을 실행하면서 새 검증 스크립트를 함께 최종 검증 묶음에 포함하면 된다. 이번 단계는 runtime behavior를 바꾸지 않으므로 Thumbnail cache key 계산 결과는 Stage 2 결과와 동일해야 한다.
+
+## 승인 요청
+
+Stage 3 산출물과 검증 결과를 검토한 뒤 Stage 4 진입 여부를 승인해 달라.

--- a/mydocs/working/task_m020_388_stage4.md
+++ b/mydocs/working/task_m020_388_stage4.md
@@ -1,0 +1,56 @@
+# Task #388 Stage 4 완료 보고서
+
+## 단계 목적
+
+Thumbnail render signature의 core metadata 정합화가 실제 `ThumbnailExtension` target build와 thumbnail smoke에서 동작하는지 확인한다. 또한 #390 readiness 재측정으로 넘길 기준 상태와 residual risk를 최종 보고서에 정리한다.
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `Alhangeul.xcodeproj/project.pbxproj` | XcodeGen 재생성 결과. `RhwpCoreBuildInfo.swift`를 HostApp, ThumbnailExtension, QLExtension source phase에 포함 |
+| `mydocs/working/task_m020_388_stage4.md` | Stage 4 검증 결과 보고 |
+| `mydocs/report/task_m020_388_report.md` | Task #388 최종 보고서 |
+| `mydocs/orders/20260629.md` | #388 오늘할일 완료 처리 |
+
+## 변경 내용
+
+- `xcodegen generate`로 생성 프로젝트를 갱신해 Stage 2에서 추가한 `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift`가 Xcode build target에 포함되도록 했다.
+- Thumbnail policy smoke 산출물에서 signature가 current lock 기준 `v0.7.17`, `03351190ec35436e58cbfee0aa9278a8fdc04a59`, `native-skia`를 포함함을 확인했다.
+- `build-rust-macos --verify-lock` strict static archive byte hash 실패 UX는 이번 task 범위 밖으로 분리하고, 후속 이슈 #394를 등록했다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+문서 본문 변환 작업은 없다. 런타임 정책 변경 없이 build target 포함 범위와 검증/보고 문서만 정리했다.
+
+## 검증 결과
+
+| 명령 | 결과 | 메모 |
+|------|------|------|
+| `./scripts/check-no-appkit.sh` | 통과 | shared Swift code AppKit/UIKit 의존 없음 |
+| `xcodegen generate` | 통과 | `Alhangeul.xcodeproj` 생성 완료 |
+| `xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedData-task388 CODE_SIGNING_ALLOWED=NO build` | 통과 | `BUILD SUCCEEDED`. CoreSimulator out-of-date 경고와 AppIntents metadata skip 경고는 macOS build 성공을 막지 않음 |
+| `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task388-thumbnail-signature samples/basic/KTX.hwp samples/basic/request.hwp` | 통과 | 두 샘플 모두 `renders=8 failed=0` |
+| `rg -n "v0\\.7\\.13\|b3e16ef" Sources scripts` | 통과 | release-critical `Sources`와 `scripts`에는 stale core metadata 없음 |
+| `rg -n "v0\\.7\\.13\|b3e16ef" Sources scripts mydocs` | 참고 통과 | `mydocs`에는 과거 기준 설명과 이번 task 계획/단계 보고서의 stale 상태 기록이 남음 |
+| `git diff --check` | 통과 | whitespace error 없음 |
+
+대표 smoke signature:
+
+```text
+coreGraphicsOnly|thumbnail-renderer-v1|v0.7.17|03351190ec35436e58cbfee0aa9278a8fdc04a59|native-skia|skia-max-dimension-0
+skiaOptIn|thumbnail-renderer-v1|v0.7.17|03351190ec35436e58cbfee0aa9278a8fdc04a59|native-skia|skia-max-dimension-0
+```
+
+## 잔여 위험
+
+- `Alhangeul.xcodeproj`는 XcodeGen 산출물이다. 원본은 계속 `project.yml`이며, 직접 편집은 하지 않았다.
+- local strict `./scripts/build-rust-macos.sh --verify-lock`의 static archive byte hash mismatch는 #394에서 별도 UX 개선과 portable verify 분리로 추적한다.
+
+## 다음 단계 영향
+
+#390 readiness 재측정은 Thumbnail render signature가 current core lock 기준으로 cache를 분리한다는 전제에서 진행할 수 있다. 특히 Stage 4 smoke 산출물은 CoreGraphics/Skia 양쪽 policy signature가 모두 current lock metadata를 포함한다는 입력으로 사용할 수 있다.
+
+## 승인 요청
+
+Stage 4 산출물과 최종 보고서를 검토한 뒤 PR 게시 단계 진입 여부를 승인해 달라.

--- a/scripts/check-no-appkit.sh
+++ b/scripts/check-no-appkit.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 SHARED_FILES=(
+  "$ROOT/Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift"
   "$ROOT/Sources/RhwpCoreBridge/RhwpDocument.swift"
   "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift"
   "$ROOT/Sources/RhwpCoreBridge/FontFallback.swift"

--- a/scripts/smoke-thumbnail-skia-policy.sh
+++ b/scripts/smoke-thumbnail-skia-policy.sh
@@ -83,6 +83,7 @@ swiftc -parse-as-library \
   -module-cache-path "$SWIFT_MODULE_CACHE" \
   -Xcc -fmodules-cache-path="$CLANG_MODULE_CACHE" \
   -I "$MODULEMAP_DIR" \
+  "$ROOT/Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift" \
   "$ROOT/Sources/RhwpCoreBridge/RhwpDocument.swift" \
   "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \
   "$ROOT/Sources/RhwpCoreBridge/PageOverlayImages.swift" \

--- a/scripts/verify-rhwp-core-build-info.sh
+++ b/scripts/verify-rhwp-core-build-info.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+READ_LOCK="$ROOT/scripts/ci/read-rhwp-core-lock.sh"
+BUILD_INFO="$ROOT/Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0
+
+Verifies that Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift mirrors the
+current rhwp-core.lock release tag, resolved commit, and enabled features.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -ne 0 ]; then
+  usage
+  exit 1
+fi
+
+if [ ! -x "$READ_LOCK" ]; then
+  echo "ERROR: missing executable lock reader: $READ_LOCK" >&2
+  exit 1
+fi
+
+if [ ! -f "$BUILD_INFO" ]; then
+  echo "ERROR: missing Swift build info: $BUILD_INFO" >&2
+  exit 1
+fi
+
+swift_scalar() {
+  local key="$1"
+  awk -v key="$key" '
+    $0 ~ "static[[:space:]]+let[[:space:]]+" key "[[:space:]]*=" {
+      value = $0
+      sub(/^.*=[[:space:]]*"/, "", value)
+      sub(/".*$/, "", value)
+      print value
+      found = 1
+      exit
+    }
+    END {
+      if (!found) {
+        exit 2
+      }
+    }
+  ' "$BUILD_INFO"
+}
+
+compare_scalar() {
+  local lock_key="$1"
+  local swift_key="$2"
+  local expected
+  local actual
+
+  expected="$("$READ_LOCK" "$lock_key")"
+  if ! actual="$(swift_scalar "$swift_key")"; then
+    echo "ERROR: missing RhwpCoreBuildInfo.$swift_key in $BUILD_INFO" >&2
+    exit 1
+  fi
+
+  if [ "$expected" != "$actual" ]; then
+    echo "ERROR: RhwpCoreBuildInfo.$swift_key differs from rhwp-core.lock" >&2
+    echo "Lock key:       $lock_key" >&2
+    echo "Expected value: $expected" >&2
+    echo "Actual value:   $actual" >&2
+    echo "Update:         $BUILD_INFO" >&2
+    exit 1
+  fi
+}
+
+compare_scalar rhwp_release_tag releaseTag
+compare_scalar rhwp_commit commit
+compare_scalar rhwp_enabled_features enabledFeatures
+
+echo "OK: RhwpCoreBuildInfo matches rhwp-core.lock"


### PR DESCRIPTION
## 요약

- 대상 타스크: Issue #388 Thumbnail render signature를 `rhwp-core.lock` 기준으로 생성/검증
- 왜: Thumbnail cache key가 stale core metadata를 포함하면 core update 뒤에도 오래된 thumbnail이 재사용될 수 있음
- 무엇: `RhwpCoreBuildInfo`를 추가하고 Thumbnail signature, smoke, lock/build info 검증을 current core provenance 기준으로 정렬
- 리뷰 포인트: `RhwpCoreBuildInfo` 위치와 target 포함 범위, `HwpThumbnailRenderSignature.identifier` 필드 순서 유지, 신규 검증 스크립트 failure mode

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/20da3e05d226dee45769fbf52cca116b7f89c156/mydocs/working/task_m020_388_stage1.md)** ([d3151c7](https://github.com/postmelee/alhangeul-macos/commit/d3151c715c1ab1a6069bf81c3300a96c366c05d3)): build info 위치를 `Sources/RhwpCoreBridge`로 정하고 lock parser 재사용 경로를 확인
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/20da3e05d226dee45769fbf52cca116b7f89c156/mydocs/working/task_m020_388_stage2.md)** ([36643d9](https://github.com/postmelee/alhangeul-macos/commit/36643d9430e46fa88dae07aa06a660039d4aa01d)): `RhwpCoreBuildInfo` 추가와 Thumbnail signature core metadata refactor
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/20da3e05d226dee45769fbf52cca116b7f89c156/mydocs/working/task_m020_388_stage3.md)** ([6756ba1](https://github.com/postmelee/alhangeul-macos/commit/6756ba1357b7d0ace844f51a6d4c2b23ce170990)): lock/build info standalone verification command 추가
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/20da3e05d226dee45769fbf52cca116b7f89c156/mydocs/working/task_m020_388_stage4.md)** ([20da3e0](https://github.com/postmelee/alhangeul-macos/commit/20da3e05d226dee45769fbf52cca116b7f89c156)): XcodeGen, ThumbnailExtension build, thumbnail smoke, 최종 보고 정리

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| Core provenance | `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift` 추가 | platform-neutral constant로 AppKit/UIKit 의존 없음 |
| Thumbnail cache | `HwpThumbnailRenderSignature`가 build info를 참조 | identifier 필드 순서와 cache 분리 의미 유지 |
| 검증 자동화 | `scripts/verify-rhwp-core-build-info.sh` 추가 | lock mismatch 시 갱신 대상과 기대값/실제값 출력 |
| Build project | `Alhangeul.xcodeproj` XcodeGen 산출물 갱신 | `RhwpCoreBuildInfo.swift` target source phase 포함 |

- 수행 계획서: [task_m020_388.md](https://github.com/postmelee/alhangeul-macos/blob/20da3e05d226dee45769fbf52cca116b7f89c156/mydocs/plans/task_m020_388.md)
- 구현 계획서: [task_m020_388_impl.md](https://github.com/postmelee/alhangeul-macos/blob/20da3e05d226dee45769fbf52cca116b7f89c156/mydocs/plans/task_m020_388_impl.md)
- 최종 보고서: [task_m020_388_report.md](https://github.com/postmelee/alhangeul-macos/blob/20da3e05d226dee45769fbf52cca116b7f89c156/mydocs/report/task_m020_388_report.md)

## 핵심 리뷰 포인트

- `RhwpCoreBuildInfo`가 source of truth가 아니라 `rhwp-core.lock` mirror라는 점이 검증 스크립트와 보고서에 유지되는지
- `HwpThumbnailRenderSignature.identifier`가 `coreGraphicsOnly|thumbnail-renderer-v1|v0.7.17|03351190ec35436e58cbfee0aa9278a8fdc04a59|native-skia|skia-max-dimension-0` 형태로 current lock 기준 metadata를 포함하는지
- local strict static archive byte hash mismatch를 이번 PR에서 lock update로 해결하지 않고 Issue #394 후속으로 분리한 판단

## 검증

- `./scripts/verify-rhwp-core-build-info.sh`
- `./scripts/check-no-appkit.sh`
- `xcodegen generate`
- `xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedData-task388 CODE_SIGNING_ALLOWED=NO build`
- `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task388-thumbnail-signature samples/basic/KTX.hwp samples/basic/request.hwp`
- `rg -n "v0\\.7\\.13|b3e16ef" Sources scripts`
- `git diff --check`

## 관련 이슈

- Issue #387 Preview/Thumbnail Skia readiness 후속 개선 추적
- Issue #390 P1 readiness 재측정 입력
- Issue #394 `--verify-lock` strict 실패 UX 개선과 portable verify 분리

## 후속 이슈 제안

- 없음. strict artifact hash UX 개선은 Issue #394 후속 이슈로 등록 완료.

## 남은 리스크

- `RhwpCoreBuildInfo`는 현재 수동 constant이며, core pin update 때 갱신 누락은 신규 검증 스크립트로 잡는다.
- local strict `./scripts/build-rust-macos.sh --verify-lock`는 static archive byte hash/size 차이로 실패할 수 있다. 이번 PR은 lock 갱신 없이 source/header/ABI 중심 검증 경로를 유지한다.
