### PR TITLE
Task #396: Skia renderer baseline suite 도입

### DIFF
--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -6,5 +6,5 @@
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
 | #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |
-| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |
+| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 진행중 | M020, Stage 1 완료보고서 승인 대기 |
 | #398 | preview visual diff harness automation load path 추가 | 완료 | 완료: 18:07, Stage 5 최종 보고서 작성 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -6,4 +6,5 @@
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
 | #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |
+| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
 | #398 | preview visual diff harness automation load path 추가 | 완료 | 완료: 18:07, Stage 5 최종 보고서 작성 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -6,5 +6,5 @@
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
 | #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |
-| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 진행중 | M020, Stage 1 완료보고서 승인 대기 |
+| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 진행중 | M020, Stage 2 완료보고서 승인 대기 |
 | #398 | preview visual diff harness automation load path 추가 | 완료 | 완료: 18:07, Stage 5 최종 보고서 작성 |

--- a/mydocs/orders/20260629.md
+++ b/mydocs/orders/20260629.md
@@ -6,5 +6,5 @@
 |------|--------|------|------|
 | #388 | Thumbnail render signature를 rhwp-core.lock 기준으로 생성/검증 | 완료 | 완료: 10:36, Stage 4 검증과 최종 보고서 작성 |
 | #390 | rhwp v0.7.17 기준 Skia readiness gate 재측정 | 완료 | 완료: 13:21, Stage 5 최종 보고서 작성 |
-| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |
 | #398 | preview visual diff harness automation load path 추가 | 완료 | 완료: 18:07, Stage 5 최종 보고서 작성 |

--- a/mydocs/orders/20260630.md
+++ b/mydocs/orders/20260630.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 진행중 | Stage 4 완료보고서 승인 대기 |
+| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 완료 | 최종 보고서 작성, PR 게시 승인 대기 |

--- a/mydocs/orders/20260630.md
+++ b/mydocs/orders/20260630.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 진행중 | Stage 3 완료보고서 승인 대기 |
+| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 진행중 | Stage 4 완료보고서 승인 대기 |

--- a/mydocs/orders/20260630.md
+++ b/mydocs/orders/20260630.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 6월 30일
+
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 진행중 | Stage 3 완료보고서 승인 대기 |

--- a/mydocs/orders/20260630.md
+++ b/mydocs/orders/20260630.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 완료 | 최종 보고서 작성, PR 게시 승인 대기 |
+| #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 완료 | 완료: 15:16, PR 게시 진행 |

--- a/mydocs/plans/task_m020_396.md
+++ b/mydocs/plans/task_m020_396.md
@@ -1,0 +1,147 @@
+# Task M020 #396 수행계획서
+
+## 목적
+
+업스트림 `rhwp` renderer baseline 방식을 macOS Quick Look/Thumbnail Skia 품질 검증에 맞게 이식한다.
+
+#390에서 `rhwp v0.7.17` 기준 Skia readiness를 재측정한 결과, Skia는 fallback 없이 동작하고 일부 latency가 개선됐지만 `KTX.hwp` visual regression, `복학원서.hwp` reference capture contamination, Thumbnail 1px dimension 차이가 남았다. 따라서 Skia를 기본값 후보로 다시 평가하려면 단일 샘플 수동 확인이 아니라 대표 샘플, diff metric, artifact, smoke/full sweep 구분을 갖춘 반복 가능한 검증 체계가 필요하다.
+
+## 배경
+
+업스트림 `edwardkim/rhwp`에는 renderer 품질을 확인하는 여러 층의 검증 체계가 있다.
+
+- PR/수동 browser canvas visual diff
+- 수동 full renderer sweep
+- 대표 샘플 manifest 기반 renderer baseline
+- `native-skia`와 CanvasKit baseline parity 비교
+- golden SVG snapshot 회귀 테스트
+
+다만 업스트림 검증은 Rust/WASM/browser/CanvasKit 중심이며, 이 저장소가 소유하는 macOS Quick Look/Thumbnail surface의 `CoreGraphics`와 `Skia opt-in` 비교를 직접 커버하지 않는다.
+
+현재 저장소에는 `scripts/preview-visual-diff-harness.sh`와 `scripts/preview_visual_diff_harness.swift`가 있어 bundled `rhwp-studio` reference PNG, native renderer PNG, diff PNG, `ChangedPercent`, `MeanRGBDelta`, `NativeMs`를 만들 수 있다. #396은 이 기반 위에 업스트림식 대표 manifest와 실행/report 계층을 얹어 Skia default 전환 판단의 품질 기준을 정렬한다.
+
+## 범위
+
+포함:
+
+- 업스트림 renderer baseline 구조와 현재 macOS visual diff harness의 gap 정리
+- Quick Look/Thumbnail Skia 검증용 대표 샘플 manifest 초안 작성
+- sample별 category, page, surface, expected risk, threshold/triage policy 기록
+- 빠른 smoke와 확장 sweep 실행 기준 분리
+- CoreGraphics/Skia opt-in visual diff 결과를 같은 report 구조로 수집하는 wrapper 또는 report 구조 설계/구현
+- `KTX.hwp` regression, `복학원서.hwp` reference contamination, Thumbnail 1px dimension 차이 같은 known case를 분류할 수 있는 summary 형식 정리
+- #387 추적 이슈와 #390 결과에서 참조 가능한 최종 기준 문서 작성
+
+제외:
+
+- Skia를 Quick Look/Thumbnail release default로 전환
+- upstream `edwardkim/rhwp` 수정
+- HostApp viewer renderer 전환
+- full native viewer/editor 구현
+- 전체 `samples/` 전수 비교를 기본 PR gate로 강제
+- signed/notarized release, Homebrew Cask, 배포 작업
+- Skia visual regression 자체 수정
+
+## 설계 방향
+
+전체 샘플 전수 비교를 기본 gate로 만들지 않는다. 대신 다음 2단계 구조를 둔다.
+
+| 계층 | 목적 | 예상 규모 | 실행 시점 |
+|------|------|-----------|-----------|
+| quick smoke | PR/단계 검증에서 빠르게 회귀 방향 확인 | 3-5개 대표 샘플, page 1 중심 | Skia/renderer 관련 변경마다 |
+| extended sweep | default 전환 또는 release readiness 판단 | category별 15-25개 대표 샘플, 필요 시 일부 다중 page | 수동 또는 readiness 단계 |
+
+대표 샘플은 기존 `mydocs/tech/skia_quicklook_thumbnail_backend.md`의 readiness taxonomy와 업스트림 manifest category를 결합한다.
+
+초기 category 후보:
+
+| category | 후보 샘플 | 목적 |
+|----------|-----------|------|
+| single-page-basic | `samples/basic/request.hwp`, `samples/basic/KTX.hwp` | 단일 PNG, 기본 text/table, #390 regression 재현 |
+| multi-page | `samples/hwp-multi-001.hwp`, `samples/hwpx/hwpx-01.hwpx`, `samples/basic/exam_math.hwp` | Quick Look PDF/page loop/HWPX |
+| image | `samples/hwp-img-001.hwp`, `samples/img-start-001.hwp`, `samples/pic-crop-01.hwp` | image decode, crop, placement |
+| equation-shape | `samples/eq-01.hwp`, `samples/group-drawing-02.hwp`, `samples/draw-group.hwp` | 수식, vector/group drawing |
+| form-field | `samples/form-01.hwp`, `samples/hwpx/form-002.hwpx`, `samples/field-01.hwp` | form, placeholder, field |
+| text-font | `samples/footnote-01.hwp`, `samples/lseg-02-mixed.hwp`, `samples/re-font-batang-hancom.hwp` | font fallback, line segment, footnote |
+| known-risk | `samples/복학원서.hwp` | reference capture contamination/overlay 분리 |
+
+자동 hard gate는 보수적으로 둔다. 우선은 failure phase, size mismatch, renderer fallback, artifact path, diff metric을 안정적으로 남기고, pass/fail threshold는 triage 기준으로 문서화한다.
+
+## 예상 변경 파일
+
+- `mydocs/plans/task_m020_396.md`
+- `mydocs/plans/task_m020_396_impl.md`
+- `mydocs/working/task_m020_396_stage*.md`
+- `mydocs/report/task_m020_396_report.md`
+- `mydocs/orders/20260629.md`
+- `mydocs/tech/skia_preview_renderer_baseline.md` 또는 기존 `mydocs/tech/skia_quicklook_thumbnail_backend.md`의 baseline 섹션
+- 대표 manifest 파일 후보: `scripts/preview_renderer_baseline_manifest.json`
+- 실행 helper 후보: `scripts/preview-renderer-baseline.sh`
+- 필요 시 report 집계 helper: `scripts/preview_renderer_baseline.py`
+
+제품 Swift/Rust renderer source는 기본 변경 대상이 아니다. 기존 harness의 결함을 고쳐야 하는 경우에도 #396의 검증 체계 범위 안에서 최소 보정하고, renderer 동작 변경은 별도 이슈로 분리한다.
+
+## 잠정 단계
+
+1. Stage 1: upstream/local baseline 구조 inventory
+   - 업스트림 renderer baseline workflow, manifest, metric, artifact 구조를 현재 저장소 harness와 매핑한다.
+   - #390 결과의 blocker와 known risk를 baseline 요구사항으로 변환한다.
+2. Stage 2: 대표 샘플 manifest와 threshold/triage policy 설계
+   - quick smoke/extended sweep sample set, category, page, surface, expected risk, threshold 후보를 문서화한다.
+   - `복학원서.hwp`처럼 reference contamination이 있는 샘플은 known-risk로 분리한다.
+3. Stage 3: baseline 실행 helper와 report 구조 구현
+   - manifest 기반으로 기존 visual diff harness를 CoreGraphics/Skia opt-in 양쪽에 실행하는 wrapper/report 구조를 만든다.
+   - output directory, summary markdown, artifact 경로, failure phase를 고정한다.
+4. Stage 4: quick smoke와 확장 후보 검증
+   - quick smoke를 실제 실행해 반복 가능성을 확인한다.
+   - 가능한 범위에서 extended candidate 일부를 실행하고, sandbox/WebKit 환경 실패와 renderer failure를 분리한다.
+5. Stage 5: 최종 기준 정리와 PR 준비
+   - #387/#390/#392/#389/#393 후속 관계를 정리하고 최종 보고서를 작성한다.
+
+## 검증 계획
+
+기본 검증:
+
+```bash
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+git diff --check
+```
+
+manifest/report 검증 후보:
+
+```bash
+python3 -m json.tool scripts/preview_renderer_baseline_manifest.json >/dev/null
+./scripts/preview-renderer-baseline.sh --help
+./scripts/preview-renderer-baseline.sh build.noindex/task396-baseline-smoke --suite quick
+rg -n "CoreGraphics|Skia|ChangedPercent|MeanRGBDelta|NativeMs|fallback|KTX|복학원서|summary" \
+  build.noindex/task396-baseline-smoke mydocs/working/task_m020_396_stage*.md
+```
+
+Visual diff harness 직접 검증 후보:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task396-direct-cg --page 1 \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+./scripts/preview-visual-diff-harness.sh build.noindex/task396-direct-skia --page 1 --policy skiaOptIn \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+WebKit 기반 visual diff harness는 sandbox 내부에서 readiness timeout이 날 수 있다. 이런 경우 실패 phase를 기록하고, 승인 경로 재실행으로 environment failure와 renderer failure를 분리한다.
+
+## 리스크
+
+- 대표 manifest 설계가 과도하게 커지면 #396이 전수 비교 작업처럼 변질될 수 있다. quick smoke와 extended sweep을 반드시 분리한다.
+- `ChangedPercent` 하나만으로 정확도를 판단하면 text antialiasing이나 rasterizer 차이를 과대평가할 수 있다.
+- `복학원서.hwp`처럼 reference capture가 오염된 샘플은 renderer 회귀와 구분해야 한다.
+- 기존 visual diff harness는 bundled `rhwp-studio` reference에 의존하므로 WebKit/sandbox 환경 영향을 받을 수 있다.
+- Skia/CanvasKit parity와 Quick Look/Thumbnail CoreGraphics/Skia parity는 같은 문제가 아니다. 업스트림 방식을 그대로 복제하지 않고 macOS surface 기준 adapter를 둔다.
+- 이 작업은 품질 측정 체계 구축이며, `KTX.hwp` visual regression 자체를 고치는 작업이 아니다.
+
+## 승인 요청 사항
+
+- 기준 브랜치는 `devel`, 작업 브랜치는 `local/task396`으로 진행한다.
+- 이 작업은 #387 추적 이슈의 하위 후속 이슈 #396으로 진행한다.
+- 수행계획서 승인 후 구현계획서를 작성하고 Stage 1 inventory부터 시작한다.
+- #396의 원칙은 Skia default 전환이 아니라 default 전환 판단을 위한 반복 가능한 대표/확장 visual suite 구축이다.

