### PR TITLE
Task #392: Thumbnail Skia maxDimension mapping 실험

### DIFF
--- a/Sources/Shared/HwpPageImageRenderer.swift
+++ b/Sources/Shared/HwpPageImageRenderer.swift
@@ -187,7 +187,8 @@ enum HwpPageImageRenderer {
                 document: document,
                 pageIndex: pageIndex,
                 pageSize: pageSize,
-                scale: scale
+                scale: scale,
+                maxDimension: skiaMaxDimension(from: maximumPixelSize)
             )
             if let page = attempt.page {
                 return page
@@ -330,13 +331,14 @@ enum HwpPageImageRenderer {
         document: RhwpDocument,
         pageIndex: Int,
         pageSize: CGSize,
-        scale: CGFloat
+        scale: CGFloat,
+        maxDimension: Int
     ) -> SkiaRenderAttempt {
         let skiaStart = DispatchTime.now().uptimeNanoseconds
         let png = document.renderPagePNG(
             at: pageIndex,
-            scale: Double(scale),
-            maxDimension: 0
+            scale: maxDimension > 0 ? 0 : Double(scale),
+            maxDimension: maxDimension
         )
         let skiaRenderMs = elapsedMilliseconds(since: skiaStart)
 
@@ -528,5 +530,17 @@ enum HwpPageImageRenderer {
             maximumPixelSize.height / pageSize.height
         )
         return scale.isFinite && scale > 0 ? scale : 1
+    }
+
+    private static func skiaMaxDimension(from maximumPixelSize: CGSize?) -> Int {
+        guard let maximumPixelSize else {
+            return 0
+        }
+        let longestEdge = max(maximumPixelSize.width, maximumPixelSize.height)
+        guard longestEdge.isFinite, longestEdge > 0 else {
+            return 0
+        }
+        let cappedEdge = min(ceil(longestEdge), CGFloat(Int32.max))
+        return Int(cappedEdge)
     }
 }

