### PR TITLE
Task #390: rhwp v0.7.17 기준 Skia readiness gate 재측정

### DIFF
--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -5,3 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
+| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | M020, 수행계획서 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
-| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | Stage 3 완료보고서 승인 대기 |
+| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | Stage 4 완료보고서 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
-| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | Stage 4 완료보고서 승인 대기 |
+| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
-| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | Stage 1 완료보고서 승인 대기 |
+| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | Stage 2 완료보고서 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
-| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | Stage 2 완료보고서 승인 대기 |
+| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | Stage 3 완료보고서 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
-| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | 구현계획서 승인 대기 |
+| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | Stage 1 완료보고서 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
-| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | M020, 수행계획서 승인 대기 |
+| #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 진행중 | 구현계획서 승인 대기 |

--- a/mydocs/plans/task_m020_390.md
+++ b/mydocs/plans/task_m020_390.md
@@ -1,0 +1,159 @@
+# Task M020 #390 수행계획서
+
+## 목적
+
+`rhwp v0.7.17` 기준으로 Quick Look/Thumbnail Skia readiness gate를 다시 측정한다.
+
+#259의 visual/performance/package 판단은 `rhwp v0.7.13` 기준이었다. 현재 `rhwp-core.lock`과 bundled `rhwp-studio` 기준이 올라간 상태이므로, CoreGraphics default와 Skia opt-in 결과를 현재 core 기준으로 다시 비교해 후속 #389, #392, #393, #391의 우선순위와 범위를 결정할 입력을 만든다.
+
+## 배경
+
+#388에서 Thumbnail render signature가 `rhwp-core.lock` 기준 build info를 사용하도록 정리되었다. 이제 Thumbnail cache/smoke 결과가 current core provenance를 반영한다는 전제에서 #390 readiness 재측정을 진행할 수 있다.
+
+기존 #259 결론은 다음이었다.
+
+- Quick Look/Thumbnail release default는 CoreGraphics/native renderer 유지
+- Skia는 `.skiaOptIn` diagnostic backend로 유지
+- 일부 샘플은 Skia visual diff가 개선되지만, `KTX.hwp` 악화와 다중 PDF latency, package size 비용 때문에 default 전환은 보류
+
+#390은 이 판단을 뒤집는 구현 작업이 아니라, `v0.7.17` 기준에서 같은 판단 근거가 유지되는지 재측정하는 작업이다.
+
+## 범위
+
+포함:
+
+- `rhwp-core.lock`, bundled `rhwp-studio` manifest, #388 signature 결과 기준 확인
+- #259의 `v0.7.13` readiness 결과와 현재 측정 항목 매핑
+- Quick Look policy smoke 재측정
+- Thumbnail policy smoke 재측정
+- CoreGraphics와 Skia opt-in visual diff harness 재측정
+- package/static artifact size 기록
+- sample별 `changedPercent`, `meanRGBDelta`, `NativeMs`, reply type, backend, fallback, output bytes 정리
+- Quick Look 단일 PNG, Quick Look 다중 PDF, Finder Thumbnail별 다음 작업 조건 정리
+
+제외:
+
+- renderer 구현 변경
+- Skia direct PNG fast path 구현
+- Thumbnail diagnostic logging 추가
+- Thumbnail maxDimension mapping 변경
+- filename/external image context ABI 구현
+- Skia release default 전환
+- release, signing, notarization, Homebrew Cask 작업
+
+## 설계 방향
+
+이번 작업은 측정과 판단 기록을 중심으로 한다. 제품 코드 변경은 기본적으로 하지 않고, 측정 도구가 current build에서 실행되지 않는 경우에만 별도 승인 후 보정 범위를 분리한다.
+
+대표 샘플은 #259와 #390 이슈 본문을 기준으로 먼저 고정한다.
+
+| 샘플 | 목적 |
+|------|------|
+| `samples/basic/request.hwp` | 과거 Skia latency 변동과 visual 개선 여부 확인 |
+| `samples/basic/KTX.hwp` | 과거 Skia visual regression 재확인 |
+| `samples/복학원서.hwp` | 과거 Skia visual 개선 재확인 |
+| `samples/hwp-multi-001.hwp` | Quick Look 다중 PDF 성능 확인 |
+| `samples/hwpx/hwpx-01.hwpx` | HWPX 다중 PDF/visual 기준 확인 |
+
+필요하면 `mydocs/tech/skia_quicklook_thumbnail_backend.md`의 readiness sample taxonomy에서 text/font 민감 또는 form/raw object 후보를 추가하되, 기본 측정 세트와 확장 세트를 보고서에서 분리한다.
+
+## 예상 변경 파일
+
+- `mydocs/plans/task_m020_390.md`
+- `mydocs/plans/task_m020_390_impl.md`
+- `mydocs/working/task_m020_390_stage*.md`
+- `mydocs/report/task_m020_390_report.md`
+- `mydocs/orders/20260629.md`
+- 필요 시 측정 결과 요약 문서 또는 `mydocs/tech/skia_quicklook_thumbnail_backend.md`의 current readiness 섹션
+
+제품 Swift/Rust source와 build script는 기본 변경 대상이 아니다. 측정 도구 결함이 발견되면 구현 변경으로 섞지 않고 별도 승인 또는 후속 이슈로 분리한다.
+
+## 잠정 단계
+
+1. Stage 1: 기준 inventory와 측정 설계 확정
+   - #259 결과, #388 결과, current core/studio provenance, sample set, 측정 command를 한 문서에 정렬한다.
+2. Stage 2: Quick Look/Thumbnail policy smoke 재측정
+   - reply type, backend, fallback, latency, output bytes, thumbnail cache/signature 값을 기록한다.
+3. Stage 3: visual diff harness 재측정
+   - CoreGraphics와 Skia opt-in을 같은 sample set으로 실행하고 `changedPercent`, `meanRGBDelta`, `NativeMs`, diff artifact를 비교한다.
+4. Stage 4: package/build gate와 readiness 판단 정리
+   - staticlib/xcframework size, extension build, #259 대비 delta, surface별 default 유지/후속 조건을 정리한다.
+5. Stage 5: 최종 보고서와 PR 정리
+   - #389, #392, #393, #391, #394와의 후속 관계를 정리하고 PR 게시 준비를 한다.
+
+## 검증 계획
+
+기본 검증:
+
+```bash
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+du -sh Frameworks/universal/librhwp.a Frameworks/Rhwp.xcframework
+```
+
+Quick Look policy smoke:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task390-skia-policy \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+Thumbnail policy smoke:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task390-thumbnail-policy \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp
+```
+
+Visual diff harness:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task390-visual-cg --page 1 \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+
+./scripts/preview-visual-diff-harness.sh build.noindex/task390-visual-skia --page 1 --policy skiaOptIn \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+Build 확인:
+
+```bash
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task390 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task390 CODE_SIGNING_ALLOWED=NO build
+git diff --check
+```
+
+WebKit 기반 visual diff harness와 Xcode build는 sandbox 내부에서 환경 제약이 발생할 수 있다. 이 경우 실패 원인을 기록하고, 승인 경로로 재실행해 measurement failure와 renderer failure를 분리한다.
+
+## 리스크
+
+- Visual diff harness는 WKWebView/rhwp-studio reference capture를 사용하므로 sandbox/WebKit readiness 실패와 renderer regression을 혼동할 수 있다.
+- Skia first-call latency는 cache 상태와 runner 상태에 민감할 수 있다. 보고서에는 cold/warm 여부와 반복 측정 필요성을 분리해야 한다.
+- `changedPercent` 하나만으로 default 전환 여부를 판단하면 안 된다. `meanRGBDelta`, diff bounds, native render time, fallback, package size를 함께 본다.
+- #394의 strict staticlib hash UX 문제는 이번 측정의 blocker가 아니다. strict `--verify-lock` 실패가 재현되면 source/header/ABI 검증과 static archive byte hash mismatch를 분리해 기록한다.
+- 샘플 수를 과도하게 늘리면 Stage 2-3 검증 시간이 커진다. 기본 대표군을 먼저 고정하고, 실패 계열만 확장한다.
+
+## 승인 요청 사항
+
+- 기준 브랜치는 `devel`, 작업 브랜치는 `local/task390`로 진행한다.
+- 이 작업은 #387 추적 이슈의 P1 하위 이슈 #390으로 진행한다.
+- 수행계획서 승인 후 구현계획서를 작성하고, Stage 1 inventory부터 시작한다.
+- 이번 task의 기본 원칙은 제품 코드 변경 없이 current `rhwp v0.7.17` readiness를 재측정하는 것이다. 측정 도구 보정이 필요하면 별도 승인 후 범위를 확정한다.

--- a/mydocs/plans/task_m020_390_impl.md
+++ b/mydocs/plans/task_m020_390_impl.md
@@ -1,0 +1,309 @@
+# Task M020 #390 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_390.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #390 `rhwp v0.7.17` 기준 Skia readiness gate 재측정
+- 추적 이슈: #387 Preview/Thumbnail Skia readiness 후속 개선 추적
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task390`
+- 목표: #259의 `v0.7.13` 기준 Skia visual/performance/package 판단을 현재 `rhwp v0.7.17` core/studio 기준으로 재측정하고, Quick Look/Thumbnail surface별 후속 작업 조건을 정리한다.
+
+## 구현 원칙
+
+- #390은 측정과 판단 기록 작업이다. 제품 renderer 정책, Skia default 여부, cache policy를 변경하지 않는다.
+- `CoreGraphics default + Skia opt-in diagnostic backend`라는 현재 정책을 기준으로 양쪽 결과를 비교한다.
+- #388에서 정리한 `RhwpCoreBuildInfo`와 Thumbnail render signature 정합성을 readiness 측정의 선행 조건으로 본다.
+- #394의 strict static archive byte hash UX 문제는 이번 작업의 blocker가 아니다. source/header/ABI 중심 검증과 static archive byte hash mismatch는 분리해 기록한다.
+- visual diff 숫자 하나로 default 전환을 판단하지 않는다. `ChangedPercent`, `MeanRGBDelta`, `NativeMs`, fallback, output bytes, package size, sample 성격을 함께 본다.
+- WebKit/rhwp-studio reference capture 실패와 renderer 회귀를 혼동하지 않는다. sandbox/WebKit readiness 실패가 나오면 실패 phase를 기록하고 승인 경로 재실행으로 분리한다.
+- 측정 도구 결함이나 제품 코드 보정 필요성이 발견되면 즉시 별도 승인 또는 후속 이슈로 분리한다.
+
+## 측정 기준
+
+### 기본 샘플 세트
+
+| 샘플 | 용도 |
+|------|------|
+| `samples/basic/request.hwp` | #259에서 Skia latency 변동과 visual 개선이 함께 관찰된 기본 HWP |
+| `samples/basic/KTX.hwp` | #259에서 Skia visual regression이 컸던 HWP |
+| `samples/복학원서.hwp` | #259에서 Skia visual diff가 크게 개선된 watermark 계열 HWP |
+| `samples/hwp-multi-001.hwp` | Quick Look 다중 PDF 성능과 page 반복 경로 |
+| `samples/hwpx/hwpx-01.hwpx` | HWPX 다중 PDF/visual 기준 |
+
+### 주요 비교 항목
+
+| 항목 | 기록 방식 |
+|------|-----------|
+| core/studio provenance | `rhwp-core.lock`, `RhwpCoreBuildInfo`, rhwp-studio manifest |
+| Quick Look policy smoke | reply type, pages, CoreGraphics seconds, Skia seconds, fallback count |
+| Thumbnail policy smoke | policy별 cache event, bucket reuse, backend, fallback, render ms, signature |
+| Visual diff | `ChangedPercent`, `MeanRGBDelta`, `MaxRGBDelta`, `DiffBounds`, `NativeBackend`, `NativeMs` |
+| package/static artifact | `Frameworks/universal/librhwp.a`, `Frameworks/Rhwp.xcframework` size |
+| #259 대비 delta | `v0.7.13` 기준 표와 `v0.7.17` 측정값의 방향성 비교 |
+
+## Stage 1. 기준 inventory와 측정 설계 확정
+
+### 목표
+
+#259, #388, current `rhwp-core.lock` 기준을 하나로 정렬하고, Stage 2-3에서 실행할 측정 명령과 sample set을 확정한다.
+
+### 대상
+
+- `rhwp-core.lock`
+- `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift`
+- `Sources/HostApp/Resources/rhwp-studio/manifest.json`
+- `mydocs/report/task_m020_259_report.md`
+- `mydocs/report/task_m020_388_report.md`
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- `scripts/smoke-quicklook-skia-policy.sh`
+- `scripts/smoke-thumbnail-skia-policy.sh`
+- `scripts/preview-visual-diff-harness.sh`
+- `mydocs/working/task_m020_390_stage1.md`
+
+### 작업
+
+1. current core/studio provenance를 확인한다.
+2. #388 보고서에서 current Thumbnail signature 전제와 #390 handoff를 추출한다.
+3. #259 보고서에서 `v0.7.13` 기준 Quick Look smoke, visual diff, package size, final policy 결론을 추출한다.
+4. 세 measurement script의 입력/출력 형식과 summary 위치를 확인한다.
+5. 기본 샘플 파일 존재 여부와 다중 page/단일 page 분류를 확인한다.
+6. Stage 1 보고서에 Stage 2-3 실행 명령, 산출물 경로, 비교표 template을 고정한다.
+
+### 검증
+
+```bash
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+rg -n "v0\\.7\\.17|03351190ec35436e58cbfee0aa9278a8fdc04a59|native-skia" \
+  rhwp-core.lock Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift \
+  Sources/HostApp/Resources/rhwp-studio/manifest.json
+rg -n "request\\.hwp|KTX\\.hwp|복학원서\\.hwp|hwp-multi-001\\.hwp|hwpx-01\\.hwpx|changed|fallback|NativeMs|package" \
+  mydocs/report/task_m020_259_report.md mydocs/report/task_m020_388_report.md \
+  mydocs/working/task_m020_390_stage1.md
+test -f samples/basic/request.hwp
+test -f samples/basic/KTX.hwp
+test -f samples/복학원서.hwp
+test -f samples/hwp-multi-001.hwp
+test -f samples/hwpx/hwpx-01.hwpx
+git diff --check
+```
+
+### 완료 조건
+
+- `v0.7.17` 기준 측정 전제가 Stage 1 보고서에 정리되어 있다.
+- #259와 비교할 표의 컬럼과 sample set이 확정되어 있다.
+- Stage 2-3 명령과 산출물 경로가 확정되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #390 Stage 1: Skia readiness 측정 기준 inventory
+```
+
+## Stage 2. Quick Look/Thumbnail policy smoke 재측정
+
+### 목표
+
+current `v0.7.17` 기준으로 Quick Look과 Thumbnail의 CoreGraphics/Skia opt-in smoke 결과를 측정하고, fallback과 latency, output bytes, Thumbnail signature/cache behavior를 기록한다.
+
+### 대상
+
+- `build.noindex/task390-skia-policy/`
+- `build.noindex/task390-thumbnail-policy/`
+- `mydocs/working/task_m020_390_stage2.md`
+
+### 작업
+
+1. 기본 검증 command를 실행해 core/studio/build boundary를 확인한다.
+2. Quick Look policy smoke를 기본 샘플 5개로 실행한다.
+3. Thumbnail policy smoke를 단일 page 중심 샘플 3개로 실행한다.
+4. Quick Look summary에서 reply type, page count, CG/Skia seconds, fallback count를 추출한다.
+5. Thumbnail summary에서 policy별 cache event, backend, fallback, render ms, signature를 추출한다.
+6. #259 smoke 결과와 `v0.7.17` 측정값의 방향 차이를 Stage 2 보고서에 기록한다.
+
+### 검증
+
+```bash
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task390-skia-policy \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task390-thumbnail-policy \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp
+rg -n "fallback|Fallback|Signature|v0\\.7\\.17|03351190ec35436e58cbfee0aa9278a8fdc04a59|native-skia|failed=0|OK" \
+  build.noindex/task390-skia-policy build.noindex/task390-thumbnail-policy \
+  mydocs/working/task_m020_390_stage2.md
+git diff --check
+```
+
+### 완료 조건
+
+- Quick Look 기본 샘플 5개 결과가 report에 있다.
+- Thumbnail 기본 샘플 3개 결과가 report에 있다.
+- fallback count와 실패 여부가 명확하다.
+- Thumbnail signature가 #388 기준 current core metadata를 포함한다.
+
+### 커밋 메시지
+
+```text
+Task #390 Stage 2: Quick Look Thumbnail Skia smoke 재측정
+```
+
+## Stage 3. visual diff harness 재측정
+
+### 목표
+
+rhwp-studio reference 대비 CoreGraphics와 Skia opt-in visual diff를 같은 샘플 세트로 다시 측정하고, #259 대비 개선/악화 방향을 정리한다.
+
+### 대상
+
+- `build.noindex/task390-visual-cg/`
+- `build.noindex/task390-visual-skia/`
+- `mydocs/working/task_m020_390_stage3.md`
+
+### 작업
+
+1. CoreGraphics policy visual diff harness를 실행한다.
+2. Skia opt-in policy visual diff harness를 실행한다.
+3. 각 `summary.md`에서 `ChangedPercent`, `MeanRGBDelta`, `NativeBackend`, `NativeMs`를 추출한다.
+4. hard fail, reference capture failure, renderer failure를 구분한다.
+5. #259 `v0.7.13` visual diff 표와 비교해 sample별 delta를 정리한다.
+6. Stage 3 보고서에는 숫자뿐 아니라 `KTX.hwp`, `복학원서.hwp`, `request.hwp`의 방향성이 유지/변경됐는지 해석한다.
+
+### 검증
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task390-visual-cg --page 1 \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task390-visual-skia --page 1 --policy skiaOptIn \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+rg -n "FAIL|OK|ChangedPercent|MeanRGBDelta|NativeBackend|NativeMs|fallback|readiness timed out|WKErrorDomain" \
+  build.noindex/task390-visual-cg build.noindex/task390-visual-skia \
+  mydocs/working/task_m020_390_stage3.md
+git diff --check
+```
+
+### 완료 조건
+
+- CoreGraphics와 Skia opt-in visual diff summary가 모두 생성되어 있다.
+- 실패가 있으면 phase와 원인을 renderer 문제와 실행 환경 문제로 분리했다.
+- #259 대비 sample별 visual direction이 정리되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #390 Stage 3: Skia visual diff 재측정
+```
+
+## Stage 4. package/build gate와 readiness 판단 정리
+
+### 목표
+
+Stage 1-3 측정값을 종합해 surface별 readiness 판단을 정리하고, 현재 default 유지/후속 실험 조건을 명확히 한다.
+
+### 대상
+
+- `Alhangeul.xcodeproj/project.pbxproj` (xcodegen 결과가 바뀌는 경우만)
+- `mydocs/working/task_m020_390_stage4.md`
+- 필요 시 `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+
+### 작업
+
+1. static artifact size를 기록한다.
+2. `xcodegen generate`를 실행하고 diff 여부를 확인한다.
+3. QLExtension과 ThumbnailExtension Debug build를 실행한다.
+4. Stage 2-3 결과를 surface별로 종합한다.
+   - Quick Look 단일 PNG
+   - Quick Look 다중 PDF
+   - Finder Thumbnail
+5. #389, #392, #393, #391, #394 중 어떤 후속이 measurement 결과상 우선인지 정리한다.
+6. 필요 시 기술 문서에 current readiness 요약을 추가하되, 단순 중복이면 최종 보고서로만 남긴다.
+
+### 검증
+
+```bash
+du -sh Frameworks/universal/librhwp.a Frameworks/Rhwp.xcframework
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task390 CODE_SIGNING_ALLOWED=NO build
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task390 CODE_SIGNING_ALLOWED=NO build
+rg -n "#389|#391|#392|#393|#394|Quick Look|Thumbnail|CoreGraphics|Skia|readiness|fallback|package" \
+  mydocs/working/task_m020_390_stage4.md
+git diff --check
+git status --short
+```
+
+### 완료 조건
+
+- package/static artifact size가 기록되어 있다.
+- QLExtension과 ThumbnailExtension build가 통과한다.
+- Quick Look/Thumbnail surface별 default 유지 또는 후속 실험 조건이 명확하다.
+- 후속 이슈 우선순위가 측정 근거와 연결되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #390 Stage 4: Skia readiness 판단 정리
+```
+
+## Stage 5. 최종 보고서와 PR 정리
+
+### 목표
+
+#390 결과를 최종 보고서로 정리하고 PR 게시 준비를 완료한다.
+
+### 대상
+
+- `mydocs/report/task_m020_390_report.md`
+- `mydocs/orders/20260629.md`
+- 필요 시 `mydocs/working/task_m020_390_stage5.md`
+
+### 작업
+
+1. 최종 보고서에 작업 요약, 변경 파일 목록, #259 대비 정량 비교, 검증 결과, 잔여 위험, 후속 작업을 표로 정리한다.
+2. 오늘할일 #390 상태를 완료 처리한다.
+3. PR body에 Stage별 요약, 핵심 리뷰 포인트, 검증 결과, 후속 이슈를 정리한다.
+4. PR 게시 전 `git status`, `git diff --check`, branch log를 확인한다.
+
+### 검증
+
+```bash
+rg -n "#390|#387|#389|#391|#392|#393|#394|v0\\.7\\.17|Skia|CoreGraphics|Quick Look|Thumbnail|readiness" \
+  mydocs/report/task_m020_390_report.md mydocs/orders/20260629.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task390
+```
+
+### 완료 조건
+
+- 최종 보고서가 존재하고 #259 대비 `v0.7.17` 재측정 결론을 포함한다.
+- 오늘할일 #390이 완료 상태다.
+- PR 게시 준비가 가능하다.
+
+### 커밋 메시지
+
+```text
+Task #390 Stage 5 + 최종 보고서: Skia readiness 재측정 정리
+```

--- a/mydocs/report/task_m020_390_report.md
+++ b/mydocs/report/task_m020_390_report.md
@@ -1,0 +1,139 @@
+# Task #390 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | #390 `rhwp v0.7.17` 기준 Skia readiness gate 재측정 |
+| 추적 이슈 | #387 Preview/Thumbnail Skia readiness 후속 개선 추적 |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 단계 수 | 5 |
+| 작업 브랜치 | `local/task390` |
+
+`rhwp v0.7.17` / `03351190ec35436e58cbfee0aa9278a8fdc04a59` / `native-skia` 기준으로 Quick Look과 Finder Thumbnail의 Skia readiness를 다시 측정했다. 제품 코드와 renderer 정책은 변경하지 않았고, current core/studio provenance, Quick Look/Thumbnail smoke, visual diff, package/build gate를 문서화했다.
+
+최종 판단은 `CoreGraphics default + Skia opt-in diagnostic backend` 유지다. Skia는 fallback 없이 동작하고 일부 단일 PNG/Thumbnail latency가 개선됐지만, `KTX.hwp` visual regression과 다중 PDF latency, Thumbnail dimension 차이 때문에 default 전환 근거가 부족하다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/plans/task_m020_390.md` | #390 수행계획서. 범위, 샘플 세트, 제외 항목, 검증 계획 정리 |
+| `mydocs/plans/task_m020_390_impl.md` | 단계별 구현계획서. Stage 1-5 목표, 대상, 검증 명령 고정 |
+| `mydocs/working/task_m020_390_stage1.md` | current core/studio provenance, #259 기준값, #388 handoff, 측정 명령 inventory |
+| `mydocs/working/task_m020_390_stage2.md` | Quick Look/Thumbnail policy smoke 재측정 결과 |
+| `mydocs/working/task_m020_390_stage3.md` | CoreGraphics/Skia opt-in visual diff 재측정 결과 |
+| `mydocs/working/task_m020_390_stage4.md` | package/build gate와 surface별 readiness 판단 |
+| `mydocs/report/task_m020_390_report.md` | 최종 보고서 |
+| `mydocs/orders/20260629.md` | #390 오늘할일 완료 처리 |
+
+제품 Swift/Rust source, `project.yml`, `Alhangeul.xcodeproj`에는 최종 diff가 없다. `xcodegen generate` 실행 후에도 project 파일 변경은 없었다.
+
+## 변경 전·후 정량 비교
+
+### provenance
+
+| 항목 | #259 기준 | #390 기준 |
+|------|-----------|-----------|
+| core release | `v0.7.13` | `v0.7.17` |
+| core commit | `b3e16ef212af81ef37d973ddb86d6816d3804642` | `03351190ec35436e58cbfee0aa9278a8fdc04a59` |
+| enabled features | `native-skia` | `native-skia` |
+| bundled studio | #259 당시 bundle | current `rhwp-studio` manifest가 `v0.7.17` commit과 일치 |
+
+### Quick Look smoke
+
+| 샘플 | #259 CG/Skia sec | #390 CG/Skia sec | #390 fallback | 판단 |
+|------|------------------|------------------|---------------|------|
+| `request.hwp` | 1.073779 / 0.069324 | 1.188107 / 0.068532 | 0 | Skia latency 우위 유지 |
+| `KTX.hwp` | 0.069717 / 0.071174 | 0.072109 / 0.059391 | 0 | latency는 Skia 우위로 개선 |
+| `복학원서.hwp` | 0.160401 / 0.065900 | 0.049888 / 0.063096 | 0 | CG가 개선되어 이번 smoke는 CG 우위 |
+| `hwp-multi-001.hwp` | 0.390930 / 0.666077 | 0.420672 / 0.482924 | 0 | Skia gap 감소, 여전히 CG 우위 |
+| `hwpx-01.hwpx` | 0.376997 / 0.617429 | 0.376054 / 0.514870 | 0 | Skia gap 감소, 여전히 CG 우위 |
+
+### visual diff
+
+| 샘플 | #390 CG changed | #390 Skia changed | Skia-CG delta | 판단 |
+|------|-----------------|-------------------|---------------|------|
+| `request.hwp` | 17.6908% | 11.6265% | -6.0643pp | Skia visual 우위 |
+| `KTX.hwp` | 30.8921% | 46.3795% | +15.4874pp | Skia visual regression 유지 |
+| `복학원서.hwp` | 99.5953% | 99.3883% | -0.2070pp | reference capture contamination으로 품질 판단 제외 |
+| `hwp-multi-001.hwp` | 14.1976% | 13.9298% | -0.2678pp | visual 유사, Skia latency는 느림 |
+| `hwpx-01.hwpx` | 14.0216% | 13.8212% | -0.2004pp | visual 유사, Skia latency는 느림 |
+
+### package/build
+
+| 항목 | #259 `v0.7.13` | #390 `v0.7.17` | 판단 |
+|------|---------------|---------------|------|
+| `Frameworks/universal/librhwp.a` exact size | 203,436,808 bytes | 202,925,096 bytes | 소폭 감소 |
+| `du -sh Frameworks/universal/librhwp.a` | `194M` | `194M` | package cost 변화 없음 |
+| `du -sh Frameworks/Rhwp.xcframework` | `194M` | `194M` | package cost 변화 없음 |
+| QLExtension Debug build | #259 통과 | 통과 | sandbox 밖 재실행 기준 |
+| ThumbnailExtension Debug build | #259 통과 | 통과 | sandbox 밖 재실행 기준 |
+
+## 단계 요약
+
+| Stage | 커밋 | 요약 |
+|------|------|------|
+| 계획 | `6df276e` | 수행계획서 작성과 오늘할일 갱신 |
+| 구현계획 | `ccb8fe4` | 단계별 구현계획서 작성 |
+| Stage 1 | `792df78` | current provenance, #259 baseline, 측정 script inventory 정리 |
+| Stage 2 | `b562fda` | Quick Look/Thumbnail smoke 재측정 |
+| Stage 3 | `0f92558` | CoreGraphics/Skia visual diff 재측정 |
+| Stage 4 | `e2921fc` | package/build gate와 readiness 판단 정리 |
+| Stage 5 | 이번 커밋 | 최종 보고서 작성과 오늘할일 완료 처리 |
+
+## 최종 판단
+
+| surface | 판단 | 근거 |
+|---------|------|------|
+| Quick Look 단일 PNG | CoreGraphics default 유지, Skia opt-in 유지 | `request.hwp`는 Skia 우위지만 `KTX.hwp` visual regression이 blocker |
+| Quick Look 다중 PDF | CoreGraphics default 유지 | 2개 다중 page 샘플 모두 Skia가 CG보다 느림 |
+| Finder Thumbnail | CoreGraphics default 유지, Skia diagnostic 우선 | fallback은 없지만 Skia output dimension 1px 차이와 `KTX.hwp` visual risk가 남음 |
+| Skia default 전환 | 보류 | visual, 다중 PDF latency, package cost를 종합하면 default 전환 기준 미달 |
+
+## 검증 결과
+
+| 수용 기준 | 결과 | 근거 |
+|-----------|------|------|
+| current core/studio provenance 확인 | OK | `rhwp-core.lock`, `RhwpCoreBuildInfo`, studio manifest가 `v0.7.17` commit과 일치 |
+| Quick Look smoke | OK | 5개 샘플 모두 `OK`, fallback 0 |
+| Thumbnail smoke | OK | 3개 샘플 모두 `renders=8 failed=0`, signature에 current core metadata 포함 |
+| CoreGraphics visual diff | OK | sandbox 내부 첫 실행은 readiness timeout, sandbox 밖 재실행 통과 |
+| Skia opt-in visual diff | OK | sandbox 밖 실행 통과 |
+| package size 기록 | OK | `librhwp.a`, `Rhwp.xcframework` 둘 다 `194M` |
+| Xcode project 생성 | OK | `xcodegen generate` 통과, project diff 없음 |
+| QLExtension Debug build | OK | sandbox 밖 재실행에서 `BUILD SUCCEEDED` |
+| ThumbnailExtension Debug build | OK | sandbox 밖 재실행에서 `BUILD SUCCEEDED` |
+| whitespace 점검 | OK | `git diff --check` 통과 |
+
+## 잔여 위험과 후속 작업
+
+| 항목 | 상태 | 처리 |
+|------|------|------|
+| Skia visual regression | 잔여 | `KTX.hwp` regression이 default 전환 blocker. #396 visual suite와 upstream renderer 개선 추적 필요 |
+| 대표/확장 visual suite 부재 | 후속 | #396 `업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식` 우선 |
+| Thumbnail Skia dimension 차이 | 후속 | #392 `Thumbnail Skia maxDimension mapping 실험` 우선 |
+| Finder 실제 경로 진단 부족 | 후속 | #389 `Thumbnail Skia opt-in diagnostic path와 cache logging 추가` 우선 |
+| Quick Look direct PNG fast path | 제한적 후속 | #393은 default 전환이 아니라 opt-in fast path 실험으로 제한 |
+| filename/external image context | 후속 | #391에서 ABI와 bridge 설계 조사 |
+| strict verify UX | 후속 | #394에서 `--verify-lock strict` 실패 UX와 portable verify 분리 |
+| visual reference contamination | 잔여 | `복학원서.hwp` reference overlay 문제는 #396 또는 harness 보정에서 분리 |
+
+## PR 게시 준비 메모
+
+권장 PR 제목:
+
+```text
+Task #390: rhwp v0.7.17 기준 Skia readiness gate 재측정
+```
+
+권장 리뷰 포인트:
+
+- 제품 코드 변경 없이 측정/판단 문서만 추가한 범위가 맞는지
+- `KTX.hwp` visual regression을 Skia default blocker로 보는 결론이 타당한지
+- #396, #392, #389를 후속 우선순위로 두는 정렬이 적절한지
+- sandbox 내부 실패를 environment failure로 분리한 기록이 충분한지
+
+## 작업지시자 승인 요청
+
+Task #390의 측정과 최종 보고서 작성을 완료했다. PR 게시 단계 진입 여부를 승인해 달라.

