### PR TITLE
Task #398: preview visual diff harness automation load path 추가

### DIFF
--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
 | #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |
-| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, Stage 2 완료보고서 승인 대기 |
+| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, Stage 3 완료보고서 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
 | #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |
-| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |
+| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, Stage 1 완료보고서 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -6,3 +6,4 @@
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
 | #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |
+| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
 | #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |
-| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
 | #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |
-| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, Stage 4 완료보고서 승인 대기 |
+| #398 | preview visual diff harness automation load path 추가 | 완료 | 완료: 18:07, Stage 5 최종 보고서 작성 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
 | #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |
-| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, Stage 3 완료보고서 승인 대기 |
+| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, Stage 4 완료보고서 승인 대기 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -6,4 +6,4 @@
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
 | #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |
-| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, Stage 1 완료보고서 승인 대기 |
+| #398 | preview visual diff harness automation load path 추가 | 진행중 | M020, Stage 2 완료보고서 승인 대기 |

--- a/mydocs/plans/task_m020_398.md
+++ b/mydocs/plans/task_m020_398.md
@@ -1,0 +1,113 @@
+# Task M020 #398 수행계획서
+
+## 목적
+
+`preview-visual-diff-harness`의 `rhwp-studio` reference capture가 로컬 글꼴 감지 모달/토스트 같은 사용자 UI에 오염되지 않도록, 분석/자동화용 document load path를 추가한다.
+
+#396의 Skia 대표/확장 visual suite에서 `samples/복학원서.hwp`는 중요한 sentinel sample이다. 그러나 #390에서는 `rhwp-studio` reference capture에 `로컬 글꼴 감지` UI가 섞여 CoreGraphics/Skia visual diff가 모두 99%대로 측정됐고, renderer 품질 판단에서 제외됐다. #398은 이 capture 신뢰성 문제를 먼저 해결해 #396 Stage 4에서 `복학원서.hwp`를 정상 visual sample 후보로 다시 해석할 수 있게 한다.
+
+## 배경
+
+upstream `rhwp-studio`의 renderer e2e helper는 일반 파일 열기 UI를 통하지 않고 `window.__wasm.loadDocument(...)`와 `window.__canvasView.loadDocument()`를 직접 호출한다. 이 방식은 renderer/canvas 자동화에서 local font prompt, file input, autosave recovery prompt 같은 사용자 UI를 대부분 우회한다.
+
+반면 현재 downstream `scripts/preview_visual_diff_harness.swift`의 `StudioReferenceRenderer`는 bundled `rhwp-studio`를 reference renderer처럼 사용하면서 WebView 앱 로드와 문서 로드 흐름을 함께 다룬다. 이 경로에서 로컬 글꼴 감지 모달/토스트가 reference PNG에 섞이면 visual diff 결과는 renderer 차이가 아니라 capture contamination이 된다.
+
+이미 #293에서 `복학원서.hwp`의 DOM overlay 포함 capture는 보정됐다. 따라서 #398은 canvas-only capture로 되돌리는 작업이 아니라, 문서 로드만 자동화 경로로 분리하고 기존 `domComposite`/overlay metadata 의미를 유지하는 작업이다.
+
+## 범위
+
+포함:
+
+- `scripts/preview_visual_diff_harness.swift`의 `StudioReferenceRenderer` document load 경로 inventory
+- bundled `rhwp-studio`에서 automation load가 가능한 JS API/전역 객체 확인
+- `window.__wasm.loadDocument(...)`와 `window.__canvasView.loadDocument()` 기반 분석용 load path 추가
+- 기존 `domComposite`, `webViewSnapshot`, `canvasDataURL` capture decision 유지
+- reference capture metadata에 automation load와 UI contamination 진단 필드 추가
+  - 후보: `automationLoad`, `captureContaminated`, `modalCount`, `toastCount`, `uiSuppressed`
+- `samples/복학원서.hwp`와 overlay 없는 대표 sample에서 모달/토스트 오염 여부 검증
+- #396 manifest의 `bokhakwonseo-capture-sentinel` 해석에 넘길 결과 정리
+
+제외:
+
+- Skia/CoreGraphics renderer 동작 변경
+- upstream `edwardkim/rhwp` 수정
+- bundled `rhwp-studio` minified asset 직접 patch
+- canvas-only capture로 회귀
+- #396 baseline manifest/helper 전체 구현
+- Skia default 전환 판단
+
+## 설계 방향
+
+문서 로드와 캡처를 분리한다.
+
+| 구분 | 방향 |
+|------|------|
+| 앱 초기화 | 기존처럼 bundled `rhwp-studio`를 WKWebView에 로드하고 WASM/canvasView 준비를 기다린다 |
+| 문서 로드 | 일반 파일 열기 UI 대신 automation JS로 document bytes를 직접 전달한다 |
+| capture | 기존 `domComposite` 우선 정책과 overlay metadata를 유지한다 |
+| contamination 감지 | capture 직전 modal/toast/status UI 상태를 metadata에 기록하고, 오염이 남으면 renderer failure와 분리한다 |
+| fallback | automation load가 불가능하면 명확한 phase/error로 실패시키고 조용히 UI load로 후퇴하지 않는다 |
+
+모달 버튼을 클릭해 닫는 방식은 보조 수단으로만 둔다. 클릭은 UI 문구와 selector에 취약하고, 이미 font detection state가 바뀐 뒤 capture될 수 있다. 우선순위는 upstream e2e helper처럼 사용자 UI를 처음부터 우회하는 load path다.
+
+## 예상 변경 파일
+
+- `scripts/preview_visual_diff_harness.swift`
+- `scripts/preview-visual-diff-harness.sh`는 필요 시 help 문구 또는 옵션만 최소 보정
+- `mydocs/working/task_m020_398_stage*.md`
+- `mydocs/report/task_m020_398_report.md`
+- `mydocs/orders/20260629.md`
+
+제품 앱 source, RustBridge, renderer source는 기본 변경 대상이 아니다.
+
+## 잠정 단계
+
+1. Stage 1: current harness load/capture contamination inventory
+   - `StudioReferenceRenderer`의 현재 navigation, document scheme, readiness, capture decision을 정리한다.
+   - `복학원서.hwp` contamination 재현 여부와 기존 #293 overlay capture 계약을 확인한다.
+2. Stage 2: automation load path 설계 및 구현
+   - WebView 준비 후 JS로 document bytes를 직접 넘겨 `window.__wasm.loadDocument(...)`와 `window.__canvasView.loadDocument()`를 호출한다.
+   - 기존 `domComposite` capture와 overlay metadata를 유지한다.
+3. Stage 3: contamination metadata와 failure 분리
+   - capture 직전 modal/toast/status UI count를 metadata에 기록한다.
+   - 오염 UI가 남으면 renderer failure가 아니라 capture contamination 또는 environment failure로 분리한다.
+4. Stage 4: target sample smoke 검증
+   - `복학원서.hwp`, `request.hwp`, 필요 시 `KTX.hwp`로 visual diff harness를 실행한다.
+   - `복학원서.hwp`가 정상 reference capture 후보로 복구됐는지 확인한다.
+5. Stage 5: 최종 보고서와 #396 handoff
+   - #396에서 `bokhakwonseo-capture-sentinel`을 어떻게 해석할지 정리하고 PR 준비를 완료한다.
+
+## 검증 계획
+
+기본 검증:
+
+```bash
+git diff --check
+swiftc -parse scripts/preview_visual_diff_harness.swift
+```
+
+target smoke 후보:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task398-automation-load --page 1 \
+  samples/복학원서.hwp samples/basic/request.hwp
+
+rg -n "captureMode|overlayIncluded|automationLoad|captureContaminated|modal|toast|복학원서|request" \
+  build.noindex/task398-automation-load
+```
+
+필요 시 sandbox/WebKit readiness failure는 sandbox 밖 재실행으로 environment failure와 renderer/capture failure를 분리한다.
+
+## 리스크
+
+- bundled `rhwp-studio`의 전역 객체 이름이나 API가 upstream 변경에 따라 바뀔 수 있다.
+- direct JS load가 일반 앱 초기화 경로의 일부 side effect를 우회할 수 있다. renderer reference 목적에 필요한 side effect와 사용자 UI side effect를 구분해야 한다.
+- `복학원서.hwp`에는 capture contamination 외에도 기존 layout overflow, displayText 민감성, watermark/effect 이력이 있다. capture가 깨끗해져도 모든 diff가 renderer regression으로 단정되는 것은 아니다.
+- WKWebView sandbox에서는 readiness timeout이 재현될 수 있다. 이 경우 환경 실패로 분리해야 한다.
+
+## 승인 요청 사항
+
+- 기준 브랜치는 `devel`, 작업 브랜치는 `local/task398`로 진행한다.
+- #398은 #396 Stage 4 전에 선행 처리하는 harness 보정 이슈로 진행한다.
+- 수행계획서 승인 후 구현계획서를 작성하고 Stage 1 inventory부터 시작한다.
+- 이번 작업은 reference capture 신뢰성 보정이며 Skia default 전환 판단은 포함하지 않는다.

--- a/mydocs/plans/task_m020_398_impl.md
+++ b/mydocs/plans/task_m020_398_impl.md
@@ -1,0 +1,326 @@
+# Task M020 #398 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_398.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #398 `preview visual diff harness automation load path 추가`
+- 차단/후속 관계: #396 Stage 4 전 선행 처리
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task398`
+- 목표: `preview-visual-diff-harness`의 `rhwp-studio` reference capture가 로컬 글꼴 감지 모달/토스트 같은 사용자 UI에 오염되지 않도록 automation document load path와 contamination metadata를 추가한다.
+
+## 구현 원칙
+
+- Skia/CoreGraphics renderer output은 변경하지 않는다.
+- bundled `rhwp-studio` minified asset은 직접 patch하지 않는다.
+- #293에서 보정한 `domComposite` / `overlayIncluded=true` 의미를 유지한다.
+- 일반 앱 문서 열기 UI 흐름이 아니라 upstream e2e helper와 같은 direct WASM/canvas load 방식을 우선한다.
+- UI를 클릭해 닫는 방식은 보조 수단으로만 둔다. 핵심은 사용자 UI가 처음부터 뜨지 않는 분석용 load path다.
+- automation load 실패 시 기존 UI load로 조용히 fallback하지 않는다. 실패 phase와 원인을 드러낸다.
+- `복학원서.hwp`는 capture가 깨끗해져도 기존 layout overflow/displayText/watermark 이력이 있으므로, visual metric 해석은 #396에서 별도로 한다.
+
+## 현재 코드 관찰
+
+현재 `StudioReferenceRenderer.capture`는 다음 흐름이다.
+
+1. input file bytes를 읽는다.
+2. `makeLoadURL(filename:revision:)`로 `alhangeul-studio://app/index.html?url=alhangeul-document://document&filename=...` URL을 만든다.
+3. WebView가 URL query의 `url`을 보고 `rhwp-studio` 일반 문서 로드 경로를 탄다.
+4. page ready 후 `alignAndHideChromeScript`로 메뉴/툴바/상태바/ruler만 숨긴다.
+5. overlay-positive page면 `domComposite`, overlay가 없고 canvas가 비면 `webViewSnapshot`, 그 외에는 `canvasDataURL`을 쓴다.
+
+upstream `rhwp-studio/e2e/helpers.mjs`의 `loadHwpFile()`은 다음 방식이다.
+
+```javascript
+const resp = await fetch(url);
+const buf = await resp.arrayBuffer();
+const docInfo = window.__wasm?.loadDocument(new Uint8Array(buf), fname);
+window.__canvasView?.loadDocument?.();
+```
+
+이 방식은 `initDoc` 이후의 local font prompt, autosave/file-open UI, validation prompt 등 사용자-facing 흐름을 대부분 우회한다.
+
+## 설계 방향
+
+### Automation load URL
+
+기존 `makeLoadURL`은 문서 URL query를 포함하므로 일반 앱 로드 흐름을 유발한다. #398에서는 `index.html`만 여는 URL을 추가한다.
+
+예상 함수:
+
+```swift
+private func makeAutomationAppURL() throws -> URL
+```
+
+이 URL은 `alhangeul-studio://app/index.html`만 가리킨다. 문서 bytes는 기존 `StudioDocumentSchemeHandler`를 그대로 유지하고, page 안의 JS가 `fetch("alhangeul-document://document?revision=1")`로 읽는다. 이렇게 하면 Swift에서 큰 base64 script를 만들지 않아도 된다.
+
+### Automation readiness
+
+기존 `waitForPageReady`는 문서 canvas가 있어야 통과한다. automation path에서는 먼저 앱 shell만 준비된 상태를 기다린 뒤 문서를 직접 주입해야 한다.
+
+예상 함수:
+
+```swift
+private func waitForAutomationRuntime(timeout: TimeInterval) throws
+```
+
+검사 항목:
+
+- navigation commit/finish 또는 JS evaluation 가능
+- `window.__wasm` 존재
+- `window.__canvasView` 존재
+
+### Automation document load
+
+예상 함수:
+
+```swift
+private func loadDocumentForAutomation(documentURL: URL, filename: String) throws -> AutomationLoadInfo
+```
+
+JS 동작:
+
+1. `fetch(documentURL)`로 document scheme bytes를 읽는다.
+2. `window.__wasm.loadDocument(new Uint8Array(buf), filename)`을 호출한다.
+3. `window.__canvasView.loadDocument()`를 호출한다.
+4. page count, source format, status text를 JSON으로 반환한다.
+
+성공 후에는 기존 `waitForPageReady`, `alignPageAndHideChrome`, `currentPageState`, capture decision을 그대로 사용한다.
+
+### UI contamination metadata
+
+capture 직전과 capture 직후에 사용자 UI 상태를 probe한다.
+
+예상 field:
+
+- `automationLoad: Bool`
+- `captureContaminated: Bool`
+- `uiSuppressed: Bool`
+- `modalCount: Int`
+- `toastCount: Int`
+- `localFontUIVisible: Bool`
+- `contaminationText: [String]`
+
+초기 selector 후보:
+
+- `dialog`, `[role="dialog"]`, `[aria-modal="true"]`
+- `.modal`, `.toast`, `.snackbar`, `.notification`
+- text probe: `로컬 글꼴`, `글꼴 감지`, `폰트 감지`
+
+automation load가 정상이라면 suppression 없이도 `modalCount=0`, `toastCount=0`, `localFontUIVisible=false`가 기대값이다. 숨김 CSS는 잔여 UI가 있을 때만 `uiSuppressed=true`로 기록하고, 이 경우에도 report에서 contamination risk로 드러낸다.
+
+## Stage 1. current harness load/capture contamination inventory
+
+### 목표
+
+현재 harness의 document load, readiness, capture decision과 upstream direct load 방식을 코드 기준으로 매핑한다.
+
+### 대상
+
+- `scripts/preview_visual_diff_harness.swift`
+- `/Users/melee/Documents/projects/forks/rhwp/rhwp-studio/e2e/helpers.mjs`
+- `mydocs/report/task_m014_293_report.md`
+- `mydocs/report/task_m020_390_report.md`
+- `mydocs/working/task_m020_398_stage1.md`
+
+### 작업
+
+1. 현재 `StudioReferenceRenderer.capture` 흐름을 navigation, document scheme, readiness, capture decision으로 분해한다.
+2. upstream `loadHwpFile()` direct load 방식과 downstream WebView/WKURLSchemeHandler 차이를 정리한다.
+3. #293의 `domComposite`/`overlayIncluded=true` 계약과 #390의 contamination 관찰을 연결한다.
+4. Stage 2 구현 지점을 함수 단위로 확정한다.
+
+### 검증
+
+```bash
+rg -n "makeLoadURL|waitForPageReady|alignAndHideChrome|domComposite|overlayIncluded|captureMode" \
+  scripts/preview_visual_diff_harness.swift mydocs/working/task_m020_398_stage1.md
+rg -n "loadHwpFile|__wasm|__canvasView|loadDocument" \
+  /Users/melee/Documents/projects/forks/rhwp/rhwp-studio/e2e/helpers.mjs \
+  mydocs/working/task_m020_398_stage1.md
+git diff --check
+```
+
+### 완료 조건
+
+- 기존 UI load path와 새 automation load path의 분기점이 문서화되어 있다.
+- #293 overlay capture 계약을 유지해야 하는 이유가 문서화되어 있다.
+- Stage 2 구현 범위가 함수 단위로 정리되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #398 Stage 1: preview harness automation load inventory
+```
+
+## Stage 2. automation load path 구현
+
+### 목표
+
+`StudioReferenceRenderer`가 일반 문서 열기 UI를 거치지 않고 document bytes를 direct WASM/canvas path로 로드하게 한다.
+
+### 대상
+
+- `scripts/preview_visual_diff_harness.swift`
+- `mydocs/working/task_m020_398_stage2.md`
+
+### 작업
+
+1. `makeAutomationAppURL()` 또는 기존 `makeLoadURL` option을 추가한다.
+2. `waitForAutomationRuntime(timeout:)`를 추가한다.
+3. `loadDocumentForAutomation(documentURL:filename:)`를 추가한다.
+4. `capture`에서 navigation 후 runtime readiness -> automation load -> page readiness 순서로 실행한다.
+5. 기존 `domComposite`/`webViewSnapshot`/`canvasDataURL` decision은 유지한다.
+6. automation load 실패 시 `.readiness` 또는 별도 detail로 실패시킨다.
+
+### 검증
+
+```bash
+swiftc -parse scripts/preview_visual_diff_harness.swift
+rg -n "automation|__wasm|__canvasView|loadDocument|domComposite|overlayIncluded" \
+  scripts/preview_visual_diff_harness.swift mydocs/working/task_m020_398_stage2.md
+git diff --check
+```
+
+가능하면 target smoke를 시도하되, WebKit readiness timeout이 나면 Stage 4에서 sandbox 밖 재실행 기준으로 분리한다.
+
+### 완료 조건
+
+- harness가 automation load path를 코드상 가진다.
+- 일반 `?url=` 문서 로드 흐름을 거치지 않는다.
+- 기존 capture decision이 유지된다.
+
+### 커밋 메시지
+
+```text
+Task #398 Stage 2: preview harness automation load 구현
+```
+
+## Stage 3. contamination metadata와 failure 분리
+
+### 목표
+
+reference capture가 사용자 UI에 오염됐는지 summary/metadata에서 확인할 수 있게 한다.
+
+### 대상
+
+- `scripts/preview_visual_diff_harness.swift`
+- 필요 시 `scripts/preview-visual-diff-harness.sh` help text
+- `mydocs/working/task_m020_398_stage3.md`
+
+### 작업
+
+1. `StudioCaptureMetadata`에 automation/UI contamination field를 추가한다.
+2. capture 전후 UI probe JS를 추가한다.
+3. `modalCount`, `toastCount`, `localFontUIVisible`, `captureContaminated`를 JSON에 기록한다.
+4. contamination이 남으면 renderer failure와 구분되는 phase/detail을 남긴다.
+5. summary에 최소한 `StudioCapture` 또는 metadata path로 확인 가능한 근거를 남긴다. summary column 확장은 필요할 때만 한다.
+
+### 검증
+
+```bash
+swiftc -parse scripts/preview_visual_diff_harness.swift
+rg -n "automationLoad|captureContaminated|modalCount|toastCount|localFontUIVisible|uiSuppressed" \
+  scripts/preview_visual_diff_harness.swift mydocs/working/task_m020_398_stage3.md
+git diff --check
+```
+
+### 완료 조건
+
+- `studio/*.json`에서 automation load 여부와 UI contamination 여부를 확인할 수 있다.
+- contamination은 renderer diff 수치와 분리된다.
+- 기존 metadata field와 capture decision이 유지된다.
+
+### 커밋 메시지
+
+```text
+Task #398 Stage 3: capture contamination metadata 추가
+```
+
+## Stage 4. target sample smoke 검증
+
+### 목표
+
+`복학원서.hwp`와 overlay 없는 대표 sample에서 automation load가 실제로 capture contamination을 제거하는지 확인한다.
+
+### 대상
+
+- `build.noindex/task398-automation-load/`
+- `mydocs/working/task_m020_398_stage4.md`
+
+### 작업
+
+1. `복학원서.hwp`, `request.hwp` visual diff harness를 실행한다.
+2. 필요 시 `KTX.hwp`를 추가해 #396 quick suite 연동성을 확인한다.
+3. `studio/*.json`에서 `automationLoad`, `captureContaminated`, `modalCount`, `toastCount`, `overlayIncluded`, `captureMode`를 확인한다.
+4. `복학원서.hwp` capture가 정상 sample 후보로 복구됐는지 판단한다.
+5. sandbox/WebKit 실패는 environment failure로 분리하고, 필요한 경우 승인 경로에서 재실행한다.
+
+### 검증
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task398-automation-load --page 1 \
+  samples/복학원서.hwp samples/basic/request.hwp
+rg -n "captureMode|overlayIncluded|automationLoad|captureContaminated|modalCount|toastCount|localFontUIVisible|복학원서|request" \
+  build.noindex/task398-automation-load mydocs/working/task_m020_398_stage4.md
+git diff --check
+```
+
+### 완료 조건
+
+- `복학원서.hwp` reference capture에 로컬 글꼴 감지 UI가 섞이지 않는다.
+- `복학원서.hwp`의 overlay-positive capture 의미가 유지된다.
+- `request.hwp` 같은 overlay 없는 sample이 불필요하게 악화되지 않는다.
+- 실패 시 renderer failure와 capture/environment failure가 구분된다.
+
+### 커밋 메시지
+
+```text
+Task #398 Stage 4: automation capture smoke 검증
+```
+
+## Stage 5. 최종 보고서와 #396 handoff
+
+### 목표
+
+#398 결과를 최종 보고서로 정리하고 #396 Stage 4에서 `bokhakwonseo-capture-sentinel`을 어떻게 해석할지 handoff한다.
+
+### 대상
+
+- `mydocs/report/task_m020_398_report.md`
+- `mydocs/orders/20260629.md`
+- 필요 시 `mydocs/working/task_m020_398_stage5.md`
+
+### 작업
+
+1. automation load 구현 결과와 metadata field를 요약한다.
+2. target smoke 결과를 정리한다.
+3. #396 manifest의 `bokhakwonseo-capture-sentinel` 해석 업데이트 방향을 정리한다.
+4. 오늘할일 #398을 완료 처리한다.
+5. PR body 초안에 들어갈 검증 결과를 정리한다.
+
+### 검증
+
+```bash
+rg -n "#398|#396|automationLoad|captureContaminated|복학원서|Skia|CoreGraphics|preview visual diff" \
+  mydocs/report/task_m020_398_report.md mydocs/orders/20260629.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task398
+```
+
+### 완료 조건
+
+- 최종 보고서가 #398의 capture 신뢰성 보정 결과를 설명한다.
+- #396으로 넘길 sample 해석이 정리되어 있다.
+- PR 게시 준비가 가능하다.
+
+### 커밋 메시지
+
+```text
+Task #398 Stage 5 + 최종 보고서: automation capture path 정리
+```

--- a/mydocs/report/task_m020_398_report.md
+++ b/mydocs/report/task_m020_398_report.md
@@ -1,0 +1,227 @@
+# Task #398 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | #398 `preview visual diff harness automation load path 추가` |
+| 선행/후속 관계 | #396 Stage 4 전 선행 harness 보정 |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 단계 수 | 5 |
+| 작업 브랜치 | `local/task398` |
+
+`preview-visual-diff-harness`의 `rhwp-studio` reference capture가 로컬 글꼴 감지 모달/토스트 같은 사용자 UI에 오염되지 않도록 automation document load path와 contamination metadata를 추가했다.
+
+핵심 판단은 `복학원서.hwp`를 더 이상 local font modal contamination 때문에 제외할 필요가 없다는 것이다. 최종 smoke에서 `복학원서.hwp`는 `automationLoad=true`, `captureMode=domComposite`, `overlayIncluded=true`, `captureContaminated=false`, `modalCount=0`, `toastCount=0`, `localFontUIVisible=false`로 확인됐다. 다만 기존 `LAYOUT_OVERFLOW` warning은 남아 있으므로, #396에서는 renderer/layout 품질 이슈로 별도 해석해야 한다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `scripts/preview_visual_diff_harness.swift` | automation app load URL, automation runtime readiness, document load JS, non-persistent local font snapshot seed, contamination metadata, sibling canvas overlay counting 보정 |
+| `mydocs/plans/task_m020_398.md` | 수행계획서. 목적, 범위, 설계 방향, 리스크 정리 |
+| `mydocs/plans/task_m020_398_impl.md` | Stage 1-5 구현계획서 |
+| `mydocs/working/task_m020_398_stage1.md` | current harness load/capture contamination inventory |
+| `mydocs/working/task_m020_398_stage2.md` | automation load path 구현 보고 |
+| `mydocs/working/task_m020_398_stage3.md` | contamination metadata와 failure 분리 보고 |
+| `mydocs/working/task_m020_398_stage4.md` | target sample smoke 검증 보고 |
+| `mydocs/report/task_m020_398_report.md` | 최종 보고서 |
+| `mydocs/orders/20260629.md` | #398 오늘할일 완료 처리 |
+
+제품 앱 source, RustBridge, Skia/CoreGraphics renderer source, bundled `rhwp-studio` minified asset, sample 문서는 변경하지 않았다.
+
+## 구현 결과
+
+### Automation load path
+
+기존 reference load는 다음 URL로 일반 문서 열기 흐름을 탔다.
+
+```text
+alhangeul-studio://app/index.html?url=alhangeul-document://document&filename=...
+```
+
+변경 후 harness는 앱 shell만 로드한다.
+
+```text
+alhangeul-studio://app/index.html
+```
+
+문서 bytes는 기존 `StudioDocumentSchemeHandler`를 유지하고, page 안 automation JS가 `alhangeul-document://current?revision=1`를 `fetch`해 로드한다.
+
+### Runtime strategy
+
+구현계획서는 upstream e2e helper처럼 `window.__wasm.loadDocument(...)`와 `window.__canvasView.loadDocument()` direct path를 우선했다. current bundled production asset은 이 debug global을 노출하지 않았기 때문에 실제 smoke에서는 `rhwp-request` message API의 `ready` / `loadFile` strategy를 사용했다.
+
+`rhwp-request loadFile`는 앱 내부 `loadBytes/initDoc` 경로를 통과하므로 local font prompt가 다시 뜰 수 있었다. 이를 막기 위해 harness 전용 non-persistent WKWebView의 `localStorage["rhwp-local-fonts"]`에 빈 complete snapshot을 문서 로드 직전에 주입했다.
+
+이 상태는 smoke 실행 바깥으로 유지되지 않는다.
+
+### Contamination metadata
+
+`studio/*.json`에 다음 진단 필드를 추가했다.
+
+| 필드 | 의미 |
+|------|------|
+| `automationLoad` | automation path 사용 여부 |
+| `automationStrategy` | `direct-globals` 또는 `rhwp-request` |
+| `automationPageCount` | automation load가 반환한 page count |
+| `automationFileName` | automation load 파일명 |
+| `automationSourceFormat` | source format metadata |
+| `automationLocalFontsSeeded` | harness-local local font snapshot seed 여부 |
+| `captureContaminated` | capture 전후 UI contamination 감지 여부 |
+| `uiSuppressed` | residual UI를 숨긴 경우 |
+| `modalCount` | visible modal/dialog 후보 수 |
+| `toastCount` | visible toast/notification 후보 수 |
+| `localFontUIVisible` | 로컬 글꼴/폰트 감지 계열 UI text 감지 여부 |
+| `contaminationText` | 감지된 contamination text sample |
+| `preCaptureUI` / `postCaptureUI` | capture 전후 probe detail |
+
+`summary.md`의 `StudioCapture` column에는 column을 늘리지 않고 `;ui=clean` 또는 contamination hint를 붙이도록 했다.
+
+### Sibling canvas overlay 보정
+
+Stage 4 smoke 중 `복학원서.hwp`가 `captureContaminated=false`인데도 dark `webViewSnapshot` PNG로 떨어지는 문제가 드러났다. 원인은 current `rhwp-studio`가 background/behind/front layer를 sibling canvas로 렌더링하는데, harness의 page state probe가 target canvas 외 canvas를 overlay 후보에서 제외하고 있었기 때문이다.
+
+보정 후 target 자신만 제외하고 겹치는 sibling canvas layer를 overlay 후보로 계산한다. 기존 `domComposite` exporter는 이미 intersecting canvas/img를 합성하므로 exporter 자체는 변경하지 않았다.
+
+## 변경 전·후 정량 비교
+
+`복학원서.hwp` 기준:
+
+| 항목 | #390 측정 | #398 최종 |
+|------|-----------|-----------|
+| reference 해석 | local font UI contamination으로 품질 판단 제외 | clean capture sample 후보로 복구 |
+| `captureMode` | contamination 때문에 diff 99%대 | `domComposite` |
+| `overlayIncluded` | 해석 불가 | `true` |
+| `captureContaminated` | metadata 없음 | `false` |
+| `modalCount` | metadata 없음 | `0` |
+| `toastCount` | metadata 없음 | `0` |
+| `localFontUIVisible` | metadata 없음 | `false` |
+| `ChangedPercent` | CoreGraphics 99.5953% / Skia 99.3883% | CoreGraphics 7.2888% |
+
+Stage 4 smoke 최종 수치:
+
+| sample | Status | StudioCapture | automationStrategy | automationLocalFontsSeeded | captureContaminated | modal/toast/localFont | ChangedPercent |
+|--------|--------|---------------|--------------------|----------------------------|---------------------|-----------------------|----------------|
+| `복학원서.hwp` | OK | `domComposite;ui=clean` | `rhwp-request` | `true` | `false` | `0 / 0 / false` | `7.2888%` |
+| `request.hwp` | OK | `domComposite;ui=clean` | `rhwp-request` | `true` | `false` | `0 / 0 / false` | `17.6908%` |
+| `KTX.hwp` | OK | `domComposite;ui=clean` | `rhwp-request` | `true` | `false` | `0 / 0 / false` | `30.8921%` |
+
+## 단계 요약
+
+| Stage | 커밋 | 요약 |
+|------|------|------|
+| 계획 | `3015b98` | 수행계획서 작성과 오늘할일 갱신 |
+| 구현계획 | `1f4232f` | 단계별 구현계획서 작성 |
+| Stage 1 | `f77a350` | current harness load/capture contamination inventory |
+| Stage 2 | `f563e9a` | automation load path 구현 |
+| Stage 3 | `14eba20` | contamination metadata와 failure 분리 |
+| Stage 4 | `09203f3` | target sample smoke와 sibling canvas overlay 보정 |
+| Stage 5 | 이번 커밋 | 최종 보고서 작성과 #396 handoff 정리 |
+
+## 검증 결과
+
+정적 검증:
+
+```bash
+swiftc -parse scripts/preview_visual_diff_harness.swift
+git diff --check
+```
+
+결과: 둘 다 출력 없이 성공.
+
+Target smoke:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task398-automation-load --page 1 \
+  samples/복학원서.hwp samples/basic/request.hwp
+```
+
+결과:
+
+```text
+OK 복학원서.hwp
+OK request.hwp
+```
+
+`복학원서.hwp`는 smoke 중 기존 `LAYOUT_OVERFLOW` warning을 출력했다. 이 warning은 capture contamination이 아니라 renderer/layout 이력으로 분리한다.
+
+Optional KTX smoke:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task398-automation-load-ktx --page 1 \
+  samples/basic/KTX.hwp
+```
+
+결과:
+
+```text
+OK KTX.hwp
+```
+
+최종 보고서 검증:
+
+```bash
+rg -n "#398|#396|automationLoad|captureContaminated|복학원서|Skia|CoreGraphics|preview visual diff" \
+  mydocs/report/task_m020_398_report.md mydocs/orders/20260629.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task398
+```
+
+## #396 Handoff
+
+#396 Stage 4에서 `bokhakwonseo-capture-sentinel`을 해석할 때 다음 기준을 적용한다.
+
+| 항목 | 기준 |
+|------|------|
+| local font modal contamination | #398 이후 제외 사유로 보지 않는다 |
+| clean capture 확인 | `automationLoad=true`, `automationStrategy=rhwp-request`, `automationLocalFontsSeeded=true`, `captureContaminated=false` 확인 |
+| overlay-positive reference | `captureMode=domComposite`, `overlayIncluded=true`, `usedOverlayUnion=true` 확인 |
+| residual UI | `modalCount=0`, `toastCount=0`, `localFontUIVisible=false` 확인 |
+| layout warning | `LAYOUT_OVERFLOW`는 capture contamination이 아니라 renderer/layout 이슈로 별도 해석 |
+| Skia default 판단 | #398 범위 밖. #396 visual suite와 renderer parity 기준에서 별도 판단 |
+
+권장 재측정 명령:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task396-after-task398 --page 1 \
+  samples/복학원서.hwp samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+해석 기준:
+
+- `복학원서.hwp`: 더 이상 `local font modal contamination`으로 제외하지 않는다.
+- `복학원서.hwp`: `LAYOUT_OVERFLOW`, watermark/effect, displayText 민감성은 renderer parity 항목으로 분리한다.
+- `KTX.hwp`: #390에서 확인한 visual regression 판단은 #398로 바뀌지 않았다.
+- `request.hwp`, `KTX.hwp`도 current `rhwp-studio` layered canvas rendering 때문에 `overlayIncluded=true`가 될 수 있다. 이 값은 과거 “overlay 없는 sample” 표현과 다르므로 `captureMode`만으로 sample 성격을 단정하지 않는다.
+
+## 잔여 위험과 후속 작업
+
+| 항목 | 상태 | 처리 |
+|------|------|------|
+| production asset direct globals 부재 | 잔여 | `rhwp-request` strategy를 metadata에 명시. upstream/source와 production asset 차이는 별도 추적 가능 |
+| local font prompt 회피 방식 | 제한적 해결 | non-persistent local font snapshot seed로 분석용 capture에서는 해결. 일반 앱 UI 동작은 변경하지 않음 |
+| sibling canvas overlay detector | 해결 | target 외 canvas layer를 overlay 후보로 포함하도록 보정 |
+| `복학원서.hwp` layout overflow | 잔여 | #396 renderer/layout 해석 대상으로 이관 |
+| Skia visual default 판단 | 범위 밖 | #396 visual suite, #392, #389 등 후속 이슈에서 판단 |
+
+## PR 게시 준비 메모
+
+권장 PR 제목:
+
+```text
+Task #398: preview visual diff harness automation load path 추가
+```
+
+권장 리뷰 포인트:
+
+- bundled `rhwp-studio` asset을 직접 patch하지 않고 harness 쪽 automation load path로만 해결한 범위가 맞는지
+- non-persistent local font snapshot seed가 분석용 reference capture에 한정되어 있는지
+- `captureContaminated`, `modalCount`, `toastCount`, `localFontUIVisible` metadata로 renderer failure와 capture contamination을 구분할 수 있는지
+- sibling canvas overlay counting 보정이 #293의 `domComposite` / `overlayIncluded=true` 계약을 유지하는지
+- #396 handoff에서 `복학원서.hwp`를 clean capture sample 후보로 복구하되 layout overflow를 별도로 해석하는 정리가 충분한지
+
+## 작업지시자 승인 요청
+
+Task #398의 구현, target smoke, 최종 보고서 작성, 오늘할일 완료 처리를 완료했다. PR 게시 단계 진입 여부를 승인해 달라.

--- a/mydocs/working/task_m020_398_stage1.md
+++ b/mydocs/working/task_m020_398_stage1.md
@@ -1,0 +1,161 @@
+# Task M020 #398 Stage 1 완료보고서
+
+## 단계 목적
+
+현재 `preview-visual-diff-harness`의 `rhwp-studio` reference load/capture 경로를 inventory하고, #398 Stage 2에서 추가할 automation load path의 함수 단위 구현 지점을 고정한다.
+
+이번 단계는 조사와 보고서 작성만 수행했다. 제품 Swift/Rust renderer source와 harness script는 수정하지 않았다.
+
+## 조사 대상
+
+| 대상 | 확인 내용 |
+|------|-----------|
+| `scripts/preview_visual_diff_harness.swift` | `StudioReferenceRenderer.capture`, URL scheme, readiness, capture decision |
+| `/Users/melee/Documents/projects/forks/rhwp/rhwp-studio/e2e/helpers.mjs` | upstream `loadHwpFile()` direct load 방식 |
+| `/Users/melee/Documents/projects/forks/rhwp/rhwp-studio/src/main.ts` | 일반 load path에서 local font prompt/toast가 발생하는 지점 |
+| `mydocs/report/task_m014_293_report.md` | `domComposite` / `overlayIncluded=true` overlay capture 계약 |
+| `mydocs/report/task_m020_390_report.md` | `복학원서.hwp` reference capture contamination 관찰 |
+
+## 현재 downstream harness 흐름
+
+`StudioReferenceRenderer.capture`의 현재 흐름은 다음과 같다.
+
+1. input file bytes를 읽어 `StudioDocumentSchemeHandler`에 넣는다.
+2. `makeLoadURL(filename:revision:)`가 `alhangeul-studio://app/index.html?url=alhangeul-document://document&filename=...` URL을 만든다.
+3. WebView가 `index.html`을 로드하고, bundled `rhwp-studio` 앱이 query의 `url`을 보고 일반 문서 로드 path를 수행한다.
+4. `waitForPageReady(pageNumber:timeout:)`가 `#scroll-content canvas` 기반 page ready를 기다린다.
+5. `alignAndHideChromeScript(pageNumber:)`가 메뉴/툴바/상태바/ruler를 CSS로 숨긴다.
+6. `currentPageState(pageNumber:)`가 canvas와 overlay DOM 후보를 조사한다.
+7. capture decision을 수행한다.
+   - overlay DOM 또는 union이 있으면 `domComposite`
+   - canvas sample이 비어 있으면 `webViewSnapshot`
+   - 그 외에는 `canvasDataURL`
+
+현재 chrome hide selector는 다음 UI만 숨긴다.
+
+| selector |
+|----------|
+| `#menu-bar` |
+| `#icon-toolbar` |
+| `#style-bar` |
+| `#status-bar` |
+| `#ruler-corner` |
+| `#h-ruler` |
+| `#v-ruler` |
+
+따라서 local font modal/toast, validation modal, autosave recovery prompt 같은 사용자-facing UI는 현재 selector 정책만으로는 구조적으로 차단되지 않는다.
+
+## contamination 발생 경로
+
+bundled `rhwp-studio`의 일반 load path는 문서 load 후 `initDoc` 계열 side effect를 수행한다.
+
+확인한 일반 path side effect:
+
+| 단계 | side effect |
+|------|-------------|
+| web font load | status text가 `폰트 로딩 중...`으로 변경 |
+| `canvasView.loadDocument()` | page canvas render |
+| toolbar enable/init | font/style dropdown 초기화 |
+| validation warning | 필요 시 validation modal 표시 |
+| `promptLocalFontsIfNeeded` | 필요 시 local font modal 표시 |
+| local font detect success/failure | `로컬 글꼴 ...` status/toast 표시 |
+
+#390에서 `복학원서.hwp`는 CoreGraphics/Skia visual diff가 모두 99%대로 튀었고, 최종 보고서는 이를 `reference capture contamination`으로 분리했다. 이 수치는 renderer output 자체보다 reference PNG에 사용자 UI가 섞였다는 신호로 해석해야 한다.
+
+## upstream direct load 방식
+
+upstream `rhwp-studio/e2e/helpers.mjs`의 `loadHwpFile()`은 일반 file input/UI path를 거치지 않는다.
+
+핵심 흐름:
+
+1. sample URL을 `fetch`한다.
+2. `arrayBuffer()`를 `Uint8Array`로 만든다.
+3. `window.__wasm.loadDocument(new Uint8Array(buf), fname)`를 직접 호출한다.
+4. `window.__canvasView.loadDocument()`를 직접 호출한다.
+5. canvas selector가 나타날 때까지 기다린다.
+
+이 경로는 `src/main.ts`의 `initDoc`에서 수행하는 validation prompt, local font prompt/toast, toolbar init 같은 사용자 UI side effect를 우회한다. #398 Stage 2에서 downstream harness가 따라야 할 기준은 이 direct WASM/canvas load 방식이다.
+
+## #293 overlay capture 계약
+
+#293은 `복학원서.hwp`의 DOM overlay가 reference PNG에서 누락되던 문제를 이미 해결했다.
+
+유지해야 하는 계약:
+
+| 항목 | 기대값 |
+|------|--------|
+| overlay-positive reference | `captureMode=domComposite` |
+| overlay metadata | `overlayIncluded=true` |
+| `복학원서.hwp` 역할 | BehindText overlay positive fixture |
+| overlay 없는 회귀 기준 | `canvasDataURL`, `overlayIncluded=false` 유지 |
+
+따라서 #398은 capture decision을 canvas-only로 되돌리면 안 된다. 수정 지점은 document load path와 contamination metadata이며, `domComposite` 합성 방식은 유지해야 한다.
+
+## Stage 2 구현 지점
+
+| 구현 지점 | 결정 |
+|-----------|------|
+| app URL 생성 | 기존 `makeLoadURL(filename:revision:)`와 별도로 `makeAutomationAppURL()`을 추가한다 |
+| document URL 생성 | `StudioDocumentSchemeHandler`는 유지하고 `makeDocumentURL(revision:)` 같은 작은 helper로 분리한다 |
+| WebView navigation | `alhangeul-studio://app/index.html`만 로드한다. `url` query를 넣지 않는다 |
+| runtime readiness | 문서 canvas가 아니라 `window.__wasm`와 `window.__canvasView` 존재를 기다리는 `waitForAutomationRuntime(timeout:)`를 추가한다 |
+| document load | page JS에서 `fetch(documentURL)` 후 `window.__wasm.loadDocument(...)`, `window.__canvasView.loadDocument()`를 호출한다 |
+| post-load readiness | 기존 `waitForPageReady(pageNumber:timeout:)`와 `currentPageState`를 재사용한다 |
+| capture decision | 기존 `domComposite` / `webViewSnapshot` / `canvasDataURL` 순서를 유지한다 |
+| fallback | automation load 실패 시 기존 UI load로 조용히 fallback하지 않는다 |
+
+예상 Stage 2 흐름:
+
+```text
+createWebView(documentData, revision)
+-> load(makeAutomationAppURL())
+-> waitForAutomationRuntime()
+-> loadDocumentForAutomation(documentURL, filename)
+-> waitForPageReady(pageNumber)
+-> alignPageAndHideChrome(pageNumber)
+-> currentPageState(pageNumber)
+-> existing capture decision
+```
+
+## Stage 3 metadata 입력
+
+Stage 1 기준으로 Stage 3에서 추가해야 할 metadata 후보는 다음과 같다.
+
+| field | 의미 |
+|-------|------|
+| `automationLoad` | automation direct load path 사용 여부 |
+| `captureContaminated` | capture 전후 사용자 UI contamination 감지 여부 |
+| `uiSuppressed` | residual UI를 숨긴 경우 |
+| `modalCount` | visible modal/dialog 후보 수 |
+| `toastCount` | visible toast/notification 후보 수 |
+| `localFontUIVisible` | `로컬 글꼴`, `글꼴 감지`, `폰트 감지` 계열 text 감지 |
+| `contaminationText` | 감지된 contamination text sample |
+
+Stage 2 구현만으로 contamination이 사라져야 하지만, Stage 3 metadata가 있어야 #396 Stage 4에서 `복학원서.hwp` 결과를 정상 sample로 해석할지 근거를 남길 수 있다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+해당 없음. 이번 단계는 inventory 보고서 작성과 오늘할일 비고 갱신만 수행했다. 기존 문서와 source는 수정하지 않았다.
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| downstream harness keyword `rg` | 통과: load URL, readiness, chrome hide, capture decision keyword 확인 |
+| upstream direct load keyword `rg` | 통과: `loadHwpFile`, `__wasm`, `__canvasView`, `loadDocument` 확인 |
+| `git diff --check` | 통과 |
+
+## 잔여 위험
+
+- 현재 workspace context에서는 upstream fork가 조사용 read target으로 접근 가능했지만, #398의 실제 변경은 downstream repo에만 적용한다.
+- direct load가 `initDoc`의 toolbar/font dropdown side effect를 우회하므로, renderer reference에 필요한 side effect와 사용자 UI side effect를 Stage 2 smoke에서 구분해야 한다.
+- `복학원서.hwp`는 capture contamination을 제거해도 layout overflow, displayText, watermark/effect 이력이 남아 있다. clean capture가 곧 Skia default 통과를 의미하지 않는다.
+- WebKit readiness timeout은 renderer failure가 아니라 environment failure로 계속 분리해야 한다.
+
+## 다음 단계 영향
+
+Stage 2에서는 `scripts/preview_visual_diff_harness.swift`에 automation app URL, automation runtime readiness, direct document load JS를 추가한다. Stage 2는 metadata 확장까지 한 번에 하지 않고, 기존 capture decision 유지와 direct load 성공을 먼저 닫는다.
+
+## 승인 요청
+
+Stage 1 결과에 따라 Stage 2 `automation load path 구현`으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_398_stage2.md
+++ b/mydocs/working/task_m020_398_stage2.md
@@ -1,0 +1,169 @@
+# Task M020 #398 Stage 2 완료 보고서
+
+## 단계 목적
+
+`preview_visual_diff_harness.swift`의 `StudioReferenceRenderer`가 `rhwp-studio` 일반 `?url=` 문서 로드 URL을 거치지 않고, 앱 shell 로드 후 automation JavaScript로 문서 bytes를 주입하도록 변경한다.
+
+기존 `domComposite` / `webViewSnapshot` / `canvasDataURL` capture decision은 유지한다.
+
+## 산출물
+
+| 파일 | 변경 |
+|------|------|
+| `scripts/preview_visual_diff_harness.swift` | automation app URL, runtime readiness, document load JS, local font modal 방지용 harness-local snapshot 주입 추가 |
+
+변경량:
+
+```text
+scripts/preview_visual_diff_harness.swift | 340 +++++++++++++++++++++++++++++-
+1 file changed, 337 insertions(+), 3 deletions(-)
+```
+
+현재 파일 라인 수:
+
+```text
+2444 scripts/preview_visual_diff_harness.swift
+```
+
+## 구현 내용
+
+- `capture`의 reference load URL을 `alhangeul-studio://app/index.html?url=...`에서 `alhangeul-studio://app/index.html`로 변경했다.
+- 기존 document bytes 전달은 `StudioDocumentSchemeHandler`를 유지하고, page 안 automation JS가 `alhangeul-document://current?revision=1`을 `fetch`한다.
+- `waitForAutomationRuntime(timeout:)`를 추가해 앱 shell load 완료 후 automation readiness를 확인한다.
+- `loadDocumentForAutomation(documentURL:filename:timeout:)`를 추가해 문서 load 완료와 page count를 명시적으로 확인한다.
+- automation load 실패 시 기존 UI load로 조용히 fallback하지 않고 `.readiness` phase failure로 드러낸다.
+- 기존 capture decision은 변경하지 않았다. `overlayCount > 0`이면 `domComposite`, canvas가 비어 있으면 `webViewSnapshot`, 그 외에는 `canvasDataURL` 흐름을 그대로 사용한다.
+
+## 구현 중 확인한 제약과 조정
+
+구현계획서는 upstream source 기준 `window.__wasm.loadDocument(...)`와 `window.__canvasView.loadDocument()` direct path를 우선했다. 그러나 현재 bundled production asset은 source와 달리 이 debug global을 노출하지 않았다.
+
+따라서 Stage 2 구현은 다음 순서로 동작한다.
+
+1. `window.__wasm`와 `window.__canvasView`가 있으면 direct global path를 사용한다.
+2. production asset처럼 global이 없으면 bundled asset이 이미 제공하는 `rhwp-request` message API의 `ready` / `loadFile`를 사용한다.
+
+`rhwp-request loadFile`는 앱 내부 `loadBytes/initDoc` 경로를 통과하므로, `복학원서.hwp`에서는 local font modal이 promise를 막았다. 이를 해결하기 위해 하네스 전용 non-persistent WKWebView의 `localStorage`에 다음 의미의 빈 snapshot을 문서 로드 직전에 주입했다.
+
+- key: `rhwp-local-fonts`
+- source: `local-font-access`
+- families: `[]`
+
+upstream logic상 이 상태는 "로컬 글꼴 전체 확인 완료, 설치 글꼴 없음"으로 해석되어 local font prompt를 띄우지 않는다. 하네스의 WKWebView는 `WKWebsiteDataStore.nonPersistent()`를 사용하므로 이 상태는 smoke 실행 바깥으로 유지되지 않는다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+제품 문서나 sample 본문은 변경하지 않았다. 변경 범위는 visual diff harness 코드와 본 보고서뿐이다.
+
+## 검증 결과
+
+정적 검증:
+
+```bash
+swiftc -parse scripts/preview_visual_diff_harness.swift
+git diff --check
+```
+
+결과: 둘 다 출력 없이 성공.
+
+구현 지점 확인:
+
+```bash
+rg -n "automation|__wasm|__canvasView|loadDocument|domComposite|overlayIncluded" \
+  scripts/preview_visual_diff_harness.swift
+```
+
+주요 확인 지점:
+
+```text
+582:        let automationLoadInfo = try loadDocumentForAutomation(
+614:            captureMode = "domComposite"
+615:            overlayIncluded = true
+820:                    automationReadyStartScript(),
+876:    private func loadDocumentForAutomation(
+1190:    private func automationReadyStartScript() -> String
+1229:    private func automationLoadStartScript(documentURL: URL, filename: String) -> String
+1291:              if (window.__wasm && window.__canvasView) {
+1308:                const result = await postRhwpRequest('loadFile', {
+```
+
+기본 sample smoke:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task398-stage2-smoke-rpc --page 1 \
+  samples/basic/request.hwp
+```
+
+결과:
+
+```text
+OK: rhwp-studio assets verified at /Users/melee/Documents/projects/rhwp-mac/Sources/HostApp/Resources/rhwp-studio
+OK request.hwp: studioPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-stage2-smoke-rpc/studio/request.hwp-page1-studio.png nativePNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-stage2-smoke-rpc/native/request.hwp-page1-native.png diffPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-stage2-smoke-rpc/diff/request.hwp-page1-diff.png
+```
+
+metadata 확인:
+
+```text
+loadURL: alhangeul-studio://app/index.html
+captureMode: domComposite
+overlayIncluded: true
+statusText: request.hwp — 1페이지 (automation)
+```
+
+target sample smoke:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task398-stage2-smoke-bokhak --page 1 \
+  samples/복학원서.hwp
+```
+
+결과:
+
+```text
+OK: rhwp-studio assets verified at /Users/melee/Documents/projects/rhwp-mac/Sources/HostApp/Resources/rhwp-studio
+LAYOUT_OVERFLOW: page=0, sec=0, col=0, para=16, type=Shape, first=false, y=1087.2, bottom=1084.7, overflow=2.5px
+LAYOUT_OVERFLOW: page=0, sec=0, col=0, para=16, type=Shape, first=false, y=1087.2, bottom=1084.7, overflow=2.5px
+OK 복학원서.hwp: studioPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-stage2-smoke-bokhak/studio/복학원서.hwp-page1-studio.png nativePNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-stage2-smoke-bokhak/native/복학원서.hwp-page1-native.png diffPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-stage2-smoke-bokhak/diff/복학원서.hwp-page1-diff.png
+```
+
+metadata 확인:
+
+```text
+loadURL: alhangeul-studio://app/index.html
+captureMode: webViewSnapshot
+overlayIncluded: false
+statusText: 복학원서.hwp — 1페이지 (automation)
+canvasCount: 4
+overlayCount: 0
+```
+
+중간 실패 기록:
+
+- sandbox 안 smoke는 기존 #390류 WebKit readiness 문제와 같은 계열로 실패했다.
+- 첫 production smoke는 `window.__wasm && window.__canvasView`가 false여서 automation runtime timeout이 났다.
+- `복학원서.hwp` 첫 `rhwp-request loadFile` smoke는 local font modal이 promise를 막아 document load timeout이 났다.
+- 빈 complete local font snapshot 주입 뒤 `복학원서.hwp` smoke가 통과했다.
+
+## 잔여 위험
+
+- current bundled asset은 direct globals를 노출하지 않아 production 경로에서는 `rhwp-request loadFile`를 사용한다. 이 경로는 local font prompt는 막았지만, 앱 내부 `initDoc`의 다른 사용자-facing modal이 있는 문서에서는 추가 metadata나 별도 suppression이 필요할 수 있다.
+- `복학원서.hwp` smoke에서 `LAYOUT_OVERFLOW` warning은 여전히 출력된다. 이는 capture contamination이 아니라 기존 layout 이력으로 해석해야 한다.
+- Stage 2에서는 metadata field 확장을 아직 하지 않았다. `automationStrategy`, `localFontsSeeded`, `captureContaminated` 같은 값은 Stage 3에서 `studio/*.json`에 기록해야 한다.
+
+## 다음 단계 영향
+
+Stage 3에서는 현재 Stage 2 결과를 metadata로 관측 가능하게 만든다.
+
+- `automationLoad`
+- `automationStrategy`
+- `localFontsSeeded`
+- `modalCount`
+- `toastCount`
+- `localFontUIVisible`
+- `captureContaminated`
+
+이후 Stage 4에서 `복학원서.hwp`와 `request.hwp`를 공식 target smoke로 다시 실행하고, #396 Stage 4에서 `bokhakwonseo-capture-sentinel`을 정상 sample 후보로 돌릴 수 있는지 판단한다.
+
+## 승인 요청
+
+Stage 2는 완료했다. Stage 3 `contamination metadata와 failure 분리`로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_398_stage3.md
+++ b/mydocs/working/task_m020_398_stage3.md
@@ -1,0 +1,152 @@
+# Task M020 #398 Stage 3 완료 보고서
+
+## 단계 목적
+
+reference capture가 사용자 UI에 오염됐는지 `studio/*.json`과 `summary.md`에서 확인할 수 있게 한다.
+
+Stage 2에서 automation load path는 동작했지만, capture 결과가 깨끗한지 판단할 metadata가 없었다. Stage 3에서는 renderer diff 수치와 capture contamination 상태를 분리해서 기록한다.
+
+## 산출물
+
+| 파일 | 변경 |
+|------|------|
+| `scripts/preview_visual_diff_harness.swift` | automation metadata, capture 전후 UI probe, contamination aggregate field, summary 힌트 추가 |
+| `mydocs/working/task_m020_398_stage3.md` | Stage 3 완료 보고서 |
+| `mydocs/orders/20260629.md` | #398 상태를 Stage 3 승인 대기로 갱신 |
+
+변경량:
+
+```text
+scripts/preview_visual_diff_harness.swift | 192 +++++++++++++++++++++++++++++-
+1 file changed, 191 insertions(+), 1 deletion(-)
+```
+
+현재 Swift 파일 라인 수:
+
+```text
+2634 scripts/preview_visual_diff_harness.swift
+```
+
+## 구현 내용
+
+`StudioCaptureMetadata`에 automation load와 UI contamination 필드를 추가했다.
+
+- `automationLoad`
+- `automationStrategy`
+- `automationPageCount`
+- `automationFileName`
+- `automationSourceFormat`
+- `automationLocalFontsSeeded`
+- `captureContaminated`
+- `uiSuppressed`
+- `modalCount`
+- `toastCount`
+- `localFontUIVisible`
+- `contaminationText`
+- `preCaptureUI`
+- `postCaptureUI`
+
+capture 직전과 직후에 DOM probe를 실행한다.
+
+- modal 후보: `dialog`, `[role="dialog"]`, `[aria-modal="true"]`, `.modal-overlay`, `.dialog-wrap`, `.modal`, class/id에 `modal`이 포함된 요소
+- toast 후보: `#rhwp-toast-container`, `.toast`, `.snackbar`, `.notification`, 관련 class/id
+- local font UI text 후보: `로컬 글꼴`, `로컬 폰트`, `글꼴 감지`, `폰트 감지`, `Local Font`
+
+동일 modal tree 안에서 overlay와 dialog가 동시에 잡히지 않도록 outermost visible element만 count한다.
+
+`summary.md`의 기존 `StudioCapture` column에는 column을 늘리지 않고 UI 상태 힌트만 붙인다.
+
+예:
+
+```text
+domComposite;ui=clean
+```
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+제품 앱, renderer, sample 문서는 변경하지 않았다. 변경 범위는 visual diff harness와 작업 보고서/오늘할일 문서뿐이다.
+
+## 검증 결과
+
+정적 검증:
+
+```bash
+swiftc -parse scripts/preview_visual_diff_harness.swift
+git diff --check
+```
+
+결과: 둘 다 출력 없이 성공.
+
+Stage 3 필드 확인:
+
+```bash
+rg -n "automationLoad|captureContaminated|modalCount|toastCount|localFontUIVisible|uiSuppressed" \
+  scripts/preview_visual_diff_harness.swift build.noindex/task398-stage3-smoke/studio/request.hwp-page1-studio.json build.noindex/task398-stage3-smoke/summary.md
+```
+
+결과: Swift source와 smoke metadata에서 필드 확인.
+
+metadata smoke:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task398-stage3-smoke --page 1 \
+  samples/basic/request.hwp
+```
+
+결과:
+
+```text
+OK: rhwp-studio assets verified at /Users/melee/Documents/projects/rhwp-mac/Sources/HostApp/Resources/rhwp-studio
+OK request.hwp: studioPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-stage3-smoke/studio/request.hwp-page1-studio.png nativePNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-stage3-smoke/native/request.hwp-page1-native.png diffPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-stage3-smoke/diff/request.hwp-page1-diff.png
+```
+
+`studio/request.hwp-page1-studio.json` 핵심 값:
+
+```json
+{
+  "automationLoad": true,
+  "automationStrategy": "rhwp-request",
+  "automationPageCount": 1,
+  "automationFileName": "request.hwp",
+  "automationSourceFormat": null,
+  "automationLocalFontsSeeded": true,
+  "captureMode": "domComposite",
+  "overlayIncluded": true,
+  "captureContaminated": false,
+  "uiSuppressed": false,
+  "modalCount": 0,
+  "toastCount": 0,
+  "localFontUIVisible": false,
+  "contaminationText": []
+}
+```
+
+`summary.md` row의 `StudioCapture` 값:
+
+```text
+domComposite;ui=clean
+```
+
+## 잔여 위험
+
+- Stage 3는 metadata와 failure 분리 근거를 추가하는 단계다. `복학원서.hwp`와 대표 sample 전체 target smoke는 Stage 4에서 수행한다.
+- `captureContaminated=true`가 되면 해당 visual diff 수치는 renderer failure가 아니라 capture failure로 해석해야 한다. 현재 Stage 3에서는 산출물을 남기기 위해 즉시 fail 처리하지 않고 metadata와 summary에 표시한다.
+- `uiSuppressed`는 현재 false만 기록한다. Stage 2의 local font snapshot 주입으로 local font modal을 처음부터 막는 것이 우선이며, 실제 UI 숨김 CSS는 추가하지 않았다.
+- production bundled asset은 direct global 대신 `rhwp-request` strategy를 사용한다. 이 값이 metadata에 남으므로 #396 Stage 4에서 sample 해석 시 확인할 수 있다.
+
+## 다음 단계 영향
+
+Stage 4에서는 다음 값을 기준으로 target smoke를 판정한다.
+
+- `automationLoad=true`
+- `captureContaminated=false`
+- `modalCount=0`
+- `toastCount=0`
+- `localFontUIVisible=false`
+- `captureMode`와 `overlayIncluded` 유지
+
+`복학원서.hwp`의 layout warning은 capture contamination과 별도로 해석한다.
+
+## 승인 요청
+
+Stage 3는 완료했다. Stage 4 `target sample smoke 검증`으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_398_stage4.md
+++ b/mydocs/working/task_m020_398_stage4.md
@@ -1,0 +1,158 @@
+# Task M020 #398 Stage 4 완료 보고서
+
+## 단계 목적
+
+`복학원서.hwp`와 대표 sample에서 automation load가 실제로 reference capture contamination을 제거하는지 확인한다.
+
+Stage 4 중간 검증에서 `복학원서.hwp`가 `ui=clean`이지만 `webViewSnapshot` dark PNG로 떨어지는 문제가 드러났다. 원인은 current `rhwp-studio`가 BehindText/InFrontOfText를 `img` DOM overlay가 아니라 sibling canvas layer로 렌더링하는데, harness의 page state probe가 target canvas 외의 canvas layer를 overlay 후보로 세지 않았기 때문이다.
+
+이 단계에서 page state probe를 한 줄 보정해 target canvas와 겹치는 sibling canvas layer도 overlay 후보로 세도록 했다. 기존 `domComposite` exporter는 이미 intersecting canvas/img를 합성하므로 exporter 자체는 변경하지 않았다.
+
+## 산출물
+
+| 파일/경로 | 내용 |
+|-----------|------|
+| `scripts/preview_visual_diff_harness.swift` | sibling canvas layer overlay counting 보정 |
+| `build.noindex/task398-automation-load/` | `복학원서.hwp`, `request.hwp` target smoke 산출물 |
+| `build.noindex/task398-automation-load-ktx/` | `KTX.hwp` optional quick-suite smoke 산출물 |
+| `mydocs/working/task_m020_398_stage4.md` | Stage 4 완료 보고서 |
+| `mydocs/orders/20260629.md` | #398 상태를 Stage 4 승인 대기로 갱신 |
+
+변경량:
+
+```text
+scripts/preview_visual_diff_harness.swift | 2 +-
+1 file changed, 1 insertion(+), 1 deletion(-)
+```
+
+현재 Swift 파일 라인 수:
+
+```text
+2634 scripts/preview_visual_diff_harness.swift
+```
+
+## 구현 보정
+
+기존 page state probe는 overlay 후보를 셀 때 `canvas` 태그를 제외했다.
+
+```javascript
+if (element === target || element.tagName.toLowerCase() === 'canvas') {
+  continue;
+}
+```
+
+현재 bundled `rhwp-studio`는 page background/behind/front layer를 sibling canvas로 만든다. 따라서 target canvas만 보고 non-canvas DOM overlay만 세면 `복학원서.hwp`의 overlay layer를 놓치고, 첫 canvas가 blank일 때 `webViewSnapshot` fallback으로 떨어진다.
+
+보정 후에는 target 자신만 제외하고 겹치는 sibling canvas layer를 overlay 후보로 계산한다.
+
+```javascript
+if (element === target) {
+  continue;
+}
+```
+
+이 변경으로 `복학원서.hwp`는 `canvasCount=4`, `overlayCount=3`, `captureMode=domComposite`, `overlayIncluded=true`로 회복됐다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+제품 앱 source, renderer source, sample 문서는 변경하지 않았다. 변경 범위는 visual diff harness의 probe 로직과 작업 보고서/오늘할일 문서뿐이다.
+
+## 검증 결과
+
+정적 검증:
+
+```bash
+swiftc -parse scripts/preview_visual_diff_harness.swift
+git diff --check
+```
+
+결과: 둘 다 출력 없이 성공.
+
+공식 target smoke:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task398-automation-load --page 1 \
+  samples/복학원서.hwp samples/basic/request.hwp
+```
+
+결과:
+
+```text
+OK: rhwp-studio assets verified at /Users/melee/Documents/projects/rhwp-mac/Sources/HostApp/Resources/rhwp-studio
+LAYOUT_OVERFLOW: page=0, sec=0, col=0, para=16, type=Shape, first=false, y=1087.2, bottom=1084.7, overflow=2.5px
+LAYOUT_OVERFLOW: page=0, sec=0, col=0, para=16, type=Shape, first=false, y=1087.2, bottom=1084.7, overflow=2.5px
+OK 복학원서.hwp: studioPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-automation-load/studio/복학원서.hwp-page1-studio.png nativePNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-automation-load/native/복학원서.hwp-page1-native.png diffPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-automation-load/diff/복학원서.hwp-page1-diff.png
+OK request.hwp: studioPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-automation-load/studio/request.hwp-page1-studio.png nativePNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-automation-load/native/request.hwp-page1-native.png diffPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-automation-load/diff/request.hwp-page1-diff.png
+```
+
+Optional KTX smoke:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task398-automation-load-ktx --page 1 \
+  samples/basic/KTX.hwp
+```
+
+결과:
+
+```text
+OK: rhwp-studio assets verified at /Users/melee/Documents/projects/rhwp-mac/Sources/HostApp/Resources/rhwp-studio
+OK KTX.hwp: studioPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-automation-load-ktx/studio/KTX.hwp-page1-studio.png nativePNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-automation-load-ktx/native/KTX.hwp-page1-native.png diffPNG=/Users/melee/Documents/projects/rhwp-mac/build.noindex/task398-automation-load-ktx/diff/KTX.hwp-page1-diff.png
+```
+
+핵심 metadata:
+
+| sample | automationLoad | captureMode | overlayIncluded | captureContaminated | modalCount | toastCount | localFontUIVisible | ChangedPercent |
+|--------|----------------|-------------|------------------|---------------------|------------|------------|--------------------|----------------|
+| `복학원서.hwp` | `true` | `domComposite` | `true` | `false` | `0` | `0` | `false` | `7.2888%` |
+| `request.hwp` | `true` | `domComposite` | `true` | `false` | `0` | `0` | `false` | `17.6908%` |
+| `KTX.hwp` | `true` | `domComposite` | `true` | `false` | `0` | `0` | `false` | `30.8921%` |
+
+검증 grep:
+
+```bash
+rg -n "captureMode|overlayIncluded|automationLoad|captureContaminated|modalCount|toastCount|localFontUIVisible|복학원서|request" \
+  build.noindex/task398-automation-load
+rg -n "captureMode|overlayIncluded|automationLoad|captureContaminated|modalCount|toastCount|localFontUIVisible|KTX" \
+  build.noindex/task398-automation-load-ktx
+```
+
+결과: 각 `studio/*.json`에서 `automationLoad=true`, `captureContaminated=false`, `modalCount=0`, `toastCount=0`, `localFontUIVisible=false` 확인.
+
+## 중간 실패와 해결
+
+첫 Stage 4 smoke에서는 `복학원서.hwp`가 `captureContaminated=false`였지만 `captureMode=webViewSnapshot`, `overlayIncluded=false`, PNG가 어두운 빈 snapshot이었다. 이 상태는 local font modal contamination은 제거됐지만 reference capture가 정상 sample로 복구된 상태가 아니었다.
+
+source 확인 결과 current `rhwp-studio`는 overlay를 sibling canvas layer로 만든다.
+
+- `data-rhwp-overlay-page`
+- `data-rhwp-layer-kind`
+- `background`, `behind`, `front`
+
+따라서 harness가 non-canvas overlay만 세면 #293의 `domComposite` 계약을 놓친다. sibling canvas layer counting 보정 뒤 `복학원서.hwp`는 `domComposite;ui=clean`으로 회복됐다.
+
+## 완료 조건 판정
+
+| 완료 조건 | 판정 | 근거 |
+|-----------|------|------|
+| `복학원서.hwp` reference capture에 로컬 글꼴 감지 UI가 섞이지 않는다 | OK | `captureContaminated=false`, `modalCount=0`, `toastCount=0`, `localFontUIVisible=false` |
+| `복학원서.hwp`의 overlay-positive capture 의미가 유지된다 | OK | `captureMode=domComposite`, `overlayIncluded=true`, `overlayCount=3` |
+| 대표 sample이 불필요하게 악화되지 않는다 | OK | `request.hwp`, `KTX.hwp` 모두 `OK`, `ui=clean` |
+| 실패 시 renderer failure와 capture/environment failure가 구분된다 | OK | Stage 3 metadata와 Stage 4 중간 dark snapshot 기록으로 분리 가능 |
+
+## 잔여 위험
+
+- `request.hwp`, `KTX.hwp`도 current detector에서 sibling canvas layer 때문에 `overlayIncluded=true`가 된다. 이는 current `rhwp-studio`의 layered canvas rendering을 반영한 결과이며, 과거 문서의 “overlay 없는 sample” 표현은 더 이상 정확하지 않다.
+- `복학원서.hwp`의 `LAYOUT_OVERFLOW` warning은 남아 있다. 이는 capture contamination이 아니라 renderer/layout 이력으로 #396에서 별도 해석해야 한다.
+- `KTX.hwp` diff 30.8921%는 capture contamination이 아니라 renderer parity 측정값이다. #398에서는 default 전환 판단을 하지 않는다.
+
+## 다음 단계 영향
+
+Stage 5에서는 #398 최종 보고서와 #396 handoff를 정리한다. 핵심 handoff는 다음과 같다.
+
+- `bokhakwonseo-capture-sentinel`은 더 이상 local font modal contamination으로 제외할 필요가 없다.
+- 단, `복학원서.hwp`의 layout overflow와 renderer parity 수치는 #396에서 별도 기준으로 해석한다.
+- `rhwp-studio` reference metadata의 `automationStrategy=rhwp-request`, `automationLocalFontsSeeded=true`, `captureContaminated=false`를 같이 확인해야 한다.
+
+## 승인 요청
+
+Stage 4는 완료했다. Stage 5 `최종 보고서와 #396 handoff`로 진행해도 되는지 승인 요청한다.

--- a/scripts/preview_visual_diff_harness.swift
+++ b/scripts/preview_visual_diff_harness.swift
@@ -82,6 +82,12 @@ struct StudioCaptureMetadata: Codable {
     let filename: String
     let page: Int
     let loadURL: String
+    let automationLoad: Bool
+    let automationStrategy: String
+    let automationPageCount: Int
+    let automationFileName: String
+    let automationSourceFormat: String?
+    let automationLocalFontsSeeded: Bool
     let selector: String
     let rect: RectMetadata
     let canvasRect: RectMetadata
@@ -97,6 +103,14 @@ struct StudioCaptureMetadata: Codable {
     let captureMode: String
     let overlayIncluded: Bool
     let statusText: String
+    let captureContaminated: Bool
+    let uiSuppressed: Bool
+    let modalCount: Int
+    let toastCount: Int
+    let localFontUIVisible: Bool
+    let contaminationText: [String]
+    let preCaptureUI: UIContaminationProbe
+    let postCaptureUI: UIContaminationProbe
     let captureMs: Double
     let settleMs: Int
     let studioReleaseTag: String
@@ -121,6 +135,8 @@ struct StudioCaptureResult {
     let canvasSampleNonWhitePixels: Int
     let canvasSamplePixels: Int
     let captureMode: String
+    let captureContaminated: Bool
+    let uiSuppressed: Bool
     let captureMs: Double
 }
 
@@ -129,7 +145,26 @@ struct AutomationLoadInfo {
     let fileName: String
     let sourceFormat: String?
     let strategy: String?
+    let localFontsSeeded: Bool
     let statusText: String
+}
+
+struct UIContaminationProbe: Codable {
+    let modalCount: Int
+    let toastCount: Int
+    let localFontUIVisible: Bool
+    let contaminationText: [String]
+
+    var captureContaminated: Bool {
+        modalCount > 0 || toastCount > 0 || localFontUIVisible
+    }
+
+    init(dictionary: [String: Any]) {
+        modalCount = intValue(dictionary["modalCount"])
+        toastCount = intValue(dictionary["toastCount"])
+        localFontUIVisible = dictionary["localFontUIVisible"] as? Bool ?? false
+        contaminationText = stringArrayValue(dictionary["contaminationText"])
+    }
 }
 
 struct PNGOutput {
@@ -603,6 +638,7 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             throw PreviewHarnessError(description: "page \(pageNumber) rect is unavailable")
         }
 
+        let preCaptureUI = try currentUIContaminationProbe()
         var png: PNGOutput
         var captureMode = "canvasDataURL"
         var overlayIncluded = false
@@ -627,6 +663,13 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
                 snapshotSamplePixels = snapshotPNG.samplePixels
             }
         }
+        let postCaptureUI = try currentUIContaminationProbe()
+        let captureContaminated = preCaptureUI.captureContaminated || postCaptureUI.captureContaminated
+        let uiSuppressed = false
+        let modalCount = max(preCaptureUI.modalCount, postCaptureUI.modalCount)
+        let toastCount = max(preCaptureUI.toastCount, postCaptureUI.toastCount)
+        let localFontUIVisible = preCaptureUI.localFontUIVisible || postCaptureUI.localFontUIVisible
+        let contaminationText = combinedContaminationText(preCaptureUI, postCaptureUI)
         try png.data.write(to: pngURL, options: .atomic)
 
         let elapsedMs = Date().timeIntervalSince(startTime) * 1000
@@ -635,6 +678,12 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             filename: inputURL.lastPathComponent,
             page: pageNumber,
             loadURL: loadURL.absoluteString,
+            automationLoad: true,
+            automationStrategy: automationLoadInfo.strategy ?? "unknown",
+            automationPageCount: automationLoadInfo.pageCount,
+            automationFileName: automationLoadInfo.fileName.isEmpty ? inputURL.lastPathComponent : automationLoadInfo.fileName,
+            automationSourceFormat: automationLoadInfo.sourceFormat,
+            automationLocalFontsSeeded: automationLoadInfo.localFontsSeeded,
             selector: pageState.selector,
             rect: snapshotRectMetadata,
             canvasRect: canvasRectMetadata,
@@ -650,6 +699,14 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             captureMode: captureMode,
             overlayIncluded: overlayIncluded,
             statusText: pageState.statusText,
+            captureContaminated: captureContaminated,
+            uiSuppressed: uiSuppressed,
+            modalCount: modalCount,
+            toastCount: toastCount,
+            localFontUIVisible: localFontUIVisible,
+            contaminationText: contaminationText,
+            preCaptureUI: preCaptureUI,
+            postCaptureUI: postCaptureUI,
             captureMs: elapsedMs,
             settleMs: settleMilliseconds,
             studioReleaseTag: manifest.source_release_tag,
@@ -675,6 +732,8 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             canvasSampleNonWhitePixels: pageState.canvasSampleNonWhitePixels,
             canvasSamplePixels: pageState.canvasSamplePixels,
             captureMode: captureMode,
+            captureContaminated: captureContaminated,
+            uiSuppressed: uiSuppressed,
             captureMs: elapsedMs
         )
     }
@@ -945,6 +1004,7 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             fileName: dictionary["fileName"] as? String ?? "",
             sourceFormat: dictionary["sourceFormat"] as? String,
             strategy: dictionary["strategy"] as? String,
+            localFontsSeeded: dictionary["localFontsSeeded"] as? Bool ?? false,
             statusText: dictionary["statusText"] as? String ?? ""
         )
     }
@@ -1008,6 +1068,34 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             )
         }
         return PageState(dictionary: dictionary)
+    }
+
+    private func currentUIContaminationProbe() throws -> UIContaminationProbe {
+        let value = try evaluateJavaScript(uiContaminationProbeScript(), timeout: 5, phase: .settle)
+        guard let json = value as? String,
+              let data = json.data(using: .utf8),
+              let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw PreviewHarnessPhaseError(
+                phase: .settle,
+                detail: "unexpected UI contamination probe result: \(describeJavaScriptValue(value))"
+            )
+        }
+        return UIContaminationProbe(dictionary: dictionary)
+    }
+
+    private func combinedContaminationText(_ first: UIContaminationProbe, _ second: UIContaminationProbe) -> [String] {
+        var seen = Set<String>()
+        var values: [String] = []
+        for text in first.contaminationText + second.contaminationText {
+            let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !normalized.isEmpty, !seen.contains(normalized) else {
+                continue
+            }
+            seen.insert(normalized)
+            values.append(normalized)
+        }
+        return values
     }
 
     private func evaluateJavaScript(
@@ -1490,6 +1578,92 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             });
           }
         })()
+        """
+    }
+
+    private func uiContaminationProbeScript() -> String {
+        """
+        JSON.stringify((() => {
+          const isVisible = (element) => {
+            if (!element || !(element instanceof Element)) {
+              return false;
+            }
+            const style = window.getComputedStyle(element);
+            if (style.display === 'none' || style.visibility === 'hidden' || Number(style.opacity) === 0) {
+              return false;
+            }
+            const rect = element.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0;
+          };
+          const uniqueElements = (selectors) => {
+            const seen = new Set();
+            const elements = [];
+            for (const selector of selectors) {
+              for (const element of Array.from(document.querySelectorAll(selector))) {
+                if (seen.has(element)) {
+                  continue;
+                }
+                seen.add(element);
+                if (isVisible(element)) {
+                  elements.push(element);
+                }
+              }
+            }
+            return elements;
+          };
+          const outermostElements = (elements) => elements.filter((element) =>
+            !elements.some((other) => other !== element && other.contains(element))
+          );
+          const textOf = (element) => (element.textContent || '').replace(/\\s+/g, ' ').trim();
+          const snippet = (text) => text.length > 160 ? `${text.slice(0, 157)}...` : text;
+          const modalElements = outermostElements(uniqueElements([
+            'dialog',
+            '[role="dialog"]',
+            '[aria-modal="true"]',
+            '.modal-overlay',
+            '.dialog-wrap',
+            '.modal',
+            '[class*="modal"]',
+            '[id*="modal"]'
+          ]));
+          const toastElements = outermostElements(uniqueElements([
+            '#rhwp-toast-container > *',
+            '#rhwp-toast-container [role="status"]',
+            '.toast',
+            '.snackbar',
+            '.notification',
+            '[class*="toast"]',
+            '[class*="snackbar"]',
+            '[class*="notification"]'
+          ]));
+          const statusElements = uniqueElements(['#sb-message', '[role="alert"]']);
+          const candidateElements = [...modalElements, ...toastElements, ...statusElements];
+          const localFontPattern = /로컬\\s*(글꼴|폰트)|글꼴\\s*감지|폰트\\s*감지|Local\\s*Font/i;
+          const contaminationTexts = [];
+          for (const element of candidateElements) {
+            const text = textOf(element);
+            if (!text) {
+              continue;
+            }
+            if (modalElements.includes(element) || toastElements.includes(element) || localFontPattern.test(text)) {
+              contaminationTexts.push(snippet(text));
+            }
+          }
+          const dedupedTexts = [];
+          const seenTexts = new Set();
+          for (const text of contaminationTexts) {
+            if (!seenTexts.has(text)) {
+              seenTexts.add(text);
+              dedupedTexts.push(text);
+            }
+          }
+          return {
+            modalCount: modalElements.length,
+            toastCount: toastElements.length,
+            localFontUIVisible: candidateElements.some((element) => localFontPattern.test(textOf(element))),
+            contaminationText: dedupedTexts.slice(0, 12)
+          };
+        })())
         """
     }
 
@@ -2009,7 +2183,7 @@ struct PreviewVisualDiffHarness {
                     formatDouble(diff.meanRGBDelta),
                     "\(diff.maxRGBDelta)",
                     boundsString(diff.bounds),
-                    result.captureMode,
+                    studioCaptureSummary(result),
                     native.backendUsed + fallbackSuffix(native.fallbackReason),
                     formatMilliseconds(native.renderMs),
                     markdownCell(result.pngURL.path),
@@ -2271,6 +2445,16 @@ private func doubleValue(_ value: Any?, default defaultValue: Double = 0) -> Dou
     return defaultValue
 }
 
+private func stringArrayValue(_ value: Any?) -> [String] {
+    if let strings = value as? [String] {
+        return strings
+    }
+    if let values = value as? [Any] {
+        return values.compactMap { $0 as? String }
+    }
+    return []
+}
+
 private func markdownCell(_ value: String) -> String {
     value.replacingOccurrences(of: "|", with: "/")
 }
@@ -2342,6 +2526,12 @@ private func boundsString(_ bounds: CGRect?) -> String {
         return "-"
     }
     return "\(Int(bounds.minX)),\(Int(bounds.minY)) \(Int(bounds.width))x\(Int(bounds.height))"
+}
+
+private func studioCaptureSummary(_ result: StudioCaptureResult) -> String {
+    let contamination = result.captureContaminated ? "ui=contaminated" : "ui=clean"
+    let suppression = result.uiSuppressed ? ";suppressed=true" : ""
+    return "\(result.captureMode);\(contamination)\(suppression)"
 }
 
 private func renderPolicyName(_ policy: HwpPageRenderPolicy) -> String {

--- a/scripts/preview_visual_diff_harness.swift
+++ b/scripts/preview_visual_diff_harness.swift
@@ -1492,7 +1492,7 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             let overlayCount = 0;
 
             for (const element of Array.from(content.querySelectorAll('*'))) {
-              if (element === target || element.tagName.toLowerCase() === 'canvas') {
+              if (element === target) {
                 continue;
               }
               const style = window.getComputedStyle(element);

--- a/scripts/preview_visual_diff_harness.swift
+++ b/scripts/preview_visual_diff_harness.swift
@@ -124,6 +124,14 @@ struct StudioCaptureResult {
     let captureMs: Double
 }
 
+struct AutomationLoadInfo {
+    let pageCount: Int
+    let fileName: String
+    let sourceFormat: String?
+    let strategy: String?
+    let statusText: String
+}
+
 struct PNGOutput {
     let data: Data
     let width: Int
@@ -536,14 +544,16 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         pageNumber: Int,
         manifest: StudioManifest
     ) throws -> StudioCaptureResult {
+        let revision = 1
         let data = try Data(contentsOf: inputURL)
-        let loadURL = try makeLoadURL(filename: inputURL.lastPathComponent, revision: 1)
+        let documentURL = try makeDocumentURL(revision: revision)
+        let loadURL = try makeAutomationAppURL()
         let baseName = outputStem(for: inputURL)
         let outputBase = "\(baseName)-page\(pageNumber)"
         let pngURL = outputDir.appendingPathComponent("\(outputBase)-studio.png", isDirectory: false)
         let jsonURL = outputDir.appendingPathComponent("\(outputBase)-studio.json", isDirectory: false)
 
-        try createWebView(documentData: data, revision: 1)
+        try createWebView(documentData: data, revision: revision)
         defer {
             webView?.navigationDelegate = nil
             webView?.stopLoading()
@@ -567,6 +577,18 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         }
         if navigation == nil {
             recordNavigationEvent("loadReturnedNil:\(loadURL.scheme ?? "nil")")
+        }
+        try waitForAutomationRuntime(timeout: 30)
+        let automationLoadInfo = try loadDocumentForAutomation(
+            documentURL: documentURL,
+            filename: inputURL.lastPathComponent,
+            timeout: 30
+        )
+        guard pageNumber >= 1, pageNumber <= automationLoadInfo.pageCount else {
+            throw PreviewHarnessPhaseError(
+                phase: .readiness,
+                detail: "automation load page \(pageNumber) is out of range: pageCount=\(automationLoadInfo.pageCount)"
+            )
         }
         try waitForPageReady(pageNumber: pageNumber, timeout: 30)
         try alignPageAndHideChrome(pageNumber: pageNumber)
@@ -781,6 +803,152 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         )
     }
 
+    private func waitForAutomationRuntime(timeout: TimeInterval) throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastJSON = ""
+        var lastError: Error?
+        var errorCount = 0
+        var startedProbe = false
+        while Date() < deadline {
+            try throwIfNavigationFailed()
+            guard case .success = navigationResult else {
+                RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+                continue
+            }
+            if !startedProbe {
+                _ = try evaluateJavaScript(
+                    automationReadyStartScript(),
+                    timeout: 5,
+                    phase: .readiness
+                )
+                startedProbe = true
+            }
+            do {
+                let value = try evaluateJavaScript(
+                    "String(window.__alhangeulPreviewAutomationReadyJSON || '')",
+                    timeout: 2,
+                    phase: .readiness
+                )
+                if let json = value as? String, !json.isEmpty {
+                    lastJSON = json
+                    guard let data = json.data(using: .utf8),
+                          let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+                    else {
+                        throw PreviewHarnessPhaseError(
+                            phase: .readiness,
+                            detail: "unexpected automation ready result: \(json)"
+                        )
+                    }
+                    if dictionary["ok"] as? Bool == true {
+                        return
+                    }
+                    let errorMessage = dictionary["error"] as? String ?? "unknown automation ready error"
+                    throw PreviewHarnessPhaseError(
+                        phase: .readiness,
+                        detail: "rhwp-studio automation runtime failed: \(errorMessage)"
+                    )
+                }
+            } catch {
+                lastError = error
+                errorCount += 1
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+
+        var details = [
+            "navigation=\(navigationStatusDescription)",
+            "events=[\(navigationEvents.joined(separator: ","))]",
+            "scheme={\(schemeStats.summary)}",
+            "lastAutomationJSON=\(lastJSON)"
+        ]
+        if let lastError {
+            details.append("lastError={\(lastError)}")
+        }
+        if errorCount > 0 {
+            details.append("errorCount=\(errorCount)")
+        }
+        throw PreviewHarnessPhaseError(
+            phase: .readiness,
+            detail: "rhwp-studio automation runtime timed out: \(details.joined(separator: "; "))"
+        )
+    }
+
+    private func loadDocumentForAutomation(
+        documentURL: URL,
+        filename: String,
+        timeout: TimeInterval
+    ) throws -> AutomationLoadInfo {
+        _ = try evaluateJavaScript(
+            automationLoadStartScript(documentURL: documentURL, filename: filename),
+            timeout: 5,
+            phase: .readiness
+        )
+
+        let deadline = Date().addingTimeInterval(timeout)
+        var lastJSON = ""
+        var lastError: Error?
+        while Date() < deadline {
+            do {
+                let value = try evaluateJavaScript(
+                    "String(window.__alhangeulPreviewAutomationLoadJSON || '')",
+                    timeout: 2,
+                    phase: .readiness
+                )
+                if let json = value as? String, !json.isEmpty {
+                    lastJSON = json
+                    return try automationLoadInfo(from: json)
+                }
+            } catch {
+                lastError = error
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+
+        var details = [
+            "filename=\(filename)",
+            "documentURL=\(documentURL.absoluteString)",
+            "navigation=\(navigationStatusDescription)",
+            "events=[\(navigationEvents.joined(separator: ","))]",
+            "scheme={\(schemeStats.summary)}"
+        ]
+        if !lastJSON.isEmpty {
+            details.append("lastAutomationJSON=\(lastJSON)")
+        }
+        if let lastError {
+            details.append("lastError={\(lastError)}")
+        }
+        throw PreviewHarnessPhaseError(
+            phase: .readiness,
+            detail: "rhwp-studio automation document load timed out: \(details.joined(separator: "; "))"
+        )
+    }
+
+    private func automationLoadInfo(from json: String) throws -> AutomationLoadInfo {
+        guard let data = json.data(using: .utf8),
+              let dictionary = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else {
+            throw PreviewHarnessPhaseError(
+                phase: .readiness,
+                detail: "unexpected automation load result: \(json)"
+            )
+        }
+        if dictionary["ok"] as? Bool != true {
+            let errorMessage = dictionary["error"] as? String ?? "unknown automation load error"
+            throw PreviewHarnessPhaseError(
+                phase: .readiness,
+                detail: "rhwp-studio automation document load failed: \(errorMessage)"
+            )
+        }
+
+        return AutomationLoadInfo(
+            pageCount: intValue(dictionary["pageCount"]),
+            fileName: dictionary["fileName"] as? String ?? "",
+            sourceFormat: dictionary["sourceFormat"] as? String,
+            strategy: dictionary["strategy"] as? String,
+            statusText: dictionary["statusText"] as? String ?? ""
+        )
+    }
+
     private func throwIfNavigationFailed() throws {
         if case .failure(let error) = navigationResult {
             throw PreviewHarnessPhaseError(
@@ -978,7 +1146,7 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         )
     }
 
-    private func makeLoadURL(filename: String, revision: Int) throws -> URL {
+    private func makeDocumentURL(revision: Int) throws -> URL {
         var documentComponents = URLComponents()
         documentComponents.scheme = StudioDocumentSchemeHandler.scheme
         documentComponents.host = StudioDocumentSchemeHandler.host
@@ -988,6 +1156,22 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
         guard let documentURL = documentComponents.url else {
             throw PreviewHarnessError(description: "failed to build document URL")
         }
+        return documentURL
+    }
+
+    private func makeAutomationAppURL() throws -> URL {
+        var components = URLComponents()
+        components.scheme = StudioResourceSchemeHandler.scheme
+        components.host = StudioResourceSchemeHandler.host
+        components.path = "/index.html"
+        guard let url = components.url else {
+            throw PreviewHarnessError(description: "failed to build rhwp-studio automation URL")
+        }
+        return url
+    }
+
+    private func makeLoadURL(filename: String, revision: Int) throws -> URL {
+        let documentURL = try makeDocumentURL(revision: revision)
 
         var components = URLComponents()
         components.scheme = StudioResourceSchemeHandler.scheme
@@ -1001,6 +1185,156 @@ final class StudioReferenceRenderer: NSObject, WKNavigationDelegate {
             throw PreviewHarnessError(description: "failed to build rhwp-studio load URL")
         }
         return url
+    }
+
+    private func automationReadyStartScript() -> String {
+        """
+        (() => {
+          window.__alhangeulPreviewAutomationReadyJSON = '';
+          const finish = (payload) => {
+            window.__alhangeulPreviewAutomationReadyJSON = JSON.stringify(payload);
+          };
+          if (window.__wasm && window.__canvasView) {
+            finish({ ok: true, strategy: 'direct-globals' });
+            return true;
+          }
+          const requestId = `alhangeul-preview-ready-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+          const cleanup = () => {
+            clearTimeout(timer);
+            window.removeEventListener('message', onMessage);
+          };
+          const onMessage = (event) => {
+            const data = event.data;
+            if (!data || data.type !== 'rhwp-response' || data.id !== requestId) {
+              return;
+            }
+            cleanup();
+            if (data.error) {
+              finish({ ok: false, strategy: 'rhwp-request', error: String(data.error) });
+            } else {
+              finish({ ok: true, strategy: 'rhwp-request' });
+            }
+          };
+          const timer = setTimeout(() => {
+            cleanup();
+            finish({ ok: false, strategy: 'rhwp-request', error: 'ready request timed out' });
+          }, 15000);
+          window.addEventListener('message', onMessage);
+          window.postMessage({ type: 'rhwp-request', id: requestId, method: 'ready' }, '*');
+          return true;
+        })();
+        """
+    }
+
+    private func automationLoadStartScript(documentURL: URL, filename: String) -> String {
+        let documentURLLiteral = javaScriptStringLiteral(documentURL.absoluteString)
+        let filenameLiteral = javaScriptStringLiteral(filename)
+        return """
+        (() => {
+          window.__alhangeulPreviewAutomationLoadJSON = '';
+          const documentURL = \(documentURLLiteral);
+          const filename = \(filenameLiteral);
+          const finish = (payload) => {
+            window.__alhangeulPreviewAutomationLoadJSON = JSON.stringify(payload);
+          };
+          const seedAutomationLocalFonts = () => {
+            try {
+              window.localStorage?.setItem('rhwp-local-fonts', JSON.stringify({
+                version: 1,
+                source: 'local-font-access',
+                detectedAt: '1970-01-01T00:00:00.000Z',
+                families: []
+              }));
+              return true;
+            } catch (_) {
+              return false;
+            }
+          };
+          const postRhwpRequest = (method, params) => new Promise((resolve, reject) => {
+            const requestId = `alhangeul-preview-load-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+            const cleanup = () => {
+              clearTimeout(timer);
+              window.removeEventListener('message', onMessage);
+            };
+            const onMessage = (event) => {
+              const data = event.data;
+              if (!data || data.type !== 'rhwp-response' || data.id !== requestId) {
+                return;
+              }
+              cleanup();
+              if (data.error) {
+                reject(new Error(String(data.error)));
+              } else {
+                resolve(data.result);
+              }
+            };
+            const timer = setTimeout(() => {
+              cleanup();
+              reject(new Error(`${method} request timed out`));
+            }, 30000);
+            window.addEventListener('message', onMessage);
+            window.postMessage({ type: 'rhwp-request', id: requestId, method, params }, '*');
+          });
+          (async () => {
+            try {
+              const localFontsSeeded = seedAutomationLocalFonts();
+              const response = await fetch(documentURL, { cache: 'no-store' });
+              if (!response.ok) {
+                throw new Error(`document fetch failed: HTTP ${response.status}`);
+              }
+              const buffer = await response.arrayBuffer();
+              const bytes = new Uint8Array(buffer);
+              let strategy = 'direct-globals';
+              let pageCount = 0;
+              let fileName = filename;
+              let sourceFormat = null;
+              if (window.__wasm && window.__canvasView) {
+                const docInfo = window.__wasm.loadDocument(bytes, filename);
+                if (!docInfo) {
+                  throw new Error('window.__wasm.loadDocument returned null');
+                }
+                if (typeof window.__canvasView.loadDocument !== 'function') {
+                  throw new Error('window.__canvasView.loadDocument is not available');
+                }
+                window.__canvasView.loadDocument();
+                pageCount = Number(docInfo.pageCount ?? window.__wasm.pageCount ?? 0) || 0;
+                fileName = window.__wasm.fileName || filename;
+                sourceFormat = typeof window.__wasm.getSourceFormat === 'function'
+                  ? window.__wasm.getSourceFormat()
+                  : null;
+              } else {
+                strategy = 'rhwp-request';
+                const result = await postRhwpRequest('loadFile', {
+                  data: bytes,
+                  fileName: filename,
+                  skipUnsavedGuard: true
+                });
+                pageCount = Number(result?.pageCount || 0) || 0;
+              }
+              const statusText = `${filename} — ${pageCount}페이지 (automation)`;
+              const statusElement = document.querySelector('#sb-message');
+              if (statusElement) {
+                statusElement.textContent = statusText;
+              }
+              finish({
+                ok: true,
+                pageCount,
+                fileName,
+                sourceFormat,
+                strategy,
+                localFontsSeeded,
+                statusText
+              });
+            } catch (error) {
+              finish({
+                ok: false,
+                error: error && error.message ? error.message : String(error)
+              });
+            }
+          })();
+          return true;
+        })();
+        """
     }
 
     private func pageStateScript(pageNumber: Int) -> String {


### PR DESCRIPTION
## 요약

- 대상 타스크: #398 `preview visual diff harness automation load path 추가`
- 왜: `복학원서.hwp` reference capture가 local font UI에 오염되면 #396 visual suite에서 renderer 품질을 잘못 판정할 수 있음
- 무엇: rhwp-studio reference load를 automation path로 분리하고, contamination metadata와 sibling canvas overlay counting을 추가함
- 리뷰 포인트: `captureContaminated=false`와 `domComposite;ui=clean` 기준이 #396 handoff에 충분한지 확인

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/8a9f455bc61b7568b9ee664592797634298c1981/mydocs/working/task_m020_398_stage1.md)** ([f77a350](https://github.com/postmelee/alhangeul-macos/commit/f77a350)): current harness load/capture contamination inventory 정리
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/8a9f455bc61b7568b9ee664592797634298c1981/mydocs/working/task_m020_398_stage2.md)** ([f563e9a](https://github.com/postmelee/alhangeul-macos/commit/f563e9a)): automation app URL, runtime readiness, document load path 구현
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/8a9f455bc61b7568b9ee664592797634298c1981/mydocs/working/task_m020_398_stage3.md)** ([14eba20](https://github.com/postmelee/alhangeul-macos/commit/14eba20)): capture contamination metadata와 summary `ui=clean` 힌트 추가
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/8a9f455bc61b7568b9ee664592797634298c1981/mydocs/working/task_m020_398_stage4.md)** ([09203f3](https://github.com/postmelee/alhangeul-macos/commit/09203f3)): `복학원서.hwp`, `request.hwp`, `KTX.hwp` smoke와 sibling canvas overlay counting 보정
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/8a9f455bc61b7568b9ee664592797634298c1981/mydocs/report/task_m020_398_report.md)** ([8a9f455](https://github.com/postmelee/alhangeul-macos/commit/8a9f455bc61b7568b9ee664592797634298c1981)): 최종 보고서와 #396 handoff 정리

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `scripts/preview_visual_diff_harness.swift` | 일반 `?url=` 문서 로드 대신 automation app shell load 후 document bytes를 주입 | bundled production asset에서 `rhwp-request` strategy로 동작하는 흐름이 적절한지 |
| `scripts/preview_visual_diff_harness.swift` | non-persistent WKWebView local font snapshot seed | 분석용 capture에만 영향이 한정되는지 |
| `scripts/preview_visual_diff_harness.swift` | `automationLoad`, `captureContaminated`, `modalCount`, `toastCount`, `localFontUIVisible` metadata 추가 | renderer diff와 capture contamination을 충분히 분리하는지 |
| `scripts/preview_visual_diff_harness.swift` | target 외 sibling canvas layer를 overlay 후보로 계산 | #293 `domComposite` / `overlayIncluded=true` 계약을 유지하는지 |
| `mydocs/` | Stage 보고서와 최종 보고서 작성 | #396 `bokhakwonseo-capture-sentinel` handoff가 명확한지 |

- 수행 계획서: [task_m020_398.md](https://github.com/postmelee/alhangeul-macos/blob/8a9f455bc61b7568b9ee664592797634298c1981/mydocs/plans/task_m020_398.md)
- 구현 계획서: [task_m020_398_impl.md](https://github.com/postmelee/alhangeul-macos/blob/8a9f455bc61b7568b9ee664592797634298c1981/mydocs/plans/task_m020_398_impl.md)
- 최종 보고서: [task_m020_398_report.md](https://github.com/postmelee/alhangeul-macos/blob/8a9f455bc61b7568b9ee664592797634298c1981/mydocs/report/task_m020_398_report.md)

## 핵심 리뷰 포인트

- `rhwp-request` + non-persistent local font snapshot seed가 사용자 UI contamination을 막되 일반 앱 동작을 바꾸지 않는지
- `captureContaminated`, `modalCount`, `toastCount`, `localFontUIVisible` metadata가 #396 visual suite 해석에 충분한지
- sibling canvas overlay counting 보정이 current rhwp-studio layered canvas rendering과 #293 overlay capture 계약에 맞는지

## 검증

- `swiftc -parse scripts/preview_visual_diff_harness.swift`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task398-automation-load --page 1 samples/복학원서.hwp samples/basic/request.hwp`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task398-automation-load-ktx --page 1 samples/basic/KTX.hwp`
- `rg -n "#398|#396|automationLoad|captureContaminated|복학원서|Skia|CoreGraphics|preview visual diff" mydocs/report/task_m020_398_report.md mydocs/orders/20260629.md`
- `git diff --check`

## 관련 이슈

- #293: `복학원서.hwp` overlay-positive reference capture 계약
- #390: `복학원서.hwp` reference capture contamination으로 visual diff 99%대가 관찰된 측정
- #396: #398 결과를 받아 `bokhakwonseo-capture-sentinel`을 재해석할 후속 visual suite 작업

## 후속 이슈 제안

없음. #396 작업에서 `복학원서.hwp` clean capture 기준을 이어서 반영한다.

## 남은 리스크

- current bundled production asset은 direct globals를 노출하지 않아 실제 strategy는 `rhwp-request`다.
- local font snapshot seed는 분석용 non-persistent WKWebView capture에 한정되며 일반 앱 UI 정책을 변경하지 않는다.
- `복학원서.hwp`의 `LAYOUT_OVERFLOW` warning은 남아 있고, #396 작업에서 renderer/layout 이슈로 별도 해석해야 한다.
- `KTX.hwp` visual regression 판단은 이 PR로 바뀌지 않는다.