--- a/mydocs/plans/task_m020_396_impl.md
+++ b/mydocs/plans/task_m020_396_impl.md
@@ -1,0 +1,279 @@
+# Task M020 #396 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_396.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #396 `업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식`
+- 추적 이슈: #387 Preview/Thumbnail Skia readiness 후속 개선 추적
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task396`
+- 목표: 업스트림 renderer baseline의 manifest/report/sweep 구조를 macOS Quick Look/Thumbnail Skia 품질 검증에 맞게 이식하고, `CoreGraphics default + Skia opt-in` 비교를 반복 가능한 quick smoke/extended sweep 체계로 정리한다.
+
+## 구현 원칙
+
+- #396은 Skia default 전환 작업이 아니라 default 전환 판단 기준을 만드는 작업이다.
+- 전체 `samples/` 전수 비교를 기본 gate로 강제하지 않는다. 대표 manifest 기반 quick smoke와 수동 extended sweep을 분리한다.
+- 기존 `scripts/preview-visual-diff-harness.sh`와 `scripts/preview_visual_diff_harness.swift`를 우선 재사용한다.
+- 새로운 helper는 orchestration/report aggregation에 집중하고, renderer 동작 변경은 하지 않는다.
+- `ChangedPercent` 단일 수치로 pass/fail을 확정하지 않는다. failure phase, size mismatch, fallback, artifact path, known risk를 같이 기록한다.
+- `복학원서.hwp`처럼 reference capture contamination이 있는 샘플은 품질 회귀가 아니라 capture/known-risk로 분리한다.
+- WebKit/sandbox readiness failure와 renderer failure를 반드시 구분한다.
+
+## Stage 1. upstream/local baseline 구조 inventory
+
+### 목표
+
+업스트림 renderer baseline 체계와 현재 macOS visual diff harness를 비교해, #396에서 가져올 요소와 새로 필요한 adapter 범위를 고정한다.
+
+### 대상
+
+- 업스트림 조사 결과
+  - `.github/workflows/render-diff.yml`
+  - `.github/workflows/full-renderer-sweep.yml`
+  - `scripts/renderer_baseline.py`
+  - `scripts/renderer_baseline_manifest.json`
+  - `tests/svg_snapshot.rs`
+- 현재 저장소
+  - `scripts/preview-visual-diff-harness.sh`
+  - `scripts/preview_visual_diff_harness.swift`
+  - `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+  - `mydocs/report/task_m020_390_report.md`
+  - `mydocs/working/task_m020_390_stage*.md`
+  - `mydocs/working/task_m020_396_stage1.md`
+
+### 작업
+
+1. 업스트림 baseline 요소를 `manifest`, `capture`, `diff metric`, `threshold`, `artifact`, `workflow tier`로 분해한다.
+2. 현재 visual diff harness summary column과 output directory 구조를 inventory한다.
+3. #390의 `KTX.hwp`, `복학원서.hwp`, Thumbnail 1px dimension 결과를 baseline 요구사항으로 변환한다.
+4. macOS Quick Look/Thumbnail surface에서 업스트림 방식과 달라야 하는 adapter 지점을 정리한다.
+5. Stage 1 보고서에 Stage 2 manifest schema와 Stage 3 helper 방향을 확정한다.
+
+### 검증
+
+```bash
+rg -n "render-diff|full-renderer-sweep|renderer_baseline|native-skia|canvaskit|pixelmatch|svg_snapshot" \
+  mydocs/working/task_m020_396_stage1.md
+rg -n "ChangedPercent|MeanRGBDelta|NativeMs|StudioCapture|NativeBackend|fallback|KTX|복학원서|dimension" \
+  scripts/preview_visual_diff_harness.swift mydocs/report/task_m020_390_report.md \
+  mydocs/working/task_m020_396_stage1.md
+git diff --check
+```
+
+### 완료 조건
+
+- 업스트림에서 이식할 요소와 이식하지 않을 요소가 구분되어 있다.
+- 현재 harness output과 #396 target report의 gap이 문서화되어 있다.
+- Stage 2 manifest schema 초안 입력이 준비되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #396 Stage 1: renderer baseline 구조 inventory
+```
+
+## Stage 2. 대표 샘플 manifest와 threshold/triage policy 설계
+
+### 목표
+
+Quick Look/Thumbnail Skia 품질 검증용 대표 manifest와 sample별 threshold/triage policy를 문서와 JSON 초안으로 고정한다.
+
+### 대상
+
+- `scripts/preview_renderer_baseline_manifest.json`
+- `mydocs/tech/skia_preview_renderer_baseline.md`
+- `mydocs/working/task_m020_396_stage2.md`
+- 필요 시 `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+
+### 작업
+
+1. manifest schema를 정의한다.
+   - `id`
+   - `path`
+   - `category`
+   - `suite`: `quick`, `extended`
+   - `pages`
+   - `surfaces`: `quicklook`, `thumbnail`, `visual`
+   - `knownRisk`
+   - `threshold`
+   - `notes`
+2. quick smoke 샘플 3-5개를 확정한다.
+3. extended sweep 샘플 15-25개 후보를 category별로 고정한다.
+4. `KTX.hwp`는 regression sentinel, `복학원서.hwp`는 known-risk/capture sentinel로 분리한다.
+5. threshold는 hard gate가 아니라 triage 정책으로 문서화한다.
+6. JSON manifest 유효성과 샘플 파일 존재를 검증한다.
+
+### 검증
+
+```bash
+python3 -m json.tool scripts/preview_renderer_baseline_manifest.json >/dev/null
+python3 - <<'PY'
+import json
+from pathlib import Path
+data = json.loads(Path("scripts/preview_renderer_baseline_manifest.json").read_text())
+missing = [item["path"] for item in data["samples"] if not Path(item["path"]).is_file()]
+if missing:
+    raise SystemExit("missing samples: " + ", ".join(missing))
+print(f"samples={len(data['samples'])}")
+PY
+rg -n "quick|extended|KTX|복학원서|threshold|known-risk|ChangedPercent|MeanRGBDelta" \
+  scripts/preview_renderer_baseline_manifest.json mydocs/tech/skia_preview_renderer_baseline.md \
+  mydocs/working/task_m020_396_stage2.md
+git diff --check
+```
+
+### 완료 조건
+
+- manifest JSON이 유효하다.
+- 모든 manifest sample path가 존재한다.
+- quick smoke와 extended sweep이 분리되어 있다.
+- sample별 known risk와 triage policy가 문서화되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #396 Stage 2: Skia baseline manifest 설계
+```
+
+## Stage 3. baseline 실행 helper와 report 구조 구현
+
+### 목표
+
+manifest 기반으로 기존 visual diff harness를 CoreGraphics/Skia opt-in 양쪽에 실행하고, 비교 가능한 summary를 생성하는 helper/report 구조를 구현한다.
+
+### 대상
+
+- `scripts/preview-renderer-baseline.sh`
+- 필요 시 `scripts/preview_renderer_baseline.py`
+- `scripts/preview_renderer_baseline_manifest.json`
+- `mydocs/working/task_m020_396_stage3.md`
+
+### 작업
+
+1. `preview-renderer-baseline.sh` CLI를 구현한다.
+   - `--suite quick|extended|all`
+   - `--manifest`
+   - `--page-mode first|manifest`
+   - `--policy-pair coreGraphicsOnly,skiaOptIn`
+2. helper가 output directory 아래에 CoreGraphics/Skia harness output을 분리 생성하게 한다.
+3. helper가 summary markdown을 생성하거나 집계 helper를 호출하게 한다.
+4. summary에는 sample id, category, policy별 status, `ChangedPercent`, `MeanRGBDelta`, `NativeMs`, size mismatch, fallback, known risk, artifact path를 남긴다.
+5. 실패 시 phase를 보존하고 다음 샘플 진행 또는 명확한 exit 정책을 둔다.
+6. `--help`와 dry-run 또는 manifest validation mode를 제공할 수 있으면 추가한다.
+
+### 검증
+
+```bash
+./scripts/preview-renderer-baseline.sh --help
+python3 -m json.tool scripts/preview_renderer_baseline_manifest.json >/dev/null
+./scripts/preview-renderer-baseline.sh build.noindex/task396-helper-smoke --suite quick --page-mode first
+rg -n "CoreGraphics|Skia|ChangedPercent|MeanRGBDelta|NativeMs|fallback|knownRisk|KTX|복학원서|summary" \
+  build.noindex/task396-helper-smoke mydocs/working/task_m020_396_stage3.md
+git diff --check
+```
+
+### 완료 조건
+
+- helper가 quick suite를 실행할 수 있다.
+- CoreGraphics와 Skia opt-in output이 같은 run 아래에 남는다.
+- summary가 sample별 artifact와 metric을 연결한다.
+- 실패 phase가 report에 남는다.
+
+### 커밋 메시지
+
+```text
+Task #396 Stage 3: Skia baseline 실행 helper 구현
+```
+
+## Stage 4. quick smoke와 확장 후보 검증
+
+### 목표
+
+Stage 2-3에서 만든 manifest/helper를 실제로 실행해 quick smoke 반복 가능성과 extended 후보의 실행 가능성을 검증한다.
+
+### 대상
+
+- `build.noindex/task396-baseline-quick/`
+- `build.noindex/task396-baseline-extended-sample/`
+- `mydocs/working/task_m020_396_stage4.md`
+
+### 작업
+
+1. 기본 검증 command를 실행한다.
+2. quick suite를 실행하고 summary를 기록한다.
+3. 가능한 범위에서 extended suite 일부 또는 전체를 실행한다.
+4. sandbox/WebKit readiness failure가 발생하면 sandbox 밖 재실행 조건과 결과를 기록한다.
+5. `KTX.hwp` regression sentinel과 `복학원서.hwp` known-risk sentinel이 summary에서 의도대로 분류되는지 확인한다.
+6. #392/#389/#393에 넘길 후속 판단 입력을 정리한다.
+
+### 검증
+
+```bash
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+./scripts/preview-renderer-baseline.sh build.noindex/task396-baseline-quick --suite quick
+./scripts/preview-renderer-baseline.sh build.noindex/task396-baseline-extended-sample --suite extended
+rg -n "OK|FAIL|KTX|복학원서|knownRisk|ChangedPercent|MeanRGBDelta|NativeMs|fallback|readiness|summary" \
+  build.noindex/task396-baseline-quick build.noindex/task396-baseline-extended-sample \
+  mydocs/working/task_m020_396_stage4.md
+git diff --check
+```
+
+### 완료 조건
+
+- quick suite 산출물이 생성되어 있다.
+- extended 후보 실행 결과 또는 실행 제한 사유가 기록되어 있다.
+- known-risk와 hard-fail 분류가 summary에 나타난다.
+- 환경 실패와 renderer 실패가 분리되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #396 Stage 4: Skia baseline suite 검증
+```
+
+## Stage 5. 최종 기준 정리와 PR 준비
+
+### 목표
+
+#396 결과를 최종 보고서로 정리하고 PR 게시 준비를 완료한다.
+
+### 대상
+
+- `mydocs/report/task_m020_396_report.md`
+- `mydocs/orders/20260629.md`
+- 필요 시 `mydocs/working/task_m020_396_stage5.md`
+
+### 작업
+
+1. 최종 보고서에 manifest, helper, quick/extended 실행 결과, 후속 관계를 정리한다.
+2. 오늘할일 #396 상태를 완료 처리한다.
+3. #387 추적 이슈, #392, #389, #393, #394와의 관계를 정리한다.
+4. PR body 초안을 준비할 수 있도록 stage별 요약과 검증 결과를 정리한다.
+
+### 검증
+
+```bash
+rg -n "#396|#387|#389|#392|#393|#394|Skia|CoreGraphics|Quick Look|Thumbnail|baseline|manifest|quick|extended" \
+  mydocs/report/task_m020_396_report.md mydocs/orders/20260629.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task396
+```
+
+### 완료 조건
+
+- 최종 보고서가 존재하고 #396의 검증 체계를 설명한다.
+- 오늘할일 #396이 완료 상태다.
+- PR 게시 준비가 가능하다.
+
+### 커밋 메시지
+
+```text
+Task #396 Stage 5 + 최종 보고서: Skia baseline suite 정리
+```