--- a/mydocs/working/task_m020_390_stage1.md
+++ b/mydocs/working/task_m020_390_stage1.md
@@ -1,0 +1,228 @@
+# Task M020 #390 Stage 1 완료보고서
+
+## 단계 목적
+
+`rhwp v0.7.17` 기준 Skia readiness gate 재측정을 시작하기 전에, current core/studio provenance와 #259 기준 측정값, #388 handoff 조건, Stage 2-3 측정 명령을 하나의 inventory로 고정한다.
+
+이번 단계는 제품 코드와 renderer 정책을 수정하지 않고, 다음 단계의 측정 기준만 확정했다.
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/working/task_m020_390_stage1.md` | Stage 1 inventory, 기준값, 측정 명령, 산출물 경로 |
+| `mydocs/orders/20260629.md` | #390 비고를 `Stage 1 완료보고서 승인 대기`로 갱신 |
+
+## 현재 provenance
+
+| 항목 | 값 |
+|------|----|
+| core release tag | `v0.7.17` |
+| core resolved commit | `03351190ec35436e58cbfee0aa9278a8fdc04a59` |
+| enabled features | `native-skia` |
+| Swift build info | `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift` |
+| studio manifest | `Sources/HostApp/Resources/rhwp-studio/manifest.json` |
+| studio copied files | `60` |
+| studio copied bytes | `38,608,918` |
+
+확인 결과 `rhwp-core.lock`, `RhwpCoreBuildInfo.swift`, `rhwp-studio` manifest가 같은 release tag와 resolved commit을 가리킨다. 따라서 Stage 2-3 측정은 current bundled core/studio 기준으로 진행할 수 있다.
+
+## #388 handoff 조건
+
+#388에서 Thumbnail render signature가 current lock metadata를 포함하도록 정합화되었다.
+
+| 조건 | 기준 |
+|------|------|
+| Thumbnail signature core release | `v0.7.17` |
+| Thumbnail signature core commit | `03351190ec35436e58cbfee0aa9278a8fdc04a59` |
+| Thumbnail signature features | `native-skia` |
+| Stage 4 thumbnail smoke | `KTX.hwp`, `request.hwp` 모두 `renders=8 failed=0` |
+
+따라서 #390 Stage 2의 Thumbnail smoke는 stale signature로 인한 cache 재사용 문제를 전제하지 않는다. `--verify-lock` strict static archive byte hash mismatch UX는 #394로 분리되어 있으며, 이번 readiness 재측정의 blocker로 보지 않는다.
+
+## #259 기준값
+
+### Quick Look policy smoke 기준
+
+| 샘플 | reply | pages | CoreGraphics seconds | Skia seconds | fallback |
+|------|-------|-------|----------------------|--------------|----------|
+| `samples/basic/request.hwp` | `png` | 1 | 1.073779 | 0.069324 | 0 |
+| `samples/basic/KTX.hwp` | `png` | 1 | 0.069717 | 0.071174 | 0 |
+| `samples/복학원서.hwp` | `png` | 1 | 0.160401 | 0.065900 | 0 |
+| `samples/hwp-multi-001.hwp` | `pdf` | 10 | 0.390930 | 0.666077 | 0 |
+| `samples/hwpx/hwpx-01.hwpx` | `pdf` | 9 | 0.376997 | 0.617429 | 0 |
+
+#259에서는 fallback count가 모두 0으로 안정적이었지만, 다중 PDF 경로에서 Skia가 CoreGraphics보다 느렸다. Stage 2는 같은 샘플 세트로 `v0.7.17`에서 이 방향성이 유지되는지 확인한다.
+
+### Visual diff 기준
+
+| 샘플 | CG changed | Skia changed | changed delta | CG MeanRGBDelta | Skia MeanRGBDelta | CG NativeMs | Skia NativeMs | #259 해석 |
+|------|------------|--------------|---------------|-----------------|-------------------|-------------|---------------|----------|
+| `samples/basic/request.hwp` | 17.8542% | 12.8683% | -4.9859 | 11.0716 | 10.1453 | 1016.7 | 5460.6 | visual은 개선됐지만 Skia latency가 큼 |
+| `samples/basic/KTX.hwp` | 31.1362% | 47.1389% | +16.0027 | 13.6308 | 22.5798 | 52.3 | 65.3 | Skia visual regression |
+| `samples/복학원서.hwp` | 32.0188% | 6.4738% | -25.5450 | 18.2116 | 7.2558 | 157.6 | 61.1 | Skia visual 개선 |
+| `samples/hwp-multi-001.hwp` | 14.8327% | 14.3340% | -0.4987 | 14.8651 | 15.7946 | 29.2 | 66.3 | visual 유사, Skia 느림 |
+| `samples/hwpx/hwpx-01.hwpx` | 15.0285% | 14.6452% | -0.3833 | 15.2088 | 16.0791 | 33.8 | 69.2 | visual 유사, Skia 느림 |
+
+#259 최종 판단은 Quick Look default Skia 전환 보류였다. Stage 3는 숫자 하나가 아니라 `ChangedPercent`, `MeanRGBDelta`, `NativeMs`, failure phase를 함께 기록한다.
+
+## 샘플 세트
+
+| 샘플 | 크기 | 분류 | Stage 2 용도 | Stage 3 용도 |
+|------|------|------|--------------|--------------|
+| `samples/basic/request.hwp` | 64K | 단일 page HWP | Quick Look, Thumbnail | visual diff |
+| `samples/basic/KTX.hwp` | 65K | 단일 page HWP | Quick Look, Thumbnail | visual diff |
+| `samples/복학원서.hwp` | 112K | 단일 page HWP, watermark 계열 | Quick Look, Thumbnail | visual diff |
+| `samples/hwp-multi-001.hwp` | 481K | 다중 page HWP | Quick Look PDF 경로 | visual diff page 1 |
+| `samples/hwpx/hwpx-01.hwpx` | 473K | 다중 page HWPX | Quick Look PDF 경로 | visual diff page 1 |
+
+## 측정 script inventory
+
+| script | 입력 | 주요 산출물 | Stage |
+|--------|------|-------------|-------|
+| `scripts/smoke-quicklook-skia-policy.sh` | output dir, HWP/HWPX 파일 목록 | `summary.txt`, 파일별 detail | Stage 2 |
+| `scripts/smoke-thumbnail-skia-policy.sh` | output dir, 선택 request bucket, HWP 파일 목록 | `summary.txt`, 파일별 cache/signature detail | Stage 2 |
+| `scripts/preview-visual-diff-harness.sh` | output dir, page, policy, viewport, HWP/HWPX 파일 목록 | `summary.md`, `studio/`, `native/`, `diff/`, metadata | Stage 3 |
+
+Stage 2 산출물 경로:
+
+```text
+build.noindex/task390-skia-policy/summary.txt
+build.noindex/task390-thumbnail-policy/summary.txt
+```
+
+Stage 3 산출물 경로:
+
+```text
+build.noindex/task390-visual-cg/summary.md
+build.noindex/task390-visual-skia/summary.md
+build.noindex/task390-visual-cg/studio/
+build.noindex/task390-visual-cg/native/
+build.noindex/task390-visual-cg/diff/
+build.noindex/task390-visual-skia/studio/
+build.noindex/task390-visual-skia/native/
+build.noindex/task390-visual-skia/diff/
+```
+
+## Stage 2 고정 명령
+
+```bash
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task390-skia-policy \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task390-thumbnail-policy \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp
+rg -n "fallback|Fallback|Signature|v0\\.7\\.17|03351190ec35436e58cbfee0aa9278a8fdc04a59|native-skia|failed=0|OK" \
+  build.noindex/task390-skia-policy build.noindex/task390-thumbnail-policy \
+  mydocs/working/task_m020_390_stage2.md
+git diff --check
+```
+
+## Stage 3 고정 명령
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task390-visual-cg --page 1 \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+./scripts/preview-visual-diff-harness.sh build.noindex/task390-visual-skia --page 1 --policy skiaOptIn \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+rg -n "FAIL|OK|ChangedPercent|MeanRGBDelta|NativeBackend|NativeMs|fallback|readiness timed out|WKErrorDomain" \
+  build.noindex/task390-visual-cg build.noindex/task390-visual-skia \
+  mydocs/working/task_m020_390_stage3.md
+git diff --check
+```
+
+## 비교표 template
+
+### Stage 2 Quick Look
+
+| 샘플 | v0.7.13 reply/pages | v0.7.13 CG/Skia seconds | v0.7.17 reply/pages | v0.7.17 CG/Skia seconds | fallback | 해석 |
+|------|---------------------|-------------------------|---------------------|-------------------------|----------|------|
+| `request.hwp` |  |  |  |  |  |  |
+| `KTX.hwp` |  |  |  |  |  |  |
+| `복학원서.hwp` |  |  |  |  |  |  |
+| `hwp-multi-001.hwp` |  |  |  |  |  |  |
+| `hwpx-01.hwpx` |  |  |  |  |  |  |
+
+### Stage 2 Thumbnail
+
+| 샘플 | policy | cache event | backend | fallback | render ms | signature core | 해석 |
+|------|--------|-------------|---------|----------|-----------|----------------|------|
+| `request.hwp` | CoreGraphics |  |  |  |  |  |  |
+| `request.hwp` | Skia opt-in |  |  |  |  |  |  |
+| `KTX.hwp` | CoreGraphics |  |  |  |  |  |  |
+| `KTX.hwp` | Skia opt-in |  |  |  |  |  |  |
+| `복학원서.hwp` | CoreGraphics |  |  |  |  |  |  |
+| `복학원서.hwp` | Skia opt-in |  |  |  |  |  |  |
+
+### Stage 3 Visual diff
+
+| 샘플 | policy | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | NativeBackend | NativeMs | failure phase | 해석 |
+|------|--------|----------------|--------------|-------------|------------|---------------|----------|---------------|------|
+| `request.hwp` | CoreGraphics |  |  |  |  |  |  |  |  |
+| `request.hwp` | Skia opt-in |  |  |  |  |  |  |  |  |
+| `KTX.hwp` | CoreGraphics |  |  |  |  |  |  |  |  |
+| `KTX.hwp` | Skia opt-in |  |  |  |  |  |  |  |  |
+| `복학원서.hwp` | CoreGraphics |  |  |  |  |  |  |  |  |
+| `복학원서.hwp` | Skia opt-in |  |  |  |  |  |  |  |  |
+| `hwp-multi-001.hwp` | CoreGraphics |  |  |  |  |  |  |  |  |
+| `hwp-multi-001.hwp` | Skia opt-in |  |  |  |  |  |  |  |  |
+| `hwpx-01.hwpx` | CoreGraphics |  |  |  |  |  |  |  |  |
+| `hwpx-01.hwpx` | Skia opt-in |  |  |  |  |  |  |  |  |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+해당 없음. 이번 단계는 측정 inventory 보고서 작성과 오늘할일 비고 갱신만 수행했다.
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| `./scripts/verify-rhwp-core-build-info.sh` | 통과: `RhwpCoreBuildInfo`가 `rhwp-core.lock`과 일치 |
+| `./scripts/verify-rhwp-studio-assets.sh` | 통과: bundled `rhwp-studio` asset 검증 성공 |
+| current provenance `rg` | 통과: lock, Swift build info, studio manifest에서 `v0.7.17`, `03351190ec35436e58cbfee0aa9278a8fdc04a59`, `native-skia` 확인 |
+| #259/#388/Stage 1 기준 `rg` | 통과: sample, fallback, `NativeMs`, package 관련 기준 확인 |
+| sample file existence `test -f` | 통과: 기본 샘플 5개 존재 |
+| `git diff --check` | 통과 |
+
+대표 provenance 확인:
+
+```text
+Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift:2:    static let releaseTag = "v0.7.17"
+Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift:3:    static let commit = "03351190ec35436e58cbfee0aa9278a8fdc04a59"
+Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift:4:    static let enabledFeatures = "native-skia"
+rhwp-core.lock:4:rhwp_release_tag = "v0.7.17"
+rhwp-core.lock:5:rhwp_commit = "03351190ec35436e58cbfee0aa9278a8fdc04a59"
+rhwp-core.lock:6:rhwp_enabled_features = "native-skia"
+Sources/HostApp/Resources/rhwp-studio/manifest.json:5:  "source_release_tag": "v0.7.17",
+Sources/HostApp/Resources/rhwp-studio/manifest.json:6:  "source_resolved_commit": "03351190ec35436e58cbfee0aa9278a8fdc04a59",
+```
+
+## 잔여 위험
+
+- Stage 2-3 smoke와 visual diff는 실제 렌더링을 수행하므로 WebKit readiness, sandbox, local cache 상태의 영향을 받을 수 있다. 실패 시 `renderer failure`, `reference capture failure`, `environment failure`를 분리해 기록한다.
+- #259와 #390은 core/studio 버전이 다르므로 absolute 숫자보다 방향성과 surface별 실패 여부가 중요하다.
+- `request.hwp`처럼 visual 개선과 latency 악화가 동시에 나타날 수 있으므로 default 전환 판단은 Stage 4에서 surface별로 분리한다.
+
+## 다음 단계 영향
+
+Stage 2에서는 Quick Look 기본 샘플 5개와 Thumbnail 기본 샘플 3개의 CoreGraphics/Skia opt-in smoke를 재측정한다. Stage 2에서 제품 정책은 변경하지 않고, fallback, latency, output shape, Thumbnail signature/cache behavior만 보고한다.
+
+## 승인 요청
+
+Stage 1 inventory와 측정 설계를 기준으로 Stage 2 `Quick Look/Thumbnail policy smoke 재측정`으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_390_stage2.md
+++ b/mydocs/working/task_m020_390_stage2.md
@@ -1,0 +1,150 @@
+# Task M020 #390 Stage 2 완료보고서
+
+## 단계 목적
+
+current `rhwp v0.7.17` 기준으로 Quick Look과 Thumbnail의 CoreGraphics default / Skia opt-in smoke 결과를 재측정한다. 이번 단계는 renderer 정책을 변경하지 않고, fallback, latency, output bytes, Thumbnail signature/cache behavior를 기록했다.
+
+## 산출물
+
+| 경로 | 내용 |
+|------|------|
+| `build.noindex/task390-skia-policy/summary.txt` | Quick Look policy smoke 5개 샘플 요약 |
+| `build.noindex/task390-skia-policy/*-quicklook-skia-policy.txt` | Quick Look 파일별 detail |
+| `build.noindex/task390-thumbnail-policy/summary.txt` | Thumbnail policy smoke 3개 샘플 요약 |
+| `build.noindex/task390-thumbnail-policy/*-thumbnail-skia-policy.txt` | Thumbnail 파일별 detail과 signature |
+| `mydocs/working/task_m020_390_stage2.md` | Stage 2 측정 결과 보고 |
+| `mydocs/orders/20260629.md` | #390 비고를 `Stage 2 완료보고서 승인 대기`로 갱신 |
+
+`build.noindex/` 산출물은 로컬 측정 결과이며 커밋 대상이 아니다.
+
+## Quick Look policy smoke
+
+실행 명령:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task390-skia-policy \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+결과:
+
+| 샘플 | Load | Reply | Pages | CG backend | CG seconds | CG bytes | Skia backend | Skia seconds | Skia bytes | Skia PNG bytes | fallback |
+|------|------|-------|-------|------------|------------|----------|--------------|--------------|------------|----------------|----------|
+| `request.hwp` | OK | png | 1 | `skia:0,cg:1,embedded:0` | 1.188107 | 90472 | `skia:1,cg:0,embedded:0` | 0.068532 | 84098 | 87027 | 0 |
+| `KTX.hwp` | OK | png | 1 | `skia:0,cg:1,embedded:0` | 0.072109 | 543472 | `skia:1,cg:0,embedded:0` | 0.059391 | 181314 | 166247 | 0 |
+| `복학원서.hwp` | OK | png | 1 | `skia:0,cg:1,embedded:0` | 0.049888 | 223309 | `skia:1,cg:0,embedded:0` | 0.063096 | 196405 | 198675 | 0 |
+| `hwp-multi-001.hwp` | OK | pdf | 9 | `skia:0,cg:9,embedded:0` | 0.420672 | 1398731 | `skia:9,cg:0,embedded:0` | 0.482924 | 1102131 | 1297323 | 0 |
+| `hwpx-01.hwpx` | OK | pdf | 9 | `skia:0,cg:9,embedded:0` | 0.376054 | 1377385 | `skia:9,cg:0,embedded:0` | 0.514870 | 1093637 | 1314854 | 0 |
+
+관찰:
+
+- 5개 샘플 모두 `OK`, fallback 0이다.
+- 단일 PNG 샘플 중 `request.hwp`, `KTX.hwp`는 이번 smoke에서 Skia opt-in이 CoreGraphics보다 빠르게 측정됐다.
+- `복학원서.hwp`는 이번 smoke에서 CoreGraphics가 Skia opt-in보다 빠르게 측정됐다.
+- 다중 PDF 샘플 2개는 여전히 Skia opt-in이 CoreGraphics보다 느리지만, #259 대비 차이는 줄었다.
+- `hwp-multi-001.hwp`는 #259에서 pages 10으로 기록됐으나 이번 `v0.7.17` smoke에서는 pages 9로 기록됐다. Stage 4 판단에서 page count 변화 여부를 별도 확인 대상으로 둔다.
+- smoke stderr에 `LAYOUT_OVERFLOW` diagnostic이 출력됐지만 command exit는 0이고 fallback은 발생하지 않았다.
+
+## #259 Quick Look 기준 대비
+
+| 샘플 | v0.7.13 reply/pages | v0.7.13 CG/Skia sec | v0.7.17 reply/pages | v0.7.17 CG/Skia sec | fallback | 해석 |
+|------|---------------------|---------------------|---------------------|---------------------|----------|------|
+| `request.hwp` | png / 1 | 1.073779 / 0.069324 | png / 1 | 1.188107 / 0.068532 | 0 | Skia opt-in 우위 유지. CG는 약간 느려지고 Skia는 유사 |
+| `KTX.hwp` | png / 1 | 0.069717 / 0.071174 | png / 1 | 0.072109 / 0.059391 | 0 | smoke latency는 Skia가 개선되어 우위로 전환 |
+| `복학원서.hwp` | png / 1 | 0.160401 / 0.065900 | png / 1 | 0.049888 / 0.063096 | 0 | CG가 크게 개선되어 이번 smoke에서는 CG 우위 |
+| `hwp-multi-001.hwp` | pdf / 10 | 0.390930 / 0.666077 | pdf / 9 | 0.420672 / 0.482924 | 0 | Skia는 여전히 느리지만 격차 감소. page count 변화 확인 필요 |
+| `hwpx-01.hwpx` | pdf / 9 | 0.376997 / 0.617429 | pdf / 9 | 0.376054 / 0.514870 | 0 | Skia는 여전히 느리지만 격차 감소 |
+
+## Thumbnail policy smoke
+
+실행 명령:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task390-thumbnail-policy \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp
+```
+
+요약:
+
+| 샘플 | 결과 | cache sequence |
+|------|------|----------------|
+| `request.hwp` | `renders=8 failed=0` | `miss`, `exactHit`, `largerBucketHit(1024x1024)`, `largerBucketHit(1024x1024)` 반복 |
+| `KTX.hwp` | `renders=8 failed=0` | `miss`, `exactHit`, `largerBucketHit(1024x1024)`, `largerBucketHit(1024x1024)` 반복 |
+| `복학원서.hwp` | `renders=8 failed=0` | `miss`, `exactHit`, `largerBucketHit(1024x1024)`, `largerBucketHit(1024x1024)` 반복 |
+
+첫 render miss 기준 상세:
+
+| 샘플 | policy | backend | fallback | pixel | output bytes | PNG bytes | render ms | seconds | signature core |
+|------|--------|---------|----------|-------|--------------|-----------|-----------|---------|----------------|
+| `request.hwp` | CoreGraphics | coreGraphics | - | 732x1024 | 125618 | - | 1125.330 | 1.145840 | `v0.7.17` / `03351190ec35436e58cbfee0aa9278a8fdc04a59` / `native-skia` |
+| `request.hwp` | Skia opt-in | skia | - | 732x1025 | 117040 | 117366 | 77.710 | 0.079214 | `v0.7.17` / `03351190ec35436e58cbfee0aa9278a8fdc04a59` / `native-skia` |
+| `KTX.hwp` | CoreGraphics | coreGraphics | - | 1024x725 | 482670 | - | 67.662 | 0.069935 | `v0.7.17` / `03351190ec35436e58cbfee0aa9278a8fdc04a59` / `native-skia` |
+| `KTX.hwp` | Skia opt-in | skia | - | 1025x725 | 161652 | 148962 | 46.783 | 0.048759 | `v0.7.17` / `03351190ec35436e58cbfee0aa9278a8fdc04a59` / `native-skia` |
+| `복학원서.hwp` | CoreGraphics | coreGraphics | - | 725x1024 | 193700 | - | 46.273 | 0.047897 | `v0.7.17` / `03351190ec35436e58cbfee0aa9278a8fdc04a59` / `native-skia` |
+| `복학원서.hwp` | Skia opt-in | skia | - | 725x1025 | 170973 | 175775 | 53.810 | 0.055486 | `v0.7.17` / `03351190ec35436e58cbfee0aa9278a8fdc04a59` / `native-skia` |
+
+대표 signature:
+
+```text
+coreGraphicsOnly|thumbnail-renderer-v1|v0.7.17|03351190ec35436e58cbfee0aa9278a8fdc04a59|native-skia|skia-max-dimension-0
+skiaOptIn|thumbnail-renderer-v1|v0.7.17|03351190ec35436e58cbfee0aa9278a8fdc04a59|native-skia|skia-max-dimension-0
+```
+
+관찰:
+
+- 세 샘플 모두 CoreGraphics와 Skia opt-in에서 첫 render는 `miss`, 반복 요청은 `exactHit`, 더 작은 bucket 요청은 `largerBucketHit(1024x1024)`로 재사용됐다.
+- signature는 #388에서 정리한 current core metadata를 포함한다.
+- fallback은 `-`로 기록되어 실제 fallback 경로가 실행되지 않았다.
+- `request.hwp`, `KTX.hwp` thumbnail 첫 render는 Skia opt-in이 더 빠르게 측정됐다.
+- `복학원서.hwp` thumbnail 첫 render는 CoreGraphics가 더 빠르게 측정됐다.
+- smoke stderr에 `LAYOUT_OVERFLOW` diagnostic이 출력됐지만 command exit는 0이고 `failed=0`이다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+해당 없음. 이번 단계는 측정 실행, 측정 보고서 작성, 오늘할일 비고 갱신만 수행했다. 제품 Swift/Rust source와 renderer 정책은 수정하지 않았다.
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| `./scripts/verify-rhwp-core-build-info.sh` | 통과: `RhwpCoreBuildInfo`가 `rhwp-core.lock`과 일치 |
+| `./scripts/verify-rhwp-studio-assets.sh` | 통과: bundled `rhwp-studio` asset 검증 성공 |
+| `./scripts/check-no-appkit.sh` | 통과: shared Swift code AppKit/UIKit 의존 없음 |
+| `./scripts/smoke-quicklook-skia-policy.sh ...` | 통과: 5개 샘플 모두 `OK`, fallback 0 |
+| `./scripts/smoke-thumbnail-skia-policy.sh ...` | 통과: 3개 샘플 모두 `renders=8 failed=0` |
+| Stage 2 `rg` | 통과: fallback, Signature, current core metadata, `failed=0`, `OK` 확인 |
+| `git diff --check` | 통과 |
+
+대표 command 출력:
+
+```text
+OK request.hwp: reply=png pages=1 cg=skia:0,cg:1,embedded:0 skia=skia:1,cg:0,embedded:0 fallback=0
+OK KTX.hwp: reply=png pages=1 cg=skia:0,cg:1,embedded:0 skia=skia:1,cg:0,embedded:0 fallback=0
+OK 복학원서.hwp: reply=png pages=1 cg=skia:0,cg:1,embedded:0 skia=skia:1,cg:0,embedded:0 fallback=0
+OK hwp-multi-001.hwp: reply=pdf pages=9 cg=skia:0,cg:9,embedded:0 skia=skia:9,cg:0,embedded:0 fallback=0
+OK hwpx-01.hwpx: reply=pdf pages=9 cg=skia:0,cg:9,embedded:0 skia=skia:9,cg:0,embedded:0 fallback=0
+request.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+KTX.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+복학원서.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+```
+
+## 잔여 위험
+
+- `hwp-multi-001.hwp` page count가 #259의 10에서 이번 smoke의 9로 달라졌다. Stage 4에서 readiness 판단 전에 이 변화가 core/studio 기준 변화인지 smoke harness 차이인지 확인해야 한다.
+- `LAYOUT_OVERFLOW` diagnostic은 실패나 fallback으로 이어지지 않았지만 visual 품질 판단은 Stage 3 visual diff에서 별도로 확인해야 한다.
+- Stage 2는 smoke latency 중심이다. `KTX.hwp`는 latency가 개선되어도 #259에서 visual regression이 컸던 샘플이므로 default 전환 판단에는 Stage 3 visual diff가 필요하다.
+- `request.hwp`는 여전히 CoreGraphics 첫 render가 1초대이고 Skia opt-in이 빠르다. 이 차이가 visual diff와 함께 유지되는지 Stage 3에서 확인해야 한다.
+
+## 다음 단계 영향
+
+Stage 3에서는 같은 5개 샘플에 대해 CoreGraphics와 Skia opt-in visual diff harness를 실행한다. Stage 2 결과상 fallback은 모두 0이므로, Stage 3의 핵심 판단은 visual diff 방향성과 `NativeMs`, reference capture failure 여부가 된다.
+
+## 승인 요청
+
+Stage 2 결과에 따라 Stage 3 `visual diff harness 재측정`으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_390_stage3.md
+++ b/mydocs/working/task_m020_390_stage3.md
@@ -1,0 +1,135 @@
+# Task M020 #390 Stage 3 완료보고서
+
+## 단계 목적
+
+`rhwp v0.7.17` bundled `rhwp-studio` reference 대비 CoreGraphics default와 Skia opt-in native renderer의 visual diff를 같은 샘플 세트로 재측정한다. 이번 단계는 visual direction, `MeanRGBDelta`, `NativeMs`, reference capture failure 여부를 분리해 기록했다.
+
+## 산출물
+
+| 경로 | 내용 |
+|------|------|
+| `build.noindex/task390-visual-cg/summary.md` | CoreGraphics policy visual diff summary |
+| `build.noindex/task390-visual-cg/studio/` | CoreGraphics 비교용 rhwp-studio reference PNG/metadata |
+| `build.noindex/task390-visual-cg/native/` | CoreGraphics native renderer PNG/metadata |
+| `build.noindex/task390-visual-cg/diff/` | CoreGraphics diff PNG |
+| `build.noindex/task390-visual-skia/summary.md` | Skia opt-in policy visual diff summary |
+| `build.noindex/task390-visual-skia/studio/` | Skia 비교용 rhwp-studio reference PNG/metadata |
+| `build.noindex/task390-visual-skia/native/` | Skia native renderer PNG/metadata |
+| `build.noindex/task390-visual-skia/diff/` | Skia diff PNG |
+| `mydocs/working/task_m020_390_stage3.md` | Stage 3 측정 결과 보고 |
+| `mydocs/orders/20260629.md` | #390 비고를 `Stage 3 완료보고서 승인 대기`로 갱신 |
+
+`build.noindex/` 산출물은 로컬 측정 결과이며 커밋 대상이 아니다.
+
+## 실행 특이사항
+
+처음 sandbox 내부에서 CoreGraphics 명령을 실행했을 때 5개 샘플 모두 reference readiness에서 실패했다.
+
+```text
+FAIL ... [phase:readiness] rhwp-studio page 1 readiness timed out: navigation=pending; events=[]; scheme={resourceRequests=0, documentRequests=0}
+Could not create a 'com.apple.gputools.service' sandbox extension
+Could not create a 'com.apple.coreservices.launchservicesd' sandbox extension
+Could not create a 'com.apple.webinspector' sandbox extension
+```
+
+동일 명령을 sandbox 밖에서 재실행하자 CoreGraphics와 Skia opt-in 모두 통과했다. 따라서 첫 실패는 renderer 회귀가 아니라 WebKit/AppKit 실행 환경 제약으로 분리한다.
+
+## CoreGraphics visual diff
+
+실행 명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task390-visual-cg --page 1 \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+결과:
+
+| 샘플 | Status | StudioCapture | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | NativeBackend | NativeMs |
+|------|--------|---------------|----------------|--------------|-------------|------------|---------------|----------|
+| `request.hwp` | OK | domComposite | 17.6908% | 10.6210 | 255 | `73,77 1060x1436` | coreGraphics | 1159.8 |
+| `KTX.hwp` | OK | domComposite | 30.8921% | 13.4569 | 255 | `30,45 2185x1497` | coreGraphics | 58.7 |
+| `복학원서.hwp` | OK | webViewSnapshot | 99.5953% | 214.8923 | 241 | `0,0 1588x2246` | coreGraphics | 43.1 |
+| `hwp-multi-001.hwp` | OK | domComposite | 14.1976% | 15.0430 | 255 | `121,159 1345x1981` | coreGraphics | 32.7 |
+| `hwpx-01.hwpx` | OK | domComposite | 14.0216% | 15.0624 | 255 | `121,159 1345x1981` | coreGraphics | 27.1 |
+
+## Skia opt-in visual diff
+
+실행 명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task390-visual-skia --page 1 --policy skiaOptIn \
+  samples/basic/request.hwp \
+  samples/basic/KTX.hwp \
+  samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+결과:
+
+| 샘플 | Status | StudioCapture | ChangedPercent | MeanRGBDelta | MaxRGBDelta | DiffBounds | NativeBackend | NativeMs |
+|------|--------|---------------|----------------|--------------|-------------|------------|---------------|----------|
+| `request.hwp` | OK | domComposite | 11.6265% | 8.9443 | 255 | `73,76 987x1437` | skia | 55.7 |
+| `KTX.hwp` | OK | domComposite | 46.3795% | 20.9833 | 255 | `30,45 2185x1497` | skia | 57.4 |
+| `복학원서.hwp` | OK | webViewSnapshot | 99.3883% | 214.3673 | 247 | `0,0 1588x2246` | skia | 68.2 |
+| `hwp-multi-001.hwp` | OK | domComposite | 13.9298% | 13.0405 | 255 | `121,159 1345x1982` | skia | 62.5 |
+| `hwpx-01.hwpx` | OK | domComposite | 13.8212% | 12.8409 | 255 | `121,159 1345x1982` | skia | 58.0 |
+
+## #259 visual 기준 대비
+
+| 샘플 | #259 CG changed | #259 Skia changed | #390 CG changed | #390 Skia changed | #390 Skia-CG delta | 방향 |
+|------|-----------------|-------------------|-----------------|-------------------|---------------------|------|
+| `request.hwp` | 17.8542% | 12.8683% | 17.6908% | 11.6265% | -6.0643pp | Skia visual 우위 유지, `NativeMs`는 5460.6ms에서 55.7ms로 크게 개선 |
+| `KTX.hwp` | 31.1362% | 47.1389% | 30.8921% | 46.3795% | +15.4874pp | Skia visual regression 유지, Stage 2 latency 개선만으로 default 판단 불가 |
+| `복학원서.hwp` | 32.0188% | 6.4738% | 99.5953% | 99.3883% | -0.2070pp | reference capture에 로컬 글꼴 감지 overlay가 들어가 이번 visual 판단값은 무효 |
+| `hwp-multi-001.hwp` | 14.8327% | 14.3340% | 14.1976% | 13.9298% | -0.2678pp | visual 차이는 유사하나 Skia `NativeMs`는 62.5ms로 CG 32.7ms보다 느림 |
+| `hwpx-01.hwpx` | 15.0285% | 14.6452% | 14.0216% | 13.8212% | -0.2004pp | visual 차이는 유사하나 Skia `NativeMs`는 58.0ms로 CG 27.1ms보다 느림 |
+
+## 샘플별 해석
+
+- `request.hwp`: #259와 같이 Skia가 visual diff에서 유리하다. #259의 Skia `NativeMs` 5초대 문제는 이번 측정에서 재현되지 않았고, Stage 2 smoke와 Stage 3 visual diff 모두 Skia가 빠르게 측정됐다.
+- `KTX.hwp`: #259와 같이 Skia visual regression이 유지된다. 이번 `NativeMs`는 CG와 Skia가 비슷하지만, changed percent와 mean RGB delta 모두 Skia가 불리하므로 default 전환 blocker로 남긴다.
+- `복학원서.hwp`: rhwp-studio reference PNG에 `로컬 글꼴 감지` overlay가 포함되어 CG/Skia 모두 99%대 changed가 됐다. 이번 숫자는 renderer 품질 비교에 사용하지 않고, reference capture contamination으로 분리한다.
+- `hwp-multi-001.hwp`, `hwpx-01.hwpx`: Skia changed percent와 mean RGB delta가 CG보다 약간 낮지만, `NativeMs`는 CG보다 느리다. Stage 2의 다중 PDF smoke 결과와 같이 Skia default 전환 근거로는 부족하다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+해당 없음. 이번 단계는 visual diff 측정 실행, 측정 보고서 작성, 오늘할일 비고 갱신만 수행했다. 제품 Swift/Rust source와 renderer 정책은 수정하지 않았다.
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| CoreGraphics visual diff harness | sandbox 내부 첫 실행은 readiness timeout으로 실패, sandbox 밖 재실행 통과 |
+| Skia opt-in visual diff harness | sandbox 밖 실행 통과 |
+| Stage 3 `rg` | 통과: `OK`, `ChangedPercent`, `MeanRGBDelta`, `NativeBackend`, `NativeMs`, readiness failure 기록 확인 |
+| `git diff --check` | 통과 |
+
+대표 통과 출력:
+
+```text
+OK request.hwp: studioPNG=.../task390-visual-cg/studio/request.hwp-page1-studio.png nativePNG=.../task390-visual-cg/native/request.hwp-page1-native.png diffPNG=.../task390-visual-cg/diff/request.hwp-page1-diff.png
+OK KTX.hwp: studioPNG=.../task390-visual-cg/studio/KTX.hwp-page1-studio.png nativePNG=.../task390-visual-cg/native/KTX.hwp-page1-native.png diffPNG=.../task390-visual-cg/diff/KTX.hwp-page1-diff.png
+OK request.hwp: studioPNG=.../task390-visual-skia/studio/request.hwp-page1-studio.png nativePNG=.../task390-visual-skia/native/request.hwp-page1-native.png diffPNG=.../task390-visual-skia/diff/request.hwp-page1-diff.png
+OK KTX.hwp: studioPNG=.../task390-visual-skia/studio/KTX.hwp-page1-studio.png nativePNG=.../task390-visual-skia/native/KTX.hwp-page1-native.png diffPNG=.../task390-visual-skia/diff/KTX.hwp-page1-diff.png
+```
+
+## 잔여 위험
+
+- visual diff harness는 WKWebView를 사용하므로 managed sandbox 내부에서는 readiness timeout이 날 수 있다. Stage 4 이후 반복 측정이 필요하면 sandbox 밖 실행 조건을 명시해야 한다.
+- `복학원서.hwp` reference capture가 로컬 글꼴 감지 overlay로 오염됐다. 이 샘플은 Stage 4 readiness 판단에서 visual diff 수치 대신 reference capture issue로 분리해야 한다.
+- `KTX.hwp`는 Stage 2 latency가 개선됐지만 Stage 3 visual regression이 유지된다.
+- 다중 page 샘플은 visual diff page 1만 비교했다. Stage 4의 readiness 판단은 Stage 2 Quick Look PDF smoke와 함께 해석해야 한다.
+
+## 다음 단계 영향
+
+Stage 4에서는 Stage 2 smoke와 Stage 3 visual diff를 종합해 surface별 readiness 판단을 정리한다. 현재 근거상 Quick Look/Thumbnail default Skia 전환은 `KTX.hwp` visual regression과 `복학원서.hwp` reference capture contamination 때문에 보류 쪽으로 정리될 가능성이 높다.
+
+## 승인 요청
+
+Stage 3 결과에 따라 Stage 4 `package/build gate와 readiness 판단 정리`로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_390_stage4.md
+++ b/mydocs/working/task_m020_390_stage4.md
@@ -1,0 +1,121 @@
+# Task M020 #390 Stage 4 완료보고서
+
+## 단계 목적
+
+Stage 1-3의 `rhwp v0.7.17` Skia readiness 재측정 결과를 종합하고, package/build gate와 Quick Look/Thumbnail surface별 default 유지 여부를 판단한다.
+
+이번 단계는 제품 Swift/Rust source와 renderer 정책을 수정하지 않고, build gate와 readiness 판단만 문서화했다.
+
+## 산출물
+
+| 경로 | 내용 |
+|------|------|
+| `mydocs/working/task_m020_390_stage4.md` | package/build gate와 readiness 판단 보고 |
+| `mydocs/orders/20260629.md` | #390 비고를 `Stage 4 완료보고서 승인 대기`로 갱신 |
+| `build.noindex/DerivedData-task390/` | QLExtension/ThumbnailExtension Debug build 산출물 |
+
+`build.noindex/` 산출물은 로컬 검증 결과이며 커밋 대상이 아니다.
+
+## package/static artifact
+
+| 항목 | #259 `v0.7.13` | #390 `v0.7.17` | 변화 |
+|------|---------------|---------------|------|
+| `Frameworks/universal/librhwp.a` exact size | 203,436,808 bytes | 202,925,096 bytes | -511,712 bytes |
+| `Frameworks/Rhwp.xcframework/macos-arm64_x86_64/librhwp.a` exact size | - | 202,925,096 bytes | current xcframework 내부 staticlib와 일치 |
+| `Frameworks/generated_rhwp.h` exact size | 2,059 bytes | 2,059 bytes | 변화 없음 |
+| `Frameworks/Rhwp.xcframework/.../Headers/rhwp.h` exact size | - | 2,059 bytes | generated header와 일치 |
+| `du -sh Frameworks/universal/librhwp.a` | `194M` | `194M` | 변화 없음 |
+| `du -sh Frameworks/Rhwp.xcframework` | `194M` | `194M` | 변화 없음 |
+
+해석:
+
+- `native-skia` 포함 artifact의 package cost는 #259와 같은 수준이다.
+- staticlib exact byte size는 소폭 줄었지만 `du -sh` 기준 배포 크기 판단은 달라지지 않았다.
+- package size만으로 Skia default 전환을 새로 정당화할 근거는 없다.
+
+## build gate
+
+| 명령 | 결과 | 비고 |
+|------|------|------|
+| `xcodegen generate` | 통과 | `Alhangeul.xcodeproj/project.pbxproj` diff 없음 |
+| `xcodebuild ... -scheme QLExtension ... build` | sandbox 내부 1회 실패, sandbox 밖 재실행 통과 | 최초 실패는 Sparkle SwiftPM dependency를 GitHub에서 resolve하지 못한 네트워크 제한 |
+| `xcodebuild ... -scheme ThumbnailExtension ... build` | sandbox 내부 1회 실패, sandbox 밖 재실행 통과 | 최초 실패는 SwiftPM/module cache를 사용자 cache 경로에 기록하지 못한 sandbox 제한 |
+
+빌드 통과 기준:
+
+```text
+** BUILD SUCCEEDED ** [14.412 sec]
+** BUILD SUCCEEDED ** [1.666 sec]
+```
+
+Xcode 실행 중 `CoreSimulator is out of date` 경고가 반복됐지만 macOS Debug build 자체는 통과했다. 이번 단계에서는 simulator workflow를 사용하지 않으므로 renderer readiness blocker로 보지 않는다.
+
+## Stage 2-3 종합
+
+| surface | positive signal | negative/risk signal | Stage 4 판단 |
+|---------|-----------------|----------------------|--------------|
+| Quick Look 단일 PNG | 3개 단일 샘플 모두 fallback 0. `request.hwp`, `KTX.hwp` smoke latency는 Skia 우위 | `KTX.hwp` Skia visual diff가 CG보다 +15.4874pp 악화. `복학원서.hwp` reference capture contamination으로 visual 판단 불가 | CoreGraphics default 유지. Skia는 opt-in/diagnostic 유지 |
+| Quick Look 다중 PDF | `hwp-multi-001.hwp`, `hwpx-01.hwpx` 모두 fallback 0. #259 대비 Skia latency gap 감소 | 두 샘플 모두 Skia smoke latency가 CG보다 느림. Visual page 1만 비교했고 다중 page 전체 visual coverage는 없음 | CoreGraphics default 유지. Skia PDF default 전환 근거 부족 |
+| Finder Thumbnail | 3개 샘플 모두 `renders=8 failed=0`, signature가 current core metadata 포함, cache sequence 정상 | Skia output pixel dimension이 CG와 1px 차이. `KTX.hwp` visual regression이 thumbnail 기본 전환에도 위험 신호 | CoreGraphics default 유지. Skia opt-in diagnostic과 maxDimension 실험을 먼저 진행 |
+
+## sample별 핵심 판단
+
+| 샘플 | Stage 4 판단 |
+|------|--------------|
+| `request.hwp` | Skia가 latency와 visual diff 모두 유리하다. 다만 단일 성공 사례로 default 전환을 정당화하기에는 부족하다. |
+| `KTX.hwp` | latency는 개선됐지만 visual regression이 유지된다. Skia default 전환의 가장 명확한 blocker다. |
+| `복학원서.hwp` | Quick Look/Thumbnail smoke는 통과했지만 visual reference에 `로컬 글꼴 감지` overlay가 섞여 이번 visual 수치는 품질 신호로 쓰지 않는다. |
+| `hwp-multi-001.hwp` | Skia PDF latency가 #259보다 개선됐지만 여전히 CG보다 느리다. page count가 #259의 10에서 9로 달라진 점은 별도 확인 대상이다. |
+| `hwpx-01.hwpx` | visual page 1 차이는 유사하나 Skia PDF latency가 CG보다 느리다. HWPX default 전환 근거는 없다. |
+
+## 후속 이슈 우선순위
+
+| 이슈 | 제목 | #390 측정 근거상 우선순위 |
+|------|------|--------------------------|
+| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 높음. Skia default 전환 전 대표/확장 visual suite가 필요하다. 전수 샘플 비교보다 upstream식 manifest + 수동 full sweep이 적합하다. |
+| #392 | Thumbnail Skia maxDimension mapping 실험 | 높음. Thumbnail smoke에서 Skia output pixel dimension이 CG와 1px 차이난다. cache bucket과 시각 비교 기준을 안정화하려면 먼저 확인해야 한다. |
+| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 높음. fallback은 없었지만 backend/cache/signature 관찰이 smoke 산출물에 의존한다. 실제 Finder 경로에서 진단을 남기는 기반이 필요하다. |
+| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 중간. `request.hwp`, `KTX.hwp` latency는 긍정적이지만 `KTX.hwp` visual regression이 남아 default 전환 실험보다 opt-in fast path로 제한해야 한다. |
+| #391 | filename/external image context ABI 조사 및 bridge 설계 | 중간. 이번 샘플 세트의 직접 blocker는 아니지만 renderer fidelity 확장과 upstream parity에는 필요하다. |
+| #394 | build-rust-macos verify-lock strict 실패 UX 개선과 portable verify 분리 | 중간. readiness 판단 blocker는 아니지만 장기 CI/로컬 검증 UX를 안정화해야 한다. |
+
+## 결론
+
+`rhwp v0.7.17` 기준 Skia backend는 fallback 없이 동작하고, 일부 단일 PNG/Thumbnail latency는 #259보다 좋아졌다. 그러나 다음 이유로 Quick Look/Thumbnail default 전환은 보류한다.
+
+1. `KTX.hwp` visual regression이 #259와 같은 방향으로 유지된다.
+2. 다중 PDF 경로에서 Skia는 여전히 CoreGraphics보다 느리다.
+3. Thumbnail Skia output pixel dimension이 CoreGraphics와 1px 차이난다.
+4. `복학원서.hwp` visual reference capture가 오염되어 대표 샘플 하나를 품질 판단에 사용할 수 없다.
+5. package size는 #259와 같은 `194M` 수준으로 유지되어 default 전환의 추가 근거가 되지 않는다.
+
+따라서 현 정책은 `CoreGraphics default + Skia opt-in diagnostic backend`로 유지하는 것이 맞다. Skia를 기본 후보로 다시 올리려면 #396 대표/확장 visual suite와 #392 Thumbnail dimension mapping, #389 diagnostic path를 먼저 진행해야 한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+해당 없음. 이번 단계는 build/package 검증과 판단 보고서 작성만 수행했다. 제품 Swift/Rust source, renderer 정책, `project.yml`, `Alhangeul.xcodeproj`에는 최종 diff가 없다.
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| `du -sh Frameworks/universal/librhwp.a Frameworks/Rhwp.xcframework` | 통과: 둘 다 `194M` |
+| `stat -f '%z %N' ...` | 통과: staticlib/header exact size 기록 |
+| `xcodegen generate` | 통과: project diff 없음 |
+| `xcodebuild -scheme QLExtension ... build` | sandbox 밖 재실행 통과 |
+| `xcodebuild -scheme ThumbnailExtension ... build` | sandbox 밖 재실행 통과 |
+
+## 잔여 위험
+
+- Stage 3 visual diff는 page 1 중심이다. 다중 PDF 전체 page visual coverage는 #396에서 별도 suite로 다루는 편이 적절하다.
+- `복학원서.hwp` reference capture contamination은 visual harness 안정성 문제로 분리해야 한다.
+- xcodebuild는 sandbox 내부에서 SwiftPM network/cache 접근 때문에 실패할 수 있다. Stage 4 build gate는 sandbox 밖 재실행 통과로 판정한다.
+- `hwp-multi-001.hwp` page count 변화는 이번 Stage 4에서 원인 분석까지 포함하지 않았다. 후속 visual suite 또는 별도 smoke 정리에서 확인해야 한다.
+
+## 다음 단계 영향
+
+Stage 5에서는 #390 최종 보고서를 작성하고 오늘할일을 완료 처리한다. 최종 보고서에는 `Skia default 전환 보류`, `#396/#392/#389 우선`, `#393 opt-in 제한`, `#394 별도 UX 개선`을 후속 관계로 정리한다.
+
+## 승인 요청
+
+Stage 4 결과에 따라 Stage 5 `최종 보고서와 PR 정리`로 진행해도 되는지 승인 요청한다.


