### PR TITLE
Task #389: Thumbnail Skia opt-in diagnostic path와 cache logging 추가

### DIFF
--- a/Alhangeul.xcodeproj/project.pbxproj
+++ b/Alhangeul.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		37B400334D28A4A06AC40307 /* CoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E4457E7F57DA695C2D4A7757 /* CoreServices.framework */; };
 		39EB4CA94F5944239BDB869F /* FontResourceRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2D57719DF9672E7C311D7 /* FontResourceRegistry.swift */; };
 		3BA210E4DB4D1BF2C8E03893 /* HwpNativePageCompositor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541160BFAFD7D51040244110 /* HwpNativePageCompositor.swift */; };
+		3BAE06A9A748D31D69C23101 /* HwpThumbnailPolicyResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7117AC630958C9A5DAE6545 /* HwpThumbnailPolicyResolver.swift */; };
 		41C5D25E1060BEF211833C8A /* HwpPreviewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F373DBDDC753FC79292E2D /* HwpPreviewProvider.swift */; };
 		44CDAB1946DFA27A7CADCF6D /* RecentDocumentThumbnailRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4915E7318DD22D9A61F584 /* RecentDocumentThumbnailRefresher.swift */; };
 		4603821692664AB0F6480AD4 /* FontFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF11065A3E3439B4C5B8DD7 /* FontFallback.swift */; };
@@ -223,6 +224,7 @@
 		A5315FE25D0AB65823C1D91A /* libz.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		A8E9CC5E34BCCA387A0B385E /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		B49CA0DEC91C628C9B92B7A1 /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
+		B7117AC630958C9A5DAE6545 /* HwpThumbnailPolicyResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HwpThumbnailPolicyResolver.swift; sourceTree = "<group>"; };
 		B74C6D69DBD1D9B163C9A247 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		B85C87F3CD3C8EFD709842FF /* ApplicationServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ApplicationServices.framework; path = System/Library/Frameworks/ApplicationServices.framework; sourceTree = SDKROOT; };
 		BED96A22509C493BF3039CEC /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
@@ -400,6 +402,7 @@
 			isa = PBXGroup;
 			children = (
 				7B8D5D5DECBC9E6071002C34 /* .gitkeep */,
+				B7117AC630958C9A5DAE6545 /* HwpThumbnailPolicyResolver.swift */,
 				8BDDD5E15FCF571ED9D88598 /* HwpThumbnailProvider.swift */,
 				895C9E62B889A9E90C3FF8C6 /* HwpThumbnailRenderCache.swift */,
 				9EE454540A36086BCFD273BC /* Info.plist */,
@@ -724,6 +727,7 @@
 				A9D512641E80997A3D087945 /* HwpNativePageCompositor.swift in Sources */,
 				C898F0CA6BE3F209145CAC28 /* HwpPageImageRenderer.swift in Sources */,
 				D6ECD4A743DEDC3A090EEEF4 /* HwpPreviewPDFRenderer.swift in Sources */,
+				3BAE06A9A748D31D69C23101 /* HwpThumbnailPolicyResolver.swift in Sources */,
 				8348EA8DD0B313DC71B3E9C7 /* HwpThumbnailProvider.swift in Sources */,
 				539DFB38A0293062B5A01ED9 /* HwpThumbnailRenderCache.swift in Sources */,
 				7561FA65463CDF9CC5BED398 /* PageOverlayImages.swift in Sources */,