--- a/mydocs/report/task_m020_396_report.md
+++ b/mydocs/report/task_m020_396_report.md
@@ -1,0 +1,204 @@
+# Task M020 #396 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | #396 `업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식` |
+| 추적 이슈 | #387 Preview/Thumbnail Skia readiness 후속 개선 추적 |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 단계 수 | 5 |
+| 작업 브랜치 | `local/task396` |
+
+업스트림 renderer baseline의 manifest/report/sweep 구조를 macOS Quick Look/Thumbnail Skia 품질 검증에 맞게 이식했다. 결과물은 Skia default 전환이 아니라, `CoreGraphics default + Skia opt-in` 상태에서 품질 신호를 반복 측정하는 기준 체계다.
+
+제품 renderer 동작, RustBridge ABI, Xcode project, bundled rhwp core는 변경하지 않았다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/plans/task_m020_396.md` | #396 수행계획서 |
+| `mydocs/plans/task_m020_396_impl.md` | Stage 1-5 구현계획서 |
+| `scripts/preview_renderer_baseline_manifest.json` | quick/extended 대표 sample manifest, threshold, known risk 정의 |
+| `scripts/preview-renderer-baseline.sh` | baseline helper shell entrypoint |
+| `scripts/preview_renderer_baseline.py` | manifest 검증, policy별 harness 실행, pair summary 집계 |
+| `mydocs/tech/skia_preview_renderer_baseline.md` | suite 정책, triage, 실행 runbook, Stage 4 기준 해석 |
+| `mydocs/working/task_m020_396_stage1.md` | 업스트림/local baseline 구조 inventory |
+| `mydocs/working/task_m020_396_stage2.md` | manifest와 threshold/triage 설계 보고 |
+| `mydocs/working/task_m020_396_stage3.md` | helper 구현과 quick smoke 보고 |
+| `mydocs/working/task_m020_396_stage4.md` | quick/extended 실행 결과와 readiness 분리 보고 |
+| `mydocs/working/task_m020_396_stage5.md` | Stage 5 최종 정리 보고 |
+| `mydocs/report/task_m020_396_report.md` | 본 최종 보고서 |
+| `mydocs/orders/20260630.md` | #396 오늘할일 완료 처리 |
+
+## 단계 요약
+
+| Stage | 커밋 | 요약 |
+|------|------|------|
+| 계획 | `a90f751` | 수행계획서 작성과 오늘할일 갱신 |
+| 구현계획 | `e558e32` | 단계별 구현계획서 작성 |
+| Stage 1 | `84f927c` | 업스트림 baseline과 macOS visual harness gap inventory |
+| Stage 2 | `37bc7a7` | quick/extended manifest, threshold, known risk 설계 |
+| Stage 3 | `6ed6915` | manifest 기반 baseline helper 구현 |
+| Stage 4 | `b25cb64` | quick/extended suite 실행과 readiness failure 분리 |
+| Stage 5 | 이번 커밋 | 운영 가이드, 최종 보고서, PR 준비 정리 |
+
+## 구현 결과
+
+새 helper:
+
+```bash
+./scripts/preview-renderer-baseline.sh <output-dir> \
+  --suite quick|extended|all \
+  --manifest scripts/preview_renderer_baseline_manifest.json \
+  --page-mode first|manifest \
+  --policy-pair coreGraphicsOnly,skiaOptIn
+```
+
+제공 기능:
+
+- manifest JSON 구조와 sample path 검증
+- quick/extended suite filtering
+- CoreGraphics default와 Skia opt-in policy pair 실행
+- policy/page별 output directory 분리
+- 기존 `preview-visual-diff-harness.sh` 재사용
+- top-level `summary.md` 생성
+- sample별 `ChangedPercent`, `MeanRGBDelta`, `NativeMs`, backend, fallback, size drift, known risk, artifact link 집계
+- harness run 하나가 실패해도 다른 run을 계속 실행하고 failure phase를 summary에 보존
+
+## Manifest 기준
+
+Quick suite는 다음 5개 sample이다.
+
+| id | sample | 역할 |
+|----|--------|------|
+| `request-basic-quick` | `samples/basic/request.hwp` | 건강한 단일 page 기준선 |
+| `ktx-regression-sentinel` | `samples/basic/KTX.hwp` | #390 Skia visual regression sentinel |
+| `bokhakwonseo-capture-sentinel` | `samples/복학원서.hwp` | #398 이후 clean capture/layout known-risk sentinel |
+| `hwp-multi-001-page-loop` | `samples/hwp-multi-001.hwp` | multi-page preview loop |
+| `hwpx-01-path` | `samples/hwpx/hwpx-01.hwpx` | HWPX path |
+
+Extended suite는 quick 5개에 image, equation/shape, form/field, text/font, table category를 더한 20개 sample, 21개 sample page다.
+
+## Stage 4 측정 결과
+
+Quick suite:
+
+```text
+coreGraphicsOnly page-1: exitCode=0, inputs=5
+skiaOptIn page-1: exitCode=0, inputs=5
+```
+
+대표 triage:
+
+| id | CG changed | Skia changed | Skia-CG delta | triage |
+|----|------------|--------------|---------------|--------|
+| `request-basic-quick` | `17.6908%` | `11.6265%` | `-6.0643pp` | `warn:skia-changed` |
+| `ktx-regression-sentinel` | `30.8921%` | `46.3795%` | `+15.4874pp` | `warn:skia-delta` |
+| `bokhakwonseo-capture-sentinel` | `7.2888%` | `6.9406%` | `-0.3482pp` | `known-risk` |
+| `hwp-multi-001-page-loop` | `14.1976%` | `13.9298%` | `-0.2678pp` | `warn:skia-changed` |
+| `hwpx-01-path` | `14.0216%` | `13.8212%` | `-0.2004pp` | `warn:skia-changed` |
+
+Extended suite:
+
+```text
+coreGraphicsOnly page-1: exitCode=1, inputs=20
+coreGraphicsOnly page-2: exitCode=0, inputs=1
+skiaOptIn page-1: exitCode=1, inputs=20
+skiaOptIn page-2: exitCode=0, inputs=1
+```
+
+Extended 주요 판단:
+
+| id | 결과 |
+|----|------|
+| `ktx-regression-sentinel` | `warn:skia-delta`, `+15.4874pp` |
+| `bokhakwonseo-capture-sentinel` | `known-risk`, `domComposite;ui=clean`, `-0.3482pp` |
+| `field-01-field` | `warn:skia-delta`, `+8.9979pp` |
+| `hwp-multi-001-page-loop` page 2 | `ok`, `-0.2265pp` |
+| `shortcut-control-mark` | `known-risk`, `display-text-sensitive` |
+
+Readiness failure 분리:
+
+| sample | 판단 |
+|--------|------|
+| `form-002.hwpx` | CoreGraphics/Skia 양쪽에서 persistent `readiness` document load timeout. renderer 품질 실패로 세지 않음 |
+| `table-complex.hwp` | full batch에서는 timeout, 소규모 CoreGraphics 재시도 통과 |
+| `pic-crop-01.hwp` | full batch에서는 timeout, 소규모 Skia 재시도 통과 |
+
+## 최종 판단
+
+| 항목 | 판단 |
+|------|------|
+| Skia default 전환 | 보류. #396은 전환 기준을 만드는 작업이며, 전환 자체는 하지 않음 |
+| Quick smoke | 반복 가능. PR review와 renderer 관련 변경 smoke에 사용 가능 |
+| Extended sweep | 수동 readiness sweep으로 사용 가능. CI hard gate 전 retry/flake 정책 필요 |
+| KTX | `warn:skia-delta` 유지. Skia default blocker 성격 |
+| 복학원서 | #398 이후 clean capture로 복구. capture contamination이 아니라 layout/displayText known-risk로 분리 |
+| field-01 | extended에서 새 Skia delta 후보로 확인 |
+| Thumbnail 판단 | visual suite만으로 완료하지 않음. #392/#389 surface smoke 필요 |
+
+## 후속 이슈 관계
+
+| 이슈 | 관계 |
+|------|------|
+| #387 | #396 결과를 상위 추적 이슈의 renderer baseline 입력으로 연결 |
+| #389 | Finder Thumbnail cache/signature/logging은 visual suite 범위 밖이므로 계속 필요 |
+| #392 | Thumbnail maxDimension mapping과 size drift 판단은 별도 surface smoke로 이어감 |
+| #393 | direct PNG fast path는 default 전환 수단이 아니라 opt-in 검증 축으로 유지 |
+| #394 | `--verify-lock strict` UX 개선/portable verify 분리는 #396 baseline helper와 별도 운영성 작업 |
+| #398 | `복학원서.hwp` capture contamination을 clean metadata 기반 known-risk로 재분류하게 한 선행 작업 |
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| `./scripts/verify-rhwp-core-build-info.sh` | OK |
+| `./scripts/verify-rhwp-studio-assets.sh` | OK |
+| `./scripts/check-no-appkit.sh` | OK |
+| `python3 -m json.tool scripts/preview_renderer_baseline_manifest.json >/dev/null` | OK |
+| `./scripts/preview-renderer-baseline.sh --validate-only --suite extended --page-mode manifest` | OK, `samples=20`, `samplePages=21` |
+| `./scripts/preview-renderer-baseline.sh build.noindex/task396-baseline-quick --suite quick` | OK |
+| `./scripts/preview-renderer-baseline.sh build.noindex/task396-baseline-extended-sample --suite extended` | readiness failure 포함 exit 1. 실패 phase 보존 |
+| readiness 실패 샘플 소규모 재시도 | `form-002.hwpx` persistent readiness, 나머지 transient로 분리 |
+| `git diff --check` | OK |
+
+## PR 게시 준비 메모
+
+권장 PR 제목:
+
+```text
+Task #396: Skia renderer baseline suite 도입
+```
+
+권장 PR 본문 요약:
+
+```text
+## Summary
+- Add a manifest-driven preview renderer baseline suite for CoreGraphics default vs Skia opt-in comparison.
+- Add quick and extended sample policy with known-risk/threshold metadata.
+- Add a helper that runs the existing visual diff harness for both policies and writes an aggregate summary.
+- Document Stage 4 quick/extended results and follow-up issue handoff.
+
+## Verification
+- ./scripts/verify-rhwp-core-build-info.sh
+- ./scripts/verify-rhwp-studio-assets.sh
+- ./scripts/check-no-appkit.sh
+- python3 -m json.tool scripts/preview_renderer_baseline_manifest.json >/dev/null
+- ./scripts/preview-renderer-baseline.sh --validate-only --suite extended --page-mode manifest
+- ./scripts/preview-renderer-baseline.sh build.noindex/task396-baseline-quick --suite quick
+- ./scripts/preview-renderer-baseline.sh build.noindex/task396-baseline-extended-sample --suite extended
+- git diff --check
+```
+
+리뷰 포인트:
+
+- manifest schema와 quick/extended sample 선정이 M020 Skia 판단에 충분한지
+- `warn:skia-delta`, `warn:skia-changed`, `known-risk`, `readiness` failure 분리가 이해 가능한지
+- extended suite를 아직 CI hard gate로 두지 않는 판단이 적절한지
+- #392/#389/#393 후속으로 넘긴 Thumbnail/Finder surface 판단 범위가 적절한지
+
+## 작업지시자 승인 요청
+
+Task #396의 구현, 검증, 최종 보고서 작성을 완료했다. PR 게시 단계 진입 여부를 승인 요청한다.

--- a/mydocs/tech/skia_preview_renderer_baseline.md
+++ b/mydocs/tech/skia_preview_renderer_baseline.md
@@ -46,7 +46,7 @@ quick suite는 다음 5개로 고정한다.
 |----|------|------|
 | `request-basic-quick` | `samples/basic/request.hwp` | 건강한 단일 page 기준선 |
 | `ktx-regression-sentinel` | `samples/basic/KTX.hwp` | #390 Skia visual regression sentinel |
-| `bokhakwonseo-capture-sentinel` | `samples/복학원서.hwp` | reference capture contamination / displayText 민감 sample |
+| `bokhakwonseo-capture-sentinel` | `samples/복학원서.hwp` | #398 clean capture sentinel / layout overflow와 displayText 민감 sample |
 | `hwp-multi-001-page-loop` | `samples/hwp-multi-001.hwp` | HWP multi-page preview loop |
 | `hwpx-01-path` | `samples/hwpx/hwpx-01.hwpx` | HWPX path |
 
@@ -89,12 +89,14 @@ Thumbnail surface가 포함된 quick sample은 #390의 1px dimension 차이를 �
 |-----------|------|
 | `regression-sentinel` | quick/extended 모두에서 유지하고 Skia-CG `ChangedPercent` delta를 항상 노출 |
 | `capture-contamination` | reference capture가 정리되기 전에는 renderer 품질 점수로 사용하지 않음 |
+| `clean-capture-sentinel` | #398 이후 automation capture metadata가 clean인지 확인하고 visual metric을 renderer triage 입력으로 사용 |
+| `layout-overflow-watch` | capture contamination이 아니라 renderer/layout warning으로 별도 해석 |
 | `size-drift-watch` | 1px thumbnail drift를 triage warning으로 기록하되 cache 실패와 분리 |
 | `display-text-sensitive` | diff 수치가 낮아도 사용자-facing text와 control mark를 눈검증 |
 
 `KTX.hwp`는 `regression-sentinel`이다. #390에서 Skia changed percent는 `46.3795%`, CoreGraphics는 `30.8921%`였고 delta는 `+15.4874pp`였다. 이 sample이 악화된 상태라면 Skia default 전환은 막는다.
 
-`복학원서.hwp`는 `capture-contamination` sentinel이다. #390에서 rhwp-studio reference PNG에 `로컬 글꼴 감지` overlay가 포함되어 CoreGraphics/Skia 모두 99%대 changed percent가 나왔다. 이 sample은 visual metric이 아니라 capture 안정성과 displayText 민감성 확인용으로 해석한다.
+`복학원서.hwp`는 #398 이후 `clean-capture-sentinel`이다. #390에서는 rhwp-studio reference PNG에 `로컬 글꼴 감지` overlay가 포함되어 CoreGraphics/Skia 모두 99%대 changed percent가 나왔지만, #398에서 automation load와 local font UI contamination metadata를 추가해 `captureContaminated=false` 기준을 확보했다. 따라서 이 sample은 더 이상 local font modal contamination 때문에 제외하지 않고, 남은 `LAYOUT_OVERFLOW`와 displayText 민감성을 renderer/layout triage로 분리해 해석한다.
 
 ## Surface 해석
 

--- a/mydocs/tech/skia_preview_renderer_baseline.md
+++ b/mydocs/tech/skia_preview_renderer_baseline.md
@@ -1,0 +1,120 @@
+# Skia Preview Renderer Baseline
+
+## 목적
+
+이 문서는 #396에서 도입하는 Quick Look/Thumbnail Skia 품질 검증용 대표 manifest와 threshold/triage 정책을 정의한다.
+
+기존 정책 문서 [`skia_quicklook_thumbnail_backend.md`](skia_quicklook_thumbnail_backend.md)는 backend 선택과 fallback contract를 설명한다. 이 문서는 그 정책을 검증할 sample suite와 report 해석 기준만 다룬다. Skia default 전환, renderer 동작 변경, upstream `rhwp` 수정은 범위가 아니다.
+
+## Manifest 위치와 기본 규칙
+
+대표 manifest는 `scripts/preview_renderer_baseline_manifest.json`이다.
+
+기본 규칙:
+
+- `pageIndexBase`는 `1`이다. 기존 `preview-visual-diff-harness.sh --page`가 1-based이기 때문이다.
+- `policyPair`는 `coreGraphicsOnly`, `skiaOptIn`이다.
+- `suite`는 배열이며, quick sample은 extended에도 포함할 수 있다.
+- `surfaces`는 `visual`, `quicklook`, `thumbnail` 중 하나 이상을 가진다.
+- `threshold`는 자동 hard gate가 아니라 triage metadata다.
+- `knownRisk`가 있는 sample은 summary에서 별도 column으로 노출해야 한다.
+
+필수 sample field:
+
+| 필드 | 의미 |
+|------|------|
+| `id` | report와 artifact path에서 사용할 안정 식별자 |
+| `path` | repo root 상대 sample path |
+| `category` | renderer feature category |
+| `suite` | `quick`, `extended` 포함 여부 |
+| `pages` | 1-based page list. quick 실행은 기본적으로 첫 page만 사용 |
+| `surfaces` | 이 sample을 해석할 surface |
+| `knownRisk` | regression, capture contamination, size drift 같은 known signal |
+| `threshold` | warning threshold 후보 |
+| `notes` | sample 선정 이유와 기존 측정 근거 |
+
+## Suite 정책
+
+| suite | 규모 | 실행 시점 | 목적 |
+|-------|------|-----------|------|
+| `quick` | 5 samples | renderer 관련 단계 검증, PR review, smoke | #390에서 확인한 핵심 신호를 빠르게 재측정 |
+| `extended` | 20 samples | 수동 readiness sweep, Skia default 판단 전 | category별 대표성을 확보하고 failure 계열을 좁힘 |
+
+quick suite는 다음 5개로 고정한다.
+
+| id | path | 역할 |
+|----|------|------|
+| `request-basic-quick` | `samples/basic/request.hwp` | 건강한 단일 page 기준선 |
+| `ktx-regression-sentinel` | `samples/basic/KTX.hwp` | #390 Skia visual regression sentinel |
+| `bokhakwonseo-capture-sentinel` | `samples/복학원서.hwp` | reference capture contamination / displayText 민감 sample |
+| `hwp-multi-001-page-loop` | `samples/hwp-multi-001.hwp` | HWP multi-page preview loop |
+| `hwpx-01-path` | `samples/hwpx/hwpx-01.hwpx` | HWPX path |
+
+extended suite는 quick 5개에 image, equation/shape, form/field, text/font, table category를 추가한 20개다. 전수 비교가 아니라 대표 sweep이며, 실패 category가 나오면 그 category 안에서 별도 follow-up으로 확장한다.
+
+## Threshold / Triage 정책
+
+자동 hard fail은 pixel diff 비율 하나로 결정하지 않는다. 다음 signal은 hard fail 후보로 본다.
+
+- crash, hang, timeout
+- empty output 또는 PNG decode failure
+- page size나 aspect ratio mismatch
+- 본문, 표, 이미지, 수식, form control의 주요 구조 누락
+- 전체 page offset, 잘림, 반전, 투명 배경
+- Skia 실패 후 CoreGraphics fallback도 실패
+
+`ChangedPercent`는 다음처럼 해석한다.
+
+| 구간 | 의미 | 조치 |
+|------|------|------|
+| `0-1%` | antialiasing 또는 작은 rasterizer 차이 가능성 | summary 기록 |
+| `1-5%` | text edge, 1px rounding, 일부 object 차이 가능성 | diff PNG 눈검증 |
+| `5-10%` | 구조 차이 가능성 있음 | sample별 known difference 또는 follow-up 분류 |
+| `10%+` | 큰 구조 차이 가능성이 높음 | default 전환 차단 후보 |
+
+기본 warning threshold:
+
+| 항목 | 기본값 | 의미 |
+|------|--------|------|
+| `maxAllowedSizeDriftPx` | `0` | 기본 visual/Quick Look 비교는 size drift를 허용하지 않음 |
+| `maxChangedPercentWarn` | `10.0` | 구조 차이 가능성 warning |
+| `maxSkiaMinusCGChangedPercentWarn` | `5.0` | 같은 reference 대비 Skia가 CoreGraphics보다 악화되는지 보는 warning |
+| `maxMeanRGBDeltaWarn` | `20.0` | 평균 RGB delta warning |
+
+Thumbnail surface가 포함된 quick sample은 #390의 1px dimension 차이를 반영해 `maxAllowedSizeDriftPx: 1`을 둔다. 이 값은 cache 성공 기준이 아니라 visual triage 기준이다. 잘림, aspect ratio 변경, 구조 누락은 1px drift 허용과 별개로 hard fail 후보가 된다.
+
+## Known Risk 정책
+
+| knownRisk | 처리 |
+|-----------|------|
+| `regression-sentinel` | quick/extended 모두에서 유지하고 Skia-CG `ChangedPercent` delta를 항상 노출 |
+| `capture-contamination` | reference capture가 정리되기 전에는 renderer 품질 점수로 사용하지 않음 |
+| `size-drift-watch` | 1px thumbnail drift를 triage warning으로 기록하되 cache 실패와 분리 |
+| `display-text-sensitive` | diff 수치가 낮아도 사용자-facing text와 control mark를 눈검증 |
+
+`KTX.hwp`는 `regression-sentinel`이다. #390에서 Skia changed percent는 `46.3795%`, CoreGraphics는 `30.8921%`였고 delta는 `+15.4874pp`였다. 이 sample이 악화된 상태라면 Skia default 전환은 막는다.
+
+`복학원서.hwp`는 `capture-contamination` sentinel이다. #390에서 rhwp-studio reference PNG에 `로컬 글꼴 감지` overlay가 포함되어 CoreGraphics/Skia 모두 99%대 changed percent가 나왔다. 이 sample은 visual metric이 아니라 capture 안정성과 displayText 민감성 확인용으로 해석한다.
+
+## Surface 해석
+
+| surface | Stage 2 의미 | Stage 3 helper에서의 1차 처리 |
+|---------|--------------|-------------------------------|
+| `visual` | rhwp-studio reference와 native renderer PNG diff | 기존 `preview-visual-diff-harness.sh`로 실행 |
+| `quicklook` | Quick Look preview default 전환 판단에 반영 | visual 결과와 Quick Look smoke 결과를 연결 |
+| `thumbnail` | Finder thumbnail default 전환 판단에 반영 | visual 결과와 thumbnail policy smoke 결과를 연결 |
+
+Stage 3의 1차 구현은 `visual` orchestration과 pair summary에 집중한다. Quick Look extension 등록 smoke와 Thumbnail cache/signature smoke는 이미 있는 script 결과를 Stage 4에서 연결한다.
+
+## Stage 3 Helper 입력 계약
+
+Stage 3 helper는 manifest를 읽어 다음을 수행해야 한다.
+
+1. JSON 구조와 sample path를 검증한다.
+2. `--suite quick|extended|all`로 sample을 필터링한다.
+3. `--page-mode first|manifest`로 page list를 결정한다.
+4. `coreGraphicsOnly`, `skiaOptIn`을 같은 output root 아래에서 실행한다.
+5. sample별 `ChangedPercent`, `MeanRGBDelta`, `NativeMs`, size drift, fallback, known risk, artifact path를 같은 summary에 모은다.
+6. `knownRisk` sample은 failure와 별도 column으로 표시한다.
+
+이 계약은 Skia default 전환 기준이 아니라 반복 가능한 측정 구조다. default 판단은 Stage 4 실행 결과와 #392/#389/#393 후속 입력을 종합해 별도 승인으로 결정한다.

--- a/mydocs/tech/skia_preview_renderer_baseline.md
+++ b/mydocs/tech/skia_preview_renderer_baseline.md
@@ -120,3 +120,54 @@ Stage 3 helper는 manifest를 읽어 다음을 수행해야 한다.
 6. `knownRisk` sample은 failure와 별도 column으로 표시한다.
 
 이 계약은 Skia default 전환 기준이 아니라 반복 가능한 측정 구조다. default 판단은 Stage 4 실행 결과와 #392/#389/#393 후속 입력을 종합해 별도 승인으로 결정한다.
+
+## 실행 Runbook
+
+Quick smoke:
+
+```bash
+./scripts/preview-renderer-baseline.sh build.noindex/skia-baseline-quick --suite quick
+```
+
+Extended sweep:
+
+```bash
+./scripts/preview-renderer-baseline.sh build.noindex/skia-baseline-extended --suite extended
+```
+
+입력만 검증할 때:
+
+```bash
+./scripts/preview-renderer-baseline.sh --validate-only --suite extended --page-mode manifest
+```
+
+기본 해석 순서:
+
+1. top-level `summary.md`의 `Runs`에서 policy/page별 exit code를 본다.
+2. `Pair Summary`에서 `Triage`, `KnownRisk`, `SkiaMinusCGChangedPercent`, `NativeSizeDriftPx`를 먼저 본다.
+3. `FAIL` row는 `Phase` 또는 status prefix의 `[phase:...]`를 기준으로 `readiness`, `render`, `comparison`을 분리한다.
+4. `warn:skia-delta`는 Skia가 같은 reference 대비 CoreGraphics보다 악화된 signal이다. default 전환 blocker 후보로 본다.
+5. `warn:skia-changed`는 reference 대비 changed percent가 threshold를 넘었다는 signal이다. Skia가 CoreGraphics보다 나쁘다는 뜻은 아니므로 diff PNG 눈검증으로 본다.
+6. `known-risk`는 무시가 아니라 별도 해석이다. `clean-capture-sentinel`처럼 capture가 clean한 경우에는 visual metric을 renderer triage 입력으로 쓴다.
+
+## 2026-06-30 Baseline 해석
+
+Task #396 Stage 4 기준 quick suite는 CoreGraphics/Skia 양쪽 모두 exit 0이다. extended suite는 page-1 batch에서 readiness failure가 섞여 exit 1이었지만, helper가 실패 phase와 sample을 summary에 보존했다.
+
+주요 기준:
+
+| sample | 기준 해석 |
+|--------|-----------|
+| `KTX.hwp` | quick/extended 모두 `warn:skia-delta`, `+15.4874pp`. Skia default 전환 blocker 성격의 regression sentinel |
+| `복학원서.hwp` | quick/extended 모두 `domComposite;ui=clean`, `known-risk`. capture contamination이 아니라 layout overflow/displayText 민감성으로 해석 |
+| `field-01.hwp` | extended에서 `warn:skia-delta`, `+8.9979pp`. text/form field 계열 Skia regression 후보 |
+| `form-002.hwpx` | CoreGraphics/Skia 양쪽에서 persistent `readiness` document load timeout. renderer 품질 실패로 세지 않음 |
+| `table-complex.hwp`, `pic-crop-01.hwp` | extended full batch에서는 readiness timeout이 있었지만 소규모 재시도에서 통과. transient readiness failure로 기록 |
+
+현재 운영 기준:
+
+- PR smoke에는 quick suite를 우선 사용한다.
+- extended suite는 Skia default 판단 전 수동 sweep으로 사용한다.
+- extended suite를 CI hard gate로 올리기 전에는 retry/flake 정책이 필요하다.
+- `form-002.hwpx`는 rhwp-studio automation readiness 개선 전까지 renderer 품질 판단에서 제외하거나 persistent readiness failure로 별도 표기한다.
+- Thumbnail/Finder cache 판단은 이 visual suite만으로 완료하지 않는다. #392, #389 후속 작업의 surface smoke가 필요하다.

--- a/mydocs/working/task_m020_396_stage1.md
+++ b/mydocs/working/task_m020_396_stage1.md
@@ -1,0 +1,216 @@
+# Task M020 #396 Stage 1 완료보고서
+
+## 단계 목적
+
+업스트림 `rhwp` renderer baseline 체계와 현재 macOS preview visual diff harness를 비교해, #396에서 이식할 요소와 macOS Quick Look/Thumbnail surface에 맞게 새로 필요한 adapter 범위를 고정한다.
+
+이번 단계는 inventory와 설계 입력 정리만 수행했다. 제품 Swift/Rust renderer source와 기존 script는 수정하지 않았다.
+
+## 기준 upstream 상태
+
+| 항목 | 값 |
+|------|----|
+| upstream repo | `https://github.com/edwardkim/rhwp.git` |
+| remote `main` HEAD | `10f5c51e65e0e8e9260cf1498972db14ea04c29e` |
+| local inspect clone | `/private/tmp/rhwp-upstream-inspect` |
+| inspect 방식 | working tree가 LFS checkout 실패 흔적으로 dirty라서 `git show HEAD:...`로 파일 내용을 확인 |
+
+참조 파일:
+
+- https://github.com/edwardkim/rhwp/blob/main/.github/workflows/render-diff.yml
+- https://github.com/edwardkim/rhwp/blob/main/.github/workflows/full-renderer-sweep.yml
+- https://github.com/edwardkim/rhwp/blob/main/scripts/renderer_baseline.py
+- https://github.com/edwardkim/rhwp/blob/main/scripts/renderer_baseline_manifest.json
+- https://github.com/edwardkim/rhwp/blob/main/tests/svg_snapshot.rs
+
+## upstream baseline 요소 분해
+
+| 요소 | upstream 구현 | #396에서 이식할 부분 | 그대로 이식하지 않을 부분 |
+|------|---------------|---------------------|---------------------------|
+| workflow tier | `render-diff.yml`은 PR/수동 빠른 canvas visual diff, `full-renderer-sweep.yml`은 수동 full renderer sweep | quick smoke와 extended sweep 분리 | Linux CI, WASM build, browser CanvasKit setup 자체 |
+| manifest | `renderer_baseline_manifest.json`에 `id`, `file`, `category`, `page`, `notes`, sample별 threshold 기록 | 대표 sample manifest와 category/known risk/threshold field | upstream의 `file`은 `samples/` 상대, `page`는 0-based라 로컬 adapter 필요 |
+| capture | `renderer_baseline.py`가 `legacy-svg`, `layer-svg`, `native-skia`, `canvas2d`, `canvaskit-*` 산출물을 profile별 capture | 다중 backend artifact matrix와 summary 구조 | macOS Quick Look/Thumbnail에서 CanvasKit surface 비교를 직접 gate로 삼지는 않음 |
+| diff metric | browser render diff는 channel tolerance와 max diff ratio를 사용. baseline parity는 `ignoreChannelDelta=8`, `maxDiffRatio=0.005` 중심 | tolerant diff ratio, max channel delta, mean channel delta 개념 | upstream threshold를 macOS CoreGraphics/Skia에 수치 그대로 적용하지 않음 |
+| artifact | PNG/SVG, `results.json`, `summary.md`, worst comparison, category/profile summary | summary markdown + machine-readable report + artifact path | upstream output tree 이름과 profile matrix 전체 |
+| regression lock | `svg_snapshot.rs`가 golden SVG를 byte-for-byte 비교하고 determinism test 포함 | `KTX.hwp`, `복학원서.hwp` 같은 sentinel sample을 manifest에 명시 | SVG golden 자체는 upstream core 회귀용이며 macOS Quick Look visual parity gate는 아님 |
+
+## upstream workflow inventory
+
+### `render-diff.yml`
+
+- PR path filter는 renderer, WASM API, rhwp-studio, workflow 파일 중심이다.
+- 기본 fixture는 browser canvas path의 소수 sample이다.
+- 수동 실행에서 fixture list, max pages, full suite, image artifact 여부를 조정한다.
+- output은 `rhwp-studio/e2e/screenshots/render-diff/`, `output/e2e/`, Vite log artifact를 남긴다.
+- pass 기준은 same size와 diff ratio threshold이며, 실패 또는 `write-images` 옵션에서 PNG artifact를 쓴다.
+
+### `full-renderer-sweep.yml`
+
+- 수동 workflow만 제공한다.
+- `cargo test --features native-skia skia`, WASM release build, studio build, browser render diff full suite, renderer baseline multi-profile capture를 묶는다.
+- `screen`, `print`, `high-quality`, `fast-preview` profile과 CanvasKit surface 변형을 다룬다.
+- output은 layer/svg/skia/e2e/renderer-baseline artifact를 업로드한다.
+
+### `renderer_baseline.py` / `renderer-baseline*.mjs`
+
+- manifest를 읽어 sample id/category/page를 정규화한다.
+- native side는 `legacy-svg`, `layer-svg`, `native-skia`를 capture한다.
+- browser side는 `canvas2d`, `canvaskit-compat`, `canvaskit-default`를 capture한다.
+- `native-skia`와 `canvaskit-default` parity는 1px 이하 size drift를 crop해서 비교하고, `ignoreChannelDelta=8`, `maxDiffRatio=0.005` 기준을 쓴다.
+- report는 sample matrix, browser timing, backend parity, native Skia parity, worst comparisons, category/profile summary를 포함한다.
+
+## local harness inventory
+
+현재 macOS harness는 다음 구조다.
+
+| 항목 | 현재 구현 |
+|------|-----------|
+| entry point | `scripts/preview-visual-diff-harness.sh <out-dir> [--page N] [--policy coreGraphicsOnly|skiaOptIn] ... <files...>` |
+| compile target | `scripts/preview_visual_diff_harness.swift`를 AppKit/WebKit 포함 standalone binary로 compile |
+| reference capture | bundled `Sources/HostApp/Resources/rhwp-studio`에서 `StudioReferenceRenderer`로 PNG capture |
+| native capture | `HwpPageImageRenderer` policy에 따라 CoreGraphics 또는 Skia opt-in PNG 생성 |
+| output dirs | `studio/`, `native/`, `diff/`, `summary.md` |
+| page convention | CLI `--page`는 1-based |
+| policy convention | 한 번의 실행은 `coreGraphicsOnly` 또는 `skiaOptIn` 단일 policy |
+| diff pixel | RGB channel max delta가 `12`보다 크면 changed pixel |
+| summary fields | `File`, `Status`, `Phase`, `StudioSize`, `NativeSize`, `CompareSize`, `ChangedPixels`, `ChangedPercent`, `MeanRGBDelta`, `MaxRGBDelta`, `DiffBounds`, `StudioCapture`, `NativeBackend`, `NativeMs`, artifact path |
+| failure phase | navigation/readiness/snapshot/native render/diff 계열 phase로 분류 |
+
+현재 harness의 장점:
+
+- 이미 `CoreGraphics`와 `Skia opt-in` 양쪽을 같은 reference에 대해 측정할 수 있다.
+- `ChangedPercent`, `MeanRGBDelta`, `NativeMs`, `StudioCapture`, `NativeBackend`, fallback suffix를 남긴다.
+- `studio`, `native`, `diff` PNG artifact가 sample별로 남는다.
+- sandbox/WebKit failure를 renderer failure와 구분할 phase field가 있다.
+
+현재 harness의 gap:
+
+- manifest가 없어서 sample category, known risk, threshold, suite tier가 실행 명령 밖에 흩어진다.
+- 한 번의 실행은 한 policy만 다루므로 CoreGraphics/Skia pair summary가 자동으로 합쳐지지 않는다.
+- `summary.md`는 사람 읽기용 table 중심이고 machine-readable JSON 결과가 없다.
+- upstream처럼 category/profile/worst comparison summary가 없다.
+- Thumbnail smoke와 visual diff가 한 report에서 연결되지 않는다.
+- `복학원서.hwp` 같은 reference capture contamination을 known-risk로 표시할 위치가 없다.
+- quick smoke와 extended sweep을 분리하는 표준 CLI가 없다.
+
+## #390 결과를 baseline 요구사항으로 변환
+
+| #390 관찰 | baseline 요구사항 |
+|-----------|-------------------|
+| `KTX.hwp` Skia changed percent가 CG보다 +15.4874pp 악화 | `KTX.hwp`를 regression sentinel로 manifest에 포함하고, CoreGraphics/Skia delta를 summary에 직접 노출한다 |
+| `복학원서.hwp` reference에 `로컬 글꼴 감지` overlay가 섞여 CG/Skia 모두 99%대 diff | known-risk/capture-contamination field를 두고 renderer regression과 분리한다 |
+| 다중 PDF 샘플은 page 1 visual만 있고 Skia latency는 CG보다 느림 | manifest에 `pages`와 `surface`를 분리하고, quick smoke는 page 1, extended는 manifest pages를 따른다 |
+| Thumbnail Skia output이 CG와 1px dimension 차이 | size mismatch field와 `maxAllowedSizeDriftPx` 후보를 manifest/report에 둔다 |
+| sandbox 내부 WebKit readiness timeout | `environmentFailure` 또는 `phase=readiness`를 renderer hard fail과 분리한다 |
+| package size는 #259와 같은 `194M` | #396 visual suite 자체의 blocker는 아니며 최종 readiness report에서만 연결한다 |
+
+## macOS adapter 결정
+
+| adapter | 결정 |
+|---------|------|
+| sample path | upstream `file`과 달리 local manifest는 repo root 상대 `path`를 사용한다 |
+| page index | local harness CLI가 1-based라 manifest `pages`도 1-based로 둔다. upstream 0-based page는 참고만 한다 |
+| policy pair | Stage 3 helper가 `coreGraphicsOnly`와 `skiaOptIn`을 같은 run 아래에서 실행한다 |
+| suite tier | `suite: quick|extended`를 sample 단위 또는 entry 단위로 둔다 |
+| known risk | `knownRisk` 배열에 `regression-sentinel`, `capture-contamination`, `size-drift-watch` 같은 문자열을 둔다 |
+| threshold | hard fail threshold가 아니라 triage metadata로 둔다. 예: `maxChangedPercentWarn`, `maxSkiaMinusCGChangedPercentWarn`, `maxAllowedSizeDriftPx` |
+| output tree | `<out>/coreGraphics/`, `<out>/skia/`, `<out>/summary.md`, 필요 시 `<out>/results.json` 구조로 둔다 |
+| failure handling | individual harness failure는 phase/status를 보존한다. quick suite에서는 실패를 명확히 exit nonzero로 반환하되 report는 남긴다 |
+| Thumbnail 연결 | Stage 3 helper의 1차 범위는 visual diff orchestration이고, Thumbnail cache/logging 연결은 #389/#392 결과를 받는 확장 지점으로 둔다 |
+
+## Stage 2 manifest schema 초안
+
+Stage 2에서 JSON으로 고정할 schema 후보:
+
+```json
+{
+  "label": "quicklook-thumbnail-skia-baseline",
+  "version": 1,
+  "pageIndexBase": 1,
+  "suites": {
+    "quick": { "description": "fast regression smoke" },
+    "extended": { "description": "manual readiness sweep" }
+  },
+  "samples": [
+    {
+      "id": "ktx-regression-sentinel",
+      "path": "samples/basic/KTX.hwp",
+      "category": "single-page-basic",
+      "suite": ["quick", "extended"],
+      "pages": [1],
+      "surfaces": ["quicklook", "thumbnail", "visual"],
+      "knownRisk": ["regression-sentinel"],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 1,
+        "maxSkiaMinusCGChangedPercentWarn": 10.0
+      },
+      "notes": "Skia visual regression persisted in #390."
+    }
+  ]
+}
+```
+
+필수 필드 후보:
+
+- `id`
+- `path`
+- `category`
+- `suite`
+- `pages`
+- `surfaces`
+- `knownRisk`
+- `threshold`
+- `notes`
+
+## Stage 3 helper 방향
+
+Stage 3 helper는 새 renderer를 만들지 않고 orchestration/report만 담당한다.
+
+예상 CLI:
+
+```bash
+./scripts/preview-renderer-baseline.sh <out-dir> \
+  --suite quick \
+  --manifest scripts/preview_renderer_baseline_manifest.json \
+  --page-mode first \
+  --policy-pair coreGraphicsOnly,skiaOptIn
+```
+
+예상 동작:
+
+1. manifest를 검증한다.
+2. suite와 page-mode에 맞는 sample/page list를 만든다.
+3. `scripts/preview-visual-diff-harness.sh`를 CoreGraphics와 Skia opt-in으로 각각 실행한다.
+4. 각 `summary.md`를 집계해 pair summary를 만든다.
+5. `KTX.hwp` 같은 regression sentinel은 CoreGraphics/Skia delta를 표에 노출한다.
+6. `복학원서.hwp` 같은 known-risk sample은 failure가 아니라 별도 risk column에 표시한다.
+7. machine-readable `results.json`은 Stage 3에서 구현 가능하면 추가하고, 어렵다면 Stage 4 이전에 최소 summary markdown부터 고정한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+해당 없음. 이번 단계는 upstream/local inventory 보고서 작성과 오늘할일 비고 갱신만 수행했다. 제품 Swift/Rust source와 기존 script는 수정하지 않았다.
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| upstream remote HEAD 확인 | 통과: `10f5c51e65e0e8e9260cf1498972db14ea04c29e` |
+| upstream 파일 확인 | 통과: `git show HEAD:...`로 workflow, manifest, baseline script, SVG snapshot 확인 |
+| Stage 1 keyword `rg` | 통과: upstream workflow/manifest/diff 관련 keyword 확인 |
+| local harness keyword `rg` | 통과: local harness metric, #390 sentinel, fallback/dimension keyword 확인 |
+| `git diff --check` | 통과 |
+
+## 잔여 위험
+
+- upstream clone working tree는 LFS checkout 실패 흔적으로 dirty지만, Stage 1 근거는 `git show HEAD:...`와 원격 HEAD 확인으로 확보했다.
+- upstream threshold는 browser/CanvasKit parity 기준이므로 macOS CoreGraphics/Skia threshold로 그대로 쓰면 안 된다.
+- Stage 2 manifest가 너무 커지면 #396이 전수 비교 작업으로 변질될 수 있다. quick suite는 반드시 작게 유지한다.
+- local harness는 WebKit/AppKit 실행 환경의 영향을 받으므로 Stage 3-4에서 sandbox 밖 재실행 기준을 계속 분리해야 한다.
+
+## 다음 단계 영향
+
+Stage 2에서는 이 보고서의 schema 초안을 바탕으로 `scripts/preview_renderer_baseline_manifest.json`과 `mydocs/tech/skia_preview_renderer_baseline.md`를 작성한다. 특히 `KTX.hwp`는 regression sentinel, `복학원서.hwp`는 capture contamination sentinel로 분리한다.
+
+## 승인 요청
+
+Stage 1 결과에 따라 Stage 2 `대표 샘플 manifest와 threshold/triage policy 설계`로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_396_stage2.md
+++ b/mydocs/working/task_m020_396_stage2.md
@@ -1,0 +1,111 @@
+# Task M020 #396 Stage 2 완료보고서
+
+## 단계 목적
+
+Quick Look/Thumbnail Skia 품질 검증용 대표 manifest와 sample별 threshold/triage policy를 문서와 JSON 초안으로 고정한다.
+
+이번 단계는 Stage 3 helper가 사용할 입력 계약을 만드는 작업이다. 제품 Swift/Rust renderer source와 기존 harness script는 수정하지 않았다.
+
+## 변경 파일
+
+| 파일 | 변경 |
+|------|------|
+| `scripts/preview_renderer_baseline_manifest.json` | quick/extended suite, surfaces, threshold policy, 20개 대표 sample 정의 |
+| `mydocs/tech/skia_preview_renderer_baseline.md` | manifest schema, suite 정책, threshold/triage, known risk 처리 문서화 |
+| `mydocs/working/task_m020_396_stage2.md` | Stage 2 완료 보고서 |
+| `mydocs/orders/20260629.md` | #396 비고를 Stage 2 완료보고서 승인 대기로 갱신 |
+
+## Manifest 설계 결과
+
+| 항목 | 결정 |
+|------|------|
+| label | `quicklook-thumbnail-skia-baseline` |
+| page index | 1-based |
+| policy pair | `coreGraphicsOnly`, `skiaOptIn` |
+| quick suite | 5 samples |
+| extended suite | 20 samples |
+| surfaces | `visual`, `quicklook`, `thumbnail` |
+| threshold 성격 | hard gate가 아니라 warning/triage metadata |
+| known risk | `regression-sentinel`, `capture-contamination`, `size-drift-watch`, `display-text-sensitive` |
+
+quick suite는 #390에서 실제 visual diff와 readiness 판단에 사용한 핵심 5개 sample로 고정했다.
+
+| id | path | 역할 |
+|----|------|------|
+| `request-basic-quick` | `samples/basic/request.hwp` | 건강한 단일 page 기준선 |
+| `ktx-regression-sentinel` | `samples/basic/KTX.hwp` | Skia visual regression sentinel |
+| `bokhakwonseo-capture-sentinel` | `samples/복학원서.hwp` | capture contamination/displayText sentinel |
+| `hwp-multi-001-page-loop` | `samples/hwp-multi-001.hwp` | HWP multi-page path |
+| `hwpx-01-path` | `samples/hwpx/hwpx-01.hwpx` | HWPX path |
+
+extended suite는 quick 5개에 다음 category를 추가했다.
+
+| category | sample 수 | 목적 |
+|----------|-----------|------|
+| `image` | 3 | image decode, placement, crop |
+| `equation-shape` | 4 | equation, grouped drawing, vector replay |
+| `form-field` | 3 | HWP/HWPX form, field |
+| `text-font` | 4 | footnote, line segment, font fallback, display text |
+| `table` | 1 | complex table layout |
+| quick overlap | 5 | single-page, multi-page, HWPX, known sentinel 유지 |
+
+## Threshold / Triage 결정
+
+`ChangedPercent`는 자동 통과/실패 기준으로 쓰지 않는다. 기본 warning band는 다음처럼 문서화했다.
+
+| 구간 | 해석 |
+|------|------|
+| `0-1%` | antialiasing 또는 작은 rasterizer 차이 가능성 |
+| `1-5%` | text edge, 1px rounding, 일부 object 차이 가능성 |
+| `5-10%` | 구조 차이 가능성이 있어 눈검증 필요 |
+| `10%+` | 큰 구조 차이 가능성이 높아 default 전환 차단 후보 |
+
+hard fail 후보는 crash, hang/timeout, empty output, decode failure, aspect ratio mismatch, 주요 구조 누락, page offset/잘림/반전, fallback failure로 분리했다.
+
+`KTX.hwp`는 `regression-sentinel`로 두고 `maxSkiaMinusCGChangedPercentWarn`을 `10.0`으로 기록했다. #390의 `+15.4874pp` 악화는 warning을 넘으므로 Stage 3-4 summary에서 계속 default blocker로 보여야 한다.
+
+`복학원서.hwp`는 `capture-contamination`으로 두었다. reference capture가 정리되기 전에는 changed percent를 renderer 품질 점수로 쓰지 않는다.
+
+Thumbnail surface가 포함된 quick sample은 #390의 1px dimension 차이를 반영해 `maxAllowedSizeDriftPx: 1`을 둔다. 이 허용은 cache 성공 판정이 아니라 visual triage 용도다.
+
+## Stage 3 입력 계약
+
+Stage 3 helper는 다음 계약을 따르면 된다.
+
+```bash
+./scripts/preview-renderer-baseline.sh <out-dir> \
+  --suite quick \
+  --manifest scripts/preview_renderer_baseline_manifest.json \
+  --page-mode first \
+  --policy-pair coreGraphicsOnly,skiaOptIn
+```
+
+helper는 manifest path 검증, suite/page filtering, CoreGraphics/Skia harness 실행, pair summary 생성을 담당한다. summary에는 sample id, category, policy별 status, `ChangedPercent`, `MeanRGBDelta`, `NativeMs`, size drift, fallback, known risk, artifact path가 들어가야 한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+해당 없음. 이번 단계는 신규 manifest/정책 문서/단계 보고서 작성과 오늘할일 비고 갱신만 수행했다. 기존 문서의 본문은 수정하지 않았고 제품 source/script 동작도 변경하지 않았다.
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| `python3 -m json.tool scripts/preview_renderer_baseline_manifest.json` | 통과 |
+| manifest sample path 검증 | 통과: `samples=20 quick=5 extended=20` |
+| Stage 2 keyword `rg` | 통과: suite, sentinel, threshold, metric keyword 확인 |
+| `git diff --check` | 통과 |
+
+## 잔여 위험
+
+- threshold 값은 release hard gate가 아니라 warning metadata다. Stage 4 실행 결과 없이 default 전환 기준으로 해석하면 안 된다.
+- `복학원서.hwp`는 여전히 reference capture contamination sample이다. 이 sample의 visual diff 수치는 renderer 품질 점수에서 제외해야 한다.
+- multi-page sample은 manifest에 page 2 후보를 포함하지만, Stage 3 quick mode는 page 1만 실행해야 한다. extended mode에서 page count/실행 시간을 다시 확인해야 한다.
+- Thumbnail dimension drift는 manifest에 triage metadata로만 반영했다. 실제 `maxDimension` mapping 원인은 #392와 연결해야 한다.
+
+## 다음 단계 영향
+
+Stage 3에서는 `scripts/preview-renderer-baseline.sh`와 필요 시 집계 helper를 구현한다. 기존 `preview-visual-diff-harness.sh`를 정책별로 실행하고, 이번 manifest의 known risk와 threshold metadata를 summary에 연결한다.
+
+## 승인 요청
+
+Stage 2 결과에 따라 Stage 3 `baseline 실행 helper와 report 구조 구현`으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_396_stage3.md
+++ b/mydocs/working/task_m020_396_stage3.md
@@ -1,0 +1,178 @@
+# Task M020 #396 Stage 3 완료 보고서
+
+## 단계 목적
+
+manifest 기반으로 기존 visual diff harness를 CoreGraphics/Skia opt-in 양쪽에 실행하고, 비교 가능한 baseline summary를 생성하는 helper/report 구조를 구현한다.
+
+Stage 3 재개 전에 `local/task396`을 최신 `devel` 위로 rebase해 #398 결과를 반영했다. 이에 따라 `복학원서.hwp`는 더 이상 local font modal contamination 제외 sample이 아니라, clean capture metadata를 확인한 뒤 layout overflow/displayText 민감성을 별도로 보는 known-risk sample로 갱신했다.
+
+## 산출물
+
+| 파일/경로 | 내용 |
+|-----------|------|
+| `scripts/preview-renderer-baseline.sh` | manifest 기반 baseline helper shell entrypoint |
+| `scripts/preview_renderer_baseline.py` | manifest 검증, suite/page filtering, policy별 harness 실행, pair summary 집계 |
+| `scripts/preview_renderer_baseline_manifest.json` | `복학원서.hwp` knownRisk를 #398 이후 clean capture/layout overflow 기준으로 갱신 |
+| `mydocs/tech/skia_preview_renderer_baseline.md` | #398 이후 `복학원서.hwp` 해석 정책 갱신 |
+| `build.noindex/task396-helper-smoke/` | quick suite CoreGraphics/Skia helper smoke 산출물 |
+| `mydocs/working/task_m020_396_stage3.md` | Stage 3 완료 보고서 |
+| `mydocs/orders/20260630.md` | #396 재개와 Stage 3 승인 대기 상태 기록 |
+
+현재 주요 파일 라인 수:
+
+```text
+7 scripts/preview-renderer-baseline.sh
+542 scripts/preview_renderer_baseline.py
+540 scripts/preview_renderer_baseline_manifest.json
+122 mydocs/tech/skia_preview_renderer_baseline.md
+```
+
+## 구현 내용
+
+`scripts/preview-renderer-baseline.sh`는 얇은 shell entrypoint로 두고, 실제 orchestration은 `scripts/preview_renderer_baseline.py`가 담당한다.
+
+지원 CLI:
+
+```text
+./scripts/preview-renderer-baseline.sh <output-dir>
+  --suite quick|extended|all
+  --manifest scripts/preview_renderer_baseline_manifest.json
+  --page-mode first|manifest
+  --policy-pair coreGraphicsOnly,skiaOptIn
+  --dry-run
+  --validate-only
+```
+
+주요 동작:
+
+1. manifest JSON 구조와 sample path를 검증한다.
+2. `--suite`로 sample을 필터링한다.
+3. `--page-mode first`면 각 sample의 첫 page만 실행하고, `manifest`면 manifest의 page list를 모두 실행한다.
+4. output root 아래에 policy/page별 harness output을 분리한다.
+   - `runs/coreGraphicsOnly/page-1/`
+   - `runs/skiaOptIn/page-1/`
+5. 기존 `preview-visual-diff-harness.sh`를 policy별로 호출한다.
+6. 각 harness의 `summary.md`를 파싱해 top-level `summary.md`를 생성한다.
+7. harness run 하나가 실패해도 다른 policy/page run은 계속 실행하고, exit code와 failure row를 summary에 남긴다.
+
+Top-level summary column:
+
+- sample id/category/page
+- knownRisk
+- policy별 status
+- policy별 `StudioCapture`
+- policy별 `ChangedPercent`
+- policy별 `MeanRGBDelta`
+- policy별 `NativeMs`
+- policy별 backend/fallback
+- `SkiaMinusCGChangedPercent`
+- `NativeSizeDriftPx`
+- triage
+- policy별 artifact summary link
+
+## #398 반영
+
+Stage 2 당시 `복학원서.hwp`는 `capture-contamination` sentinel이었다. #398 merge 후 automation load와 contamination metadata가 들어왔으므로 Stage 3에서 manifest를 다음처럼 갱신했다.
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| category | `known-risk-capture` | `known-risk-layout` |
+| knownRisk | `capture-contamination`, `display-text-sensitive` | `clean-capture-sentinel`, `layout-overflow-watch`, `display-text-sensitive` |
+| 해석 | reference capture가 정리되기 전 visual metric 제외 | `captureContaminated=false` 확인 후 layout overflow/displayText를 renderer triage로 분리 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+제품 앱 source, renderer source, RustBridge ABI, sample 문서는 변경하지 않았다. 변경 범위는 helper script, manifest/policy 문서, 작업 보고서/오늘할일 문서다.
+
+## 검증 결과
+
+정적/입력 검증:
+
+```bash
+./scripts/preview-renderer-baseline.sh --help
+python3 -m json.tool scripts/preview_renderer_baseline_manifest.json >/dev/null
+./scripts/preview-renderer-baseline.sh --validate-only --suite quick --page-mode first
+./scripts/preview-renderer-baseline.sh --validate-only --suite extended --page-mode manifest
+python3 -m py_compile scripts/preview_renderer_baseline.py
+git diff --check
+```
+
+결과:
+
+```text
+quick validate: samples=5, samplePages=5
+extended validate: samples=20, samplePages=21
+```
+
+Dry-run:
+
+```bash
+./scripts/preview-renderer-baseline.sh build.noindex/task396-helper-dry-run --suite quick --page-mode first --dry-run
+```
+
+결과:
+
+```text
+dry-run: runs=2 samples=5
+```
+
+Helper quick smoke:
+
+```bash
+./scripts/preview-renderer-baseline.sh build.noindex/task396-helper-smoke --suite quick --page-mode first
+```
+
+결과:
+
+```text
+coreGraphicsOnly page-1: exitCode=0, inputs=5
+skiaOptIn page-1: exitCode=0, inputs=5
+```
+
+Quick suite aggregate:
+
+| id | CG changed | Skia changed | Skia-CG delta | triage |
+|----|------------|--------------|---------------|--------|
+| `request-basic-quick` | `17.6908%` | `11.6265%` | `-6.0643pp` | `warn:skia-changed` |
+| `ktx-regression-sentinel` | `30.8921%` | `46.3795%` | `+15.4874pp` | `warn:skia-delta` |
+| `bokhakwonseo-capture-sentinel` | `7.2888%` | `6.9406%` | `-0.3482pp` | `known-risk` |
+| `hwp-multi-001-page-loop` | `14.1976%` | `13.9298%` | `-0.2678pp` | `warn:skia-changed` |
+| `hwpx-01-path` | `14.0216%` | `13.8212%` | `-0.2004pp` | `warn:skia-changed` |
+
+`복학원서.hwp` capture metadata 확인:
+
+```text
+automationLoad=true
+captureMode=domComposite
+overlayIncluded=true
+captureContaminated=false
+modalCount=0
+toastCount=0
+localFontUIVisible=false
+StudioCapture=domComposite;ui=clean
+```
+
+Stage 3 keyword 검증:
+
+```bash
+rg -n "CoreGraphics|Skia|coreGraphicsOnly|skiaOptIn|ChangedPercent|MeanRGBDelta|NativeMs|fallback|knownRisk|KnownRisk|KTX|복학원서|summary|domComposite;ui=clean" \
+  build.noindex/task396-helper-smoke mydocs/working/task_m020_396_stage3.md \
+  scripts/preview_renderer_baseline_manifest.json mydocs/tech/skia_preview_renderer_baseline.md
+```
+
+결과: helper 산출물, Stage 보고서, manifest/policy 문서에서 핵심 keyword 확인.
+
+## 잔여 위험
+
+- Stage 3 helper는 visual diff orchestration에 집중한다. Quick Look extension 등록 smoke와 Thumbnail cache/signature smoke 연결은 Stage 4에서 수행한다.
+- `warn:skia-changed`는 Skia가 CoreGraphics보다 악화됐다는 뜻이 아니라, reference 대비 changed percent가 sample threshold를 넘었다는 triage signal이다. 실제 default 전환 판단은 Stage 4에서 image artifact와 surface smoke를 함께 본다.
+- `KTX.hwp`는 예상대로 `warn:skia-delta`를 유지한다. 이는 #390의 visual regression blocker가 helper summary에 다시 드러난 것이다.
+- `복학원서.hwp`는 clean capture로 복구됐지만 `LAYOUT_OVERFLOW` warning이 남아 있다. 이 warning은 capture contamination이 아니라 renderer/layout risk로 이어서 본다.
+
+## 다음 단계 영향
+
+Stage 4에서는 helper를 기준으로 quick suite를 공식 산출물 경로에서 다시 실행하고, 가능한 범위에서 extended suite 일부 또는 전체를 실행한다. 또한 `KTX.hwp` regression sentinel, `복학원서.hwp` clean-capture/layout sentinel, Thumbnail 1px dimension watch가 summary에서 의도대로 분류되는지 확인한다.
+
+## 승인 요청
+
+Stage 3는 완료했다. Stage 4 `quick smoke와 확장 후보 검증`으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_396_stage4.md
+++ b/mydocs/working/task_m020_396_stage4.md
@@ -1,0 +1,186 @@
+# Task M020 #396 Stage 4 완료 보고서
+
+## 단계 목적
+
+Stage 2-3에서 만든 `preview-renderer-baseline` manifest/helper를 실제 산출물 경로에서 실행해 quick smoke 반복 가능성과 extended 후보 suite의 실행 가능성을 확인한다.
+
+#398 merge 이후 기준을 반영해 `복학원서.hwp`는 capture contamination sample이 아니라 `clean-capture-sentinel`, `layout-overflow-watch`, `display-text-sensitive` known-risk sample로 검증했다.
+
+## 산출물
+
+| 경로 | 내용 |
+|------|------|
+| `build.noindex/task396-baseline-quick/` | quick suite 공식 baseline 실행 산출물 |
+| `build.noindex/task396-baseline-extended-sample/` | extended suite 전체 후보 실행 산출물 |
+| `build.noindex/task396-baseline-extended-retry/` | readiness 실패 샘플 재시도 산출물 |
+| `mydocs/working/task_m020_396_stage4.md` | Stage 4 완료 보고서 |
+| `mydocs/orders/20260630.md` | Stage 4 승인 대기 상태 갱신 |
+
+## 기본 검증
+
+다음 명령을 실행했다.
+
+```bash
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+python3 -m json.tool scripts/preview_renderer_baseline_manifest.json >/dev/null
+./scripts/preview-renderer-baseline.sh --validate-only --suite extended --page-mode manifest
+```
+
+결과:
+
+```text
+OK: RhwpCoreBuildInfo matches rhwp-core.lock
+OK: rhwp-studio assets verified
+OK: Sources/RhwpCoreBridge has no forbidden AppKit/UIKit imports
+extended validate: samples=20, samplePages=21
+```
+
+## Quick suite 결과
+
+실행:
+
+```bash
+./scripts/preview-renderer-baseline.sh build.noindex/task396-baseline-quick --suite quick
+```
+
+결과:
+
+```text
+coreGraphicsOnly page-1: exitCode=0, inputs=5
+skiaOptIn page-1: exitCode=0, inputs=5
+```
+
+대표 summary:
+
+| id | CG changed | Skia changed | Skia-CG delta | triage |
+|----|------------|--------------|---------------|--------|
+| `request-basic-quick` | `17.6908%` | `11.6265%` | `-6.0643pp` | `warn:skia-changed` |
+| `ktx-regression-sentinel` | `30.8921%` | `46.3795%` | `+15.4874pp` | `warn:skia-delta` |
+| `bokhakwonseo-capture-sentinel` | `7.2888%` | `6.9406%` | `-0.3482pp` | `known-risk` |
+| `hwp-multi-001-page-loop` | `14.1976%` | `13.9298%` | `-0.2678pp` | `warn:skia-changed` |
+| `hwpx-01-path` | `14.0216%` | `13.8212%` | `-0.2004pp` | `warn:skia-changed` |
+
+확인 사항:
+
+- quick suite는 CoreGraphics/Skia 양쪽 모두 exit 0으로 반복 실행 가능하다.
+- `KTX.hwp`는 예상대로 `warn:skia-delta`다. Skia opt-in changed percent가 CoreGraphics보다 `+15.4874pp` 높게 나와 #390에서 확인한 visual regression blocker가 baseline summary에 다시 드러났다.
+- `복학원서.hwp`는 `domComposite;ui=clean` + `known-risk`다. 즉 모달/토스트/local font UI가 capture를 오염시킨 상태가 아니라, clean capture 위에서 layout/display text 민감 sample로 분리된다.
+- quick suite의 `NativeSizeDriftPx`는 모든 row가 `0`이었다.
+
+## Extended suite 결과
+
+실행:
+
+```bash
+./scripts/preview-renderer-baseline.sh build.noindex/task396-baseline-extended-sample --suite extended
+```
+
+결과:
+
+```text
+coreGraphicsOnly page-1: exitCode=1, inputs=20
+coreGraphicsOnly page-2: exitCode=0, inputs=1
+skiaOptIn page-1: exitCode=1, inputs=20
+skiaOptIn page-2: exitCode=0, inputs=1
+```
+
+page-1 전체 batch에서 readiness failure가 섞여 exit 1이 되었지만, helper는 실패 phase와 실패 sample을 summary에 보존했다. page-2 run은 CoreGraphics/Skia 모두 exit 0이었다.
+
+주요 triage:
+
+| id | page | 결과 |
+|----|------|------|
+| `ktx-regression-sentinel` | 1 | `warn:skia-delta`, `+15.4874pp` |
+| `bokhakwonseo-capture-sentinel` | 1 | `known-risk`, `domComposite;ui=clean`, `-0.3482pp` |
+| `field-01-field` | 1 | `warn:skia-delta`, `+8.9979pp` |
+| `hwp-multi-001-page-loop` | 2 | `ok`, `-0.2265pp` |
+| `shortcut-control-mark` | 1 | `known-risk`, `display-text-sensitive` |
+
+Extended readiness failure:
+
+| policy | sample | phase | 해석 |
+|--------|--------|-------|------|
+| `coreGraphicsOnly` | `hwpx/form-002.hwpx` | `readiness` document load timeout | 양쪽 renderer 공통 실패로 Skia 품질 실패가 아님 |
+| `coreGraphicsOnly` | `table-complex.hwp` | `readiness` ready request timeout | 재시도에서 통과해 긴 batch 실행 중 transient readiness failure로 분류 |
+| `skiaOptIn` | `pic-crop-01.hwp` | `readiness` ready request timeout | 재시도에서 통과해 긴 batch 실행 중 transient readiness failure로 분류 |
+| `skiaOptIn` | `hwpx/form-002.hwpx` | `readiness` document load timeout | 양쪽 renderer 공통 실패로 Skia 품질 실패가 아님 |
+
+## Readiness 실패 재시도
+
+CoreGraphics 재시도:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task396-baseline-extended-retry/coreGraphicsOnly --page 1 --policy coreGraphicsOnly \
+  samples/hwpx/form-002.hwpx samples/table-complex.hwp
+```
+
+결과:
+
+| sample | result | metric |
+|--------|--------|--------|
+| `form-002.hwpx` | FAIL, `[phase:readiness]` document load timeout | - |
+| `table-complex.hwp` | OK | `ChangedPercent=8.8441%`, `MeanRGBDelta=7.7621`, `NativeMs=1035.5` |
+
+Skia 재시도:
+
+```bash
+./scripts/preview-visual-diff-harness.sh build.noindex/task396-baseline-extended-retry/skiaOptIn --page 1 --policy skiaOptIn \
+  samples/pic-crop-01.hwp samples/hwpx/form-002.hwpx
+```
+
+결과:
+
+| sample | result | metric |
+|--------|--------|--------|
+| `pic-crop-01.hwp` | OK | `ChangedPercent=3.0393%`, `MeanRGBDelta=1.9914`, `NativeMs=35.4` |
+| `form-002.hwpx` | FAIL, `[phase:readiness]` document load timeout | - |
+
+재시도 판단:
+
+- `form-002.hwpx`는 CoreGraphics/Skia 양쪽에서 반복적으로 `document load timed out`이다. renderer backend 차이가 아니라 rhwp-studio automation/document readiness 쪽 제한으로 본다.
+- `table-complex.hwp`와 `pic-crop-01.hwp`는 소규모 재시도에서 통과했다. extended full batch에서는 WebKit automation readiness가 긴 run 중 일부 sample에서 흔들릴 수 있으므로, Stage 5에서는 report 소비자가 renderer failure와 environment/readiness failure를 혼동하지 않게 문서화해야 한다.
+
+## Sentinel 해석
+
+`KTX.hwp`:
+
+- quick/extended 모두 `warn:skia-delta`다.
+- `NativeSizeDriftPx=0`이므로 이번 산출물에서 보인 핵심 문제는 크기 mismatch가 아니라 pixel delta다.
+- Skia default 전환 판단에서는 계속 blocker 성격의 regression sentinel로 남겨야 한다.
+
+`복학원서.hwp`:
+
+- quick/extended 모두 `domComposite;ui=clean`, `known-risk`다.
+- `captureContaminated=false`, `modalCount=0`, `toastCount=0`, `localFontUIVisible=false` metadata가 확인된다.
+- 남은 `LAYOUT_OVERFLOW` warning은 capture contamination이 아니라 layout/display text 민감성으로 후속 triage해야 한다.
+
+`field-01.hwp`:
+
+- extended suite에서 `warn:skia-delta`로 새로 드러났다.
+- Skia changed percent `12.2456%`, CoreGraphics `3.2477%`, delta `+8.9979pp`다.
+- KTX 다음 단계에서 Skia text/form field 계열 대표 regression 후보로 같이 봐야 한다.
+
+## 후속 이슈 입력
+
+- #392 Thumbnail maxDimension mapping: 이번 preview baseline의 quick sentinel은 `NativeSizeDriftPx=0`이지만, extended `exam-math-equation`에서 `NativeSizeDriftPx=1`이 한 번 보였다. Finder Thumbnail surface의 maxDimension/cache 경로는 별도 smoke가 필요하므로 #392는 계속 유효하다.
+- #389 Thumbnail diagnostic/cache logging: visual suite는 document render 비교에 집중하고 Finder cache 동작은 보지 못한다. cache/signature 관측성은 별도 작업으로 유지해야 한다.
+- #393 direct PNG fast path: KTX/field delta가 남아 있으므로 direct PNG fast path는 default 전환 수단이 아니라 opt-in 검증 축으로 유지하는 편이 맞다.
+
+## 완료 조건 판단
+
+- quick suite 공식 산출물을 생성했고 CoreGraphics/Skia 모두 exit 0이다.
+- extended suite 전체 후보를 실행했고, 성공 row와 readiness failure row를 같은 summary에 보존했다.
+- `KTX.hwp` regression sentinel과 `복학원서.hwp` known-risk sentinel이 의도대로 분류된다.
+- renderer warning, known-risk, readiness failure가 분리되어 Stage 5 문서화 입력으로 사용할 수 있다.
+
+## 잔여 위험
+
+- `form-002.hwpx`는 persistent readiness failure다. 이 sample은 renderer 품질 판단에서 제외하거나, rhwp-studio automation readiness 개선 후 다시 포함해야 한다.
+- extended full batch는 긴 run에서 일부 transient readiness failure가 발생할 수 있다. 현재 helper는 이를 phase로 보존하지만, CI gate로 쓰기 전에는 retry/flake 정책이 추가로 필요하다.
+- `warn:skia-changed`는 Skia가 CoreGraphics보다 나쁘다는 뜻이 아니다. reference 대비 threshold 초과 signal이며, default 전환 판단에는 `warn:skia-delta`, size drift, fallback, artifact 확인을 함께 봐야 한다.
+
+## 승인 요청
+
+Stage 4는 완료했다. Stage 5 `문서화/운영 가이드 정리`로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_396_stage5.md
+++ b/mydocs/working/task_m020_396_stage5.md
@@ -1,0 +1,50 @@
+# Task M020 #396 Stage 5 완료 보고서
+
+## 단계 목적
+
+#396 결과를 최종 기준 문서와 최종 보고서로 정리하고 PR 게시 준비 상태로 만든다.
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/tech/skia_preview_renderer_baseline.md` | baseline suite 실행 runbook과 2026-06-30 기준 해석 추가 |
+| `mydocs/report/task_m020_396_report.md` | #396 최종 보고서 |
+| `mydocs/working/task_m020_396_stage5.md` | Stage 5 완료 보고서 |
+| `mydocs/orders/20260630.md` | #396 완료 처리 |
+
+## 정리 내용
+
+- quick suite는 PR smoke와 renderer 관련 변경의 빠른 재측정 기준으로 고정했다.
+- extended suite는 Skia default 판단 전 수동 sweep으로 고정하되, CI hard gate 전 retry/flake 정책이 필요하다고 명시했다.
+- `KTX.hwp`는 계속 `warn:skia-delta` regression sentinel로 남겼다.
+- `복학원서.hwp`는 #398 이후 `domComposite;ui=clean` known-risk sample로 정리했다.
+- `field-01.hwp`는 extended에서 확인된 text/form field 계열 Skia delta 후보로 기록했다.
+- `form-002.hwpx`는 CoreGraphics/Skia 공통 persistent readiness failure로 분리했다.
+- #387, #389, #392, #393, #394, #398 관계를 최종 보고서에 정리했다.
+
+## 검증
+
+실행 대상:
+
+```bash
+rg -n "#396|#387|#389|#392|#393|#394|Skia|CoreGraphics|Quick Look|Thumbnail|baseline|manifest|quick|extended" \
+  mydocs/report/task_m020_396_report.md mydocs/orders/20260630.md \
+  mydocs/tech/skia_preview_renderer_baseline.md mydocs/working/task_m020_396_stage5.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task396
+```
+
+결과는 Stage 5 커밋 전 최종 확인으로 남긴다.
+
+## 완료 판단
+
+- 최종 보고서가 존재하고 #396의 검증 체계를 설명한다.
+- 운영 가이드가 quick/extended 실행과 triage 해석 기준을 포함한다.
+- 오늘할일 #396이 완료 상태로 갱신된다.
+- PR 게시 준비에 필요한 summary와 검증 명령이 정리되어 있다.
+
+## 승인 요청
+
+Stage 5는 완료했다. 최종 보고서 검토 후 PR 게시 단계 진행 여부를 승인 요청한다.