### PR DESCRIPTION
## 요약

- 대상 타스크: #390 `rhwp v0.7.17` 기준 Skia readiness gate 재측정
- 왜: #259 기준 Skia readiness 판단을 current core/studio provenance로 다시 확인하기 위해
- 무엇: Quick Look/Thumbnail smoke, visual diff, package/build gate, surface별 default 판단을 문서화
- 리뷰 포인트: Skia default 보류 결론과 #396, #392, #389 후속 우선순위가 타당한지

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/38e7c74a96c465f6c5d0694d4db9d1facc3f2ecc/mydocs/working/task_m020_390_stage1.md)** ([792df78](https://github.com/postmelee/alhangeul-macos/commit/792df78)): current provenance, #259 baseline, 측정 script inventory 정리
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/38e7c74a96c465f6c5d0694d4db9d1facc3f2ecc/mydocs/working/task_m020_390_stage2.md)** ([b562fda](https://github.com/postmelee/alhangeul-macos/commit/b562fda)): Quick Look/Thumbnail policy smoke 재측정
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/38e7c74a96c465f6c5d0694d4db9d1facc3f2ecc/mydocs/working/task_m020_390_stage3.md)** ([0f92558](https://github.com/postmelee/alhangeul-macos/commit/0f92558)): CoreGraphics/Skia opt-in visual diff 재측정
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/38e7c74a96c465f6c5d0694d4db9d1facc3f2ecc/mydocs/working/task_m020_390_stage4.md)** ([e2921fc](https://github.com/postmelee/alhangeul-macos/commit/e2921fc)): package/build gate와 readiness 판단 정리
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/38e7c74a96c465f6c5d0694d4db9d1facc3f2ecc/mydocs/report/task_m020_390_report.md)** ([38e7c74](https://github.com/postmelee/alhangeul-macos/commit/38e7c74)): 최종 보고서와 오늘할일 완료 처리

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| Skia readiness 측정 문서 | #259 대비 `v0.7.17` smoke, visual diff, package/build gate 재정리 | `KTX.hwp` visual regression을 default blocker로 보는 판단 |
| Quick Look/Thumbnail 판단 | CoreGraphics default 유지, Skia opt-in diagnostic 유지로 결론 | surface별 근거가 충분히 분리됐는지 |
| 후속 이슈 정렬 | #396, #392, #389 우선순위 기록 | 전수 비교 대신 upstream식 baseline suite를 먼저 두는 방향 |

- 수행 계획서: [task_m020_390.md](https://github.com/postmelee/alhangeul-macos/blob/38e7c74a96c465f6c5d0694d4db9d1facc3f2ecc/mydocs/plans/task_m020_390.md)
- 구현 계획서: [task_m020_390_impl.md](https://github.com/postmelee/alhangeul-macos/blob/38e7c74a96c465f6c5d0694d4db9d1facc3f2ecc/mydocs/plans/task_m020_390_impl.md)
- 최종 보고서: [task_m020_390_report.md](https://github.com/postmelee/alhangeul-macos/blob/38e7c74a96c465f6c5d0694d4db9d1facc3f2ecc/mydocs/report/task_m020_390_report.md)

## 핵심 리뷰 포인트

- Skia default 전환 보류 결론이 Stage 2-4 측정 근거와 일치하는지
- `KTX.hwp` visual regression, 다중 PDF latency, Thumbnail dimension 차이를 각각 별도 blocker로 보는 판단이 적절한지
- #396, #392, #389 순으로 후속 작업 우선순위를 잡는 정렬이 적절한지

## 검증

- `./scripts/verify-rhwp-core-build-info.sh`
- `./scripts/verify-rhwp-studio-assets.sh`
- `./scripts/check-no-appkit.sh`
- `./scripts/smoke-quicklook-skia-policy.sh build.noindex/task390-skia-policy ...`
- `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task390-thumbnail-policy ...`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task390-visual-cg --page 1 ...`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task390-visual-skia --page 1 --policy skiaOptIn ...`
- `du -sh Frameworks/universal/librhwp.a Frameworks/Rhwp.xcframework`
- `xcodegen generate`
- `xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedData-task390 CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedData-task390 CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
- `scripts/validate-github-body.sh build.noindex/task390-pr-body.md`

## 관련 이슈

- #387 Preview/Thumbnail Skia readiness 후속 개선 추적
- #388 Thumbnail render signature를 `rhwp-core.lock` 기준으로 생성/검증
- #259 Skia backend visual/performance/package regression gate 정리

## 후속 이슈 제안

- #396 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식
- #392 Thumbnail Skia maxDimension mapping 실험
- #389 Thumbnail Skia opt-in diagnostic path와 cache logging 추가
- #393 Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험
- #391 filename/external image context ABI 조사 및 bridge 설계
- #394 build-rust-macos verify-lock strict 실패 UX 개선과 portable verify 분리

## 남은 리스크

- Stage 3 visual diff는 page 1 중심이며, 다중 PDF 전체 page visual coverage는 #396 이슈에서 다루는 편이 적절하다.
- `복학원서.hwp`는 reference capture에 `로컬 글꼴 감지` overlay가 섞여 visual 품질 수치에서 제외했다.
- xcodebuild와 visual diff harness는 sandbox 내부에서 network/cache/WebKit 제약을 받을 수 있어, 보고서에는 sandbox 밖 재실행 통과를 별도로 기록했다.