--- a/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift
+++ b/Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift
@@ -51,7 +51,7 @@ struct HwpThumbnailRenderSignature: Hashable {
     private static let coreReleaseTag = RhwpCoreBuildInfo.releaseTag
     private static let coreCommit = RhwpCoreBuildInfo.commit
     private static let coreEnabledFeatures = RhwpCoreBuildInfo.enabledFeatures
-    private static let maxDimensionPolicyVersion = "skia-max-dimension-0"
+    private static let maxDimensionPolicyVersion = "skia-max-dimension-thumbnail-v1"
 
     let backendPolicy: String
     let rendererOptionVersion: String

--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #392 | Thumbnail Skia maxDimension mapping 실험 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |
+| #392 | Thumbnail Skia maxDimension mapping 실험 | 완료 | Stage 5 최종 보고와 기술 문서 반영 완료, PR 게시 준비 |

--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #392 | Thumbnail Skia maxDimension mapping 실험 | 완료 | Stage 5 최종 보고와 기술 문서 반영 완료, PR 게시 준비 |
+| #392 | Thumbnail Skia maxDimension mapping 실험 | 완료 | 완료: 18:48, Stage 5 최종 보고와 기술 문서 반영 완료, PR 게시 준비 |

--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 7월 3일
+
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #392 | Thumbnail Skia maxDimension mapping 실험 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #392 | Thumbnail Skia maxDimension mapping 실험 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #392 | Thumbnail Skia maxDimension mapping 실험 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/plans/task_m020_392.md
+++ b/mydocs/plans/task_m020_392.md
@@ -1,0 +1,119 @@
+# Task M020 #392 수행계획서
+
+## 목적
+
+Finder Thumbnail의 Skia opt-in 진단 경로에서 `maximumPixelSize`를 upstream Skia PNG export의 `maxDimension`으로 매핑했을 때 output pixel size, latency, cache signature가 예측 가능하게 동작하는지 확인한다.
+
+#389에서 Thumbnail provider/cache 관측성과 policy별 cache signature separation을 확보했지만, 같은 `1024x1024` bucket에서 Skia 결과가 CoreGraphics보다 긴 축 기준 1px 크게 나오는 패턴이 반복됐다. #392는 이 size drift가 현재 `maxDimension: 0` scale-only 정책 때문인지, `maximumPixelSize -> maxDimension` 매핑으로 완화되는지 검증하는 실험 작업이다.
+
+## 배경
+
+현재 `RhwpDocument.renderPagePNG(at:scale:maxDimension:)`는 `maxDimension` 인자를 받을 수 있다. 하지만 `HwpPageImageRenderer.renderSkiaPage`는 `maxDimension: 0`으로 고정하고, Thumbnail 경로는 `HwpThumbnailRenderRequest.maximumPixelSize`로 요청 bucket을 알고 있음에도 Skia export option에 이 값을 전달하지 않는다.
+
+#389 대표 smoke 기준으로 Thumbnail cache는 policy별로 분리되고 fallback은 발생하지 않았다. 남은 질문은 Skia opt-in에서 output pixel size가 요청 bucket을 넘지 않도록 통제할 수 있는지, 그리고 정책 변경이 cache signature version에 정확히 반영되어 stale bitmap 재사용을 막는지다.
+
+## 범위
+
+포함:
+
+- `HwpPageImageRenderer`의 Skia render path에 Thumbnail 요청 크기 기반 `maxDimension` 입력을 연결하는 실험
+- Thumbnail path에서 `max(maximumPixelSize.width, maximumPixelSize.height)`를 `maxDimension`으로 매핑하는 정책 검토
+- scale-only 정책과 maxDimension 정책의 output pixel size, latency, output bytes, PNG bytes 비교
+- `HwpThumbnailRenderSignature`의 maxDimension policy version 갱신 필요성과 cache separation 검증
+- `scripts/smoke-thumbnail-skia-policy.sh` 또는 Swift smoke helper의 결과 표에 정책 비교에 필요한 값 보강
+- #389에서 넘긴 `request.hwp`, `KTX.hwp`, `복학원서.hwp`, `hwpx-01.hwpx`, `hwp-multi-001.hwp` 대표 샘플 기준 재측정
+
+제외:
+
+- Skia default 전환
+- Quick Look 단일 페이지 scale/direct PNG 정책 변경
+- upstream `rhwp` raster option 변경
+- 사용자-facing 설정 UI 추가
+- Finder/LaunchServices system cache 정책 변경
+- visual 품질 판정 자체. visual default 판단은 #396 baseline과 후속 readiness gate에서 종합한다.
+
+## 설계 방향
+
+실험은 production default를 바꾸지 않고 `.skiaOptIn` 진단 경로에서만 진행한다. CoreGraphics 기본 경로와 Release provider default는 계속 유지한다.
+
+우선 현재 scale-only 기준을 Stage 1 baseline으로 다시 고정한다. 이후 Skia path가 `maximumPixelSize`를 받을 수 있도록 Shared renderer contract를 좁게 확장하고, Thumbnail 요청에서만 긴 변을 `maxDimension`으로 넘긴다. 정책이 output pixel size 또는 cache 결과를 바꾸면 `HwpThumbnailRenderSignature`의 `maxDimensionPolicyVersion`을 새 값으로 올려 기존 `skia-max-dimension-0` cache와 분리한다.
+
+비교는 같은 sample, 같은 request bucket, 같은 policy pair에서 수행한다. 성공 기준은 Skia output의 긴 축이 요청 bucket을 과도하게 넘지 않고, cache pattern이 `miss -> exactHit -> largerBucketHit -> largerBucketHit` 형태로 유지되며, signature가 정책 변경을 명확히 반영하는 것이다.
+
+## 예상 변경 파일
+
+- `mydocs/plans/task_m020_392.md`
+- `mydocs/plans/task_m020_392_impl.md`
+- `mydocs/working/task_m020_392_stage*.md`
+- `mydocs/report/task_m020_392_report.md`
+- `mydocs/orders/20260703.md`
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- 필요 시 `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+- 필요 시 `scripts/thumbnail_skia_policy_smoke.swift`
+- 필요 시 `scripts/smoke-thumbnail-skia-policy.sh`
+- 필요 시 `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- 필요 시 `mydocs/tech/skia_preview_renderer_baseline.md`
+
+## 잠정 단계
+
+1. Stage 1: 현행 scale-only baseline inventory
+   - `HwpPageImageRenderer`, `RhwpDocument.renderPagePNG`, `HwpThumbnailRenderCache`, smoke helper의 maxDimension 관련 경로를 읽고 현재 계약을 정리한다.
+   - #389 대표 smoke 결과와 현재 브랜치 재측정 결과를 비교해 실험 전 baseline을 고정한다.
+2. Stage 2: maxDimension mapping 설계와 signature 정책 확정
+   - Shared renderer가 `maximumPixelSize`를 Skia `maxDimension`으로 넘기는 최소 변경안을 정한다.
+   - Thumbnail cache signature version 값을 어떻게 바꿀지 정하고 stale cache 위험을 검토한다.
+3. Stage 3: opt-in 실험 구현과 smoke 보강
+   - Thumbnail Skia opt-in path에 maxDimension mapping을 적용한다.
+   - smoke output이 output pixel size, requested bucket, backend, cache event, signature version을 비교 가능하게 남기도록 필요한 범위만 보강한다.
+4. Stage 4: 대표 샘플 비교 측정
+   - quick/representative sample에서 scale-only baseline 대비 maxDimension 정책의 pixel size, latency, bytes, cache pattern을 정리한다.
+   - `KTX.hwp`와 portrait 계열의 1px drift가 해소/유지/변형되는지 분류한다.
+5. Stage 5: 최종 보고와 문서 반영
+   - 최종 보고서와 기술 문서에 Thumbnail maxDimension 정책, 잔여 risk, #393/#259로 넘길 판단 근거를 기록한다.
+   - 오늘할일 완료 처리와 PR 게시 준비를 수행한다.
+
+## 검증 계획
+
+기본 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+git diff --check
+```
+
+빌드 검증 후보:
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask392 CODE_SIGNING_ALLOWED=NO build
+```
+
+Thumbnail smoke 후보:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+```
+
+필요 시 비교용으로 Stage 1 baseline output과 Stage 4 output의 summary/detail 파일을 `rg` 또는 작은 parser로 비교한다.
+
+## 리스크
+
+- upstream Skia의 `maxDimension` semantics가 scale과 함께 적용될 때 기대와 다를 수 있다. 이 경우 정책을 바로 default로 삼지 않고 결과를 문서화한다.
+- output pixel size가 개선되어도 visual 품질이 개선된다는 뜻은 아니다. visual 판단은 #396 baseline과 별도로 연결한다.
+- signature version을 잘못 유지하면 기존 scale-only cache와 maxDimension cache가 섞일 수 있다.
+- `maximumPixelSize`가 0, NaN, 무한대, 비정상 비율일 때 방어 로직이 필요할 수 있다.
+- smoke 수치의 latency는 로컬 환경 변동을 받으므로 절대값보다 정책별 상대 변화와 큰 회귀를 중심으로 해석한다.
+
+## 승인 요청 사항
+
+- 기준 브랜치는 `devel`, 작업 브랜치는 `local/task392`로 진행한다.
+- 이 작업은 #387 추적 이슈의 Thumbnail maxDimension 후속 #392로 진행한다.
+- 수행계획서 승인 후 구현계획서를 작성하고 Stage 1 inventory부터 시작한다.
+- production default는 CoreGraphics 유지, Skia 변경은 DEBUG/internal opt-in diagnostic 경로의 Thumbnail 실험에 한정한다.

--- a/mydocs/plans/task_m020_392_impl.md
+++ b/mydocs/plans/task_m020_392_impl.md
@@ -1,0 +1,268 @@
+# Task M020 #392 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_392.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #392 `Thumbnail Skia maxDimension mapping 실험`
+- 추적 이슈: #387 Preview/Thumbnail Skia readiness 후속 개선 추적
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task392`
+- 목표: Thumbnail Skia opt-in 경로에서 `maximumPixelSize`를 upstream PNG export `maxDimension`으로 매핑해 1px size drift와 cache/signature 영향을 측정한다.
+
+## 구현 원칙
+
+- production default는 계속 `.coreGraphicsOnly`다.
+- Skia default 전환, Quick Look direct PNG, upstream `rhwp` 변경은 하지 않는다.
+- `Sources/RhwpCoreBridge`에는 AppKit/UIKit 의존을 추가하지 않는다.
+- `project.yml`이 Xcode project 원본이다. 이번 작업은 새 Swift source 추가 없이 기존 target source만 변경하는 것을 우선한다.
+- maxDimension 정책 변경이 cache output을 바꿀 수 있으므로 `HwpThumbnailRenderSignature`의 policy version을 반드시 검토한다.
+- scale-only baseline과 maxDimension 적용 후 결과를 같은 request sequence로 비교한다.
+
+## Stage 1. 현행 scale-only baseline inventory
+
+### 목표
+
+현재 Thumbnail Skia path가 `maxDimension: 0`으로 동작하는 계약과 baseline output을 고정한다.
+
+### 대상
+
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- `scripts/smoke-thumbnail-skia-policy.sh`
+- `scripts/thumbnail_skia_policy_smoke.swift`
+- `mydocs/report/task_m020_389_report.md`
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- `mydocs/tech/skia_preview_renderer_baseline.md`
+
+### 작업
+
+1. `HwpPageImageRenderer.renderPage`가 `maximumPixelSize`로 scale을 계산하고, Skia 호출에는 `maxDimension: 0`을 넘기는 현재 흐름을 정리한다.
+2. `HwpThumbnailRenderRequest`의 pixel bucket 계산과 `HwpThumbnailRenderSignature.maxDimensionPolicyVersion == skia-max-dimension-0` 의미를 정리한다.
+3. smoke helper가 이미 기록하는 `RequestedBucket`, `MatchedBucket`, `Signature`, `Pixel`, `OutputBytes`, `PNGBytes`, `RenderMs`를 확인한다.
+4. 현재 브랜치에서 quick smoke를 실행해 #389 baseline과 같은 1px drift가 재현되는지 확인한다.
+5. Stage 2에서 변경할 source surface와 signature version 후보를 확정한다.
+
+### 검증
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage1-scale-only \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+rg -n "maxDimension|maximumPixelSize|skia-max-dimension-0|1024x1025|1025x725|Signature|Pixel" \
+  Sources/Shared/HwpPageImageRenderer.swift Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift \
+  build.noindex/task392-stage1-scale-only mydocs/working/task_m020_392_stage1.md
+git diff --check
+```
+
+### 완료 조건
+
+- 현재 scale-only Skia path와 thumbnail cache signature 의미가 문서화되어 있다.
+- quick smoke baseline에서 request bucket, Skia pixel size, cache pattern, signature가 정리되어 있다.
+- Stage 2 설계 입력이 충분하다.
+
+### 커밋 메시지
+
+```text
+Task #392 Stage 1: Thumbnail maxDimension baseline inventory
+```
+
+## Stage 2. maxDimension mapping 설계와 signature 정책 확정
+
+### 목표
+
+Shared renderer와 Thumbnail cache 사이에서 `maximumPixelSize -> maxDimension`을 어떻게 연결할지 확정한다.
+
+### 대상
+
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- `scripts/thumbnail_skia_policy_smoke.swift`
+- `mydocs/working/task_m020_392_stage2.md`
+
+### 작업
+
+1. `renderSkiaPage`가 `maximumPixelSize` 또는 계산된 `maxDimension`을 받을 수 있게 하는 최소 API 변경안을 정한다.
+2. `maxDimension` 계산 규칙을 정한다.
+   - `maximumPixelSize == nil`이면 `0`
+   - finite이고 양수인 긴 변만 사용
+   - `Int(UInt32.max)` 초과 방어는 `RhwpDocument.renderPagePNG` guard와 중복되지 않게 처리
+3. Thumbnail에서만 maxDimension mapping을 적용하고 Quick Look path 영향이 없는지 확인한다.
+4. `HwpThumbnailRenderSignature.maxDimensionPolicyVersion` 새 값을 정한다.
+   - 후보: `skia-max-dimension-thumbnail-v1`
+   - 기존 `skia-max-dimension-0` cache와 분리되는지 확인
+5. smoke summary/detail에서 signature version 변화와 pixel drift를 확인할 수 있는지 검토한다.
+
+### 검증
+
+```bash
+rg -n "renderSkiaPage|renderPagePNG|maxDimensionPolicyVersion|HwpThumbnailRenderSignature|maximumPixelSize" \
+  Sources/Shared/HwpPageImageRenderer.swift Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift \
+  scripts/thumbnail_skia_policy_smoke.swift mydocs/working/task_m020_392_stage2.md
+git diff --check
+```
+
+### 완료 조건
+
+- source 변경 전 적용할 maxDimension mapping contract가 문서화되어 있다.
+- cache signature version 변경 여부와 값이 확정되어 있다.
+- Stage 3 구현 범위가 source 단위로 명확하다.
+
+### 커밋 메시지
+
+```text
+Task #392 Stage 2: Thumbnail maxDimension mapping 설계
+```
+
+## Stage 3. opt-in 실험 구현과 smoke 보강
+
+### 목표
+
+Thumbnail Skia opt-in path에 maxDimension mapping을 적용하고, smoke 결과가 정책 변경을 추적할 수 있게 한다.
+
+### 대상
+
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift`
+- 필요 시 `scripts/thumbnail_skia_policy_smoke.swift`
+- `mydocs/working/task_m020_392_stage3.md`
+
+### 작업
+
+1. `HwpPageImageRenderer.renderPage`에서 Skia attempt 호출 시 `maximumPixelSize` 기반 maxDimension을 전달한다.
+2. CoreGraphics path와 embedded thumbnail decode path는 기존 scale/bucket 정책을 유지한다.
+3. `HwpThumbnailRenderSignature`의 maxDimension policy version을 새 값으로 갱신한다.
+4. smoke helper가 기존 `Signature`, `Pixel`, `RequestedBucket`, `MatchedBucket` column으로 충분한지 확인하고, 부족하면 최소 column만 보강한다.
+5. quick smoke로 cache miss/hit/reuse와 backend/fallback이 유지되는지 확인한다.
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage3-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+rg -n "skia-max-dimension|coreGraphicsOnly|skiaOptIn|Pixel|Signature|miss|exactHit|largerBucketHit|Fallback" \
+  build.noindex/task392-stage3-thumbnail-policy Sources scripts mydocs/working/task_m020_392_stage3.md
+git diff --check
+```
+
+가능하면 build 검증:
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask392Stage3 CODE_SIGNING_ALLOWED=NO build
+```
+
+### 완료 조건
+
+- Thumbnail Skia opt-in path에서 `maxDimension`이 요청 bucket 긴 변으로 전달된다.
+- cache signature가 기존 scale-only 정책과 분리된다.
+- quick smoke가 성공하고 fallback이 새로 발생하지 않는다.
+
+### 커밋 메시지
+
+```text
+Task #392 Stage 3: Thumbnail Skia maxDimension opt-in 적용
+```
+
+## Stage 4. 대표 샘플 비교 측정
+
+### 목표
+
+대표 샘플에서 maxDimension 정책 적용 후 pixel size, latency, bytes, cache pattern을 측정하고 #389 baseline과 비교한다.
+
+### 대상
+
+- `build.noindex/task392-stage1-scale-only/`
+- `build.noindex/task392-stage3-thumbnail-policy/`
+- `build.noindex/task392-thumbnail-policy-representative/`
+- `mydocs/working/task_m020_392_stage4.md`
+- 필요 시 `mydocs/tech/skia_preview_renderer_baseline.md`
+
+### 작업
+
+1. 기본 검증 command를 실행한다.
+2. 대표 샘플 smoke를 실행한다.
+3. `request.hwp`, `KTX.hwp`, `복학원서.hwp`, `hwpx-01.hwpx`, `hwp-multi-001.hwp`의 CoreGraphics/Skia pixel size를 비교한다.
+4. 1px drift가 해소/유지/다른 형태로 변했는지 표로 정리한다.
+5. `RenderMs`, `OutputBytes`, `PNGBytes`, cache pattern, signature를 함께 정리한다.
+6. #393 또는 #259로 넘길 판단 근거와 잔여 risk를 분리한다.
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+rg -n "OK|FAIL|coreGraphicsOnly|skiaOptIn|Pixel|OutputBytes|PNGBytes|RenderMs|Signature|skia-max-dimension|largerBucketHit" \
+  build.noindex/task392-thumbnail-policy-representative mydocs/working/task_m020_392_stage4.md
+git diff --check
+```
+
+### 완료 조건
+
+- 대표 샘플 결과가 존재하고 summary/detail을 근거로 해석 가능하다.
+- 1px drift에 대한 결론이 sample별로 정리되어 있다.
+- latency/bytes/cache signature risk가 보고서 입력으로 정리되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #392 Stage 4: Thumbnail maxDimension 대표 샘플 검증
+```
+
+## Stage 5. 최종 보고와 문서 반영
+
+### 목표
+
+#392 실험 결과를 최종 보고서와 기술 문서에 반영하고 PR 게시 준비를 완료한다.
+
+### 대상
+
+- `mydocs/report/task_m020_392_report.md`
+- `mydocs/orders/20260703.md`
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- 필요 시 `mydocs/tech/skia_preview_renderer_baseline.md`
+
+### 작업
+
+1. 최종 보고서에 maxDimension mapping 정책, signature version, smoke 결과, 비교 결론을 정리한다.
+2. 기술 문서의 Thumbnail maxDimension 기준과 잔여 판단을 갱신한다.
+3. 오늘할일 #392 상태를 완료 처리한다.
+4. #387, #389, #393, #259와의 후속 관계를 정리한다.
+5. PR body 초안에 들어갈 변경 요약과 검증 결과를 정리한다.
+
+### 검증
+
+```bash
+rg -n "#392|#387|#389|#393|#259|maxDimension|maximumPixelSize|Thumbnail|Skia|CoreGraphics|cache|signature|smoke" \
+  mydocs/report/task_m020_392_report.md mydocs/orders/20260703.md \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/tech/skia_preview_renderer_baseline.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task392
+```
+
+### 완료 조건
+
+- #392 최종 결론과 잔여 risk가 문서화되어 있다.
+- 오늘할일이 완료 처리되어 있다.
+- PR 게시에 필요한 변경 요약과 검증 결과가 정리되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #392 Stage 5 + 최종 보고서: Thumbnail maxDimension 실험 정리
+```
+
+## 승인 요청 사항
+
+- 이 구현계획서 승인 후 Stage 1 `현행 scale-only baseline inventory`를 시작한다.
+- Stage 1에서는 source 변경 없이 baseline 조사와 재측정만 수행한다.
+- Stage 3 전까지 production 동작을 바꾸는 코드는 작성하지 않는다.

--- a/mydocs/report/task_m020_392_report.md
+++ b/mydocs/report/task_m020_392_report.md
@@ -1,0 +1,218 @@
+# Task #392 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | #392 `Thumbnail Skia maxDimension mapping 실험` |
+| 추적 이슈 | #387 `Preview/Thumbnail Skia readiness 후속 개선 추적` |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 작업 브랜치 | `local/task392` |
+| 단계 수 | 5 |
+
+Finder Thumbnail production default는 `coreGraphicsOnly`로 유지하면서, DEBUG/internal `skiaOptIn` 진단 경로에서 `maximumPixelSize`를 upstream Skia PNG export의 `maxDimension`으로 매핑하는 실험을 완료했다.
+
+핵심 결과:
+
+- Thumbnail Skia opt-in path에서 `maximumPixelSize`의 긴 변을 `PngExportOptions.max_dimension`으로 전달한다.
+- `maxDimension > 0`일 때는 upstream 자동 scale 계산을 사용하도록 `scale: 0`으로 호출한다.
+- Thumbnail render signature suffix를 `skia-max-dimension-thumbnail-v1`로 갱신해 기존 scale-only cache와 분리했다.
+- 대표 5개 샘플 smoke에서 40 render rows 모두 `OK`, resolver contract `OK`, fallback 0건이었다.
+- #389에서 관찰한 1px 초과 drift는 5개 중 4개 샘플에서 해소됐다.
+- `request.hwp`는 Skia output이 `567x794`로 낮아지는 underfill risk가 확인되어, maxDimension 단독 정책은 아직 default 전환 근거로 부족하다.
+
+## 변경 파일과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `Sources/Shared/HwpPageImageRenderer.swift` | Skia render attempt에 `maxDimension` 전달, `maxDimension > 0`이면 Rust bridge 호출 시 `scale: 0` 사용, 안전한 `skiaMaxDimension(from:)` helper 추가 |
+| `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift` | `maxDimensionPolicyVersion`을 `skia-max-dimension-thumbnail-v1`로 갱신 |
+| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | #392 maxDimension 대표 smoke 결과와 underfill risk 반영 |
+| `mydocs/tech/skia_preview_renderer_baseline.md` | Thumbnail/Finder 판단 상태를 #392 결과 기준으로 갱신 |
+| `mydocs/plans/task_m020_392.md` | 수행계획서 |
+| `mydocs/plans/task_m020_392_impl.md` | 단계별 구현계획서 |
+| `mydocs/working/task_m020_392_stage1.md` | scale-only baseline inventory |
+| `mydocs/working/task_m020_392_stage2.md` | maxDimension mapping 설계 |
+| `mydocs/working/task_m020_392_stage3.md` | opt-in 구현과 quick smoke 결과 |
+| `mydocs/working/task_m020_392_stage4.md` | 대표 샘플 smoke와 drift 분류 |
+| `mydocs/report/task_m020_392_report.md` | 최종 보고서 |
+| `mydocs/orders/20260703.md` | #392 완료 처리 |
+
+Quick Look direct PNG path, Release default, 사용자-facing 설정 UI, upstream `rhwp` 코드는 변경하지 않았다.
+
+## 구현 계약
+
+Stage 2에서 확인한 upstream/bridge 계약은 다음과 같다.
+
+- RustBridge `rhwp_render_page_png`는 `scale == 0`을 `None`, `max_dimension == 0`을 `None`으로 변환한다.
+- upstream `PngExportOptions`는 명시 `scale`을 `max_dimension` 자동 scale보다 우선한다.
+- Skia raster renderer는 최종 scaled dimension이 `max_dimension`을 넘으면 error를 낼 수 있다.
+
+따라서 이번 구현은 `maxDimension > 0`인 Thumbnail 요청에서 explicit scale을 함께 넘기지 않는다.
+
+적용 계약:
+
+| 조건 | Skia 호출 |
+|------|-----------|
+| `maximumPixelSize`가 nil/invalid/0 이하 | `scale: Double(scale)`, `maxDimension: 0` |
+| `maximumPixelSize`의 긴 변이 유효 | `scale: 0`, `maxDimension: ceil(longestEdge)` |
+
+`skiaMaxDimension(from:)` helper는 non-finite 값과 0 이하 값을 `0`으로 처리하고, 유효한 값은 `Int32.max`로 상한 처리한다.
+
+## Smoke 결과
+
+### Stage 1 scale-only baseline
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage1-scale-only \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+| sample | policy | pixel | signature suffix |
+|------|------|------|------|
+| `request.hwp` | `coreGraphicsOnly` | `732x1024` | `skia-max-dimension-0` |
+| `request.hwp` | `skiaOptIn` | `732x1025` | `skia-max-dimension-0` |
+| `KTX.hwp` | `coreGraphicsOnly` | `1024x725` | `skia-max-dimension-0` |
+| `KTX.hwp` | `skiaOptIn` | `1025x725` | `skia-max-dimension-0` |
+
+### Stage 3 quick smoke
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage3-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+결과:
+
+- resolver contract: `OK`
+- render rows: 16건 모두 `OK`
+- fallback: 0건
+- cache pattern: 각 정책에서 `miss -> exactHit -> largerBucketHit(1024x1024) -> largerBucketHit(1024x1024)`
+- signature suffix: `skia-max-dimension-thumbnail-v1`
+
+| sample | policy | Stage 1 Pixel | Stage 3 Pixel | 해석 |
+|------|------|------|------|------|
+| `request.hwp` | `skiaOptIn` | `732x1025` | `567x794` | 1024px 초과는 사라졌지만 underfill risk 발생 |
+| `KTX.hwp` | `skiaOptIn` | `1025x725` | `1024x725` | 1px 초과 해소 |
+
+### Stage 4 representative smoke
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+```
+
+결과:
+
+| 항목 | 결과 |
+|------|------|
+| resolver contract | `OK` |
+| render rows | 40건 모두 `OK` |
+| cache pattern | 각 파일/정책 모두 `miss -> exactHit -> largerBucketHit -> largerBucketHit` |
+| cache signature separation | 5개 샘플 모두 `OK` |
+| backend | `coreGraphicsOnly`는 `coreGraphics`, `skiaOptIn`은 `skia` |
+| fallback | 모든 row `-` |
+
+`복학원서.hwp` 처리 중 기존 `LAYOUT_OVERFLOW` warning 3줄이 stderr에 출력됐지만 render status는 모두 `OK`였고 fallback은 발생하지 않았다.
+
+## Drift 분류
+
+비교 기준은 #389 Stage 4 scale-only 대표 smoke다.
+
+| File | #389 Skia scale-only Pixel | #392 Skia maxDimension Pixel | 분류 |
+|------|------|------|------|
+| `복학원서.hwp` | `725x1025` | `725x1024` | 해소 |
+| `KTX.hwp` | `1025x725` | `1024x725` | 해소 |
+| `request.hwp` | `732x1025` | `567x794` | 변형 |
+| `hwpx-01.hwpx` | `725x1025` | `725x1024` | 해소 |
+| `hwp-multi-001.hwp` | `725x1025` | `725x1024` | 해소 |
+
+정리하면 maxDimension 매핑은 1px 초과 drift를 통제하는 데 효과가 있다. 하지만 `request.hwp`처럼 upstream Skia가 자연 해상도 이상 확대하지 않는 문서가 있어, maxDimension 정책을 그대로 Skia default 전환 근거로 삼기는 어렵다.
+
+## 후속 이슈 관계
+
+| 이슈 | 관계 |
+|------|------|
+| #387 | #392는 Preview/Thumbnail Skia readiness 추적 중 Thumbnail size drift 실험이다 |
+| #389 | #389가 provider diagnostic path와 cache signature separation을 확보했고, #392는 그 결과로 드러난 1px drift를 실험했다 |
+| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험이다. #392의 Thumbnail maxDimension underfill risk와 별도 surface로 판단한다 |
+| #259 | Skia default/release readiness gate다. #392 결과는 1px drift 해소 신호와 `request.hwp` underfill risk를 함께 입력으로 넘긴다 |
+
+## 단계 요약
+
+| Stage | 커밋 | 요약 |
+|------|------|------|
+| 계획 | `b7b2d83` | 수행계획서 작성과 오늘할일 갱신 |
+| 구현계획 | `3be144d` | 단계별 구현계획서 작성 |
+| Stage 1 | `7b83628` | scale-only baseline inventory |
+| Stage 2 | `2546390` | maxDimension mapping 설계 |
+| Stage 3 | `e775299` | Thumbnail Skia maxDimension opt-in 적용 |
+| Stage 4 | `6a845ef` | 대표 샘플 smoke와 drift 분류 |
+| Stage 5 | 이번 커밋 | 최종 보고서와 기술 문서 반영 |
+
+## 검증 결과
+
+실행한 주요 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage1-scale-only \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage3-thumbnail-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask392Stage3 CODE_SIGNING_ALLOWED=NO build
+```
+
+결과:
+
+- `check-no-appkit.sh`: 성공.
+- `verify-rhwp-core-build-info.sh`: 성공.
+- `verify-rhwp-studio-assets.sh`: 성공.
+- Stage 1 quick smoke: 성공. 16 rows 모두 `OK`.
+- Stage 3 quick smoke: 성공. 16 rows 모두 `OK`.
+- Stage 4 representative smoke: 성공. 40 rows 모두 `OK`.
+- `xcodebuild ... ThumbnailExtension ... build`: 성공. macOS build는 `BUILD SUCCEEDED`. Xcode/CoreSimulator version warning은 출력됐지만 build 실패는 아니었다.
+- `git diff --check`: 각 단계에서 성공.
+
+최종 보고서 검증:
+
+```bash
+rg -n "#392|#387|#389|#393|#259|maxDimension|maximumPixelSize|Thumbnail|Skia|CoreGraphics|cache|signature|smoke" \
+  mydocs/report/task_m020_392_report.md mydocs/orders/20260703.md \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/tech/skia_preview_renderer_baseline.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task392
+```
+
+## 잔여 위험
+
+| 항목 | 상태 | 처리 |
+|------|------|------|
+| `request.hwp` underfill | maxDimension path에서 `567x794`로 낮아짐 | #259 visual/thumbnail readiness에서 default 전환 blocker 후보로 유지 |
+| latency 절대값 | 단일 로컬 실행값이라 변동 가능 | 대표 smoke의 상대 신호로만 해석 |
+| CoreGraphics cache invalidation | signature suffix가 공통 필드라 CoreGraphics thumbnail cache도 함께 갱신 | stale cache 방지 우선. 필요 시 per-policy option signature 분리 |
+| visual 품질 | 이번 작업은 pixel/cache smoke 중심 | #396 visual suite와 #259 readiness gate에서 종합 |
+
+## PR 게시 메모
+
+권장 PR 제목:
+
+```text
+Task #392: Thumbnail Skia maxDimension mapping 실험
+```
+
+권장 리뷰 포인트:
+
+- Release/production default가 계속 `coreGraphicsOnly`인지
+- `maxDimension > 0`일 때 explicit `scale`을 넘기지 않는 계약이 upstream 우선순위와 맞는지
+- `skia-max-dimension-thumbnail-v1` signature 갱신이 기존 cache 혼입을 막는지
+- 대표 샘플 5개 중 4개에서 1px drift가 해소된 점과 `request.hwp` underfill risk를 균형 있게 해석했는지
+- #259 default readiness로 넘길 blocker 후보가 문서화되어 있는지

--- a/mydocs/tech/skia_preview_renderer_baseline.md
+++ b/mydocs/tech/skia_preview_renderer_baseline.md
@@ -171,4 +171,5 @@ Task #396 Stage 4 기준 quick suite는 CoreGraphics/Skia 양쪽 모두 exit 0�
 - extended suite를 CI hard gate로 올리기 전에는 retry/flake 정책이 필요하다.
 - `form-002.hwpx`는 rhwp-studio automation readiness 개선 전까지 renderer 품질 판단에서 제외하거나 persistent readiness failure로 별도 표기한다.
 - Thumbnail/Finder cache 판단은 visual suite만으로 완료하지 않는다. #389에서 provider diagnostic path, resolver contract, internal thumbnail cache signature separation smoke는 확보했다.
-- 남은 Thumbnail surface 판단은 #392의 `maximumPixelSize -> Skia maxDimension/scale/rounding` mapping 실험과 visual/size drift 해석을 함께 본다.
+- #392에서 `maximumPixelSize -> Skia maxDimension` mapping을 적용한 결과, 대표 5개 중 4개는 1px thumbnail drift가 해소됐다.
+- `request-basic-quick`은 Skia maxDimension path에서 `567x794`로 낮아지는 underfill risk가 확인됐다. 따라서 Thumbnail surface 판단은 size drift 해소만으로 끝내지 않고, visual/thumbnail readiness에서 underfill과 구조 누락 여부를 함께 본다.

--- a/mydocs/tech/skia_quicklook_thumbnail_backend.md
+++ b/mydocs/tech/skia_quicklook_thumbnail_backend.md
@@ -101,7 +101,7 @@ Thumbnail은 작은 bitmap을 빠르게 제공하는 surface이므로 latency, m
 - Skia 실패는 fallback tile로 바로 가지 않고 CoreGraphics fallback을 먼저 시도한다.
 - CoreGraphics fallback까지 실패하면 기존 fallback tile 정책을 유지한다.
 
-Thumbnail은 Quick Look보다 `max_dimension` 매핑이 명확하다. 다만 PNG decode 비용과 cache key 변화가 있으므로 `Skia first` 전환은 Quick Look과 독립적으로 판단한다.
+Thumbnail은 Quick Look보다 `max_dimension` 입력 경계가 명확하다. 다만 #392에서 `request.hwp`처럼 upstream Skia가 자연 해상도 이상 확대하지 않아 output bitmap이 작아지는 underfill risk가 확인됐다. PNG decode 비용, cache key 변화, underfill risk가 있으므로 `Skia first` 전환은 Quick Look과 독립적으로 판단한다.
 
 ## option mapping
 
@@ -275,6 +275,17 @@ Skia optional backend는 다음 순서로 진행한다.
 - `scripts/smoke-thumbnail-skia-policy.sh`는 resolver contract와 cache signature separation을 summary/detail에 기록한다.
 - 2026-07-01 대표 smoke 결과는 5 files x 2 policies x 4 requests = 40 rows 모두 `OK`, resolver contract `OK`, cache signature separation 5 rows 모두 `OK`였다.
 - 동일 `1024x1024` bucket에서 Skia pixel size가 CoreGraphics보다 긴 축 기준 1px 크게 나오는 패턴은 cache 실패가 아니라 #392 `maxDimension` mapping 실험 입력으로 분리한다.
+
+2026-07-03 #392 Thumbnail maxDimension mapping 실험 결과:
+
+- Provider default는 계속 `coreGraphicsOnly`다.
+- `skiaOptIn` path는 `HwpThumbnailRenderRequest.maximumPixelSize`의 긴 변을 upstream `PngExportOptions.max_dimension`에 전달한다.
+- `maxDimension > 0`일 때는 upstream 자동 scale 계산을 사용하기 위해 `scale: 0`으로 `renderPagePNG`를 호출한다.
+- Thumbnail render signature suffix는 `skia-max-dimension-thumbnail-v1`이다. 기존 `skia-max-dimension-0` scale-only cache와 섞이지 않는다.
+- 대표 smoke 결과는 5 files x 2 policies x 4 requests = 40 rows 모두 `OK`, resolver contract `OK`, cache signature separation 5 rows 모두 `OK`, fallback 0건이었다.
+- #389 scale-only 대비 `복학원서.hwp`, `KTX.hwp`, `hwpx-01.hwpx`, `hwp-multi-001.hwp`의 1px 초과 drift는 해소됐다.
+- `request.hwp`는 `732x1025`에서 `567x794`로 바뀌었다. 1024px 초과는 없어졌지만, Skia가 자연 해상도 이상 확대하지 않는 underfill risk로 분류한다.
+- 따라서 maxDimension 매핑은 1px drift 방지에는 유효하지만, 단독으로 Thumbnail Skia default 전환 근거가 되지는 않는다. #259 readiness gate에서는 underfill risk와 visual 품질을 함께 본다.
 
 비책임:
 

--- a/mydocs/working/task_m020_392_stage1.md
+++ b/mydocs/working/task_m020_392_stage1.md
@@ -1,0 +1,158 @@
+# Task M020 #392 Stage 1 보고서
+
+## 단계 목적
+
+현행 Thumbnail Skia opt-in path가 `maxDimension: 0` scale-only 정책으로 동작한다는 사실을 코드와 smoke output으로 확인하고, #389에서 넘긴 1px size drift baseline이 현재 브랜치에서도 재현되는지 고정했다.
+
+이번 단계는 source 변경 없이 inventory와 quick smoke 재측정만 수행했다.
+
+## 산출물
+
+| 파일/산출물 | 줄 수 | 내용 |
+|------|------:|------|
+| `Sources/Shared/HwpPageImageRenderer.swift` | 532 | `maximumPixelSize` 기반 scale 계산과 Skia `maxDimension: 0` 호출 경로 확인 |
+| `Sources/RhwpCoreBridge/RhwpDocument.swift` | 260 | `renderPagePNG(at:scale:maxDimension:)` guard와 FFI 전달 계약 확인 |
+| `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift` | 280 | pixel bucket, render signature, cache hit/reuse 조건 확인 |
+| `scripts/thumbnail_skia_policy_smoke.swift` | 639 | summary/detail column과 cache signature separation 측정 항목 확인 |
+| `scripts/smoke-thumbnail-skia-policy.sh` | 111 | DEBUG smoke compile path 확인 |
+| `mydocs/report/task_m020_389_report.md` | 243 | #389 handoff의 1px drift baseline 확인 |
+| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | 453 | Thumbnail maxDimension 정책 문서 기준 확인 |
+| `mydocs/tech/skia_preview_renderer_baseline.md` | 174 | Thumbnail surface 판단이 #392 입력을 기다리는 상태 확인 |
+| `build.noindex/task392-stage1-scale-only/summary.txt` | 44 | Stage 1 quick smoke summary |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+소스 파일은 변경하지 않았다. 새로 추가한 문서는 이 Stage 1 보고서뿐이다.
+
+## Inventory 결과
+
+### Shared renderer
+
+`HwpPageImageRenderer.renderPage`는 `maximumPixelSize`가 있으면 `renderScale(pageSize:maximumPixelSize:)`로 scale을 계산한다. 그러나 `.skiaOptIn` 분기에서 `renderSkiaPage`를 호출할 때는 scale만 넘기고, `renderSkiaPage` 내부 FFI 호출은 현재 `maxDimension: 0`으로 고정되어 있다.
+
+현재 Skia 호출 형태:
+
+```swift
+document.renderPagePNG(
+    at: pageIndex,
+    scale: Double(scale),
+    maxDimension: 0
+)
+```
+
+따라서 현재 Thumbnail Skia path는 `maximumPixelSize`를 직접 upstream `max_dimension`에 전달하지 않는 scale-only 정책이다.
+
+### RustBridge wrapper
+
+`RhwpDocument.renderPagePNG(at:scale:maxDimension:)`는 `scale.isFinite`, `scale >= 0`, `maxDimension >= 0`, `maxDimension <= UInt32.max`를 확인한 뒤 `rhwp_render_page_png`에 `scale`과 `UInt32(maxDimension)`을 전달한다.
+
+즉 Swift wrapper는 이미 maxDimension 전달 능력을 갖고 있으며, #392의 변경 지점은 Shared renderer에서 이 값을 계산해 넘길지 여부다.
+
+### Thumbnail cache signature
+
+`HwpThumbnailRenderRequest`는 Finder request `maximumSize`와 `scale`로 pixel bucket을 만든다. 기본 request sequence 기준:
+
+| request | bucket |
+|------|------|
+| `large:512x512@2` | `1024x1024` |
+| `large-repeat:512x512@2` | `1024x1024` |
+| `medium-after-large:256x256@2` | `512x512` |
+| `small-after-large:128x128@1` | `128x128` |
+
+`HwpThumbnailRenderSignature`의 현재 maxDimension policy version은 `skia-max-dimension-0`이다. 이 값은 CoreGraphics와 Skia policy 양쪽 signature에 모두 포함된다.
+
+Stage 2 입력:
+
+- maxDimension mapping을 적용하면 signature version은 기존 `skia-max-dimension-0`과 분리해야 한다.
+- 후보 값은 구현계획서의 `skia-max-dimension-thumbnail-v1`을 우선 검토한다.
+- cache reuse 조건은 `candidateKey.renderSignature == requestedKey.renderSignature`를 포함하므로 version 변경은 stale cache 혼입을 차단한다.
+
+### Smoke helper
+
+현재 smoke summary/detail은 Stage 2/3 판단에 필요한 주요 값을 이미 출력한다.
+
+| 항목 | 현재 출력 위치 |
+|------|------|
+| request bucket | `RequestedBucket`, `MatchedBucket` |
+| cache event | `Cache` / `CacheEvent` |
+| signature | detail `Signature`, summary cache separation |
+| backend/fallback | `Backend`, `Fallback` |
+| output pixel size | `Pixel` / `PixelSize` |
+| bytes/timing | `OutputBytes`, `PNGBytes`, `RenderMs`, `Seconds` |
+
+따라서 Stage 3에서 helper column을 반드시 늘릴 필요는 없다. 다만 signature version을 더 쉽게 읽게 하려면 detail 또는 summary에 policy version만 별도 column으로 뽑는 보강을 검토할 수 있다.
+
+## Baseline smoke 결과
+
+실행:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage1-scale-only \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+결과 요약:
+
+```text
+resolver: OK
+request.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+KTX.hwp: renders=8 failed=0 cache=miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024),miss,exactHit,largerBucketHit(1024x1024),largerBucketHit(1024x1024)
+```
+
+핵심 비교:
+
+| sample | policy | large bucket | pixel | backend | fallback | signature suffix |
+|------|------|------|------|------|------|------|
+| `request.hwp` | `coreGraphicsOnly` | `1024x1024` | `732x1024` | `coreGraphics` | `-` | `skia-max-dimension-0` |
+| `request.hwp` | `skiaOptIn` | `1024x1024` | `732x1025` | `skia` | `-` | `skia-max-dimension-0` |
+| `KTX.hwp` | `coreGraphicsOnly` | `1024x1024` | `1024x725` | `coreGraphics` | `-` | `skia-max-dimension-0` |
+| `KTX.hwp` | `skiaOptIn` | `1024x1024` | `1025x725` | `skia` | `-` | `skia-max-dimension-0` |
+
+재현된 baseline:
+
+- `request.hwp`: Skia가 긴 축 기준 CoreGraphics보다 `+1px` 크다. `732x1024 -> 732x1025`.
+- `KTX.hwp`: Skia가 긴 축 기준 CoreGraphics보다 `+1px` 크다. `1024x725 -> 1025x725`.
+- cache pattern은 두 policy 모두 `miss -> exactHit -> largerBucketHit -> largerBucketHit`로 정상이다.
+- policy별 cache signature separation은 두 sample 모두 `OK`다.
+- fallback은 모든 row에서 `-`다.
+
+## 검증 결과
+
+구현계획서 Stage 1 검증:
+
+```bash
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage1-scale-only \
+  samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+결과: 성공. resolver contract `OK`, render rows 16개 모두 `OK`, failed `0`.
+
+추가 점검:
+
+```bash
+git diff --check
+```
+
+결과: 성공.
+
+## 잔여 위험
+
+| 항목 | 상태 | 다음 처리 |
+|------|------|------|
+| `maxDimension` semantics | 아직 미검증 | Stage 2에서 mapping contract를 정하고 Stage 3에서 적용 |
+| signature version | 현재 `skia-max-dimension-0` | Stage 2에서 새 version 값 확정 |
+| latency 절대값 | 로컬 실행 변동 가능 | Stage 4에서 대표 샘플 상대 비교 중심으로 해석 |
+| visual 품질 | 이번 Stage 범위 밖 | #396 baseline과 Stage 4 결과를 후속 판단에 연결 |
+
+## 다음 단계 영향
+
+Stage 2는 다음 결정을 내려야 한다.
+
+1. `HwpPageImageRenderer.renderSkiaPage`에 `maximumPixelSize` 또는 `maxDimension` 인자를 추가한다.
+2. `max(maximumPixelSize.width, maximumPixelSize.height)`를 finite/positive일 때만 `maxDimension`으로 사용한다.
+3. Thumbnail signature version을 `skia-max-dimension-0`에서 새 값으로 바꾼다.
+4. smoke helper는 우선 기존 column으로 충분하다고 보고, 구현 후 부족할 때만 최소 보강한다.
+
+## 승인 요청
+
+Stage 1 inventory와 scale-only baseline 고정을 완료했다. Stage 2 `maxDimension mapping 설계와 signature 정책 확정`으로 진행 승인해 달라.