--- a/scripts/preview-renderer-baseline.sh
+++ b/scripts/preview-renderer-baseline.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+exec python3 "$ROOT/scripts/preview_renderer_baseline.py" "$@"

--- a/scripts/preview_renderer_baseline.py
+++ b/scripts/preview_renderer_baseline.py
@@ -1,0 +1,542 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import unicodedata
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_MANIFEST = ROOT / "scripts" / "preview_renderer_baseline_manifest.json"
+DEFAULT_RESOURCE_DIR = ROOT / "Sources" / "HostApp" / "Resources" / "rhwp-studio"
+HARNESS = ROOT / "scripts" / "preview-visual-diff-harness.sh"
+POLICY_CHOICES = {"coreGraphicsOnly", "skiaOptIn"}
+
+
+@dataclass(frozen=True)
+class SamplePage:
+    sample_id: str
+    path: Path
+    repo_path: str
+    file_name: str
+    category: str
+    page: int
+    known_risk: list[str]
+    threshold: dict[str, Any]
+    notes: str
+
+
+@dataclass
+class RunResult:
+    policy: str
+    page: int
+    output_dir: Path
+    inputs: list[Path]
+    exit_code: int | None
+
+
+def main() -> int:
+    args = parse_args()
+    manifest_path = resolve_repo_path(args.manifest)
+    manifest = load_manifest(manifest_path)
+    validate_manifest(manifest, manifest_path)
+
+    policies = parse_policy_pair(args.policy_pair, manifest)
+    page_mode = args.page_mode or default_page_mode(args.suite, manifest)
+    sample_pages = select_sample_pages(manifest, args.suite, page_mode)
+
+    if args.validate_only:
+        print_validation_summary(manifest, sample_pages, policies, page_mode)
+        return 0
+
+    if args.output_dir is None:
+        raise SystemExit("error: output-dir is required unless --validate-only is used")
+
+    output_dir = resolve_output_path(args.output_dir)
+    runs = build_runs(output_dir, policies, sample_pages)
+    write_plan(output_dir, manifest_path, manifest, args.suite, page_mode, policies, sample_pages, runs)
+
+    if args.dry_run:
+        write_summary(output_dir, manifest, args.suite, page_mode, policies, sample_pages, runs, {})
+        print(f"dry-run: runs={len(runs)} samples={len({s.sample_id for s in sample_pages})}")
+        return 0
+
+    exit_codes: list[int] = []
+    for run in runs:
+        code = execute_run(run, args)
+        run.exit_code = code
+        exit_codes.append(code)
+
+    parsed = parse_run_summaries(runs)
+    write_summary(output_dir, manifest, args.suite, page_mode, policies, sample_pages, runs, parsed)
+    return 1 if any(code != 0 for code in exit_codes) else 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run manifest-based CoreGraphics/Skia preview visual baseline suites.",
+    )
+    parser.add_argument("output_dir", nargs="?", help="Output directory for baseline artifacts.")
+    parser.add_argument("--suite", choices=["quick", "extended", "all"], default="quick")
+    parser.add_argument("--manifest", default=str(DEFAULT_MANIFEST))
+    parser.add_argument("--page-mode", choices=["first", "manifest"])
+    parser.add_argument("--policy-pair", default=None, help="Comma-separated pair, default from manifest.")
+    parser.add_argument("--viewport", default="1400x1800")
+    parser.add_argument("--settle-ms", default="120")
+    parser.add_argument("--resource-dir", default=str(DEFAULT_RESOURCE_DIR))
+    parser.add_argument("--dry-run", action="store_true", help="Validate and write a run plan without invoking the harness.")
+    parser.add_argument("--validate-only", action="store_true", help="Validate manifest and selected samples, then exit.")
+    return parser.parse_args()
+
+
+def resolve_repo_path(value: str) -> Path:
+    path = Path(value)
+    if not path.is_absolute():
+        path = ROOT / path
+    return path
+
+
+def resolve_output_path(value: str) -> Path:
+    path = Path(value)
+    if not path.is_absolute():
+        path = ROOT / path
+    return path
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        raise SystemExit(f"error: missing manifest: {path}") from None
+    except json.JSONDecodeError as error:
+        raise SystemExit(f"error: invalid JSON manifest: {path}: {error}") from None
+
+
+def validate_manifest(manifest: dict[str, Any], manifest_path: Path) -> None:
+    samples = manifest.get("samples")
+    if not isinstance(samples, list) or not samples:
+        raise SystemExit(f"error: manifest has no samples: {manifest_path}")
+
+    seen_ids: set[str] = set()
+    missing: list[str] = []
+    for index, sample in enumerate(samples):
+        if not isinstance(sample, dict):
+            raise SystemExit(f"error: sample #{index + 1} must be an object")
+        sample_id = required_string(sample, "id", index)
+        if sample_id in seen_ids:
+            raise SystemExit(f"error: duplicate sample id: {sample_id}")
+        seen_ids.add(sample_id)
+        repo_path = required_string(sample, "path", index)
+        if not (ROOT / repo_path).is_file():
+            missing.append(repo_path)
+        required_string(sample, "category", index)
+        required_string_list(sample, "suite", index)
+        pages = sample.get("pages")
+        if not isinstance(pages, list) or not pages or any(not isinstance(p, int) or p < 1 for p in pages):
+            raise SystemExit(f"error: sample {sample_id} must have positive integer pages")
+        required_string_list(sample, "surfaces", index)
+        if not isinstance(sample.get("knownRisk", []), list):
+            raise SystemExit(f"error: sample {sample_id} knownRisk must be an array")
+        if not isinstance(sample.get("threshold", {}), dict):
+            raise SystemExit(f"error: sample {sample_id} threshold must be an object")
+
+    if missing:
+        raise SystemExit("error: missing samples: " + ", ".join(missing))
+
+
+def required_string(sample: dict[str, Any], key: str, index: int) -> str:
+    value = sample.get(key)
+    if not isinstance(value, str) or not value:
+        raise SystemExit(f"error: sample #{index + 1} missing string field {key}")
+    return value
+
+
+def required_string_list(sample: dict[str, Any], key: str, index: int) -> list[str]:
+    value = sample.get(key)
+    if not isinstance(value, list) or not value or any(not isinstance(item, str) for item in value):
+        raise SystemExit(f"error: sample #{index + 1} missing string array field {key}")
+    return value
+
+
+def parse_policy_pair(value: str | None, manifest: dict[str, Any]) -> list[str]:
+    raw = value
+    if raw is None:
+        pair = manifest.get("policyPair")
+        if not isinstance(pair, list):
+            raise SystemExit("error: manifest policyPair must be an array")
+        policies = [str(item) for item in pair]
+    else:
+        policies = [part.strip() for part in raw.split(",") if part.strip()]
+
+    if len(policies) != 2:
+        raise SystemExit("error: --policy-pair must contain exactly two policies")
+    unknown = [policy for policy in policies if policy not in POLICY_CHOICES]
+    if unknown:
+        raise SystemExit("error: unknown policy in pair: " + ", ".join(unknown))
+    if policies[0] == policies[1]:
+        raise SystemExit("error: --policy-pair must contain two different policies")
+    return policies
+
+
+def default_page_mode(suite: str, manifest: dict[str, Any]) -> str:
+    if suite == "all":
+        return "manifest"
+    suites = manifest.get("suites", {})
+    suite_info = suites.get(suite, {}) if isinstance(suites, dict) else {}
+    mode = suite_info.get("defaultPageMode", "first") if isinstance(suite_info, dict) else "first"
+    if mode not in {"first", "manifest"}:
+        raise SystemExit(f"error: invalid defaultPageMode for suite {suite}: {mode}")
+    return mode
+
+
+def select_sample_pages(manifest: dict[str, Any], suite: str, page_mode: str) -> list[SamplePage]:
+    selected: list[SamplePage] = []
+    for sample in manifest["samples"]:
+        sample_suites = sample["suite"]
+        if suite != "all" and suite not in sample_suites:
+            continue
+        pages = sample["pages"][:1] if page_mode == "first" else sample["pages"]
+        repo_path = sample["path"]
+        path = ROOT / repo_path
+        for page in pages:
+            selected.append(
+                SamplePage(
+                    sample_id=sample["id"],
+                    path=path,
+                    repo_path=repo_path,
+                    file_name=path.name,
+                    category=sample["category"],
+                    page=int(page),
+                    known_risk=[str(item) for item in sample.get("knownRisk", [])],
+                    threshold=dict(sample.get("threshold", {})),
+                    notes=str(sample.get("notes", "")),
+                )
+            )
+    if not selected:
+        raise SystemExit(f"error: suite selected no samples: {suite}")
+    return selected
+
+
+def build_runs(output_dir: Path, policies: list[str], sample_pages: list[SamplePage]) -> list[RunResult]:
+    runs: list[RunResult] = []
+    pages = sorted({sample.page for sample in sample_pages})
+    for policy in policies:
+        for page in pages:
+            inputs = [sample.path for sample in sample_pages if sample.page == page]
+            if not inputs:
+                continue
+            runs.append(
+                RunResult(
+                    policy=policy,
+                    page=page,
+                    output_dir=output_dir / "runs" / policy / f"page-{page}",
+                    inputs=inputs,
+                    exit_code=None,
+                )
+            )
+    return runs
+
+
+def write_plan(
+    output_dir: Path,
+    manifest_path: Path,
+    manifest: dict[str, Any],
+    suite: str,
+    page_mode: str,
+    policies: list[str],
+    sample_pages: list[SamplePage],
+    runs: list[RunResult],
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    plan = {
+        "label": manifest.get("label"),
+        "version": manifest.get("version"),
+        "suite": suite,
+        "pageMode": page_mode,
+        "manifest": str(manifest_path),
+        "policyPair": policies,
+        "samplePages": [
+            {
+                "id": sample.sample_id,
+                "path": sample.repo_path,
+                "category": sample.category,
+                "page": sample.page,
+                "knownRisk": sample.known_risk,
+            }
+            for sample in sample_pages
+        ],
+        "runs": [
+            {
+                "policy": run.policy,
+                "page": run.page,
+                "outputDir": str(run.output_dir),
+                "inputs": [str(path.relative_to(ROOT)) for path in run.inputs],
+            }
+            for run in runs
+        ],
+    }
+    (output_dir / "run-plan.json").write_text(json.dumps(plan, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def execute_run(run: RunResult, args: argparse.Namespace) -> int:
+    run.output_dir.mkdir(parents=True, exist_ok=True)
+    resource_dir = resolve_repo_path(args.resource_dir)
+    cmd = [
+        str(HARNESS),
+        str(run.output_dir),
+        "--page",
+        str(run.page),
+        "--policy",
+        run.policy,
+        "--viewport",
+        args.viewport,
+        "--settle-ms",
+        str(args.settle_ms),
+        "--resource-dir",
+        str(resource_dir),
+        *[str(path) for path in run.inputs],
+    ]
+    print("+ " + " ".join(shell_quote(part) for part in cmd), flush=True)
+    return subprocess.run(cmd, cwd=ROOT).returncode
+
+
+def shell_quote(value: str) -> str:
+    if not value or any(ch.isspace() or ch in "'\"$`\\|" for ch in value):
+        return "'" + value.replace("'", "'\"'\"'") + "'"
+    return value
+
+
+def parse_run_summaries(runs: list[RunResult]) -> dict[tuple[str, int, str], dict[str, str]]:
+    parsed: dict[tuple[str, int, str], dict[str, str]] = {}
+    for run in runs:
+        summary = run.output_dir / "summary.md"
+        if not summary.is_file():
+            continue
+        for row in parse_summary_rows(summary):
+            file_name = normalize_name(row.get("File", ""))
+            parsed[(run.policy, run.page, file_name)] = row
+    return parsed
+
+
+def parse_summary_rows(path: Path) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    headers: list[str] | None = None
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if cells and cells[0] == "File" and "Status" in cells:
+            headers = cells
+            continue
+        if headers is None:
+            continue
+        if cells and set(cells[0]) <= {"-"}:
+            continue
+        if len(cells) < len(headers):
+            continue
+        rows.append(dict(zip(headers, cells)))
+    return rows
+
+
+def normalize_name(value: str) -> str:
+    return unicodedata.normalize("NFC", value)
+
+
+def write_summary(
+    output_dir: Path,
+    manifest: dict[str, Any],
+    suite: str,
+    page_mode: str,
+    policies: list[str],
+    sample_pages: list[SamplePage],
+    runs: list[RunResult],
+    parsed: dict[tuple[str, int, str], dict[str, str]],
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    first_policy, second_policy = policies
+    lines: list[str] = []
+    lines.append("# Preview Renderer Baseline")
+    lines.append("")
+    lines.append(f"Label: {manifest.get('label', '-')}")
+    lines.append(f"Suite: {suite}")
+    lines.append(f"PageMode: {page_mode}")
+    lines.append(f"PolicyPair: {first_policy},{second_policy}")
+    lines.append(f"Samples: {len({sample.sample_id for sample in sample_pages})}")
+    lines.append(f"SamplePages: {len(sample_pages)}")
+    lines.append("")
+    lines.append("## Runs")
+    lines.append("")
+    lines.append("| Policy | Page | ExitCode | Inputs | Summary |")
+    lines.append("|--------|------|----------|--------|---------|")
+    for run in runs:
+        rel_summary = relative_link(output_dir, run.output_dir / "summary.md")
+        exit_code = "-" if run.exit_code is None else str(run.exit_code)
+        lines.append(
+            markdown_row(
+                [
+                    run.policy,
+                    str(run.page),
+                    exit_code,
+                    str(len(run.inputs)),
+                    f"[summary]({rel_summary})" if (run.output_dir / "summary.md").is_file() else "-",
+                ]
+            )
+        )
+    lines.append("")
+    lines.append("## Pair Summary")
+    lines.append("")
+    lines.append(
+        "| ID | Category | Page | KnownRisk | "
+        + f"{first_policy}Status | {first_policy}StudioCapture | {first_policy}ChangedPercent | {first_policy}MeanRGBDelta | {first_policy}NativeMs | {first_policy}Backend | "
+        + f"{second_policy}Status | {second_policy}StudioCapture | {second_policy}ChangedPercent | {second_policy}MeanRGBDelta | {second_policy}NativeMs | {second_policy}Backend | "
+        + "SkiaMinusCGChangedPercent | NativeSizeDriftPx | Triage | Artifacts |"
+    )
+    lines.append(
+        "|----|----------|------|-----------|"
+        "----------|-------------|----------------|-------------|----------|-------|"
+        "----------|-------------|----------------|-------------|----------|-------|"
+        "--------------------------|-------------------|--------|-----------|"
+    )
+    for sample in sample_pages:
+        first = parsed.get((first_policy, sample.page, normalize_name(sample.file_name)), {})
+        second = parsed.get((second_policy, sample.page, normalize_name(sample.file_name)), {})
+        cg_changed = percent_value(first.get("ChangedPercent"))
+        skia_changed = percent_value(second.get("ChangedPercent"))
+        delta = numeric_delta(skia_changed, cg_changed)
+        size_drift = native_size_drift(first.get("NativeSize"), second.get("NativeSize"))
+        triage = triage_status(sample, first, second, delta)
+        artifacts = artifact_links(output_dir, policies, sample.page)
+        lines.append(
+            markdown_row(
+                [
+                    sample.sample_id,
+                    sample.category,
+                    str(sample.page),
+                    ",".join(sample.known_risk) or "-",
+                    status_cell(first),
+                    first.get("StudioCapture", "-"),
+                    first.get("ChangedPercent", "-"),
+                    first.get("MeanRGBDelta", "-"),
+                    first.get("NativeMs", "-"),
+                    first.get("NativeBackend", "-"),
+                    status_cell(second),
+                    second.get("StudioCapture", "-"),
+                    second.get("ChangedPercent", "-"),
+                    second.get("MeanRGBDelta", "-"),
+                    second.get("NativeMs", "-"),
+                    second.get("NativeBackend", "-"),
+                    format_delta(delta),
+                    "-" if size_drift is None else str(size_drift),
+                    triage,
+                    artifacts,
+                ]
+            )
+        )
+    (output_dir / "summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def status_cell(row: dict[str, str]) -> str:
+    return row.get("Status", "MISSING") if row else "MISSING"
+
+
+def percent_value(value: str | None) -> float | None:
+    if not value or value == "-":
+        return None
+    try:
+        return float(value.rstrip("%"))
+    except ValueError:
+        return None
+
+
+def numeric_delta(left: float | None, right: float | None) -> float | None:
+    if left is None or right is None:
+        return None
+    return left - right
+
+
+def native_size_drift(first: str | None, second: str | None) -> int | None:
+    first_size = parse_size(first)
+    second_size = parse_size(second)
+    if first_size is None or second_size is None:
+        return None
+    return max(abs(first_size[0] - second_size[0]), abs(first_size[1] - second_size[1]))
+
+
+def parse_size(value: str | None) -> tuple[int, int] | None:
+    if not value or "x" not in value:
+        return None
+    left, right = value.split("x", 1)
+    try:
+        return int(left), int(right)
+    except ValueError:
+        return None
+
+
+def triage_status(sample: SamplePage, first: dict[str, str], second: dict[str, str], delta: float | None) -> str:
+    if not first or not second:
+        return "missing"
+    if first.get("Status") != "OK" or second.get("Status") != "OK":
+        return "failure"
+    threshold = sample.threshold
+    max_delta = float(threshold.get("maxSkiaMinusCGChangedPercentWarn", 5.0))
+    max_changed = float(threshold.get("maxChangedPercentWarn", 10.0))
+    skia_changed = percent_value(second.get("ChangedPercent"))
+    if delta is not None and delta > max_delta:
+        return "warn:skia-delta"
+    if skia_changed is not None and skia_changed > max_changed:
+        return "warn:skia-changed"
+    if sample.known_risk:
+        return "known-risk"
+    return "ok"
+
+
+def format_delta(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:+.4f}pp"
+
+
+def artifact_links(output_dir: Path, policies: list[str], page: int) -> str:
+    links = []
+    for policy in policies:
+        summary = output_dir / "runs" / policy / f"page-{page}" / "summary.md"
+        links.append(f"{policy}=[summary]({relative_link(output_dir, summary)})")
+    return ", ".join(links)
+
+
+def relative_link(base: Path, target: Path) -> str:
+    try:
+        return target.relative_to(base).as_posix()
+    except ValueError:
+        return target.as_posix()
+
+
+def markdown_row(cells: list[str]) -> str:
+    return "| " + " | ".join(markdown_cell(cell) for cell in cells) + " |"
+
+
+def markdown_cell(value: Any) -> str:
+    return str(value).replace("|", "/")
+
+
+def print_validation_summary(
+    manifest: dict[str, Any],
+    sample_pages: list[SamplePage],
+    policies: list[str],
+    page_mode: str,
+) -> None:
+    print(f"label={manifest.get('label')}")
+    print(f"policies={','.join(policies)}")
+    print(f"pageMode={page_mode}")
+    print(f"samples={len({sample.sample_id for sample in sample_pages})}")
+    print(f"samplePages={len(sample_pages)}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/preview_renderer_baseline_manifest.json
+++ b/scripts/preview_renderer_baseline_manifest.json
@@ -69,6 +69,8 @@
     "knownRiskDisposition": {
       "regression-sentinel": "Keep in both quick and extended suites and always report Skia minus CoreGraphics delta.",
       "capture-contamination": "Do not use changed-percent as renderer quality evidence until the reference capture is fixed.",
+      "clean-capture-sentinel": "Keep automation capture metadata visible and require captureContaminated=false before using visual metrics.",
+      "layout-overflow-watch": "Treat layout overflow as renderer/layout risk, not as reference capture contamination.",
       "size-drift-watch": "A 1px thumbnail drift is a triage warning, not a cache failure by itself.",
       "display-text-sensitive": "Inspect user-facing text and control marks even when changed-percent is low."
     }
@@ -128,7 +130,7 @@
     {
       "id": "bokhakwonseo-capture-sentinel",
       "path": "samples/복학원서.hwp",
-      "category": "known-risk-capture",
+      "category": "known-risk-layout",
       "suite": [
         "quick",
         "extended"
@@ -142,7 +144,8 @@
         "thumbnail"
       ],
       "knownRisk": [
-        "capture-contamination",
+        "clean-capture-sentinel",
+        "layout-overflow-watch",
         "display-text-sensitive"
       ],
       "threshold": {
@@ -150,7 +153,7 @@
         "maxChangedPercentWarn": 10.0,
         "maxSkiaMinusCGChangedPercentWarn": 5.0
       },
-      "notes": "#390 reference capture included the local font overlay, so visual metrics are tracked but excluded from default-readiness scoring."
+      "notes": "#398 fixed local font UI capture contamination. Require automationLoad=true and captureContaminated=false, then treat remaining LAYOUT_OVERFLOW/displayText sensitivity as renderer-layout triage."
     },
     {
       "id": "hwp-multi-001-page-loop",

--- a/scripts/preview_renderer_baseline_manifest.json
+++ b/scripts/preview_renderer_baseline_manifest.json
@@ -1,0 +1,537 @@
+{
+  "label": "quicklook-thumbnail-skia-baseline",
+  "version": 1,
+  "issue": 396,
+  "pageIndexBase": 1,
+  "policyPair": [
+    "coreGraphicsOnly",
+    "skiaOptIn"
+  ],
+  "suites": {
+    "quick": {
+      "description": "Fast representative smoke for renderer-related changes.",
+      "intendedUse": "Stage validation and PR review signal.",
+      "defaultPageMode": "first",
+      "expectedSampleCount": 5
+    },
+    "extended": {
+      "description": "Manual readiness sweep across renderer feature categories.",
+      "intendedUse": "Skia default-readiness or release-readiness review.",
+      "defaultPageMode": "manifest",
+      "expectedSampleCount": 20
+    }
+  },
+  "surfaces": {
+    "visual": {
+      "description": "rhwp-studio reference PNG versus native renderer PNG comparison."
+    },
+    "quicklook": {
+      "description": "Quick Look preview surface signal."
+    },
+    "thumbnail": {
+      "description": "Finder thumbnail surface signal."
+    }
+  },
+  "thresholdPolicy": {
+    "hardFailSignals": [
+      "crash",
+      "hang-or-timeout",
+      "empty-output",
+      "decode-failure",
+      "major-structure-missing",
+      "aspect-ratio-mismatch",
+      "fallback-after-skia-without-coregraphics-recovery"
+    ],
+    "changedPercentTriageBands": [
+      {
+        "range": "0-1",
+        "meaning": "Antialiasing or tiny rasterizer differences are likely."
+      },
+      {
+        "range": "1-5",
+        "meaning": "Text edges, 1px rounding, or small object differences need image review."
+      },
+      {
+        "range": "5-10",
+        "meaning": "Document structure must be checked before considering the result acceptable."
+      },
+      {
+        "range": "10+",
+        "meaning": "Large structural difference is likely; default transition is blocked until triaged."
+      }
+    ],
+    "defaults": {
+      "maxAllowedSizeDriftPx": 0,
+      "maxChangedPercentWarn": 10.0,
+      "maxSkiaMinusCGChangedPercentWarn": 5.0,
+      "maxMeanRGBDeltaWarn": 20.0
+    },
+    "knownRiskDisposition": {
+      "regression-sentinel": "Keep in both quick and extended suites and always report Skia minus CoreGraphics delta.",
+      "capture-contamination": "Do not use changed-percent as renderer quality evidence until the reference capture is fixed.",
+      "size-drift-watch": "A 1px thumbnail drift is a triage warning, not a cache failure by itself.",
+      "display-text-sensitive": "Inspect user-facing text and control marks even when changed-percent is low."
+    }
+  },
+  "samples": [
+    {
+      "id": "request-basic-quick",
+      "path": "samples/basic/request.hwp",
+      "category": "single-page-basic",
+      "suite": [
+        "quick",
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook",
+        "thumbnail"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 1,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Healthy single-page smoke sample where #390 showed Skia visual direction better than CoreGraphics."
+    },
+    {
+      "id": "ktx-regression-sentinel",
+      "path": "samples/basic/KTX.hwp",
+      "category": "single-page-regression",
+      "suite": [
+        "quick",
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook",
+        "thumbnail"
+      ],
+      "knownRisk": [
+        "regression-sentinel",
+        "size-drift-watch"
+      ],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 1,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 10.0
+      },
+      "notes": "#390 measured Skia changed percent 46.3795 versus CoreGraphics 30.8921, delta +15.4874pp."
+    },
+    {
+      "id": "bokhakwonseo-capture-sentinel",
+      "path": "samples/복학원서.hwp",
+      "category": "known-risk-capture",
+      "suite": [
+        "quick",
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook",
+        "thumbnail"
+      ],
+      "knownRisk": [
+        "capture-contamination",
+        "display-text-sensitive"
+      ],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 1,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "#390 reference capture included the local font overlay, so visual metrics are tracked but excluded from default-readiness scoring."
+    },
+    {
+      "id": "hwp-multi-001-page-loop",
+      "path": "samples/hwp-multi-001.hwp",
+      "category": "multi-page",
+      "suite": [
+        "quick",
+        "extended"
+      ],
+      "pages": [
+        1,
+        2
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook",
+        "thumbnail"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 1,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Representative HWP multi-page preview sample; quick mode should use page 1."
+    },
+    {
+      "id": "hwpx-01-path",
+      "path": "samples/hwpx/hwpx-01.hwpx",
+      "category": "hwpx",
+      "suite": [
+        "quick",
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook",
+        "thumbnail"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 1,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Representative HWPX path used by #390 readiness measurement."
+    },
+    {
+      "id": "exam-math-equation",
+      "path": "samples/exam_math.hwp",
+      "category": "equation-shape",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Math-heavy document for equation and text layout replay."
+    },
+    {
+      "id": "hwp-img-001-image",
+      "path": "samples/hwp-img-001.hwp",
+      "category": "image",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Image decode and placement representative."
+    },
+    {
+      "id": "img-start-001-image-start",
+      "path": "samples/img-start-001.hwp",
+      "category": "image",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Image-at-start layout representative."
+    },
+    {
+      "id": "pic-crop-01-image-crop",
+      "path": "samples/pic-crop-01.hwp",
+      "category": "image",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Image crop and placement representative."
+    },
+    {
+      "id": "eq-01-equation",
+      "path": "samples/eq-01.hwp",
+      "category": "equation-shape",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Equation rendering sentinel."
+    },
+    {
+      "id": "group-drawing-02-vector",
+      "path": "samples/group-drawing-02.hwp",
+      "category": "equation-shape",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Grouped drawing and vector replay representative."
+    },
+    {
+      "id": "draw-group-vector",
+      "path": "samples/draw-group.hwp",
+      "category": "equation-shape",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Drawing group replay representative."
+    },
+    {
+      "id": "form-01-form",
+      "path": "samples/form-01.hwp",
+      "category": "form-field",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "HWP form control representative."
+    },
+    {
+      "id": "hwpx-form-002-form",
+      "path": "samples/hwpx/form-002.hwpx",
+      "category": "form-field",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "HWPX form control representative."
+    },
+    {
+      "id": "field-01-field",
+      "path": "samples/field-01.hwp",
+      "category": "form-field",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Field rendering representative."
+    },
+    {
+      "id": "footnote-01-footnote",
+      "path": "samples/footnote-01.hwp",
+      "category": "text-font",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Footnote layout and text replay representative."
+    },
+    {
+      "id": "lseg-02-mixed-line",
+      "path": "samples/lseg-02-mixed.hwp",
+      "category": "text-font",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Line segment, mixed Korean/English, and spacing representative."
+    },
+    {
+      "id": "re-font-batang-hancom-font",
+      "path": "samples/re-font-batang-hancom.hwp",
+      "category": "text-font",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Font fallback and Hangul text representative."
+    },
+    {
+      "id": "shortcut-control-mark",
+      "path": "samples/basic/shortcut.hwp",
+      "category": "text-font",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [
+        "display-text-sensitive"
+      ],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Control mark and display text sensitive sample from the #259 taxonomy."
+    },
+    {
+      "id": "table-complex-table",
+      "path": "samples/table-complex.hwp",
+      "category": "table",
+      "suite": [
+        "extended"
+      ],
+      "pages": [
+        1
+      ],
+      "surfaces": [
+        "visual",
+        "quicklook"
+      ],
+      "knownRisk": [],
+      "threshold": {
+        "maxAllowedSizeDriftPx": 0,
+        "maxChangedPercentWarn": 10.0,
+        "maxSkiaMinusCGChangedPercentWarn": 5.0
+      },
+      "notes": "Complex table layout representative."
+    }
+  ]
+}


### PR DESCRIPTION
## 요약

- 대상 타스크: #396 `업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식`
- 왜: #390 에서 확인한 Skia visual regression과 Thumbnail/Quick Look readiness 신호를 반복 측정할 대표 baseline 체계가 필요했다.
- 무엇: manifest 기반 quick/extended sample suite, CoreGraphics default vs Skia opt-in 실행 helper, aggregate summary, triage/known-risk 운영 문서를 추가했다.
- 리뷰 포인트: `warn:skia-delta`, `warn:skia-changed`, `known-risk`, `readiness` failure 분리가 Skia default 판단에 충분히 명확한지 확인해 달라.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/584fe67b53b3212d63dd92d9c45d62b31405fc07/mydocs/working/task_m020_396_stage1.md)** ([84f927c](https://github.com/postmelee/alhangeul-macos/commit/84f927c)): 업스트림 renderer baseline과 macOS visual harness의 gap을 inventory했다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/584fe67b53b3212d63dd92d9c45d62b31405fc07/mydocs/working/task_m020_396_stage2.md)** ([37bc7a7](https://github.com/postmelee/alhangeul-macos/commit/37bc7a7)): quick/extended manifest, threshold, known-risk policy를 설계했다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/584fe67b53b3212d63dd92d9c45d62b31405fc07/mydocs/working/task_m020_396_stage3.md)** ([6ed6915](https://github.com/postmelee/alhangeul-macos/commit/6ed6915)): 기존 visual diff harness를 재사용하는 baseline 실행 helper와 summary 집계를 구현했다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/584fe67b53b3212d63dd92d9c45d62b31405fc07/mydocs/working/task_m020_396_stage4.md)** ([b25cb64](https://github.com/postmelee/alhangeul-macos/commit/b25cb64)): quick/extended suite를 실행하고 readiness failure와 renderer warning을 분리했다.
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/584fe67b53b3212d63dd92d9c45d62b31405fc07/mydocs/working/task_m020_396_stage5.md)** ([1f40052](https://github.com/postmelee/alhangeul-macos/commit/1f40052)): 운영 가이드와 최종 보고서를 정리했다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `scripts/preview_renderer_baseline_manifest.json` | quick 5개, extended 20개 sample과 threshold/known-risk metadata 추가 | 대표 sample과 known-risk 분류가 M020 판단에 적절한지 |
| `scripts/preview_renderer_baseline.py` | policy pair 실행, run-plan 생성, top-level summary 집계 | failure phase 보존과 triage 계산이 충분히 읽히는지 |
| `scripts/preview-renderer-baseline.sh` | helper entrypoint 추가 | 기존 script 호출 방식과 맞는지 |
| `mydocs/tech/skia_preview_renderer_baseline.md` | suite 정책, triage, runbook, 2026-06-30 baseline 해석 정리 | CI hard gate 전 retry/flake 정책을 남긴 판단이 맞는지 |
| `mydocs/report/task_m020_396_report.md` | Stage별 결과, 검증, 후속 이슈 handoff 정리 | #389/#392/#393/#394 후속 관계가 명확한지 |

- 수행 계획서: [task_m020_396.md](https://github.com/postmelee/alhangeul-macos/blob/584fe67b53b3212d63dd92d9c45d62b31405fc07/mydocs/plans/task_m020_396.md)
- 구현 계획서: [task_m020_396_impl.md](https://github.com/postmelee/alhangeul-macos/blob/584fe67b53b3212d63dd92d9c45d62b31405fc07/mydocs/plans/task_m020_396_impl.md)
- 운영 가이드: [skia_preview_renderer_baseline.md](https://github.com/postmelee/alhangeul-macos/blob/584fe67b53b3212d63dd92d9c45d62b31405fc07/mydocs/tech/skia_preview_renderer_baseline.md)
- 최종 보고서: [task_m020_396_report.md](https://github.com/postmelee/alhangeul-macos/blob/584fe67b53b3212d63dd92d9c45d62b31405fc07/mydocs/report/task_m020_396_report.md)

## 핵심 리뷰 포인트

- `KTX.hwp`를 계속 `warn:skia-delta` regression sentinel로 두고 Skia default blocker로 보는 판단.
- `복학원서.hwp`를 #398 이후 `domComposite;ui=clean` known-risk sample로 재분류한 판단.
- extended suite를 수동 readiness sweep으로 두고, CI hard gate 전 retry/flake 정책을 별도 후속으로 남긴 판단.

## 검증

- `./scripts/verify-rhwp-core-build-info.sh`
- `./scripts/verify-rhwp-studio-assets.sh`
- `./scripts/check-no-appkit.sh`
- `python3 -m json.tool scripts/preview_renderer_baseline_manifest.json >/dev/null`
- `./scripts/preview-renderer-baseline.sh --validate-only --suite extended --page-mode manifest`
- `./scripts/preview-renderer-baseline.sh build.noindex/task396-baseline-quick --suite quick`
- `./scripts/preview-renderer-baseline.sh build.noindex/task396-baseline-extended-sample --suite extended`
  - page-1 batch에서 readiness failure가 섞여 exit 1이었고, 실패 phase를 summary에 보존했다.
- `./scripts/preview-visual-diff-harness.sh build.noindex/task396-baseline-extended-retry/coreGraphicsOnly --page 1 --policy coreGraphicsOnly samples/hwpx/form-002.hwpx samples/table-complex.hwp`
- `./scripts/preview-visual-diff-harness.sh build.noindex/task396-baseline-extended-retry/skiaOptIn --page 1 --policy skiaOptIn samples/pic-crop-01.hwp samples/hwpx/form-002.hwpx`
- `rg -n "#396|#387|#389|#392|#393|#394|Skia|CoreGraphics|Quick Look|Thumbnail|baseline|manifest|quick|extended" mydocs/report/task_m020_396_report.md mydocs/orders/20260630.md mydocs/tech/skia_preview_renderer_baseline.md mydocs/working/task_m020_396_stage5.md`
- `git diff --check`
- `git log --oneline devel..local/task396`

## 관련 이슈

- #387: Preview/Thumbnail Skia readiness 후속 개선 추적
- #390: `rhwp v0.7.17` 기준 Skia readiness gate 재측정
- #398: `복학원서.hwp` capture contamination sentinel 정리
- #389: Thumbnail Skia opt-in diagnostic path와 cache logging 후속
- #392: Thumbnail Skia maxDimension mapping 후속
- #393: Quick Look direct PNG fast path 후속
- #394: `--verify-lock strict` 실패 UX 개선 / portable verify 분리 후속

## 후속 이슈 제안

- 없음. 필요한 후속은 #389, #392, #393, #394 로 이미 분리되어 있다.

## 남은 리스크

- `form-002.hwpx`는 CoreGraphics/Skia 양쪽에서 persistent readiness timeout이므로 renderer 품질 실패로 세지 않았다.
- extended suite는 긴 batch에서 transient readiness timeout이 발생할 수 있어 CI hard gate 전 retry/flake 정책이 필요하다.
- 이 PR은 Skia default 전환이 아니라 default 전환 판단 기준과 측정 구조를 추가한다.