--- a/Sources/Shared/HwpPageImageRenderer.swift
+++ b/Sources/Shared/HwpPageImageRenderer.swift
@@ -14,6 +14,15 @@ enum HwpPageRenderBackend {
 enum HwpPageRenderPolicy {
     case coreGraphicsOnly
     case skiaOptIn
+
+    var identifier: String {
+        switch self {
+        case .coreGraphicsOnly:
+            return "coreGraphicsOnly"
+        case .skiaOptIn:
+            return "skiaOptIn"
+        }
+    }
 }
 
 enum HwpPageRenderFallbackReason {

--- a/Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift
+++ b/Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift
@@ -4,9 +4,10 @@ enum HwpThumbnailPolicyResolver {
     static let environmentKey = "ALHANGEUL_THUMBNAIL_RENDER_POLICY"
 
     static func resolve(
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String]? = nil
     ) -> HwpPageRenderPolicy {
 #if DEBUG
+        let environment = environment ?? ProcessInfo.processInfo.environment
         guard let rawValue = environment[environmentKey] else {
             return .coreGraphicsOnly
         }
@@ -20,7 +21,6 @@ enum HwpThumbnailPolicyResolver {
             return .coreGraphicsOnly
         }
 #else
-        _ = environment
         return .coreGraphicsOnly
 #endif
     }

--- a/Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift
+++ b/Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+enum HwpThumbnailPolicyResolver {
+    static let environmentKey = "ALHANGEUL_THUMBNAIL_RENDER_POLICY"
+
+    static func resolve(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> HwpPageRenderPolicy {
+#if DEBUG
+        guard let rawValue = environment[environmentKey] else {
+            return .coreGraphicsOnly
+        }
+
+        switch normalizedValue(rawValue) {
+        case "skia", "skiaoptin":
+            return .skiaOptIn
+        case "coregraphics", "coregraphicsonly":
+            return .coreGraphicsOnly
+        default:
+            return .coreGraphicsOnly
+        }
+#else
+        _ = environment
+        return .coreGraphicsOnly
+#endif
+    }
+
+    static func identifier(for policy: HwpPageRenderPolicy) -> String {
+        switch policy {
+        case .coreGraphicsOnly:
+            return "coreGraphicsOnly"
+        case .skiaOptIn:
+            return "skiaOptIn"
+        }
+    }
+
+    private static func normalizedValue(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "_", with: "")
+    }
+}

--- a/Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift
+++ b/Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift
@@ -26,12 +26,7 @@ enum HwpThumbnailPolicyResolver {
     }
 
     static func identifier(for policy: HwpPageRenderPolicy) -> String {
-        switch policy {
-        case .coreGraphicsOnly:
-            return "coreGraphicsOnly"
-        case .skiaOptIn:
-            return "skiaOptIn"
-        }
+        policy.identifier
     }
 
     private static func normalizedValue(_ value: String) -> String {

--- a/Sources/ThumbnailExtension/HwpThumbnailProvider.swift
+++ b/Sources/ThumbnailExtension/HwpThumbnailProvider.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import Foundation
 import OSLog
 import QuickLookThumbnailing
 
@@ -12,20 +13,25 @@ final class HwpThumbnailProvider: QLThumbnailProvider {
         for request: QLFileThumbnailRequest,
         _ handler: @escaping (QLThumbnailReply?, Error?) -> Void
     ) {
-        Self.logger.debug("Thumbnail requested file=\(request.fileURL.lastPathComponent, privacy: .public) max=\(Int(request.maximumSize.width), privacy: .public)x\(Int(request.maximumSize.height), privacy: .public) scale=\(request.scale, privacy: .public)")
+        let policy = HwpThumbnailPolicyResolver.resolve()
+        let policyID = HwpThumbnailPolicyResolver.identifier(for: policy)
+        Self.logger.debug("Thumbnail requested file=\(request.fileURL.lastPathComponent, privacy: .public) policy=\(policyID, privacy: .public) max=\(Int(request.maximumSize.width), privacy: .public)x\(Int(request.maximumSize.height), privacy: .public) scale=\(request.scale, privacy: .public)")
         do {
             let renderRequest = try HwpThumbnailRenderRequest(
                 fileURL: request.fileURL,
                 maximumSize: request.maximumSize,
-                scale: request.scale
+                scale: request.scale,
+                policy: policy
             )
-            Self.logger.debug("Thumbnail render enqueued file=\(request.fileURL.lastPathComponent, privacy: .public) pixels=\(Int(renderRequest.maximumPixelSize.width), privacy: .public)x\(Int(renderRequest.maximumPixelSize.height), privacy: .public)")
-            HwpThumbnailRenderCache.shared.renderedPage(for: renderRequest) { result in
+            Self.logger.debug("Thumbnail render enqueued file=\(request.fileURL.lastPathComponent, privacy: .public) policy=\(policyID, privacy: .public) pixels=\(Int(renderRequest.maximumPixelSize.width), privacy: .public)x\(Int(renderRequest.maximumPixelSize.height), privacy: .public)")
+            HwpThumbnailRenderCache.shared.renderedPageResult(for: renderRequest) { result in
                 switch result {
-                case .success(let renderedPage):
+                case .success(let renderResult):
+                    let renderedPage = renderResult.page
+                    let diagnostics = renderedPage.diagnostics
                     let contextSize = Self.aspectFit(renderedPage.size, within: request.maximumSize)
                     let image = renderedPage.image
-                    Self.logger.debug("Thumbnail ready file=\(request.fileURL.lastPathComponent, privacy: .public) context=\(Int(contextSize.width), privacy: .public)x\(Int(contextSize.height), privacy: .public) page=\(Int(renderedPage.size.width), privacy: .public)x\(Int(renderedPage.size.height), privacy: .public)")
+                    Self.logger.debug("Thumbnail ready file=\(request.fileURL.lastPathComponent, privacy: .public) policy=\(policyID, privacy: .public) cache=\(renderResult.cacheEvent.description, privacy: .public) requestedBucket=\(Self.bucketDescription(renderResult.requestedKey), privacy: .public) matchedBucket=\(Self.bucketDescription(renderResult.matchedKey), privacy: .public) backend=\(Self.backendDescription(diagnostics.backendUsed), privacy: .public) fallback=\(Self.fallbackDescription(diagnostics.fallbackReason), privacy: .public) renderMs=\(Self.durationDescription(diagnostics.durationMs.totalMs), privacy: .public) pixels=\(Self.sizeDescription(diagnostics.pixelSize), privacy: .public) context=\(Self.sizeDescription(contextSize), privacy: .public) page=\(Self.sizeDescription(renderedPage.size), privacy: .public)")
                     let reply = QLThumbnailReply(contextSize: contextSize) { context in
                         Self.drawPageImage(image, in: context, size: contextSize)
                         return true
@@ -34,20 +40,20 @@ final class HwpThumbnailProvider: QLThumbnailProvider {
                     handler(reply, nil)
 
                 case .failure(let error) where HwpDocumentFallbackClassifier.shouldUseThumbnailFallback(for: error):
-                    Self.logger.warning("Thumbnail fallback file=\(request.fileURL.lastPathComponent, privacy: .public) error=\(Self.errorDescription(error), privacy: .public)")
+                    Self.logger.warning("Thumbnail fallback file=\(request.fileURL.lastPathComponent, privacy: .public) policy=\(policyID, privacy: .public) error=\(Self.errorDescription(error), privacy: .public)")
                     handler(Self.fallbackReply(for: request), nil)
 
                 case .failure(let error):
-                    Self.logger.error("Thumbnail failed file=\(request.fileURL.lastPathComponent, privacy: .public) error=\(Self.errorDescription(error), privacy: .public)")
+                    Self.logger.error("Thumbnail failed file=\(request.fileURL.lastPathComponent, privacy: .public) policy=\(policyID, privacy: .public) error=\(Self.errorDescription(error), privacy: .public)")
                     handler(nil, error)
                 }
             }
         } catch {
             if HwpDocumentFallbackClassifier.shouldUseThumbnailFallback(for: error) {
-                Self.logger.warning("Thumbnail fallback before render file=\(request.fileURL.lastPathComponent, privacy: .public) error=\(Self.errorDescription(error), privacy: .public)")
+                Self.logger.warning("Thumbnail fallback before render file=\(request.fileURL.lastPathComponent, privacy: .public) policy=\(policyID, privacy: .public) error=\(Self.errorDescription(error), privacy: .public)")
                 handler(Self.fallbackReply(for: request), nil)
             } else {
-                Self.logger.error("Thumbnail failed before render file=\(request.fileURL.lastPathComponent, privacy: .public) error=\(Self.errorDescription(error), privacy: .public)")
+                Self.logger.error("Thumbnail failed before render file=\(request.fileURL.lastPathComponent, privacy: .public) policy=\(policyID, privacy: .public) error=\(Self.errorDescription(error), privacy: .public)")
                 handler(nil, error)
             }
         }
@@ -103,6 +109,54 @@ final class HwpThumbnailProvider: QLThumbnailProvider {
             return CGRect(origin: .zero, size: fallbackSize)
         }
         return clipBounds
+    }
+
+    private static func bucketDescription(_ key: HwpThumbnailCacheKey) -> String {
+        "\(key.pixelWidth)x\(key.pixelHeight)"
+    }
+
+    private static func backendDescription(_ backend: HwpPageRenderBackend) -> String {
+        switch backend {
+        case .coreGraphics:
+            return "coreGraphics"
+        case .skia:
+            return "skia"
+        case .embeddedThumbnail:
+            return "embeddedThumbnail"
+        }
+    }
+
+    private static func fallbackDescription(_ reason: HwpPageRenderFallbackReason?) -> String {
+        guard let reason else {
+            return "-"
+        }
+
+        switch reason {
+        case .ffiUnavailable:
+            return "ffiUnavailable"
+        case .invalidDocumentHandle:
+            return "invalidDocumentHandle"
+        case .invalidPageIndex:
+            return "invalidPageIndex"
+        case .invalidRenderOptions:
+            return "invalidRenderOptions"
+        case .invalidPageSize:
+            return "invalidPageSize"
+        case .skiaRenderFailure:
+            return "skiaRenderFailure"
+        case .pngDecodeFailure:
+            return "pngDecodeFailure"
+        case .memoryTimeoutFallback:
+            return "memoryTimeoutFallback"
+        }
+    }
+
+    private static func durationDescription(_ milliseconds: Double) -> String {
+        String(format: "%.2f", milliseconds)
+    }
+
+    private static func sizeDescription(_ size: CGSize) -> String {
+        "\(Int(size.width))x\(Int(size.height))"
     }
 
     private static func errorDescription(_ error: Error) -> String {

--- a/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift
+++ b/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift
@@ -68,7 +68,7 @@ struct HwpThumbnailRenderSignature: Hashable {
         coreEnabledFeatures: String = Self.coreEnabledFeatures,
         maxDimensionPolicyVersion: String = Self.maxDimensionPolicyVersion
     ) {
-        self.backendPolicy = Self.policyIdentifier(policy)
+        self.backendPolicy = policy.identifier
         self.rendererOptionVersion = rendererOptionVersion
         self.coreReleaseTag = coreReleaseTag
         self.coreCommit = coreCommit
@@ -85,15 +85,6 @@ struct HwpThumbnailRenderSignature: Hashable {
             coreEnabledFeatures,
             maxDimensionPolicyVersion
         ].joined(separator: "|")
-    }
-
-    private static func policyIdentifier(_ policy: HwpPageRenderPolicy) -> String {
-        switch policy {
-        case .coreGraphicsOnly:
-            return "coreGraphicsOnly"
-        case .skiaOptIn:
-            return "skiaOptIn"
-        }
     }
 }
 

--- a/mydocs/orders/20260630.md
+++ b/mydocs/orders/20260630.md
@@ -5,3 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #396 | 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식 | 완료 | 완료: 15:16, PR 게시 진행 |
+| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260701.md
+++ b/mydocs/orders/20260701.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 진행중 | Stage 2 완료보고서 승인 대기 |
+| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 진행중 | Stage 3 완료보고서 승인 대기 |

--- a/mydocs/orders/20260701.md
+++ b/mydocs/orders/20260701.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 진행중 | Stage 1 완료보고서 승인 대기 |
+| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 진행중 | Stage 2 완료보고서 승인 대기 |

--- a/mydocs/orders/20260701.md
+++ b/mydocs/orders/20260701.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 7월 1일
+
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 진행중 | 구현계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260701.md
+++ b/mydocs/orders/20260701.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 진행중 | 구현계획서 작성 후 승인 대기 |
+| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 진행중 | Stage 1 완료보고서 승인 대기 |

--- a/mydocs/orders/20260701.md
+++ b/mydocs/orders/20260701.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 진행중 | Stage 3 완료보고서 승인 대기 |
+| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 진행중 | Stage 4 완료보고서 승인 대기 |

--- a/mydocs/orders/20260701.md
+++ b/mydocs/orders/20260701.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 진행중 | Stage 4 완료보고서 승인 대기 |
+| #389 | Thumbnail Skia opt-in diagnostic path와 cache logging 추가 | 완료 | 최종 보고서 작성 완료, 완료: 14:04 |

--- a/mydocs/plans/task_m020_389.md
+++ b/mydocs/plans/task_m020_389.md
@@ -1,0 +1,128 @@
+# Task M020 #389 수행계획서
+
+## 목적
+
+Finder Thumbnail production 기본 renderer는 CoreGraphics로 유지하면서, DEBUG/internal 경로에서 Skia opt-in thumbnail render를 실제 provider 진입점으로 쉽게 측정하고 cache event, backend used, fallback reason을 로그나 smoke output으로 확인할 수 있게 한다.
+
+#396에서 Quick Look/Thumbnail Skia visual baseline은 정리했지만, Finder Thumbnail 실제 경로의 cache hit/miss, backend 선택, fallback reason은 visual suite만으로 판단할 수 없다. #389는 #392 maxDimension 실험 전에 Thumbnail surface 관측성을 보강하는 기반 작업이다.
+
+## 배경
+
+#258에서 `HwpThumbnailRenderCache`는 render signature, signature-aware cache key, `renderedPageResult(for:)`, cache event diagnostics를 갖추었다. 또한 `scripts/smoke-thumbnail-skia-policy.sh`는 `.coreGraphicsOnly`와 `.skiaOptIn`을 명시해 cache event와 backend/fallback을 측정할 수 있다.
+
+하지만 production `HwpThumbnailProvider`는 여전히 별도 policy를 넘기지 않고 `HwpThumbnailRenderRequest` 기본값인 `.coreGraphicsOnly`를 사용한다. 이 기본값은 유지해야 한다. 동시에 내부 smoke나 DEBUG 진단에서는 Finder Thumbnail provider 경로에서도 Skia opt-in을 선택하고, 선택된 policy와 cache 결과를 로그로 확인할 수 있어야 한다.
+
+## 범위
+
+포함:
+
+- `HwpThumbnailProvider`의 render request 생성 지점에 internal/debug policy resolver 추가
+- 기본 provider 경로가 `.coreGraphicsOnly`임을 코드와 검증에서 보존
+- DEBUG 또는 내부 환경변수 기반 `.skiaOptIn` opt-in 경로 설계
+- `renderedPageResult(for:)`를 사용해 provider 로그에 cache event, requested/matched bucket, backend used, fallback reason, render timing을 남기는 경로 추가
+- Skia 실패 시 기존 CoreGraphics fallback 또는 fallback tile 동작을 유지하는지 확인
+- 기존 `scripts/smoke-thumbnail-skia-policy.sh`를 기준으로 diagnostic output과 provider logging 정책을 연결
+
+제외:
+
+- Skia default 전환
+- #392 `maxDimension` mapping 정책 변경
+- Quick Look direct PNG fast path
+- Finder/Quick Look release package 등록 smoke 확장
+- upstream `rhwp` 수정
+- cache eviction 정책 변경
+
+## 설계 방향
+
+`HwpThumbnailProvider`에는 작은 resolver를 둔다. resolver는 production default에서 `.coreGraphicsOnly`를 반환하고, DEBUG/internal opt-in 조건에서만 `.skiaOptIn`을 반환한다. opt-in 조건은 사용자-facing preference가 아니라 smoke/diagnostic 용도다.
+
+provider는 기존 `renderedPage(for:)` 대신 `renderedPageResult(for:)`를 사용해 성공 시 다음 값을 로그로 남긴다.
+
+| 항목 | 목적 |
+|------|------|
+| resolved policy | provider가 CoreGraphics default를 유지하는지 확인 |
+| cache event | miss/exactHit/largerBucketHit 관측 |
+| requested/matched bucket | cache reuse와 request size 연결 |
+| backend used | Skia opt-in에서 실제 Skia 사용 여부 확인 |
+| fallback reason | Skia 실패 후 CoreGraphics fallback 또는 fallback tile 여부 확인 |
+| render timing/pixel size | #392 maxDimension 실험 전 baseline 입력 |
+
+환경변수 이름과 build 조건은 Stage 1 inventory에서 확정한다. 후보는 `ALHANGEUL_THUMBNAIL_RENDER_POLICY=skiaOptIn` 같은 명시적 값이며, default가 비어 있거나 알 수 없는 값이면 CoreGraphics로 수렴한다.
+
+## 예상 변경 파일
+
+- `mydocs/plans/task_m020_389.md`
+- `mydocs/plans/task_m020_389_impl.md`
+- `mydocs/working/task_m020_389_stage*.md`
+- `mydocs/report/task_m020_389_report.md`
+- `mydocs/orders/20260630.md`
+- `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+- 필요 시 `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- 필요 시 `scripts/smoke-thumbnail-skia-policy.sh`
+- 필요 시 `scripts/thumbnail_skia_policy_smoke.swift`
+- 필요 시 `mydocs/tech/skia_quicklook_thumbnail_backend.md` 또는 `mydocs/tech/skia_preview_renderer_baseline.md`
+
+## 잠정 단계
+
+1. Stage 1: provider/cache/smoke 진단 경로 inventory
+   - `HwpThumbnailProvider`, `HwpThumbnailRenderCache`, `scripts/smoke-thumbnail-skia-policy.sh`, #258/#396 보고서를 읽고 현재 관측 가능한 값과 빈칸을 정리한다.
+   - DEBUG/internal opt-in 입력 방식 후보와 production default 보존 조건을 확정한다.
+2. Stage 2: provider policy resolver와 logging 구현
+   - provider에서 resolved policy를 `HwpThumbnailRenderRequest`에 전달한다.
+   - 성공 결과는 `renderedPageResult(for:)`로 받아 cache event/backend/fallback/timing을 로그에 남긴다.
+   - 실패/fallback tile 동작은 기존 형태를 유지한다.
+3. Stage 3: smoke/helper와 검증 보강
+   - 필요한 경우 smoke helper가 provider resolver와 같은 policy identifier를 사용하도록 보강한다.
+   - CoreGraphics default와 Skia opt-in에서 cache key가 분리되고 backend/fallback이 기록되는지 검증한다.
+4. Stage 4: 대표 샘플 smoke와 후속 handoff
+   - `request.hwp`, `KTX.hwp`, `복학원서.hwp`, `hwpx-01.hwpx` 등 대표 샘플로 smoke를 실행한다.
+   - #392 maxDimension mapping 실험에 넘길 baseline bucket/latency/cache 결과를 정리한다.
+5. Stage 5: 최종 보고와 PR 준비
+   - 최종 보고서, 오늘할일 완료 처리, PR 본문용 요약을 정리한다.
+
+## 검증 계획
+
+기본 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+git diff --check
+```
+
+Thumbnail source/build 검증 후보:
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask389 CODE_SIGNING_ALLOWED=NO build
+```
+
+Smoke 검증 후보:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+rg -n "coreGraphicsOnly|skiaOptIn|Cache|Backend|Fallback|miss|exactHit|largerBucketHit" \
+  build.noindex/task389-thumbnail-policy* mydocs/working/task_m020_389_stage*.md
+```
+
+`xcodebuild`와 Thumbnail smoke는 sandbox 내부에서 module cache 또는 system integration 제약을 받을 수 있다. 실패 시 failure phase를 기록하고, 필요한 경우 승인된 환경에서 재실행해 source regression과 sandbox 환경 실패를 분리한다.
+
+## 리스크
+
+- provider 환경변수 opt-in이 production 사용자 환경에 노출되면 default 유지 원칙이 흐려질 수 있다. opt-in은 DEBUG/internal diagnostic 경로로 제한한다.
+- OSLog는 테스트 output처럼 쉽게 수집되지 않을 수 있다. smoke output과 provider log의 역할을 구분한다.
+- `renderedPageResult(for:)`로 provider를 바꾸더라도 public reply 동작은 기존과 같아야 한다.
+- Skia fallback을 강제로 만들 fixture가 없으면 fallback reason은 정상 smoke에서 `-`로만 남을 수 있다.
+- #392 maxDimension 정책을 섞으면 이번 작업의 관측성 목표가 흐려진다. size 정책 변경은 후속으로 남긴다.
+
+## 승인 요청 사항
+
+- 기준 브랜치는 `devel`, 작업 브랜치는 `local/task389`로 진행한다.
+- 이 작업은 #387 추적 이슈의 Thumbnail 관측성 후속 #389로 진행한다.
+- 수행계획서 승인 후 구현계획서를 작성하고 Stage 1 inventory부터 시작한다.
+- production default는 CoreGraphics 유지, Skia는 DEBUG/internal opt-in diagnostic에 한정한다.

--- a/mydocs/plans/task_m020_389_impl.md
+++ b/mydocs/plans/task_m020_389_impl.md
@@ -1,0 +1,271 @@
+# Task M020 #389 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_389.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #389 `Thumbnail Skia opt-in diagnostic path와 cache logging 추가`
+- 추적 이슈: #387 Preview/Thumbnail Skia readiness 후속 개선 추적
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task389`
+- 목표: Finder Thumbnail production default는 CoreGraphics로 유지하면서 DEBUG/internal 진단 경로에서 Skia opt-in provider path와 cache/backend/fallback 로그를 관측할 수 있게 한다.
+
+## 구현 원칙
+
+- Skia default 전환은 하지 않는다.
+- Release/production provider 기본값은 `.coreGraphicsOnly`로 유지한다.
+- opt-in은 DEBUG 또는 명시 internal diagnostic 입력에서만 허용한다.
+- #392의 `maxDimension` mapping 정책 변경은 이 작업에 섞지 않는다.
+- provider의 public reply shape, fallback tile, extension badge 동작은 유지한다.
+- `project.yml`이 Xcode project 원본이다. 새 Swift 파일이 필요하면 source folder 자동 포함 여부를 확인하고, 직접 `Alhangeul.xcodeproj`를 수정하지 않는다.
+- `Sources/RhwpCoreBridge`에는 AppKit/UIKit를 추가하지 않는다.
+
+## Stage 1. provider/cache/smoke 진단 경로 inventory
+
+### 목표
+
+현재 Thumbnail provider, cache result, smoke helper가 관측할 수 있는 값과 부족한 값을 정리하고, DEBUG/internal opt-in resolver contract를 확정한다.
+
+### 대상
+
+- `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- `scripts/smoke-thumbnail-skia-policy.sh`
+- `scripts/thumbnail_skia_policy_smoke.swift`
+- `mydocs/report/task_m020_258_report.md`
+- `mydocs/report/task_m020_396_report.md`
+- `mydocs/working/task_m020_389_stage1.md`
+
+### 작업
+
+1. provider가 현재 `HwpThumbnailRenderRequest`를 만드는 위치와 기본 policy 흐름을 확인한다.
+2. `HwpThumbnailRenderCache.renderedPageResult(for:)`가 제공하는 cache event, requested/matched key, diagnostics 항목을 정리한다.
+3. smoke helper가 이미 남기는 summary/detail column을 provider logging 요구사항과 비교한다.
+4. opt-in resolver 입력을 확정한다.
+   - 후보: `ALHANGEUL_THUMBNAIL_RENDER_POLICY=skiaOptIn`
+   - 허용 alias 후보: `skia`, `skiaOptIn`, `coreGraphics`, `coreGraphicsOnly`
+   - invalid/empty value는 `.coreGraphicsOnly`
+   - Release build에서는 환경변수 값과 무관하게 `.coreGraphicsOnly`
+5. Stage 2 source 변경 범위와 Stage 3 smoke 보강 범위를 확정한다.
+
+### 검증
+
+```bash
+rg -n "HwpThumbnailProvider|HwpThumbnailRenderRequest|renderedPageResult|HwpThumbnailCacheEvent|backendUsed|fallbackReason|smoke-thumbnail-skia-policy" \
+  Sources/ThumbnailExtension scripts mydocs/report/task_m020_258_report.md \
+  mydocs/report/task_m020_396_report.md mydocs/working/task_m020_389_stage1.md
+git diff --check
+```
+
+### 완료 조건
+
+- provider default가 `.coreGraphicsOnly`인 현재 흐름이 문서화되어 있다.
+- cache/backend/fallback 중 현재 provider log에 없는 항목이 구분되어 있다.
+- DEBUG/internal resolver contract가 Stage 2 구현 입력으로 확정되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #389 Stage 1: Thumbnail provider 진단 경로 inventory
+```
+
+## Stage 2. provider policy resolver와 cache logging 구현
+
+### 목표
+
+Thumbnail provider에 DEBUG/internal opt-in policy resolver를 추가하고, provider 성공 로그가 cache/backend/fallback 정보를 포함하게 한다.
+
+### 대상
+
+- `Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift` 신규 후보
+- `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+- 필요 시 `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- `mydocs/working/task_m020_389_stage2.md`
+
+### 작업
+
+1. `HwpThumbnailPolicyResolver`를 추가한다.
+   - `ProcessInfo.processInfo.environment`를 입력으로 받는 resolver
+   - Release build 기본값 `.coreGraphicsOnly`
+   - DEBUG build에서만 명시 env opt-in 허용
+   - policy display identifier helper 제공
+2. `HwpThumbnailProvider`가 resolver 결과를 `HwpThumbnailRenderRequest(policy:)`에 전달하게 한다.
+3. provider가 `renderedPageResult(for:)`를 사용해 성공 result를 받게 한다.
+4. 성공 로그에 다음 항목을 추가한다.
+   - resolved policy
+   - cache event
+   - requested bucket / matched bucket
+   - backend used
+   - fallback reason
+   - render duration / pixel size
+5. 실패와 fallback tile 처리 경로는 기존 public behavior를 유지한다.
+6. 새 source가 Xcode target과 smoke compile list에 들어가야 하는지 확인한다.
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+rg -n "HwpThumbnailPolicyResolver|ALHANGEUL_THUMBNAIL_RENDER_POLICY|renderedPageResult|cache|backend|fallback|coreGraphicsOnly|skiaOptIn" \
+  Sources/ThumbnailExtension mydocs/working/task_m020_389_stage2.md
+git diff --check
+```
+
+가능하면 build 검증:
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask389Stage2 CODE_SIGNING_ALLOWED=NO build
+```
+
+### 완료 조건
+
+- provider 기본 policy가 CoreGraphics로 유지된다.
+- DEBUG/internal env opt-in path가 source상 명확하다.
+- provider success log에 cache/backend/fallback 진단 값이 들어간다.
+- public reply/fallback 동작 변경이 없다.
+
+### 커밋 메시지
+
+```text
+Task #389 Stage 2: Thumbnail provider Skia opt-in 진단 추가
+```
+
+## Stage 3. smoke/helper와 resolver 검증 보강
+
+### 목표
+
+smoke helper가 provider resolver contract와 diagnostic output을 검증할 수 있게 보강한다.
+
+### 대상
+
+- `scripts/smoke-thumbnail-skia-policy.sh`
+- `scripts/thumbnail_skia_policy_smoke.swift`
+- 필요 시 `Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift`
+- `mydocs/working/task_m020_389_stage3.md`
+
+### 작업
+
+1. smoke helper compile list에 새 resolver source가 필요하면 추가한다.
+2. runner가 resolver default와 env opt-in 결과를 확인할 수 있는 진단 값을 summary/detail에 남긴다.
+3. 기존 CoreGraphics/Skia policy pair 측정은 유지한다.
+4. cache key가 policy/render signature별로 분리되는지 대표 request sequence로 확인한다.
+5. fallback reason이 정상 smoke에서는 `-`로 남더라도 column이 유지되는지 확인한다.
+
+### 검증
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-stage3-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+rg -n "coreGraphicsOnly|skiaOptIn|Cache|Backend|Fallback|miss|exactHit|largerBucketHit|ALHANGEUL_THUMBNAIL_RENDER_POLICY" \
+  build.noindex/task389-stage3-thumbnail-policy scripts Sources/ThumbnailExtension \
+  mydocs/working/task_m020_389_stage3.md
+git diff --check
+```
+
+### 완료 조건
+
+- smoke helper가 새 resolver source와 함께 compile/run 된다.
+- CoreGraphics/Skia opt-in policy pair가 기존처럼 측정된다.
+- cache event/backend/fallback column이 후속 보고에 충분히 남는다.
+
+### 커밋 메시지
+
+```text
+Task #389 Stage 3: Thumbnail diagnostic smoke 보강
+```
+
+## Stage 4. 대표 샘플 smoke와 #392 handoff 정리
+
+### 목표
+
+대표 샘플로 Thumbnail diagnostic smoke를 실행하고, #392 maxDimension mapping 실험에 넘길 baseline 입력을 정리한다.
+
+### 대상
+
+- `build.noindex/task389-thumbnail-policy/`
+- `build.noindex/task389-thumbnail-policy-representative/`
+- `mydocs/working/task_m020_389_stage4.md`
+- 필요 시 `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+
+### 작업
+
+1. 기본 검증 command를 실행한다.
+2. 2개 샘플 quick smoke를 실행한다.
+3. 대표 샘플 smoke를 실행한다.
+4. cache event pattern, backend used, fallback reason, render timing, output bytes를 정리한다.
+5. provider default CoreGraphics 유지와 DEBUG/internal Skia opt-in 경로가 문서화되어 있는지 확인한다.
+6. #392에 넘길 maxDimension 관련 baseline을 분리한다.
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+rg -n "OK|FAIL|coreGraphicsOnly|skiaOptIn|Cache|Backend|Fallback|miss|exactHit|largerBucketHit|RenderMs|OutputBytes" \
+  build.noindex/task389-thumbnail-policy build.noindex/task389-thumbnail-policy-representative \
+  mydocs/working/task_m020_389_stage4.md
+git diff --check
+```
+
+### 완료 조건
+
+- 대표 샘플 smoke 결과가 존재한다.
+- default provider는 CoreGraphics 유지로 확인된다.
+- Skia opt-in diagnostic path가 backend/cache/fallback 정보를 남긴다.
+- #392 maxDimension 실험에 필요한 baseline 입력이 정리되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #389 Stage 4: Thumbnail diagnostic smoke 검증
+```
+
+## Stage 5. 최종 보고와 PR 준비
+
+### 목표
+
+#389 결과를 최종 보고서로 정리하고 PR 게시 준비를 완료한다.
+
+### 대상
+
+- `mydocs/report/task_m020_389_report.md`
+- `mydocs/orders/20260701.md`
+- 필요 시 `mydocs/working/task_m020_389_stage5.md`
+
+### 작업
+
+1. 최종 보고서에 provider resolver, cache logging, smoke 결과, 후속 관계를 정리한다.
+2. 오늘할일 #389 상태를 완료 처리한다.
+3. #387, #392, #393, #394와의 관계를 정리한다.
+4. PR body 초안을 준비할 수 있도록 stage별 요약과 검증 결과를 정리한다.
+
+### 검증
+
+```bash
+rg -n "#389|#387|#392|#393|#394|Thumbnail|Skia|CoreGraphics|cache|fallback|provider|smoke" \
+  mydocs/report/task_m020_389_report.md mydocs/orders/20260701.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task389
+```
+
+### 완료 조건
+
+- 최종 보고서가 존재하고 #389의 diagnostic path와 검증 결과를 설명한다.
+- 오늘할일 #389가 완료 상태다.
+- PR 게시 준비가 가능하다.
+
+### 커밋 메시지
+
+```text
+Task #389 Stage 5 + 최종 보고서: Thumbnail diagnostic path 정리
+```

--- a/mydocs/report/task_m020_389_report.md
+++ b/mydocs/report/task_m020_389_report.md
@@ -24,11 +24,12 @@ Finder Thumbnail production default는 CoreGraphics로 유지하면서, DEBUG/in
 
 | 파일 | 내용 |
 |------|------|
+| `Sources/Shared/HwpPageImageRenderer.swift` | `HwpPageRenderPolicy.identifier` 단일 source-of-truth 추가 |
 | `Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift` | DEBUG/internal thumbnail render policy resolver 추가 |
 | `Sources/ThumbnailExtension/HwpThumbnailProvider.swift` | resolver policy 전달, `renderedPageResult(for:)` 사용, cache/backend/fallback/timing 로그 추가 |
 | `Alhangeul.xcodeproj/project.pbxproj` | `xcodegen generate`로 신규 resolver source를 target에 반영 |
 | `scripts/smoke-thumbnail-skia-policy.sh` | resolver source compile list 추가, smoke binary `-DDEBUG` compile |
-| `scripts/thumbnail_skia_policy_smoke.swift` | resolver contract detail, cache signature separation summary/detail 추가 |
+| `scripts/thumbnail_skia_policy_smoke.swift` | resolver contract detail, Debug/Release 기대값, cache signature separation summary/detail 추가 |
 | `mydocs/tech/skia_quicklook_thumbnail_backend.md` | #389 기준 DEBUG opt-in provider diagnostic path와 대표 smoke 기준선 기록 |
 | `mydocs/tech/skia_preview_renderer_baseline.md` | #389 완료 후 Thumbnail/Finder cache 판단 상태와 #392 잔여 범위 갱신 |
 | `mydocs/plans/task_m020_389.md` | 수행계획서 |
@@ -112,6 +113,28 @@ Provider success log는 다음 진단 값을 포함한다.
 
 `복학원서.hwp` smoke 중 기존 `LAYOUT_OVERFLOW` warning 3줄이 stderr에 출력됐다. render status는 모두 `OK`였고 fallback은 발생하지 않았다.
 
+### PR review follow-up smoke
+
+Copilot review 반영 후 실행:
+
+```bash
+./scripts/check-no-appkit.sh
+git diff --check
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask389ReviewFix CODE_SIGNING_ALLOWED=NO build
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-review-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+Release 조건은 smoke runner를 `-DDEBUG` 없이 별도 컴파일해 `samples/basic/request.hwp`로 확인했다.
+
+결과:
+
+- `check-no-appkit.sh`, `git diff --check`: 성공.
+- `xcodebuild ... DerivedDataTask389ReviewFix ... build`: 성공. macOS build는 `BUILD SUCCEEDED`.
+- Debug smoke: resolver contract `OK`, 16 render rows 모두 `OK`.
+- Release smoke: `ResolverBuild: RELEASE`, `skia`/`skiaOptIn` env case가 모두 expected/resolved `coreGraphicsOnly`.
+
 ## #392 handoff
 
 #392 `Thumbnail Skia maxDimension mapping 실험`에는 다음 기준을 넘긴다.
@@ -143,7 +166,8 @@ Provider success log는 다음 진단 값을 포함한다.
 | Stage 2 | `e7a210f` | provider Skia opt-in resolver와 cache/backend/fallback logging 구현 |
 | Stage 3 | `49e9b25` | thumbnail diagnostic smoke resolver/cache separation 보강 |
 | Stage 4 | `183fcae` | 대표 샘플 smoke와 #392 handoff 정리 |
-| Stage 5 | 이번 커밋 | 최종 보고서와 기술 문서 기준선 정리 |
+| Stage 5 | `6047332` | 최종 보고서와 기술 문서 기준선 정리 |
+| PR review follow-up | 이번 커밋 | Copilot review 피드백 반영 |
 
 ## 검증 결과
 
@@ -160,6 +184,8 @@ xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuratio
 ./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy-representative \
   samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
   samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-review-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
 ```
 
 결과:
@@ -170,6 +196,8 @@ xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuratio
 - `xcodebuild ... ThumbnailExtension ... build`: 성공. macOS build는 `BUILD SUCCEEDED`. Xcode/CoreSimulator version warning은 출력됐지만 build 실패는 아니었다.
 - quick smoke: 성공. 16 rows 모두 `OK`.
 - representative smoke: 성공. 40 rows 모두 `OK`.
+- PR review follow-up Debug smoke: 성공. 16 rows 모두 `OK`.
+- PR review follow-up Release smoke: 성공. `skia`/`skiaOptIn` env case 모두 `coreGraphicsOnly`로 resolve.
 - `git diff --check`: 각 단계에서 성공.
 
 최종 보고서 검증:
@@ -186,13 +214,13 @@ git log --oneline devel..local/task389
 
 | 항목 | 상태 | 처리 |
 |------|------|------|
-| Release env opt-in 차단 | source `#if DEBUG`로 보장 | 별도 Release smoke는 이번 범위 밖 |
+| Release env opt-in 차단 | source `#if DEBUG`와 Release smoke로 확인 | 계속 유지 |
 | forced fallback reason fixture | 없음 | 정상 샘플에서는 fallback `-`; forced failure fixture는 필요 시 별도 작업 |
 | Finder/LaunchServices system cache | 범위 밖 | 이번 smoke는 extension 내부 render cache contract 검증 |
 | 1px pixel size drift | 관측됨 | #392 maxDimension mapping 실험으로 이관 |
 | Skia visual default 판단 | 범위 밖 | #396 visual suite, #392, #393 등 후속 입력과 함께 판단 |
 
-## PR 게시 준비 메모
+## PR 게시 메모
 
 권장 PR 제목:
 
@@ -208,6 +236,6 @@ Task #389: Thumbnail Skia opt-in diagnostic path와 cache logging 추가
 - smoke helper가 resolver contract와 policy별 cache signature separation을 과도한 product coupling 없이 검증하는지
 - #392로 넘긴 1px pixel size drift가 #389 범위에 섞이지 않았는지
 
-## 작업지시자 승인 요청
+## PR review follow-up
 
-Task #389의 구현, 대표 smoke, 최종 보고서, 기술 문서 갱신, 오늘할일 완료 처리를 마쳤다. PR 게시 단계 진입 여부를 승인해 달라.
+PR #401 Copilot review의 identifier 중복과 Release resolver 기대값 피드백은 본 follow-up 커밋에서 반영했다.

--- a/mydocs/report/task_m020_389_report.md
+++ b/mydocs/report/task_m020_389_report.md
@@ -1,0 +1,213 @@
+# Task #389 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | #389 `Thumbnail Skia opt-in diagnostic path와 cache logging 추가` |
+| 추적 이슈 | #387 `Preview/Thumbnail Skia readiness 후속 개선 추적` |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 작업 브랜치 | `local/task389` |
+| 단계 수 | 5 |
+
+Finder Thumbnail production default는 CoreGraphics로 유지하면서, DEBUG/internal 진단 경로에서 Skia opt-in provider path와 cache/backend/fallback 정보를 관측할 수 있게 했다.
+
+핵심 결과:
+
+- `HwpThumbnailPolicyResolver`를 추가해 `ALHANGEUL_THUMBNAIL_RENDER_POLICY`를 DEBUG/internal 진단 경로에서만 해석한다.
+- Release build와 env missing/empty/invalid 값은 모두 `coreGraphicsOnly`로 수렴한다.
+- `HwpThumbnailProvider`는 `renderedPageResult(for:)`를 사용해 cache event, requested/matched bucket, backend, fallback, render timing, pixel size를 success log에 남긴다.
+- `smoke-thumbnail-skia-policy.sh`는 resolver contract와 policy별 cache signature separation을 summary/detail 산출물에 기록한다.
+- 대표 5개 샘플 smoke에서 40 render rows 모두 `OK`, resolver contract `OK`, cache signature separation 5 rows 모두 `OK`였다.
+
+## 변경 파일과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift` | DEBUG/internal thumbnail render policy resolver 추가 |
+| `Sources/ThumbnailExtension/HwpThumbnailProvider.swift` | resolver policy 전달, `renderedPageResult(for:)` 사용, cache/backend/fallback/timing 로그 추가 |
+| `Alhangeul.xcodeproj/project.pbxproj` | `xcodegen generate`로 신규 resolver source를 target에 반영 |
+| `scripts/smoke-thumbnail-skia-policy.sh` | resolver source compile list 추가, smoke binary `-DDEBUG` compile |
+| `scripts/thumbnail_skia_policy_smoke.swift` | resolver contract detail, cache signature separation summary/detail 추가 |
+| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | #389 기준 DEBUG opt-in provider diagnostic path와 대표 smoke 기준선 기록 |
+| `mydocs/tech/skia_preview_renderer_baseline.md` | #389 완료 후 Thumbnail/Finder cache 판단 상태와 #392 잔여 범위 갱신 |
+| `mydocs/plans/task_m020_389.md` | 수행계획서 |
+| `mydocs/plans/task_m020_389_impl.md` | 단계별 구현계획서 |
+| `mydocs/working/task_m020_389_stage1.md` | provider/cache/smoke 진단 경로 inventory |
+| `mydocs/working/task_m020_389_stage2.md` | provider policy resolver와 cache logging 구현 보고 |
+| `mydocs/working/task_m020_389_stage3.md` | smoke/helper와 resolver 검증 보강 보고 |
+| `mydocs/working/task_m020_389_stage4.md` | 대표 샘플 smoke와 #392 handoff 보고 |
+| `mydocs/report/task_m020_389_report.md` | 최종 보고서 |
+| `mydocs/orders/20260701.md` | #389 완료 처리 |
+
+제품 사용자-facing 설정 UI, Release default, fallback tile shape, extension badge 동작은 변경하지 않았다. `Sources/RhwpCoreBridge`도 변경하지 않았다.
+
+## Resolver contract
+
+`HwpThumbnailPolicyResolver`의 기준:
+
+| 입력 | DEBUG 결과 | Release 결과 |
+|------|------------|--------------|
+| missing/empty/invalid | `.coreGraphicsOnly` | `.coreGraphicsOnly` |
+| `coreGraphics` | `.coreGraphicsOnly` | `.coreGraphicsOnly` |
+| `coreGraphicsOnly` | `.coreGraphicsOnly` | `.coreGraphicsOnly` |
+| `skia` | `.skiaOptIn` | `.coreGraphicsOnly` |
+| `skiaOptIn` | `.skiaOptIn` | `.coreGraphicsOnly` |
+
+값 비교는 trim, lowercase, `-`/`_` 제거 후 수행한다. display identifier는 `coreGraphicsOnly`, `skiaOptIn`이다.
+
+## Provider logging
+
+Provider success log는 다음 진단 값을 포함한다.
+
+| 필드 | 의미 |
+|------|------|
+| `policy` | provider가 결정한 render policy |
+| `cache` | `miss`, `exactHit`, `largerBucketHit(...)` |
+| `requestedBucket` | 요청 pixel bucket |
+| `matchedBucket` | 실제 cache hit/reuse bucket |
+| `backend` | `coreGraphics`, `skia`, `embeddedThumbnail` |
+| `fallback` | fallback reason. 없으면 `-` |
+| `renderMs` | renderer diagnostic total duration |
+| `pixels` | 실제 rendered pixel size |
+| `context` | Finder reply context size |
+| `page` | page size |
+
+오류와 fallback tile 경로에도 resolved `policy`를 남긴다. public reply/fallback behavior는 기존과 같다.
+
+## Smoke helper 결과
+
+### Stage 3 quick smoke
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-stage3-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+결과:
+
+- resolver contract: `OK`
+- render rows: 16개 모두 `OK`
+- cache signature separation: 2개 샘플 모두 `OK`
+- fallback: 모든 row `-`
+
+### Stage 4 representative smoke
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+```
+
+결과:
+
+| 항목 | 결과 |
+|------|------|
+| resolver contract | `OK` |
+| render rows | 40개 모두 `OK` |
+| cache pattern | 각 파일/정책 모두 `miss -> exactHit -> largerBucketHit -> largerBucketHit` |
+| cache signature separation | 5개 샘플 모두 `OK` |
+| backend | `coreGraphicsOnly`는 `coreGraphics`, `skiaOptIn`은 `skia` |
+| fallback | 모든 row `-` |
+
+`복학원서.hwp` smoke 중 기존 `LAYOUT_OVERFLOW` warning 3줄이 stderr에 출력됐다. render status는 모두 `OK`였고 fallback은 발생하지 않았다.
+
+## #392 handoff
+
+#392 `Thumbnail Skia maxDimension mapping 실험`에는 다음 기준을 넘긴다.
+
+1. 모든 대표 샘플에서 `1024x1024` bucket cache는 policy별로 정상 분리된다.
+2. 같은 bucket에서 Skia pixel size가 CoreGraphics보다 긴 축 기준 1px 큰 패턴이 반복된다.
+   - portrait 계열: `725x1024` vs `725x1025`
+   - `request.hwp`: `732x1024` vs `732x1025`
+   - landscape 계열 `KTX.hwp`: `1024x725` vs `1025x725`
+3. fallback은 발생하지 않았으므로, 우선순위는 `maximumPixelSize -> Skia maxDimension/scale/rounding` mapping 확인이다.
+4. output bytes와 PNGBytes는 policy별로 차이가 크지만 #389에서는 품질/성능 판정이 아니라 진단 baseline으로만 남긴다.
+
+## 후속 이슈 관계
+
+| 이슈 | 관계 |
+|------|------|
+| #387 | #389는 Preview/Thumbnail Skia readiness 추적의 Thumbnail 관측성 보강 작업이다 |
+| #392 | #389가 cache/backend/fallback 관측성을 확보했고, 1px size drift/maxDimension mapping은 #392에서 실험한다 |
+| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험이다. #389의 Thumbnail provider/cache 진단과 별도 surface다 |
+| #394 | `build-rust-macos --verify-lock strict` UX/portable verify 운영성 작업이다. #389 smoke나 provider 변경과 직접 결합하지 않는다 |
+
+## 단계 요약
+
+| Stage | 커밋 | 요약 |
+|------|------|------|
+| 계획 | `77a7763` | 수행계획서 작성과 오늘할일 갱신 |
+| 구현계획 | `291eb75` | 단계별 구현계획서 작성 |
+| Stage 1 | `1f1eea6` | Thumbnail provider 진단 경로 inventory |
+| Stage 2 | `e7a210f` | provider Skia opt-in resolver와 cache/backend/fallback logging 구현 |
+| Stage 3 | `49e9b25` | thumbnail diagnostic smoke resolver/cache separation 보강 |
+| Stage 4 | `183fcae` | 대표 샘플 smoke와 #392 handoff 정리 |
+| Stage 5 | 이번 커밋 | 최종 보고서와 기술 문서 기준선 정리 |
+
+## 검증 결과
+
+실행한 주요 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask389Stage2 CODE_SIGNING_ALLOWED=NO build
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+```
+
+결과:
+
+- `check-no-appkit.sh`: 성공.
+- `verify-rhwp-core-build-info.sh`: 성공.
+- `verify-rhwp-studio-assets.sh`: 성공.
+- `xcodebuild ... ThumbnailExtension ... build`: 성공. macOS build는 `BUILD SUCCEEDED`. Xcode/CoreSimulator version warning은 출력됐지만 build 실패는 아니었다.
+- quick smoke: 성공. 16 rows 모두 `OK`.
+- representative smoke: 성공. 40 rows 모두 `OK`.
+- `git diff --check`: 각 단계에서 성공.
+
+최종 보고서 검증:
+
+```bash
+rg -n "#389|#387|#392|#393|#394|Thumbnail|Skia|CoreGraphics|cache|fallback|provider|smoke" \
+  mydocs/report/task_m020_389_report.md mydocs/orders/20260701.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task389
+```
+
+## 잔여 위험
+
+| 항목 | 상태 | 처리 |
+|------|------|------|
+| Release env opt-in 차단 | source `#if DEBUG`로 보장 | 별도 Release smoke는 이번 범위 밖 |
+| forced fallback reason fixture | 없음 | 정상 샘플에서는 fallback `-`; forced failure fixture는 필요 시 별도 작업 |
+| Finder/LaunchServices system cache | 범위 밖 | 이번 smoke는 extension 내부 render cache contract 검증 |
+| 1px pixel size drift | 관측됨 | #392 maxDimension mapping 실험으로 이관 |
+| Skia visual default 판단 | 범위 밖 | #396 visual suite, #392, #393 등 후속 입력과 함께 판단 |
+
+## PR 게시 준비 메모
+
+권장 PR 제목:
+
+```text
+Task #389: Thumbnail Skia opt-in diagnostic path와 cache logging 추가
+```
+
+권장 리뷰 포인트:
+
+- Release/production default가 계속 CoreGraphics인지
+- `ALHANGEUL_THUMBNAIL_RENDER_POLICY`가 DEBUG/internal diagnostic 경로에 한정되는지
+- provider success log가 cache/backend/fallback/timing을 충분히 남기는지
+- smoke helper가 resolver contract와 policy별 cache signature separation을 과도한 product coupling 없이 검증하는지
+- #392로 넘긴 1px pixel size drift가 #389 범위에 섞이지 않았는지
+
+## 작업지시자 승인 요청
+
+Task #389의 구현, 대표 smoke, 최종 보고서, 기술 문서 갱신, 오늘할일 완료 처리를 마쳤다. PR 게시 단계 진입 여부를 승인해 달라.

--- a/mydocs/report/task_m020_389_report.md
+++ b/mydocs/report/task_m020_389_report.md
@@ -126,7 +126,7 @@ xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuratio
   samples/basic/request.hwp samples/basic/KTX.hwp
 ```
 
-Release 조건은 smoke runner를 `-DDEBUG` 없이 별도 컴파일해 `samples/basic/request.hwp`로 확인했다.
+Release 조건은 smoke runner를 `-DDEBUG` 없이 별도 컴파일해 `samples/basic/request.hwp`로 확인했다. 두 번째 Copilot review 반영 후에는 `resolve()` 기본 인자에서 `ProcessInfo.processInfo.environment`를 제거해, Release 호출 경로가 환경변수 딕셔너리를 만들지 않도록 정리했다.
 
 결과:
 
@@ -134,6 +134,7 @@ Release 조건은 smoke runner를 `-DDEBUG` 없이 별도 컴파일해 `samples/
 - `xcodebuild ... DerivedDataTask389ReviewFix ... build`: 성공. macOS build는 `BUILD SUCCEEDED`.
 - Debug smoke: resolver contract `OK`, 16 render rows 모두 `OK`.
 - Release smoke: `ResolverBuild: RELEASE`, `skia`/`skiaOptIn` env case가 모두 expected/resolved `coreGraphicsOnly`.
+- Release provider call: `resolve()` 기본 호출은 `nil` default를 사용하므로 `ProcessInfo.processInfo.environment`를 평가하지 않는다.
 
 ## #392 handoff
 
@@ -167,7 +168,8 @@ Release 조건은 smoke runner를 `-DDEBUG` 없이 별도 컴파일해 `samples/
 | Stage 3 | `49e9b25` | thumbnail diagnostic smoke resolver/cache separation 보강 |
 | Stage 4 | `183fcae` | 대표 샘플 smoke와 #392 handoff 정리 |
 | Stage 5 | `6047332` | 최종 보고서와 기술 문서 기준선 정리 |
-| PR review follow-up | 이번 커밋 | Copilot review 피드백 반영 |
+| PR review follow-up 1 | `31d26f1` | identifier 단일화와 smoke Release 기대값 반영 |
+| PR review follow-up 2 | 이번 커밋 | Release `resolve()` 기본 호출의 environment 평가 제거 |
 
 ## 검증 결과
 
@@ -214,7 +216,7 @@ git log --oneline devel..local/task389
 
 | 항목 | 상태 | 처리 |
 |------|------|------|
-| Release env opt-in 차단 | source `#if DEBUG`와 Release smoke로 확인 | 계속 유지 |
+| Release env opt-in 차단 | source `#if DEBUG`, `nil` default, Release smoke로 확인 | 계속 유지 |
 | forced fallback reason fixture | 없음 | 정상 샘플에서는 fallback `-`; forced failure fixture는 필요 시 별도 작업 |
 | Finder/LaunchServices system cache | 범위 밖 | 이번 smoke는 extension 내부 render cache contract 검증 |
 | 1px pixel size drift | 관측됨 | #392 maxDimension mapping 실험으로 이관 |
@@ -238,4 +240,4 @@ Task #389: Thumbnail Skia opt-in diagnostic path와 cache logging 추가
 
 ## PR review follow-up
 
-PR #401 Copilot review의 identifier 중복과 Release resolver 기대값 피드백은 본 follow-up 커밋에서 반영했다.
+PR #401 Copilot review의 identifier 중복, Release resolver 기대값, Release `resolve()` 기본 호출 environment 평가 피드백은 follow-up 커밋에서 반영했다.

--- a/mydocs/tech/skia_preview_renderer_baseline.md
+++ b/mydocs/tech/skia_preview_renderer_baseline.md
@@ -170,4 +170,5 @@ Task #396 Stage 4 기준 quick suite는 CoreGraphics/Skia 양쪽 모두 exit 0�
 - extended suite는 Skia default 판단 전 수동 sweep으로 사용한다.
 - extended suite를 CI hard gate로 올리기 전에는 retry/flake 정책이 필요하다.
 - `form-002.hwpx`는 rhwp-studio automation readiness 개선 전까지 renderer 품질 판단에서 제외하거나 persistent readiness failure로 별도 표기한다.
-- Thumbnail/Finder cache 판단은 이 visual suite만으로 완료하지 않는다. #392, #389 후속 작업의 surface smoke가 필요하다.
+- Thumbnail/Finder cache 판단은 visual suite만으로 완료하지 않는다. #389에서 provider diagnostic path, resolver contract, internal thumbnail cache signature separation smoke는 확보했다.
+- 남은 Thumbnail surface 판단은 #392의 `maximumPixelSize -> Skia maxDimension/scale/rounding` mapping 실험과 visual/size drift 해석을 함께 본다.

--- a/mydocs/tech/skia_quicklook_thumbnail_backend.md
+++ b/mydocs/tech/skia_quicklook_thumbnail_backend.md
@@ -266,6 +266,16 @@ Skia optional backend는 다음 순서로 진행한다.
 - Skia opt-in backend: 모든 opt-in row `skia`
 - 산출물: `build.noindex/task258-thumbnail-policy-representative/summary.txt`
 
+2026-07-01 #389 Thumbnail diagnostic path 기준선:
+
+- Provider default는 계속 `coreGraphicsOnly`다.
+- `HwpThumbnailPolicyResolver`는 `ALHANGEUL_THUMBNAIL_RENDER_POLICY`를 DEBUG/internal 진단 경로에서만 해석한다.
+- 허용 값은 `skia`, `skiaOptIn`, `coreGraphics`, `coreGraphicsOnly`다. missing/empty/invalid 값과 Release build는 모두 `coreGraphicsOnly`로 수렴한다.
+- `HwpThumbnailProvider`는 `renderedPageResult(for:)`를 사용해 success log에 `policy`, `cache`, `requestedBucket`, `matchedBucket`, `backend`, `fallback`, `renderMs`, `pixels`를 남긴다.
+- `scripts/smoke-thumbnail-skia-policy.sh`는 resolver contract와 cache signature separation을 summary/detail에 기록한다.
+- 2026-07-01 대표 smoke 결과는 5 files x 2 policies x 4 requests = 40 rows 모두 `OK`, resolver contract `OK`, cache signature separation 5 rows 모두 `OK`였다.
+- 동일 `1024x1024` bucket에서 Skia pixel size가 CoreGraphics보다 긴 축 기준 1px 크게 나오는 패턴은 cache 실패가 아니라 #392 `maxDimension` mapping 실험 입력으로 분리한다.
+
 비책임:
 
 - Quick Look provider와 다중 페이지 PDF path는 #257에서 처리한다.

--- a/mydocs/working/task_m020_389_stage1.md
+++ b/mydocs/working/task_m020_389_stage1.md
@@ -1,0 +1,185 @@
+# Task M020 #389 Stage 1 완료 보고서
+
+## 단계 목적
+
+현재 Thumbnail provider, cache result, smoke helper가 관측할 수 있는 값과 부족한 값을 정리하고, Stage 2에서 구현할 DEBUG/internal opt-in resolver contract를 확정한다.
+
+## 조사 대상
+
+| 파일 | 확인 내용 |
+|------|-----------|
+| `Sources/ThumbnailExtension/HwpThumbnailProvider.swift` | provider request 생성, 기본 policy, 현재 OSLog 항목 |
+| `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift` | render request 기본값, render signature, cache event/result contract |
+| `scripts/smoke-thumbnail-skia-policy.sh` | smoke runner compile list와 output 구조 |
+| `scripts/thumbnail_skia_policy_smoke.swift` | policy pair 측정, cache/backend/fallback summary/detail column |
+| `mydocs/report/task_m020_258_report.md` | #258 cache signature와 smoke helper handoff |
+| `mydocs/report/task_m020_396_report.md` | #396 이후 Thumbnail/Finder surface handoff |
+| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | Thumbnail backend/fallback/logging 정책 기준 |
+| `project.yml` | ThumbnailExtension source 포함 방식 |
+
+## 현재 provider 흐름
+
+`HwpThumbnailProvider.provideThumbnail`은 현재 다음 순서로 동작한다.
+
+1. `QLFileThumbnailRequest`를 받는다.
+2. `HwpThumbnailRenderRequest(fileURL:maximumSize:scale:)`를 생성한다.
+3. `HwpThumbnailRenderCache.shared.renderedPage(for:)`를 호출한다.
+4. 성공 시 aspect-fit context에 page image를 그리고 extension badge를 설정한다.
+5. fallback 대상 오류는 기존 fallback tile로 수렴한다.
+6. 그 외 오류는 handler에 error를 반환한다.
+
+현재 provider는 `HwpThumbnailRenderRequest` 생성 시 `policy`를 넘기지 않는다. 따라서 `HwpThumbnailRenderRequest` initializer의 기본값인 `.coreGraphicsOnly`가 production/default provider policy다.
+
+현재 provider 로그:
+
+| 시점 | 현재 로그 | 부족한 값 |
+|------|-----------|-----------|
+| request 시작 | file basename, requested point size, scale | resolved policy |
+| render enqueue | maximum pixel bucket | render signature |
+| render success | context size, rendered page size | cache event, requested/matched bucket, backend used, fallback reason, render timing, pixel size |
+| fallback/failure | file basename, error description | resolved policy, backend/fallback context |
+
+## cache/result contract
+
+`HwpThumbnailRenderRequest`는 다음 값을 가진다.
+
+| 항목 | 현재 값/의미 |
+|------|--------------|
+| `policy` | 기본값 `.coreGraphicsOnly`; 명시하면 `.skiaOptIn` 가능 |
+| `maximumPixelSize` | point size와 scale을 bucket화한 값. 현재 #392 maxDimension mapping과는 별개 |
+| `renderSignature` | policy, renderer option version, core release/commit/features, maxDimension policy version |
+| `key` | path, mtime, file size, pixel bucket, render signature |
+
+`HwpThumbnailRenderCache.renderedPageResult(for:)`는 성공 시 `HwpThumbnailRenderResult`를 반환한다.
+
+| 항목 | Stage 2 provider logging에 사용 가능 여부 |
+|------|------------------------------------------|
+| `page` | 가능. `page.diagnostics`에서 backend/fallback/timing/pixel 정보를 얻는다 |
+| `cacheEvent` | 가능. `miss`, `exactHit`, `largerBucketHit(...)` |
+| `requestedKey` | 가능. requested bucket과 signature 확인 |
+| `matchedKey` | 가능. cache hit에서 실제 reuse bucket 확인 |
+
+현재 cache는 이미 policy/render signature로 key와 larger bucket reuse를 분리한다. Stage 2에서 cache 자체를 변경할 필요는 없어 보인다.
+
+## smoke helper contract
+
+`scripts/smoke-thumbnail-skia-policy.sh`는 Swift runner를 compile해서 같은 입력 파일에 대해 `.coreGraphicsOnly`와 `.skiaOptIn`을 모두 측정한다.
+
+현재 summary column:
+
+```text
+File, Policy, Request, Status, Cache, RequestedBucket, MatchedBucket,
+Backend, Fallback, Pixel, OutputBytes, PNGBytes, RenderMs, Seconds
+```
+
+현재 detail file 항목:
+
+```text
+Request, Status, Error, CacheEvent, RequestedBucket, MatchedBucket,
+Signature, Backend, Fallback, PageSize, PixelSize, PNGBytes,
+OutputBytes, RenderMs, ElapsedSeconds
+```
+
+따라서 smoke helper는 이미 #389가 필요로 하는 cache event, backend used, fallback reason, timing을 대부분 갖고 있다. 부족한 부분은 provider resolver와 같은 policy identifier를 검증하거나 provider opt-in contract를 summary에 명시하는 것이다.
+
+## #258 / #396 handoff 반영
+
+#258에서 이미 확인된 기준:
+
+- Finder Thumbnail provider 기본 policy는 `.coreGraphicsOnly`.
+- cache key, in-flight key, larger bucket reuse guard는 render signature equality를 사용한다.
+- 대표 5개 샘플 smoke에서 40 rows 모두 `OK`, fallback 0.
+- 각 파일/정책 cache event는 `miss -> exactHit -> largerBucketHit -> largerBucketHit` 흐름이었다.
+- helper는 extension 내부 cache contract 검증이고 Finder/LaunchServices 시스템 cache 검증은 별도다.
+
+#396에서 이어받은 기준:
+
+- visual baseline만으로 Thumbnail/Finder cache 판단은 완료되지 않는다.
+- #389는 Finder Thumbnail cache/signature/logging 관측성을 보강하는 후속이다.
+- #392는 Thumbnail maxDimension mapping과 size drift 판단을 별도 surface smoke로 이어갈 후속이다.
+
+## project/source 포함 방식
+
+`project.yml`의 `ThumbnailExtension` target은 `Sources/ThumbnailExtension` 디렉터리 전체를 source path로 포함한다. 따라서 Stage 2에서 `Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift`를 새로 추가하면 Xcode target에는 source folder 경유로 포함된다.
+
+다만 `scripts/smoke-thumbnail-skia-policy.sh`는 `swiftc` compile list를 명시적으로 나열한다. Stage 3에서 smoke runner가 새 resolver를 참조하게 되면 compile list에 `HwpThumbnailPolicyResolver.swift`를 직접 추가해야 한다.
+
+## Stage 2 resolver contract 확정
+
+Stage 2는 `HwpThumbnailPolicyResolver` 신규 source를 추가하는 방향으로 진행한다.
+
+Resolver contract:
+
+| 항목 | 결정 |
+|------|------|
+| env key | `ALHANGEUL_THUMBNAIL_RENDER_POLICY` |
+| 허용 값 | `skia`, `skiaOptIn`, `coreGraphics`, `coreGraphicsOnly` |
+| empty/missing/invalid | `.coreGraphicsOnly` |
+| Release build | env 값과 무관하게 `.coreGraphicsOnly` |
+| DEBUG build | 명시 env 값이 `skia`/`skiaOptIn`이면 `.skiaOptIn` |
+| display identifier | `coreGraphicsOnly`, `skiaOptIn` 문자열 helper 제공 |
+| user-facing preference | 추가하지 않음 |
+
+Provider 변경 방향:
+
+1. `HwpThumbnailPolicyResolver.resolve()`로 policy를 얻는다.
+2. `HwpThumbnailRenderRequest(..., policy: resolvedPolicy)`로 전달한다.
+3. `renderedPage(for:)` 대신 `renderedPageResult(for:)`를 사용한다.
+4. success log에 다음 값을 포함한다.
+   - `policy`
+   - `cacheEvent`
+   - `requestedBucket`
+   - `matchedBucket`
+   - `backend`
+   - `fallback`
+   - `renderMs`
+   - `pixelSize`
+5. fallback/failure log에도 `policy`를 포함한다.
+
+Cache source 변경은 Stage 2의 기본 대상이 아니다. provider에서 필요한 formatting helper만 추가한다.
+
+## Stage 3 smoke 보강 범위 확정
+
+Stage 3는 다음만 보강한다.
+
+- smoke compile list에 resolver source가 필요하면 추가한다.
+- runner가 resolver default/env opt-in contract를 확인할 수 있도록 간단한 row 또는 detail 항목을 추가할지 검토한다.
+- 기존 policy pair 측정과 summary column은 유지한다.
+
+Stage 3에서 하지 않을 일:
+
+- maxDimension policy 변경
+- Finder/LaunchServices system cache 검증
+- release package registration smoke 확장
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Stage 1은 inventory 문서 작성 단계다. 제품 Swift source, shell script, project configuration, Rust bridge, sample 문서는 변경하지 않았다.
+
+## 검증 결과
+
+실행 대상:
+
+```bash
+rg -n "HwpThumbnailProvider|HwpThumbnailRenderRequest|renderedPageResult|HwpThumbnailCacheEvent|backendUsed|fallbackReason|smoke-thumbnail-skia-policy" \
+  Sources/ThumbnailExtension scripts mydocs/report/task_m020_258_report.md \
+  mydocs/report/task_m020_396_report.md mydocs/working/task_m020_389_stage1.md
+git diff --check
+```
+
+결과는 Stage 1 커밋 전 최종 확인으로 남긴다.
+
+## 잔여 위험
+
+- provider OSLog는 smoke summary처럼 파일로 바로 수집되지 않는다. Stage 2-3에서 log와 smoke output의 역할을 분리해야 한다.
+- 정상 샘플에서는 Skia fallback reason이 `-`로 남을 가능성이 높다. forced fallback fixture는 이번 작업의 완료 조건으로 두지 않는다.
+- Release build에서 env opt-in을 막는 방식은 Swift compile condition에 의존한다. Stage 2에서 `#if DEBUG` 경계가 명확해야 한다.
+- 새 resolver source는 Xcode target에는 자동 포함되지만 smoke helper의 manual compile list에는 직접 추가가 필요할 수 있다.
+
+## 다음 단계 영향
+
+Stage 2는 `HwpThumbnailPolicyResolver` 신규 source와 `HwpThumbnailProvider` logging 변경으로 진행한다. public reply/fallback behavior는 유지하고, provider가 `renderedPageResult(for:)`를 통해 cache/backend/fallback 정보를 로그에 남기는지만 바꾼다.
+
+## 승인 요청
+
+Stage 1은 완료했다. Stage 2 `provider policy resolver와 cache logging 구현`으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_389_stage2.md
+++ b/mydocs/working/task_m020_389_stage2.md
@@ -1,0 +1,99 @@
+# Task M020 #389 Stage 2 완료 보고서
+
+## 단계 목적
+
+Thumbnail provider에 DEBUG/internal opt-in policy resolver를 추가하고, provider 성공 로그가 cache/backend/fallback 진단 값을 포함하도록 구현한다.
+
+## 변경 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift` | 신규 resolver 추가. `ALHANGEUL_THUMBNAIL_RENDER_POLICY` env 값을 DEBUG 빌드에서만 해석 |
+| `Sources/ThumbnailExtension/HwpThumbnailProvider.swift` | resolver 결과를 render request policy로 전달하고 `renderedPageResult(for:)` 결과를 로그에 사용 |
+| `Alhangeul.xcodeproj/project.pbxproj` | `xcodegen generate`로 신규 resolver source를 ThumbnailExtension target source phase에 반영 |
+| `mydocs/orders/20260701.md` | Stage 2 완료보고서 승인 대기 상태로 갱신 |
+
+## resolver 동작
+
+`HwpThumbnailPolicyResolver`는 다음 contract로 구현했다.
+
+| 입력 | DEBUG 결과 | Release 결과 |
+|------|------------|--------------|
+| missing/empty/invalid | `.coreGraphicsOnly` | `.coreGraphicsOnly` |
+| `coreGraphics` | `.coreGraphicsOnly` | `.coreGraphicsOnly` |
+| `coreGraphicsOnly` | `.coreGraphicsOnly` | `.coreGraphicsOnly` |
+| `skia` | `.skiaOptIn` | `.coreGraphicsOnly` |
+| `skiaOptIn` | `.skiaOptIn` | `.coreGraphicsOnly` |
+
+값 비교는 trim, lowercase, `-`/`_` 제거 후 수행한다. display identifier helper는 `coreGraphicsOnly`, `skiaOptIn` 문자열을 반환한다.
+
+## provider 변경
+
+`HwpThumbnailProvider.provideThumbnail`의 public reply/fallback shape는 유지했다.
+
+변경된 흐름:
+
+1. request 시작 시 `HwpThumbnailPolicyResolver.resolve()`로 policy를 결정한다.
+2. `HwpThumbnailRenderRequest(fileURL:maximumSize:scale:policy:)`에 policy를 전달한다.
+3. 기존 `renderedPage(for:)` 대신 `renderedPageResult(for:)`를 호출한다.
+4. success log에 다음 값을 포함한다.
+   - `policy`
+   - `cache`
+   - `requestedBucket`
+   - `matchedBucket`
+   - `backend`
+   - `fallback`
+   - `renderMs`
+   - `pixels`
+   - `context`
+   - `page`
+5. fallback/failure log에도 `policy`를 포함한다.
+
+Cache source는 변경하지 않았다. Stage 1에서 확인한 대로 cache는 이미 policy/render signature별 key와 `HwpThumbnailRenderResult`를 제공하고 있어 provider logging에서 소비하는 것으로 충분했다.
+
+## project 반영
+
+`project.yml`은 `Sources/ThumbnailExtension` directory source를 포함한다. 신규 Swift source를 실제 Xcode project에 반영하기 위해 `xcodegen generate`를 실행했고, 생성된 `Alhangeul.xcodeproj/project.pbxproj`에는 `HwpThumbnailPolicyResolver.swift` source phase 추가만 반영되었다.
+
+`scripts/smoke-thumbnail-skia-policy.sh`의 manual compile list는 Stage 2에서 변경하지 않았다. Stage 3에서 smoke runner가 resolver contract를 직접 검증하게 되면 compile list에 resolver source를 추가한다.
+
+## 검증 결과
+
+실행:
+
+```bash
+./scripts/check-no-appkit.sh
+git diff --check
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask389Stage2 CODE_SIGNING_ALLOWED=NO build
+rg -n "HwpThumbnailPolicyResolver|ALHANGEUL_THUMBNAIL_RENDER_POLICY|renderedPageResult|cache|backend|fallback|coreGraphicsOnly|skiaOptIn" \
+  Sources/ThumbnailExtension mydocs/working/task_m020_389_stage2.md
+```
+
+결과:
+
+- `check-no-appkit`: 성공. shared Swift code에 AppKit/UIKit 의존 없음.
+- `git diff --check`: 성공.
+- `xcodegen generate`: 성공.
+- `xcodebuild`: 성공. `BUILD SUCCEEDED`.
+- `rg`: 신규 resolver, env key, provider `renderedPageResult`, cache/backend/fallback 로그 항목 확인.
+
+`xcodebuild` 중 CoreSimulator framework 버전 경고가 출력되었지만, macOS target build는 성공했다.
+
+## 잔여 위험
+
+- Release에서 env opt-in이 차단되는지는 source의 `#if DEBUG` 경계로 보장한다. Release build smoke는 이번 Stage 2 범위에 포함하지 않았다.
+- provider OSLog는 smoke summary 파일이 아니므로, Stage 3에서 smoke helper가 resolver contract와 cache/backend/fallback column을 별도로 검증하도록 보강한다.
+- 정상 샘플에서는 `fallback=-`가 기대값일 수 있다. forced fallback fixture는 이번 작업 완료 조건에 넣지 않는다.
+
+## 완료 조건 확인
+
+- provider 기본 policy는 CoreGraphics로 유지된다.
+- DEBUG/internal env opt-in path가 source상 명확하다.
+- provider success log에 cache/backend/fallback 진단 값이 들어간다.
+- public reply/fallback 동작은 변경하지 않았다.
+
+## 승인 요청
+
+Stage 2는 완료했다. Stage 3 `smoke/helper와 resolver 검증 보강`으로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_389_stage3.md
+++ b/mydocs/working/task_m020_389_stage3.md
@@ -1,0 +1,119 @@
+# Task M020 #389 Stage 3 완료 보고서
+
+## 단계 목적
+
+smoke helper가 Stage 2에서 추가한 provider policy resolver contract와 cache/backend/fallback diagnostic output을 함께 검증할 수 있게 보강한다.
+
+## 변경 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `scripts/smoke-thumbnail-skia-policy.sh` | smoke compile list에 `HwpThumbnailPolicyResolver.swift` 추가, resolver opt-in 검증을 위해 `-DDEBUG`로 compile |
+| `scripts/thumbnail_skia_policy_smoke.swift` | resolver contract summary/detail, cache signature separation summary/detail 추가 |
+| `mydocs/orders/20260701.md` | Stage 3 완료보고서 승인 대기 상태로 갱신 |
+
+## smoke helper 보강 내용
+
+### Resolver contract
+
+runner가 `HwpThumbnailPolicyResolver.resolve(environment:)`를 직접 호출해 다음 case를 기록한다.
+
+| case | 기대값 |
+|------|--------|
+| missing | `coreGraphicsOnly` |
+| empty | `coreGraphicsOnly` |
+| invalid | `coreGraphicsOnly` |
+| `coreGraphics` | `coreGraphicsOnly` |
+| `coreGraphicsOnly` | `coreGraphicsOnly` |
+| `skia` | `skiaOptIn` |
+| `skiaOptIn` | `skiaOptIn` |
+
+이 검증은 provider의 DEBUG/internal opt-in path를 확인하기 위한 것이므로 smoke binary는 `-DDEBUG`로 compile한다. Release에서 env opt-in을 무시하는 동작은 Stage 2 source의 `#if DEBUG` 경계로 유지한다.
+
+산출물:
+
+- `summary.txt`: `ResolverBuild`, `ResolverEnvKey`, `ResolverContract`, resolver contract table 추가
+- `resolver-contract.txt`: resolver contract 전용 detail 추가
+
+### Cache signature separation
+
+각 파일에 대해 첫 CoreGraphics request와 첫 Skia opt-in request를 비교한다.
+
+확인 기준:
+
+- CoreGraphics 첫 request cache event가 `miss`
+- Skia opt-in 첫 request cache event가 `miss`
+- 두 request의 render signature가 서로 다름
+
+이 기준이 충족되면 `Cache Signature Separation` status를 `OK`로 기록한다. 이는 cache key가 policy/render signature별로 분리되는지 smoke summary에서 바로 확인하기 위한 진단이다.
+
+산출물:
+
+- `summary.txt`: `## Cache Signature Separation` table 추가
+- 각 per-file detail: `[CacheSignatureSeparation]` block 추가
+
+기존 render measurement row는 유지했다.
+
+## 실행 결과
+
+실행:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-stage3-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+콘솔 요약:
+
+```text
+resolver: OK
+request.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+KTX.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+```
+
+주요 산출물:
+
+| 파일 | 결과 |
+|------|------|
+| `build.noindex/task389-stage3-thumbnail-policy/summary.txt` | resolver contract `OK`, render 16 rows 모두 `OK`, cache signature separation 2 rows 모두 `OK` |
+| `build.noindex/task389-stage3-thumbnail-policy/resolver-contract.txt` | 7개 resolver case 모두 `OK` |
+| `build.noindex/task389-stage3-thumbnail-policy/request-thumbnail-skia-policy.txt` | `CoreFirstCache: miss`, `SkiaFirstCache: miss`, signature 분리 `OK` |
+| `build.noindex/task389-stage3-thumbnail-policy/KTX-thumbnail-skia-policy.txt` | `CoreFirstCache: miss`, `SkiaFirstCache: miss`, signature 분리 `OK` |
+
+정상 샘플에서는 `Fallback: -`로 남았다. 이는 fallback이 발생하지 않았다는 의미이며, fallback column은 summary/detail에 유지된다.
+
+## 검증 결과
+
+실행:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-stage3-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+rg -n "coreGraphicsOnly|skiaOptIn|Cache|Backend|Fallback|miss|exactHit|largerBucketHit|ALHANGEUL_THUMBNAIL_RENDER_POLICY" \
+  build.noindex/task389-stage3-thumbnail-policy scripts Sources/ThumbnailExtension \
+  mydocs/working/task_m020_389_stage3.md
+git diff --check
+```
+
+결과:
+
+- smoke: 성공.
+- `rg`: resolver env key, policy names, cache/backend/fallback column, `miss/exactHit/largerBucketHit` 산출물 확인.
+- `git diff --check`: 성공.
+
+## 잔여 위험
+
+- smoke helper는 DEBUG resolver opt-in path를 검증한다. Release binary에서 env opt-in이 막히는지는 source `#if DEBUG` 경계로 보장하고, Release build smoke는 이번 단계 범위가 아니다.
+- 정상 샘플만 사용했기 때문에 forced fallback reason fixture는 검증하지 않았다.
+- Finder/LaunchServices system cache 검증은 여전히 별도 영역이며, 이번 helper는 extension 내부 render cache contract를 확인한다.
+
+## 완료 조건 확인
+
+- smoke helper가 새 resolver source와 함께 compile/run 된다.
+- CoreGraphics/Skia opt-in policy pair가 기존처럼 측정된다.
+- cache event/backend/fallback column이 summary/detail에 유지된다.
+- resolver contract와 policy signature separation 결과가 후속 보고에 충분히 남는다.
+
+## 승인 요청
+
+Stage 3은 완료했다. Stage 4 `대표 샘플 smoke와 #392 handoff 정리`로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_389_stage4.md
+++ b/mydocs/working/task_m020_389_stage4.md
@@ -1,0 +1,148 @@
+# Task M020 #389 Stage 4 완료 보고서
+
+## 단계 목적
+
+대표 샘플로 Thumbnail diagnostic smoke를 실행하고, cache/backend/fallback baseline과 #392 maxDimension mapping 실험에 넘길 입력을 정리한다.
+
+## 실행한 검증
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+```
+
+기본 검증 결과:
+
+| 명령 | 결과 |
+|------|------|
+| `check-no-appkit.sh` | 성공. shared Swift code에 AppKit/UIKit 의존 없음 |
+| `verify-rhwp-core-build-info.sh` | 성공. `RhwpCoreBuildInfo`와 `rhwp-core.lock` 일치 |
+| `verify-rhwp-studio-assets.sh` | 성공. bundled `rhwp-studio` asset 검증 통과 |
+
+## quick smoke 결과
+
+산출물:
+
+- `build.noindex/task389-thumbnail-policy/summary.txt`
+- `build.noindex/task389-thumbnail-policy/request-thumbnail-skia-policy.txt`
+- `build.noindex/task389-thumbnail-policy/KTX-thumbnail-skia-policy.txt`
+- `build.noindex/task389-thumbnail-policy/resolver-contract.txt`
+
+콘솔 요약:
+
+```text
+resolver: OK
+request.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+KTX.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+```
+
+결과:
+
+- resolver contract: `OK`
+- render rows: 16개 모두 `OK`
+- cache signature separation: 2개 샘플 모두 `OK`
+- backend: `coreGraphicsOnly`는 `coreGraphics`, `skiaOptIn`은 `skia`
+- fallback: 모든 row에서 `-`
+
+## 대표 샘플 smoke 결과
+
+산출물:
+
+- `build.noindex/task389-thumbnail-policy-representative/summary.txt`
+- `build.noindex/task389-thumbnail-policy-representative/resolver-contract.txt`
+- `build.noindex/task389-thumbnail-policy-representative/*-thumbnail-skia-policy.txt`
+
+콘솔 요약:
+
+```text
+resolver: OK
+복학원서.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+KTX.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+request.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+hwpx-01.hwpx: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+hwp-multi-001.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+```
+
+대표 smoke 결과:
+
+| 항목 | 결과 |
+|------|------|
+| resolver contract | `OK` |
+| render rows | 40개 모두 `OK` |
+| cache pattern | 각 파일/정책 모두 `miss -> exactHit -> largerBucketHit -> largerBucketHit` |
+| cache signature separation | 5개 샘플 모두 `OK` |
+| backend | `coreGraphicsOnly`는 `coreGraphics`, `skiaOptIn`은 `skia` |
+| fallback | 모든 row에서 `-` |
+
+`복학원서.hwp` 처리 중 기존 layout overflow 진단 3줄이 stderr에 출력되었다. smoke render status는 모두 `OK`였고 fallback도 발생하지 않았다.
+
+## 대표 large request baseline
+
+아래 값은 대표 smoke의 첫 요청 `large:512x512@2` 기준이다. 요청 bucket은 모두 `1024x1024`다.
+
+| File | Policy | Backend | Fallback | Pixel | OutputBytes | PNGBytes | RenderMs |
+|------|--------|---------|----------|-------|-------------|----------|----------|
+| `복학원서.hwp` | `coreGraphicsOnly` | `coreGraphics` | `-` | `725x1024` | `193700` | `-` | `1218.344` |
+| `복학원서.hwp` | `skiaOptIn` | `skia` | `-` | `725x1025` | `170973` | `175775` | `73.027` |
+| `KTX.hwp` | `coreGraphicsOnly` | `coreGraphics` | `-` | `1024x725` | `482670` | `-` | `89.693` |
+| `KTX.hwp` | `skiaOptIn` | `skia` | `-` | `1025x725` | `161652` | `148962` | `66.359` |
+| `request.hwp` | `coreGraphicsOnly` | `coreGraphics` | `-` | `732x1024` | `125618` | `-` | `30.996` |
+| `request.hwp` | `skiaOptIn` | `skia` | `-` | `732x1025` | `117040` | `117366` | `61.484` |
+| `hwpx-01.hwpx` | `coreGraphicsOnly` | `coreGraphics` | `-` | `725x1024` | `198763` | `-` | `33.656` |
+| `hwpx-01.hwpx` | `skiaOptIn` | `skia` | `-` | `725x1025` | `171059` | `187595` | `56.863` |
+| `hwp-multi-001.hwp` | `coreGraphicsOnly` | `coreGraphics` | `-` | `725x1024` | `195545` | `-` | `31.347` |
+| `hwp-multi-001.hwp` | `skiaOptIn` | `skia` | `-` | `725x1025` | `166327` | `180447` | `47.418` |
+
+## provider default 확인
+
+default provider는 CoreGraphics 유지다.
+
+- `HwpThumbnailPolicyResolver.resolve()`는 env missing/empty/invalid를 `.coreGraphicsOnly`로 반환한다.
+- Release build에서는 env 값과 무관하게 `.coreGraphicsOnly`로 반환한다.
+- Stage 4 smoke의 DEBUG resolver contract에서도 missing case가 `coreGraphicsOnly`로 확인되었다.
+- Skia path는 `ALHANGEUL_THUMBNAIL_RENDER_POLICY=skia` 또는 `skiaOptIn`에 해당하는 DEBUG/internal diagnostic path다.
+
+## #392 handoff
+
+#392에는 다음 baseline을 넘긴다.
+
+1. 모든 대표 샘플에서 `1024x1024` bucket cache는 정상적으로 policy별 분리된다.
+2. 동일 bucket에서 Skia pixel size가 CoreGraphics보다 긴 축 기준 1px 큰 패턴이 반복된다.
+   - portrait 계열: `725x1024` vs `725x1025`
+   - `request.hwp`: `732x1024` vs `732x1025`
+   - landscape 계열 `KTX.hwp`: `1024x725` vs `1025x725`
+3. fallback은 발생하지 않았으므로 #392는 fallback 원인보다 `maximumPixelSize -> Skia maxDimension/scale/rounding` mapping을 우선 검토하면 된다.
+4. output bytes와 PNGBytes는 policy별로 차이가 크지만, #389 범위에서는 성능/정확도 판정이 아니라 진단 baseline으로만 남긴다.
+
+## 검증 결과
+
+실행:
+
+```bash
+rg -n "OK|FAIL|coreGraphicsOnly|skiaOptIn|Cache|Backend|Fallback|miss|exactHit|largerBucketHit|RenderMs|OutputBytes" \
+  build.noindex/task389-thumbnail-policy build.noindex/task389-thumbnail-policy-representative \
+  mydocs/working/task_m020_389_stage4.md
+git diff --check
+```
+
+결과:
+
+- `rg`: quick/representative 산출물과 Stage 4 보고서에서 resolver, cache, backend, fallback, render timing, output bytes 항목 확인.
+- `git diff --check`: 성공.
+
+## 완료 조건 확인
+
+- 대표 샘플 smoke 결과가 존재한다.
+- default provider는 CoreGraphics 유지로 확인된다.
+- Skia opt-in diagnostic path가 backend/cache/fallback 정보를 남긴다.
+- #392 maxDimension 실험에 필요한 baseline 입력을 분리했다.
+
+## 승인 요청
+
+Stage 4는 완료했다. Stage 5 `최종 보고와 PR 준비`로 진행해도 되는지 승인 요청한다.

--- a/scripts/smoke-thumbnail-skia-policy.sh
+++ b/scripts/smoke-thumbnail-skia-policy.sh
@@ -80,6 +80,7 @@ rm -rf "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
 mkdir -p "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
 
 swiftc -parse-as-library \
+  -DDEBUG \
   -module-cache-path "$SWIFT_MODULE_CACHE" \
   -Xcc -fmodules-cache-path="$CLANG_MODULE_CACHE" \
   -I "$MODULEMAP_DIR" \
@@ -92,6 +93,7 @@ swiftc -parse-as-library \
   "$ROOT/Sources/RhwpCoreBridge/CGTreeRenderer.swift" \
   "$ROOT/Sources/Shared/HwpPageImageRenderer.swift" \
   "$ROOT/Sources/Shared/HwpNativePageCompositor.swift" \
+  "$ROOT/Sources/ThumbnailExtension/HwpThumbnailPolicyResolver.swift" \
   "$ROOT/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift" \
   "$ROOT/scripts/thumbnail_skia_policy_smoke.swift" \
   "$LIB" \

--- a/scripts/thumbnail_skia_policy_smoke.swift
+++ b/scripts/thumbnail_skia_policy_smoke.swift
@@ -43,6 +43,17 @@ struct RenderMeasurement {
     let elapsedSeconds: Double?
 }
 
+struct ResolverMeasurement {
+    let caseName: String
+    let envValue: String?
+    let expectedPolicy: String
+    let resolvedPolicy: String
+
+    var status: String {
+        expectedPolicy == resolvedPolicy ? "OK" : "FAIL"
+    }
+}
+
 struct FileMeasurement {
     let fileName: String
     let filePath: String
@@ -51,11 +62,25 @@ struct FileMeasurement {
     let skiaOptIn: [RenderMeasurement]
 }
 
+struct CacheSeparationMeasurement {
+    let fileName: String
+    let status: String
+    let coreGraphicsFirstCache: String
+    let skiaOptInFirstCache: String
+    let coreGraphicsSignature: String
+    let skiaOptInSignature: String
+    let note: String
+}
+
 @main
 struct ThumbnailSkiaPolicySmoke {
     static func main() throws {
         let parsed = try parseArguments(Array(CommandLine.arguments.dropFirst()))
         try FileManager.default.createDirectory(at: parsed.outputDir, withIntermediateDirectories: true)
+
+        let resolverMeasurements = measureResolverContract()
+        try writeResolverDetail(resolverMeasurements, outputDir: parsed.outputDir)
+        print("resolver: \(resolverStatusSummary(resolverMeasurements))")
 
         var measurements: [FileMeasurement] = []
         for inputURL in parsed.inputs {
@@ -65,7 +90,12 @@ struct ThumbnailSkiaPolicySmoke {
             print("\(measurement.fileName): \(rowSummary(measurement))")
         }
 
-        try writeSummary(measurements, requests: parsed.requests, outputDir: parsed.outputDir)
+        try writeSummary(
+            measurements,
+            requests: parsed.requests,
+            resolverMeasurements: resolverMeasurements,
+            outputDir: parsed.outputDir
+        )
     }
 
     private struct ParsedArguments {
@@ -121,6 +151,14 @@ struct ThumbnailSkiaPolicySmoke {
         RequestPreset(name: "medium-after-large", maximumSize: CGSize(width: 256, height: 256), scale: 2),
         RequestPreset(name: "small-after-large", maximumSize: CGSize(width: 128, height: 128), scale: 1)
     ]
+
+    private static var resolverBuildMode: String {
+#if DEBUG
+        "DEBUG"
+#else
+        "RELEASE"
+#endif
+    }
 
     private static func parseRequest(_ value: String) throws -> RequestPreset {
         let nameAndRest = value.split(separator: ":", maxSplits: 1).map(String.init)
@@ -270,6 +308,7 @@ struct ThumbnailSkiaPolicySmoke {
     private static func writeSummary(
         _ measurements: [FileMeasurement],
         requests: [RequestPreset],
+        resolverMeasurements: [ResolverMeasurement],
         outputDir: URL
     ) throws {
         var lines: [String] = []
@@ -277,6 +316,11 @@ struct ThumbnailSkiaPolicySmoke {
         lines.append("")
         lines.append("GeneratedAt: \(ISO8601DateFormatter().string(from: Date()))")
         lines.append("Requests: \(requests.map(\.display).joined(separator: ", "))")
+        lines.append("ResolverBuild: \(resolverBuildMode)")
+        lines.append("ResolverEnvKey: \(HwpThumbnailPolicyResolver.environmentKey)")
+        lines.append("ResolverContract: \(resolverStatusSummary(resolverMeasurements))")
+        lines.append("")
+        appendResolverContract(resolverMeasurements, lines: &lines)
         lines.append("")
         lines.append("| File | Policy | Request | Status | Cache | RequestedBucket | MatchedBucket | Backend | Fallback | Pixel | OutputBytes | PNGBytes | RenderMs | Seconds |")
         lines.append("|------|--------|---------|--------|-------|-----------------|---------------|---------|----------|-------|-------------|----------|----------|---------|")
@@ -285,6 +329,15 @@ struct ThumbnailSkiaPolicySmoke {
             for render in measurement.coreGraphics + measurement.skiaOptIn {
                 lines.append(summaryRow(fileName: measurement.fileName, render: render))
             }
+        }
+
+        lines.append("")
+        lines.append("## Cache Signature Separation")
+        lines.append("")
+        lines.append("| File | Status | CoreFirstCache | SkiaFirstCache | CoreSignature | SkiaSignature | Note |")
+        lines.append("|------|--------|----------------|----------------|---------------|---------------|------|")
+        for measurement in measurements {
+            lines.append(cacheSeparationRow(cacheSeparation(for: measurement)))
         }
 
         let failed = measurements.flatMap { $0.coreGraphics + $0.skiaOptIn }.filter { $0.status == "FAIL" }
@@ -312,9 +365,56 @@ struct ThumbnailSkiaPolicySmoke {
         var lines: [String] = []
         lines.append("File: \(measurement.filePath)")
         lines.append("FileBytes: \(measurement.fileBytes)")
+        appendCacheSeparation(cacheSeparation(for: measurement), lines: &lines)
         appendPolicy(measurement.coreGraphics, name: "CoreGraphics", lines: &lines)
         appendPolicy(measurement.skiaOptIn, name: "SkiaOptIn", lines: &lines)
         try lines.joined(separator: "\n").write(to: detailURL, atomically: true, encoding: .utf8)
+    }
+
+    private static func writeResolverDetail(
+        _ resolverMeasurements: [ResolverMeasurement],
+        outputDir: URL
+    ) throws {
+        var lines: [String] = []
+        lines.append("# Thumbnail Policy Resolver Contract")
+        lines.append("")
+        lines.append("ResolverBuild: \(resolverBuildMode)")
+        lines.append("ResolverEnvKey: \(HwpThumbnailPolicyResolver.environmentKey)")
+        lines.append("ResolverContract: \(resolverStatusSummary(resolverMeasurements))")
+        lines.append("")
+        appendResolverContract(resolverMeasurements, lines: &lines)
+        try lines.joined(separator: "\n").write(
+            to: outputDir.appendingPathComponent("resolver-contract.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    private static func appendResolverContract(
+        _ resolverMeasurements: [ResolverMeasurement],
+        lines: inout [String]
+    ) {
+        lines.append("## Resolver Contract")
+        lines.append("")
+        lines.append("| Case | EnvValue | Expected | Resolved | Status |")
+        lines.append("|------|----------|----------|----------|--------|")
+        for measurement in resolverMeasurements {
+            lines.append(resolverRow(measurement))
+        }
+    }
+
+    private static func appendCacheSeparation(
+        _ check: CacheSeparationMeasurement,
+        lines: inout [String]
+    ) {
+        lines.append("")
+        lines.append("[CacheSignatureSeparation]")
+        lines.append("Status: \(check.status)")
+        lines.append("CoreFirstCache: \(check.coreGraphicsFirstCache)")
+        lines.append("SkiaFirstCache: \(check.skiaOptInFirstCache)")
+        lines.append("CoreSignature: \(check.coreGraphicsSignature)")
+        lines.append("SkiaSignature: \(check.skiaOptInSignature)")
+        lines.append("Note: \(check.note)")
     }
 
     private static func appendPolicy(_ renders: [RenderMeasurement], name: String, lines: inout [String]) {
@@ -361,11 +461,94 @@ struct ThumbnailSkiaPolicySmoke {
         ].joined(separator: " | ").wrappedTableRow
     }
 
+    private static func resolverRow(_ measurement: ResolverMeasurement) -> String {
+        [
+            markdownCell(measurement.caseName),
+            markdownCell(measurement.envValue ?? "<missing>"),
+            measurement.expectedPolicy,
+            measurement.resolvedPolicy,
+            measurement.status
+        ].joined(separator: " | ").wrappedTableRow
+    }
+
+    private static func cacheSeparationRow(_ check: CacheSeparationMeasurement) -> String {
+        [
+            markdownCell(check.fileName),
+            check.status,
+            check.coreGraphicsFirstCache,
+            check.skiaOptInFirstCache,
+            markdownCell(check.coreGraphicsSignature),
+            markdownCell(check.skiaOptInSignature),
+            markdownCell(check.note)
+        ].joined(separator: " | ").wrappedTableRow
+    }
+
     private static func rowSummary(_ measurement: FileMeasurement) -> String {
         let renders = measurement.coreGraphics + measurement.skiaOptIn
         let failed = renders.filter { $0.status == "FAIL" }.count
         let cacheEvents = renders.map { $0.cacheEvent ?? "fail" }.joined(separator: ",")
         return "renders=\(renders.count) failed=\(failed) cache=\(cacheEvents)"
+    }
+
+    private static func measureResolverContract() -> [ResolverMeasurement] {
+        let key = HwpThumbnailPolicyResolver.environmentKey
+        let cases: [(caseName: String, envValue: String?, expectedPolicy: String)] = [
+            ("missing", nil, "coreGraphicsOnly"),
+            ("empty", "", "coreGraphicsOnly"),
+            ("invalid", "invalid", "coreGraphicsOnly"),
+            ("coreGraphics", "coreGraphics", "coreGraphicsOnly"),
+            ("coreGraphicsOnly", "coreGraphicsOnly", "coreGraphicsOnly"),
+            ("skia", "skia", "skiaOptIn"),
+            ("skiaOptIn", "skiaOptIn", "skiaOptIn")
+        ]
+
+        return cases.map { testCase in
+            let environment = testCase.envValue.map { [key: $0] } ?? [:]
+            let resolved = HwpThumbnailPolicyResolver.resolve(environment: environment)
+            return ResolverMeasurement(
+                caseName: testCase.caseName,
+                envValue: testCase.envValue,
+                expectedPolicy: testCase.expectedPolicy,
+                resolvedPolicy: HwpThumbnailPolicyResolver.identifier(for: resolved)
+            )
+        }
+    }
+
+    private static func resolverStatusSummary(_ measurements: [ResolverMeasurement]) -> String {
+        let failed = measurements.filter { $0.status != "OK" }.count
+        return failed == 0 ? "OK" : "FAIL(\(failed))"
+    }
+
+    private static func cacheSeparation(for measurement: FileMeasurement) -> CacheSeparationMeasurement {
+        let coreFirst = measurement.coreGraphics.first
+        let skiaFirst = measurement.skiaOptIn.first
+        let coreCache = coreFirst?.cacheEvent ?? "-"
+        let skiaCache = skiaFirst?.cacheEvent ?? "-"
+        let coreSignature = coreFirst?.signature ?? "-"
+        let skiaSignature = skiaFirst?.signature ?? "-"
+        let signaturesDiffer = coreSignature != "-"
+            && skiaSignature != "-"
+            && coreSignature != skiaSignature
+        let firstRequestsMiss = coreCache == "miss" && skiaCache == "miss"
+        let status = signaturesDiffer && firstRequestsMiss ? "OK" : "WARN"
+        let note: String
+        if signaturesDiffer && firstRequestsMiss {
+            note = "policy signatures are separated"
+        } else if !signaturesDiffer {
+            note = "policy signatures are not separated"
+        } else {
+            note = "first policy requests did not both miss"
+        }
+
+        return CacheSeparationMeasurement(
+            fileName: measurement.fileName,
+            status: status,
+            coreGraphicsFirstCache: coreCache,
+            skiaOptInFirstCache: skiaCache,
+            coreGraphicsSignature: coreSignature,
+            skiaOptInSignature: skiaSignature,
+            note: note
+        )
     }
 
     private static func bucketString(_ key: HwpThumbnailCacheKey) -> String {

--- a/scripts/thumbnail_skia_policy_smoke.swift
+++ b/scripts/thumbnail_skia_policy_smoke.swift
@@ -197,13 +197,13 @@ struct ThumbnailSkiaPolicySmoke {
         let coreGraphics = measurePolicy(
             inputURL: inputURL,
             requests: requests,
-            policyName: "coreGraphicsOnly",
+            policyName: HwpPageRenderPolicy.coreGraphicsOnly.identifier,
             policy: .coreGraphicsOnly
         )
         let skiaOptIn = measurePolicy(
             inputURL: inputURL,
             requests: requests,
-            policyName: "skiaOptIn",
+            policyName: HwpPageRenderPolicy.skiaOptIn.identifier,
             policy: .skiaOptIn
         )
         return FileMeasurement(
@@ -492,14 +492,16 @@ struct ThumbnailSkiaPolicySmoke {
 
     private static func measureResolverContract() -> [ResolverMeasurement] {
         let key = HwpThumbnailPolicyResolver.environmentKey
+        let coreGraphicsOnly = HwpPageRenderPolicy.coreGraphicsOnly.identifier
+        let expectedSkiaEnvPolicy = expectedSkiaEnvPolicyIdentifier
         let cases: [(caseName: String, envValue: String?, expectedPolicy: String)] = [
-            ("missing", nil, "coreGraphicsOnly"),
-            ("empty", "", "coreGraphicsOnly"),
-            ("invalid", "invalid", "coreGraphicsOnly"),
-            ("coreGraphics", "coreGraphics", "coreGraphicsOnly"),
-            ("coreGraphicsOnly", "coreGraphicsOnly", "coreGraphicsOnly"),
-            ("skia", "skia", "skiaOptIn"),
-            ("skiaOptIn", "skiaOptIn", "skiaOptIn")
+            ("missing", nil, coreGraphicsOnly),
+            ("empty", "", coreGraphicsOnly),
+            ("invalid", "invalid", coreGraphicsOnly),
+            ("coreGraphics", "coreGraphics", coreGraphicsOnly),
+            ("coreGraphicsOnly", "coreGraphicsOnly", coreGraphicsOnly),
+            ("skia", "skia", expectedSkiaEnvPolicy),
+            ("skiaOptIn", "skiaOptIn", expectedSkiaEnvPolicy)
         ]
 
         return cases.map { testCase in
@@ -512,6 +514,14 @@ struct ThumbnailSkiaPolicySmoke {
                 resolvedPolicy: HwpThumbnailPolicyResolver.identifier(for: resolved)
             )
         }
+    }
+
+    private static var expectedSkiaEnvPolicyIdentifier: String {
+#if DEBUG
+        HwpPageRenderPolicy.skiaOptIn.identifier
+#else
+        HwpPageRenderPolicy.coreGraphicsOnly.identifier
+#endif
     }
 
     private static func resolverStatusSummary(_ measurements: [ResolverMeasurement]) -> String {


### PR DESCRIPTION
## 요약

- Thumbnail provider에 DEBUG/internal `ALHANGEUL_THUMBNAIL_RENDER_POLICY` opt-in resolver를 추가했습니다.
- Release/default provider는 계속 `coreGraphicsOnly`로 유지하고, Skia는 `skia`/`skiaOptIn` env 값에서만 DEBUG 진단 경로로 선택됩니다.
- provider success log에 policy, cache event, requested/matched bucket, backend, fallback, render timing, pixel size를 남기도록 했습니다.
- thumbnail policy smoke helper가 resolver contract와 policy별 cache signature separation을 summary/detail에 기록하도록 보강했습니다.
- #392에 넘길 `1024x1024` bucket 기준 1px Skia size drift baseline을 최종 보고서와 기술 문서에 정리했습니다.

## 검증

- `./scripts/check-no-appkit.sh`
- `./scripts/verify-rhwp-core-build-info.sh`
- `./scripts/verify-rhwp-studio-assets.sh`
- `xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask389Stage2 CODE_SIGNING_ALLOWED=NO build`
- `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy samples/basic/request.hwp samples/basic/KTX.hwp`
- `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task389-thumbnail-policy-representative samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp`
- `git diff --check`

## 참고

- Related: #389, #387, #392, #393, #394
- #389 이슈 close는 merge 확인 후 cleanup 절차에서 처리합니다.