--- a/mydocs/working/task_m020_392_stage2.md
+++ b/mydocs/working/task_m020_392_stage2.md
@@ -1,0 +1,214 @@
+# Task M020 #392 Stage 2 보고서
+
+## 단계 목적
+
+Stage 1에서 고정한 scale-only baseline을 바탕으로, Stage 3에서 적용할 Thumbnail Skia `maximumPixelSize -> maxDimension` mapping contract와 cache signature 정책을 확정했다.
+
+이번 단계는 source 변경 없이 설계만 확정했다.
+
+## 산출물
+
+| 파일/산출물 | 줄 수 | 내용 |
+|------|------:|------|
+| `RustBridge/src/lib.rs` | 307 | FFI `rhwp_render_page_png`의 `scale`, `max_dimension` guard와 option 변환 확인 |
+| `/Users/melee/Documents/projects/forks/rhwp/src/document_core/queries/rendering.rs` | 4710 | upstream `PngExportOptions`와 scale 결정 우선순위 확인 |
+| `/Users/melee/Documents/projects/forks/rhwp/src/renderer/skia/renderer.rs` | 3082 | raster scale/max_dimension validation 확인 |
+| `Sources/Shared/HwpPageImageRenderer.swift` | 532 | Stage 3 변경 지점 확인 |
+| `Sources/RhwpCoreBridge/RhwpDocument.swift` | 260 | Swift wrapper guard 확인 |
+| `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift` | 280 | render signature version 변경 지점 확인 |
+| `scripts/thumbnail_skia_policy_smoke.swift` | 639 | 기존 smoke output이 Stage 3 검증에 충분한지 확인 |
+| `mydocs/working/task_m020_392_stage1.md` | 158 | scale-only baseline 입력 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+소스 파일은 변경하지 않았다. 새로 추가한 문서는 이 Stage 2 보고서뿐이다.
+
+## 확인한 upstream/bridge contract
+
+### FFI 입력 contract
+
+`RustBridge/src/lib.rs`의 `rhwp_render_page_png`는 다음 조건을 invalid option으로 처리한다.
+
+- `scale`이 finite가 아니거나 음수
+- `max_dimension > i32::MAX`
+
+이후 `PngExportOptions`로 변환할 때:
+
+```rust
+scale: if scale == 0.0 { None } else { Some(scale) },
+max_dimension: if max_dimension == 0 {
+    None
+} else {
+    Some(max_dimension as i32)
+}
+```
+
+즉 Swift에서 `maxDimension`을 meaningful하게 쓰려면 `0 < maxDimension <= Int32.max` 범위로 넘겨야 한다.
+
+### upstream scale 결정 우선순위
+
+upstream `PngExportOptions` 주석과 구현은 다음 우선순위를 가진다.
+
+1. 명시 `scale`
+2. `max_dimension` / VLM 기반 자동 계산
+3. DPI 기반 scale
+4. 기본 `1.0`
+
+중요한 점은 **명시 `scale`이 있으면 `max_dimension` 기반 자동 scale 계산보다 우선**한다는 것이다. 또한 Skia raster renderer는 최종 scaled dimension이 `max_dimension`을 넘으면 render error로 처리한다.
+
+따라서 Stage 3에서 현재 Swift scale을 그대로 넘기면서 `maxDimension`도 함께 넘기면, `1024` bucket에서 기존 `1025` 결과가 invalid/fallback으로 바뀔 가능성이 있다. 이 작업의 목표는 fallback 유도나 hard clamp가 아니라 upstream의 maxDimension 자동 scale 정책을 실험하는 것이므로, `maxDimension`이 유효할 때는 explicit scale을 넘기지 않는 계약으로 확정한다.
+
+## 확정 설계
+
+### Shared renderer contract
+
+Stage 3 변경 방향:
+
+1. `HwpPageImageRenderer.renderPage`는 기존처럼 `maximumPixelSize`로 CoreGraphics용 `scale`과 `pixelSize`를 계산한다.
+2. `.coreGraphicsOnly` path는 변경하지 않는다.
+3. `.skiaOptIn` path는 `maximumPixelSize`에서 `skiaMaxDimension`을 계산해 `renderSkiaPage`로 전달한다.
+4. `renderSkiaPage`는 `skiaMaxDimension > 0`이면 `renderPagePNG(scale: 0, maxDimension: skiaMaxDimension)`을 호출한다.
+5. `skiaMaxDimension == 0`이면 기존과 같이 `renderPagePNG(scale: Double(scale), maxDimension: 0)`을 호출한다.
+
+개념 코드:
+
+```swift
+let skiaMaxDimension = Self.skiaMaxDimension(from: maximumPixelSize)
+let skiaScale = skiaMaxDimension > 0 ? 0 : Double(scale)
+let png = document.renderPagePNG(
+    at: pageIndex,
+    scale: skiaScale,
+    maxDimension: skiaMaxDimension
+)
+```
+
+이렇게 하면 Thumbnail 요청에서는 upstream이 `max_dimension` 기반 자동 scale을 계산하고, Quick Look처럼 `maximumPixelSize == nil`인 경로는 기존 scale-only 동작을 유지한다.
+
+### maxDimension 계산 규칙
+
+Stage 3 helper 후보:
+
+```swift
+private static func skiaMaxDimension(from maximumPixelSize: CGSize?) -> Int {
+    guard let maximumPixelSize else {
+        return 0
+    }
+    let longestEdge = max(maximumPixelSize.width, maximumPixelSize.height)
+    guard longestEdge.isFinite, longestEdge > 0 else {
+        return 0
+    }
+    return min(Int(ceil(longestEdge)), Int(Int32.max))
+}
+```
+
+적용 이유:
+
+- Thumbnail bucket은 현재 정수 bucket이지만 `CGSize`라서 finite/positive guard를 둔다.
+- `ceil`은 `maximumPixelSize`가 소수로 들어와도 requested upper bound를 작게 만들지 않는다.
+- RustBridge는 `i32::MAX` 초과를 invalid option으로 처리하므로 Swift에서 `Int32.max`로 clamp한다.
+- `0`은 upstream `None` 의미이므로 fallback path가 아니라 기존 scale-only 의미로 둔다.
+
+### Signature 정책
+
+현재 signature suffix는 `skia-max-dimension-0`이다. Stage 3에서 Thumbnail Skia option semantics가 바뀌므로 새 suffix로 변경한다.
+
+확정 값:
+
+```text
+skia-max-dimension-thumbnail-v1
+```
+
+정책:
+
+- `HwpThumbnailRenderSignature.maxDimensionPolicyVersion`의 static value를 위 값으로 변경한다.
+- 이 값은 `coreGraphicsOnly` signature에도 포함되지만, 현재 구조상 signature field는 Thumbnail renderer option version 묶음에 가까우므로 우선 전체 Thumbnail render signature를 갱신한다.
+- `backendPolicy`가 signature 첫 항목이므로 CoreGraphics/Skia cache는 계속 분리된다.
+- `candidateKey.renderSignature == requestedKey.renderSignature` 조건 때문에 이전 `skia-max-dimension-0`과 새 policy cache는 섞이지 않는다.
+
+향후 per-policy signature가 필요하면 별도 리팩터링으로 분리한다. 이번 작업에서는 source surface를 줄이기 위해 static suffix 변경으로 충분하다.
+
+### Smoke helper 정책
+
+현재 smoke helper는 다음 값을 이미 출력한다.
+
+- `RequestedBucket`
+- `MatchedBucket`
+- `Signature`
+- `Pixel`
+- `OutputBytes`
+- `PNGBytes`
+- `RenderMs`
+- `Backend`
+- `Fallback`
+
+Stage 3에서는 helper column 추가 없이도 정책 변경 검증이 가능하다. 다만 Stage 3 구현 후 summary 해석이 불편하면 `Signature`에서 suffix를 별도 column으로 분리하는 최소 보강을 검토한다.
+
+## Stage 3 변경 파일 확정
+
+필수 변경:
+
+| 파일 | 변경 |
+|------|------|
+| `Sources/Shared/HwpPageImageRenderer.swift` | Skia path에 `skiaMaxDimension` 계산과 `scale: 0` 자동 scale 호출 추가 |
+| `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift` | `maxDimensionPolicyVersion`을 `skia-max-dimension-thumbnail-v1`로 갱신 |
+| `mydocs/working/task_m020_392_stage3.md` | 구현 결과와 quick smoke 기록 |
+
+조건부 변경:
+
+| 파일 | 조건 |
+|------|------|
+| `scripts/thumbnail_skia_policy_smoke.swift` | 기존 summary/detail만으로 signature suffix와 pixel drift 해석이 어렵다고 판단될 때만 최소 보강 |
+| `scripts/smoke-thumbnail-skia-policy.sh` | compile list 변경이 필요할 때만 수정. 현재는 필요 없음 |
+
+## Stage 3 예상 검증 포인트
+
+Stage 3 quick smoke에서 확인할 값:
+
+| 항목 | 기대 |
+|------|------|
+| resolver contract | `OK` |
+| render rows | `request.hwp`, `KTX.hwp` 총 16 rows `OK` |
+| cache pattern | policy별 `miss -> exactHit -> largerBucketHit -> largerBucketHit` 유지 |
+| signature suffix | `skia-max-dimension-thumbnail-v1` |
+| fallback | 모든 정상 row `-` 기대 |
+| `request.hwp` Skia pixel | 현재 `732x1025`에서 긴 축 `<=1024`로 바뀌는지 확인 |
+| `KTX.hwp` Skia pixel | 현재 `1025x725`에서 긴 축 `<=1024`로 바뀌는지 확인 |
+
+## 검증 결과
+
+구현계획서 Stage 2 검증:
+
+```bash
+rg -n "renderSkiaPage|renderPagePNG|maxDimensionPolicyVersion|HwpThumbnailRenderSignature|maximumPixelSize" \
+  Sources/Shared/HwpPageImageRenderer.swift Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift \
+  scripts/thumbnail_skia_policy_smoke.swift mydocs/working/task_m020_392_stage2.md
+git diff --check
+```
+
+결과:
+
+- `rg`: 관련 source/report 위치 확인 성공.
+- `git diff --check`: 성공.
+
+## 잔여 위험
+
+| 항목 | 상태 | 다음 처리 |
+|------|------|------|
+| scale과 maxDimension 동시 전달 | upstream 우선순위상 부적합 | Stage 3에서 `maxDimension > 0`이면 `scale: 0`으로 적용 |
+| Swift wrapper guard와 RustBridge guard 차이 | Swift는 `UInt32.max`, RustBridge는 `i32::MAX` | Stage 3 helper에서 `Int32.max` clamp |
+| CoreGraphics signature suffix도 바뀜 | 구조상 전체 Thumbnail signature suffix 변경 | source surface를 줄이고 stale cache 방지를 우선 |
+| visual 품질 판단 | 이번 Stage 범위 밖 | Stage 4/후속 #396 기준과 연결 |
+
+## 다음 단계 영향
+
+Stage 3는 바로 다음 순서로 구현한다.
+
+1. `skiaMaxDimension(from:)` helper 추가.
+2. `renderSkiaPage` 인자에 `maxDimension` 추가.
+3. `maxDimension > 0`이면 `renderPagePNG(scale: 0, maxDimension: maxDimension)` 호출.
+4. signature suffix를 `skia-max-dimension-thumbnail-v1`로 변경.
+5. quick smoke로 pixel drift와 cache/signature를 확인.
+
+## 승인 요청
+
+Stage 2 설계와 signature 정책 확정을 완료했다. Stage 3 `opt-in 실험 구현과 smoke 보강`으로 진행 승인해 달라.

--- a/mydocs/working/task_m020_392_stage2.md
+++ b/mydocs/working/task_m020_392_stage2.md
@@ -11,8 +11,8 @@ Stage 1에서 고정한 scale-only baseline을 바탕으로, Stage 3에서 적�
 | 파일/산출물 | 줄 수 | 내용 |
 |------|------:|------|
 | `RustBridge/src/lib.rs` | 307 | FFI `rhwp_render_page_png`의 `scale`, `max_dimension` guard와 option 변환 확인 |
-| `/Users/melee/Documents/projects/forks/rhwp/src/document_core/queries/rendering.rs` | 4710 | upstream `PngExportOptions`와 scale 결정 우선순위 확인 |
-| `/Users/melee/Documents/projects/forks/rhwp/src/renderer/skia/renderer.rs` | 3082 | raster scale/max_dimension validation 확인 |
+| [`edwardkim/rhwp@03351190/src/document_core/queries/rendering.rs`](https://github.com/edwardkim/rhwp/blob/03351190ec35436e58cbfee0aa9278a8fdc04a59/src/document_core/queries/rendering.rs) | 4710 | upstream `PngExportOptions`와 scale 결정 우선순위 확인 |
+| [`edwardkim/rhwp@03351190/src/renderer/skia/renderer.rs`](https://github.com/edwardkim/rhwp/blob/03351190ec35436e58cbfee0aa9278a8fdc04a59/src/renderer/skia/renderer.rs) | 3082 | raster scale/max_dimension validation 확인 |
 | `Sources/Shared/HwpPageImageRenderer.swift` | 532 | Stage 3 변경 지점 확인 |
 | `Sources/RhwpCoreBridge/RhwpDocument.swift` | 260 | Swift wrapper guard 확인 |
 | `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift` | 280 | render signature version 변경 지점 확인 |

--- a/mydocs/working/task_m020_392_stage3.md
+++ b/mydocs/working/task_m020_392_stage3.md
@@ -1,0 +1,68 @@
+# Task #392 Stage 3 보고서: Thumbnail Skia maxDimension opt-in 적용
+
+## 단계 목적
+
+- Thumbnail Skia opt-in 경로에서 Swift의 `maximumPixelSize`를 Rust Skia PNG export의 `maxDimension` 인자로 전달한다.
+- `maxDimension`을 전달하는 경우에는 기존 `scale` 기반 확대와 충돌하지 않도록 `scale: 0`을 사용해 upstream 자동 크기 결정을 따른다.
+- 캐시 재사용으로 이전 렌더 결과가 섞이지 않도록 thumbnail render signature의 maxDimension 정책 버전을 갱신한다.
+
+## 산출물
+
+| 파일 | 변경 내용 |
+| --- | --- |
+| `Sources/Shared/HwpPageImageRenderer.swift` | Skia render attempt에 `maxDimension` 전달, `maxDimension > 0`이면 Rust bridge 호출 시 `scale: 0` 사용, `maximumPixelSize`의 긴 변을 안전한 정수 maxDimension으로 변환하는 helper 추가 |
+| `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift` | `maxDimensionPolicyVersion`을 `skia-max-dimension-thumbnail-v1`로 갱신 |
+
+변경 범위는 `git diff --stat` 기준 2개 파일, 19 insertions, 5 deletions이다.
+
+## 구현 내용
+
+- `HwpPageImageRenderer.renderPage`의 `.skiaOptIn` 분기에서 `skiaMaxDimension(from: maximumPixelSize)` 값을 `renderSkiaPage`에 전달했다.
+- `renderSkiaPage`는 `maxDimension > 0`일 때 `document.renderPagePNG(at:scale:maxDimension:)`에 `scale: 0`과 실제 `maxDimension`을 넘긴다.
+- `maxDimension == 0`인 호출은 기존 동작 보존을 위해 `scale: Double(scale)`, `maxDimension: 0`을 유지한다.
+- `skiaMaxDimension(from:)` helper는 nil, non-finite, 0 이하 입력을 `0`으로 처리하고, 유효한 입력은 긴 변을 `ceil`한 뒤 `Int32.max`로 상한 처리한다.
+- thumbnail cache signature suffix를 `skia-max-dimension-thumbnail-v1`로 변경해 기존 `skia-max-dimension-0` 결과와 캐시 키가 분리되도록 했다.
+
+## Stage 1 대비 smoke 결과
+
+Stage 3 smoke 명령:
+
+```sh
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage3-thumbnail-policy samples/basic/request.hwp samples/basic/KTX.hwp
+```
+
+요약:
+
+| 샘플 | 정책 | Stage 1 Pixel | Stage 3 Pixel | 해석 |
+| --- | --- | --- | --- | --- |
+| `request.hwp` | `coreGraphicsOnly` | `732x1024` | `732x1024` | CoreGraphics 경로 변화 없음 |
+| `request.hwp` | `skiaOptIn` | `732x1025` | `567x794` | 1024px 초과는 사라졌지만 upstream Skia가 자연 해상도 이상으로 확대하지 않는 동작이 관찰됨 |
+| `KTX.hwp` | `coreGraphicsOnly` | `1024x725` | `1024x725` | CoreGraphics 경로 변화 없음 |
+| `KTX.hwp` | `skiaOptIn` | `1025x725` | `1024x725` | 긴 변 1024px 상한에 맞게 조정됨 |
+
+캐시와 signature:
+
+- resolver contract: 모든 case `OK`
+- render rows: 16건 모두 `OK`
+- fallback: 0건
+- 캐시 패턴: 각 정책에서 `miss`, `exactHit`, `largerBucketHit(1024x1024)`, `largerBucketHit(1024x1024)`
+- signature suffix: `skia-max-dimension-thumbnail-v1`
+
+## 검증
+
+| 명령 | 결과 |
+| --- | --- |
+| `git diff --check` | 성공 |
+| `./scripts/check-no-appkit.sh` | 성공 |
+| `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage3-thumbnail-policy samples/basic/request.hwp samples/basic/KTX.hwp` | 성공. resolver `OK`, renders 16건 `OK`, fallback 없음 |
+| `xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask392Stage3 CODE_SIGNING_ALLOWED=NO build` | 성공. CoreSimulator out-of-date 경고는 있었지만 `BUILD SUCCEEDED`로 종료 |
+
+## 잔여 위험과 다음 단계
+
+- `request.hwp`의 Skia 결과가 `567x794`로 낮아진 것은 실패는 아니지만, thumbnail 품질 관점에서는 판단이 필요하다. upstream Skia `maxDimension` 경로가 자연 해상도 이상 확대하지 않는 동작으로 보인다.
+- 이번 단계는 빠른 샘플 2개만 검증했다. Stage 4에서 대표 샘플 smoke와 pixel/cache/signature 결과를 더 넓게 확인해야 한다.
+- signature suffix는 backend policy와 함께 캐시 키에 포함되므로 CoreGraphics와 Skia는 계속 분리된다. 다만 suffix 자체가 공통 필드라 기존 CoreGraphics thumbnail cache도 함께 무효화된다.
+
+## 승인 요청
+
+Stage 4에서는 대표 샘플로 확장 smoke를 수행하고, `maxDimension` 경로를 유지할지 또는 보완 이슈가 필요한지 판단한다.

--- a/mydocs/working/task_m020_392_stage4.md
+++ b/mydocs/working/task_m020_392_stage4.md
@@ -1,0 +1,91 @@
+# Task #392 Stage 4 보고서: Thumbnail maxDimension 대표 샘플 검증
+
+## 단계 목적
+
+- 대표 샘플에서 Thumbnail Skia maxDimension 정책 적용 후 pixel size, latency, bytes, cache pattern, signature를 측정한다.
+- #389 Stage 4 scale-only 대표 smoke와 비교해 1px drift가 해소/유지/변형되는지 분류한다.
+- Stage 5 최종 보고서에 넘길 판단 근거와 잔여 risk를 정리한다.
+
+## 실행 명령
+
+기본 검증:
+
+```sh
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+```
+
+대표 샘플 smoke:
+
+```sh
+./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-thumbnail-policy-representative \
+  samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp \
+  samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp
+```
+
+결과:
+
+- `check-no-appkit`: 성공
+- `verify-rhwp-core-build-info`: 성공
+- `verify-rhwp-studio-assets`: 성공
+- representative smoke: 성공
+- resolver contract: `OK`
+- render rows: 40건 모두 `OK`
+- fallback: 0건
+- `복학원서.hwp` 처리 중 기존 `LAYOUT_OVERFLOW` warning 3줄이 stderr에 출력됐지만 render status는 모두 `OK`였다.
+
+## 대표 샘플 결과
+
+아래 표는 각 샘플의 첫 요청인 `large:512x512@2` 기준이다. 요청 bucket은 모두 `1024x1024`이고, 이후 반복 요청은 각 정책별로 `exactHit`, `largerBucketHit(1024x1024)`, `largerBucketHit(1024x1024)` 패턴을 유지했다.
+
+| File | Policy | Backend | Pixel | OutputBytes | PNGBytes | RenderMs |
+| --- | --- | --- | --- | ---: | ---: | ---: |
+| `복학원서.hwp` | `coreGraphicsOnly` | `coreGraphics` | `725x1024` | 193700 | - | 1628.596 |
+| `복학원서.hwp` | `skiaOptIn` | `skia` | `725x1024` | 171213 | 175952 | 168.842 |
+| `KTX.hwp` | `coreGraphicsOnly` | `coreGraphics` | `1024x725` | 482670 | - | 58.054 |
+| `KTX.hwp` | `skiaOptIn` | `skia` | `1024x725` | 161545 | 148988 | 70.815 |
+| `request.hwp` | `coreGraphicsOnly` | `coreGraphics` | `732x1024` | 125618 | - | 38.439 |
+| `request.hwp` | `skiaOptIn` | `skia` | `567x794` | 84098 | 87027 | 66.309 |
+| `hwpx-01.hwpx` | `coreGraphicsOnly` | `coreGraphics` | `725x1024` | 198763 | - | 40.292 |
+| `hwpx-01.hwpx` | `skiaOptIn` | `skia` | `725x1024` | 170807 | 187583 | 47.671 |
+| `hwp-multi-001.hwp` | `coreGraphicsOnly` | `coreGraphics` | `725x1024` | 195545 | - | 36.335 |
+| `hwp-multi-001.hwp` | `skiaOptIn` | `skia` | `725x1024` | 166500 | 180476 | 44.396 |
+
+## #389 scale-only baseline 대비 drift 분류
+
+비교 기준은 `mydocs/working/task_m020_389_stage4.md`의 대표 smoke 표다.
+
+| File | #389 Skia scale-only Pixel | #392 Skia maxDimension Pixel | 분류 | 해석 |
+| --- | --- | --- | --- | --- |
+| `복학원서.hwp` | `725x1025` | `725x1024` | 해소 | portrait 계열 1px 초과가 사라지고 CoreGraphics와 같은 긴 변이 됐다. |
+| `KTX.hwp` | `1025x725` | `1024x725` | 해소 | landscape 계열 1px 초과가 사라지고 CoreGraphics와 같은 긴 변이 됐다. |
+| `request.hwp` | `732x1025` | `567x794` | 변형 | 1024px 초과는 없어졌지만, Skia가 자연 해상도 이상으로 확대하지 않아 CoreGraphics보다 작은 bitmap이 됐다. |
+| `hwpx-01.hwpx` | `725x1025` | `725x1024` | 해소 | HWPX path에서도 1px 초과가 사라졌다. |
+| `hwp-multi-001.hwp` | `725x1025` | `725x1024` | 해소 | 다중 페이지 HWP 첫 페이지 thumbnail에서도 1px 초과가 사라졌다. |
+
+정리하면 대표 샘플 5개 중 4개는 maxDimension 정책으로 1px drift가 해소됐다. `request.hwp`는 drift가 단순 해소된 것이 아니라 Skia output 자체가 `567x794`로 낮아지는 다른 형태의 변화가 발생했다.
+
+## cache와 signature
+
+- 모든 샘플에서 policy별 첫 요청은 `miss`였고, 같은 policy 안의 반복/작은 요청은 `exactHit` 또는 `largerBucketHit(1024x1024)`로 재사용됐다.
+- `coreGraphicsOnly`와 `skiaOptIn`의 첫 요청이 서로 cache hit로 섞이지 않았다.
+- signature suffix는 두 policy 모두 `skia-max-dimension-thumbnail-v1`을 포함하고, backend policy가 `coreGraphicsOnly`/`skiaOptIn`으로 분리된다.
+
+## 해석
+
+- maxDimension 매핑은 기존 1px 초과 drift를 통제하는 데 효과가 있다. `복학원서.hwp`, `KTX.hwp`, `hwpx-01.hwpx`, `hwp-multi-001.hwp`에서는 Skia 긴 변이 1024를 넘지 않고 CoreGraphics와 같은 pixel size가 됐다.
+- `request.hwp`는 maxDimension 경로에서 upstream Skia가 확대를 수행하지 않는 것으로 보인다. 이 샘플은 `scale-only -> 732x1025`, `maxDimension -> 567x794`로 바뀌므로, maxDimension 정책을 그대로 제품 기본으로 올리면 일부 문서 thumbnail이 기대보다 작아질 수 있다.
+- OutputBytes와 PNGBytes는 `request.hwp`에서 크게 줄었다. 이는 압축 효율 개선이라기보다 pixel count 감소의 영향으로 보는 편이 타당하다.
+- RenderMs는 단일 로컬 실행값이므로 절대값으로 회귀를 판단하지 않는다. 다만 `복학원서.hwp` Skia RenderMs가 #389의 73.027ms에서 168.842ms로 증가했으므로 Stage 5에서는 성능 결론을 보수적으로 기록해야 한다.
+
+## Stage 5 입력
+
+- 적용 결과: maxDimension 정책은 1px drift 방지에는 유효하다.
+- 보류 판단: `request.hwp`처럼 Skia가 자연 해상도 이상 확대하지 않는 문서가 있어, default 전환 근거로는 아직 부족하다.
+- 후속 후보: #393/#259 쪽에서는 maxDimension 단독 정책 대신 `maxDimension + explicit upscale 필요성`, 또는 sample별 visual readiness gate를 함께 판단해야 한다.
+- 문서 반영: `skia_quicklook_thumbnail_backend.md`에는 Thumbnail Skia opt-in이 maxDimension을 사용하지만 일부 샘플에서 underfill risk가 있다는 점을 명시해야 한다.
+
+## 승인 요청
+
+Stage 5에서는 최종 보고서와 기술 문서에 이번 결과를 반영하고, 오늘할일 완료 처리와 PR 게시 준비로 넘어간다.


### PR DESCRIPTION
## 요약

- 대상 타스크: #392 Thumbnail Skia maxDimension mapping 실험
- 왜: #389 작업에서 Thumbnail Skia opt-in이 같은 `1024x1024` bucket에서 긴 축 1px 초과 drift를 반복해서 보였기 때문입니다.
- 무엇: Thumbnail Skia opt-in path에서 `maximumPixelSize`의 긴 변을 upstream `maxDimension`으로 전달하고, cache signature를 `skia-max-dimension-thumbnail-v1`로 갱신했습니다.
- 리뷰 포인트: 1px drift는 대표 5개 중 4개에서 해소됐지만, `request.hwp` underfill risk 때문에 default 전환 근거로는 보류한다는 결론입니다.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/4bd51cd11896c8e5824917674912f8442cd5a7f4/mydocs/working/task_m020_392_stage1.md)** ([7b83628](https://github.com/postmelee/alhangeul-macos/commit/7b83628c32ea0865d46565e82b21c89cfe71ccea)): scale-only baseline과 1px drift 재현 확인
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/4bd51cd11896c8e5824917674912f8442cd5a7f4/mydocs/working/task_m020_392_stage2.md)** ([2546390](https://github.com/postmelee/alhangeul-macos/commit/25463904a52d68193cf3f6f7fd7a003c2c42727b)): upstream `scale`/`maxDimension` 우선순위와 signature 정책 확정
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/4bd51cd11896c8e5824917674912f8442cd5a7f4/mydocs/working/task_m020_392_stage3.md)** ([e775299](https://github.com/postmelee/alhangeul-macos/commit/e7752999e695ccc4c3f0dda61aa8e8b168623f0d)): Thumbnail Skia opt-in maxDimension mapping 적용
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/4bd51cd11896c8e5824917674912f8442cd5a7f4/mydocs/working/task_m020_392_stage4.md)** ([6a845ef](https://github.com/postmelee/alhangeul-macos/commit/6a845ef443c1974fafe551b6707ac37625fa769b)): 대표 5개 샘플 smoke와 drift 분류
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/4bd51cd11896c8e5824917674912f8442cd5a7f4/mydocs/report/task_m020_392_report.md)** ([5a708b1](https://github.com/postmelee/alhangeul-macos/commit/5a708b14179402ce40e8df3dc0b4cac27370f2d1)): 최종 보고서와 기술 문서 반영

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| Shared renderer | Skia 호출에 `skiaMaxDimension(from:)` 전달 | `maxDimension > 0`일 때 `scale: 0`으로 upstream 자동 scale을 쓰는 계약 |
| Thumbnail cache | signature suffix를 `skia-max-dimension-thumbnail-v1`로 갱신 | 기존 scale-only cache와 stale bitmap이 섞이지 않는지 |
| 대표 smoke | 5 files x 2 policies x 4 requests 검증 | 4개 sample drift 해소와 `request.hwp` underfill risk 해석 |
| 문서 | 기술 문서와 final report에 #392 결과 반영 | #259 readiness gate로 넘길 blocker 후보가 명확한지 |

- 수행 계획서: [task_m020_392.md](https://github.com/postmelee/alhangeul-macos/blob/4bd51cd11896c8e5824917674912f8442cd5a7f4/mydocs/plans/task_m020_392.md)
- 구현 계획서: [task_m020_392_impl.md](https://github.com/postmelee/alhangeul-macos/blob/4bd51cd11896c8e5824917674912f8442cd5a7f4/mydocs/plans/task_m020_392_impl.md)
- 최종 보고서: [task_m020_392_report.md](https://github.com/postmelee/alhangeul-macos/blob/4bd51cd11896c8e5824917674912f8442cd5a7f4/mydocs/report/task_m020_392_report.md)
- 기술 문서: [skia_quicklook_thumbnail_backend.md](https://github.com/postmelee/alhangeul-macos/blob/4bd51cd11896c8e5824917674912f8442cd5a7f4/mydocs/tech/skia_quicklook_thumbnail_backend.md)

## 핵심 리뷰 포인트

- `maxDimension > 0`인 Thumbnail 요청에서 explicit `scale`을 넘기지 않는 것이 upstream `PngExportOptions` 우선순위와 맞는지 확인해 주세요.
- `HwpThumbnailRenderSignature`의 suffix 갱신이 기존 `skia-max-dimension-0` cache 혼입을 막기에 충분한지 확인해 주세요.
- `request.hwp` underfill risk 때문에 default 전환은 #259 gate로 보류한다는 결론이 적절한지 확인해 주세요.

## 검증

- `git diff --check`
- `./scripts/check-no-appkit.sh`
- `./scripts/verify-rhwp-core-build-info.sh`
- `./scripts/verify-rhwp-studio-assets.sh`
- `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage1-scale-only samples/basic/request.hwp samples/basic/KTX.hwp`
- `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-stage3-thumbnail-policy samples/basic/request.hwp samples/basic/KTX.hwp`
- `./scripts/smoke-thumbnail-skia-policy.sh build.noindex/task392-thumbnail-policy-representative samples/복학원서.hwp samples/basic/KTX.hwp samples/basic/request.hwp samples/hwpx/hwpx-01.hwpx samples/hwp-multi-001.hwp`
- `xcodebuild -project Alhangeul.xcodeproj -scheme ThumbnailExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask392Stage3 CODE_SIGNING_ALLOWED=NO build`

## 관련 이슈

- #387 Preview/Thumbnail Skia readiness 후속 개선 추적
- #389 Thumbnail Skia opt-in diagnostic path와 cache logging 추가
- #393 Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험
- #259 Skia default/release readiness gate

## 후속 이슈 제안

- 새 이슈는 만들지 않았습니다. `request.hwp` underfill과 visual 품질 판단은 #259 readiness gate에서 이어서 평가합니다.

## 남은 리스크

- `request.hwp`는 maxDimension path에서 `567x794`로 낮아져 underfill risk가 있습니다.
- latency는 단일 로컬 실행값이므로 절대 성능 결론으로 보지 않습니다.
- signature suffix가 공통 필드라 CoreGraphics thumbnail cache도 함께 무효화됩니다. stale cache 방지를 우선한 선택입니다.
