### PR TITLE
Task #393: Quick Look Skia direct PNG opt-in fast path 실험

### DIFF
--- a/Alhangeul.xcodeproj/project.pbxproj
+++ b/Alhangeul.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		3BA210E4DB4D1BF2C8E03893 /* HwpNativePageCompositor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541160BFAFD7D51040244110 /* HwpNativePageCompositor.swift */; };
 		3BAE06A9A748D31D69C23101 /* HwpThumbnailPolicyResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7117AC630958C9A5DAE6545 /* HwpThumbnailPolicyResolver.swift */; };
 		41C5D25E1060BEF211833C8A /* HwpPreviewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F373DBDDC753FC79292E2D /* HwpPreviewProvider.swift */; };
+		43A1584B860794E3A9E9FF3C /* HwpPreviewPNGRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8645A8FD6F4761F6A5BE264A /* HwpPreviewPNGRenderer.swift */; };
 		44CDAB1946DFA27A7CADCF6D /* RecentDocumentThumbnailRefresher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D4915E7318DD22D9A61F584 /* RecentDocumentThumbnailRefresher.swift */; };
 		4603821692664AB0F6480AD4 /* FontFallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCF11065A3E3439B4C5B8DD7 /* FontFallback.swift */; };
 		477B4C8AC6A0370182751D8F /* RhwpDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 423B5D870B909D2D5D87F3D6 /* RhwpDocument.swift */; };
@@ -49,6 +50,7 @@
 		4B80D13CDBFBFAD3AB4AF18D /* CGTreeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B69400B5B8A2851995C68DE /* CGTreeRenderer.swift */; };
 		539DFB38A0293062B5A01ED9 /* HwpThumbnailRenderCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 895C9E62B889A9E90C3FF8C6 /* HwpThumbnailRenderCache.swift */; };
 		5487A3B00729AE0595A43DF2 /* AboutWindowPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26979062297C483B463918BA /* AboutWindowPresenter.swift */; };
+		5527F4F08635A8EDCA74EA61 /* HwpPreviewPNGRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8645A8FD6F4761F6A5BE264A /* HwpPreviewPNGRenderer.swift */; };
 		55993B1F9BBFFBBA62397829 /* LaunchMaintenanceService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64C25EF462BA350A75A155D /* LaunchMaintenanceService.swift */; };
 		58FEED15D7979CC23FADA9D9 /* FontResourceRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2D57719DF9672E7C311D7 /* FontResourceRegistry.swift */; };
 		59DC1D6F67C3F459AC4A8ADC /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B49CA0DEC91C628C9B92B7A1 /* CoreFoundation.framework */; };
@@ -82,7 +84,9 @@
 		9E7FC8AC6078A6BD9975CD4E /* RhwpProvenance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2953DECE3F38280938C3CE2B /* RhwpProvenance.swift */; };
 		A155D58D6F716FCFDAC1675C /* DocumentOpenRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34F4546426B7A9CF2CC1B9D5 /* DocumentOpenRouter.swift */; };
 		A15CE462970FB420A669581E /* HwpNativePageCompositor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541160BFAFD7D51040244110 /* HwpNativePageCompositor.swift */; };
+		A174DAE4D877346E0350AF02 /* HwpPreviewPNGRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8645A8FD6F4761F6A5BE264A /* HwpPreviewPNGRenderer.swift */; };
 		A37A870989D1BA673D744596 /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0D03050B560F60198F4CBBB0 /* Metal.framework */; };
+		A6189FF8E0BA6CC94255FEFA /* HwpQuickLookPNGReplyModeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CACAAFF817D4598145526EE /* HwpQuickLookPNGReplyModeResolver.swift */; };
 		A6B358FD54D1069D3C08BF76 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B49CA0DEC91C628C9B92B7A1 /* CoreFoundation.framework */; };
 		A9D512641E80997A3D087945 /* HwpNativePageCompositor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 541160BFAFD7D51040244110 /* HwpNativePageCompositor.swift */; };
 		ACA5EC231EB0D299AC1CD286 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D60B1C83682555AB978A8F1C /* InfoPlist.strings */; };
@@ -209,8 +213,10 @@
 		6A6F3480DCEB0F0A30DF06A1 /* IOSurface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOSurface.framework; path = System/Library/Frameworks/IOSurface.framework; sourceTree = SDKROOT; };
 		77B27A9A00D195F9031B6311 /* PageOverlayImages.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageOverlayImages.swift; sourceTree = "<group>"; };
 		7B8D5D5DECBC9E6071002C34 /* .gitkeep */ = {isa = PBXFileReference; path = .gitkeep; sourceTree = "<group>"; };
+		7CACAAFF817D4598145526EE /* HwpQuickLookPNGReplyModeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HwpQuickLookPNGReplyModeResolver.swift; sourceTree = "<group>"; };
 		81391ABAF81F59C2FAE9880D /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		82B73611C892296A43FDC8B2 /* ColorSync.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ColorSync.framework; path = System/Library/Frameworks/ColorSync.framework; sourceTree = SDKROOT; };
+		8645A8FD6F4761F6A5BE264A /* HwpPreviewPNGRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HwpPreviewPNGRenderer.swift; sourceTree = "<group>"; };
 		8957BC445F1A6388BF82B28C /* QLExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = QLExtension.entitlements; sourceTree = "<group>"; };
 		895C9E62B889A9E90C3FF8C6 /* HwpThumbnailRenderCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HwpThumbnailRenderCache.swift; sourceTree = "<group>"; };
 		8BDDD5E15FCF571ED9D88598 /* HwpThumbnailProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HwpThumbnailProvider.swift; sourceTree = "<group>"; };
@@ -346,6 +352,7 @@
 			children = (
 				BED96A22509C493BF3039CEC /* .gitkeep */,
 				07F373DBDDC753FC79292E2D /* HwpPreviewProvider.swift */,
+				7CACAAFF817D4598145526EE /* HwpQuickLookPNGReplyModeResolver.swift */,
 				5E97EA87050B083B9FA29249 /* Info.plist */,
 				8957BC445F1A6388BF82B28C /* QLExtension.entitlements */,
 				F9934AE3C35F4086219CFA3B /* Resources */,
@@ -361,6 +368,7 @@
 				541160BFAFD7D51040244110 /* HwpNativePageCompositor.swift */,
 				4B5C316C5FBCECA08C309CF9 /* HwpPageImageRenderer.swift */,
 				2512041CBA5B9CE5521537DC /* HwpPreviewPDFRenderer.swift */,
+				8645A8FD6F4761F6A5BE264A /* HwpPreviewPNGRenderer.swift */,
 			);
 			name = Shared;
 			path = Sources/Shared;
@@ -695,6 +703,7 @@
 				A15CE462970FB420A669581E /* HwpNativePageCompositor.swift in Sources */,
 				7BF16A0B1E4314FB46041152 /* HwpPageImageRenderer.swift in Sources */,
 				02E1371B73A762F8E64ED8EF /* HwpPreviewPDFRenderer.swift in Sources */,
+				A174DAE4D877346E0350AF02 /* HwpPreviewPNGRenderer.swift in Sources */,
 				55993B1F9BBFFBBA62397829 /* LaunchMaintenanceService.swift in Sources */,
 				329C78D1A7232AF2B5ABFD9E /* PageOverlayImages.swift in Sources */,
 				09D138398C713C14EB0266D1 /* RecentDocumentStore.swift in Sources */,
@@ -727,6 +736,7 @@
 				A9D512641E80997A3D087945 /* HwpNativePageCompositor.swift in Sources */,
 				C898F0CA6BE3F209145CAC28 /* HwpPageImageRenderer.swift in Sources */,
 				D6ECD4A743DEDC3A090EEEF4 /* HwpPreviewPDFRenderer.swift in Sources */,
+				5527F4F08635A8EDCA74EA61 /* HwpPreviewPNGRenderer.swift in Sources */,
 				3BAE06A9A748D31D69C23101 /* HwpThumbnailPolicyResolver.swift in Sources */,
 				8348EA8DD0B313DC71B3E9C7 /* HwpThumbnailProvider.swift in Sources */,
 				539DFB38A0293062B5A01ED9 /* HwpThumbnailRenderCache.swift in Sources */,
@@ -748,7 +758,9 @@
 				3BA210E4DB4D1BF2C8E03893 /* HwpNativePageCompositor.swift in Sources */,
 				DBD45292114D646A364B0B87 /* HwpPageImageRenderer.swift in Sources */,
 				D9E0E7DB88B12FDF40623328 /* HwpPreviewPDFRenderer.swift in Sources */,
+				43A1584B860794E3A9E9FF3C /* HwpPreviewPNGRenderer.swift in Sources */,
 				41C5D25E1060BEF211833C8A /* HwpPreviewProvider.swift in Sources */,
+				A6189FF8E0BA6CC94255FEFA /* HwpQuickLookPNGReplyModeResolver.swift in Sources */,
 				F853A92E67C1E05F3C1C8722 /* PageOverlayImages.swift in Sources */,
 				748E5560ED13294F03F1B627 /* RenderTree.swift in Sources */,
 				5C02265DAB27BE08F8FF4D8C /* RhwpCoreBuildInfo.swift in Sources */,

--- a/Sources/QLExtension/HwpPreviewProvider.swift
+++ b/Sources/QLExtension/HwpPreviewProvider.swift
@@ -18,8 +18,9 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
         do {
             let documentContext = try HwpPreviewPDFRenderer.load(fileURL: request.fileURL)
             if documentContext.pageCount == 1 {
-                logger.debug("Preview selected PNG reply file=\(documentContext.filename, privacy: .public) pages=\(documentContext.pageCount, privacy: .public) size=\(Int(documentContext.contentSize.width), privacy: .public)x\(Int(documentContext.contentSize.height), privacy: .public)")
-                return try Self.pngReply(documentContext)
+                let mode = HwpQuickLookPNGReplyModeResolver.resolve()
+                logger.debug("Preview selected PNG reply file=\(documentContext.filename, privacy: .public) mode=\(mode.identifier, privacy: .public) pages=\(documentContext.pageCount, privacy: .public) size=\(Int(documentContext.contentSize.width), privacy: .public)x\(Int(documentContext.contentSize.height), privacy: .public)")
+                return try Self.pngReply(documentContext, mode: mode)
             } else {
                 logger.debug("Preview selected PDF reply file=\(documentContext.filename, privacy: .public) pages=\(documentContext.pageCount, privacy: .public) size=\(Int(documentContext.contentSize.width), privacy: .public)x\(Int(documentContext.contentSize.height), privacy: .public)")
                 return try Self.pdfReply(documentContext)
@@ -37,37 +38,37 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
         }
     }
 
-    private static func pngReply(_ documentContext: HwpPreviewDocumentContext) throws -> QLPreviewReply {
-        logger.debug("Preview rendering PNG file=\(documentContext.filename, privacy: .public)")
+    private static func pngReply(
+        _ documentContext: HwpPreviewDocumentContext,
+        mode: HwpPreviewPNGReplyMode
+    ) throws -> QLPreviewReply {
+        logger.debug("Preview rendering PNG file=\(documentContext.filename, privacy: .public) mode=\(mode.identifier, privacy: .public)")
         let filename = documentContext.filename
-        let contentSize = documentContext.contentSize
-        let page = try HwpPageImageRenderer.renderPage(
-            document: documentContext.document,
-            pageIndex: 0,
-            policy: .coreGraphicsOnly
+        let result = try HwpPreviewPNGRenderer.render(
+            context: documentContext,
+            mode: mode
         )
-        logRenderedPageDiagnostics(page, replyType: "PNG", filename: filename)
-        let data = try HwpPageImageRenderer.encodePNG(page.image)
-        logger.debug("Preview PNG ready file=\(filename, privacy: .public) bytes=\(data.count, privacy: .public)")
+        let data = result.data
+        logPNGDiagnostics(result, filename: filename)
+        logger.debug("Preview PNG ready file=\(filename, privacy: .public) mode=\(result.diagnostics.outputMode.identifier, privacy: .public) bytes=\(data.count, privacy: .public)")
 
         return QLPreviewReply(
             dataOfContentType: .png,
-            contentSize: contentSize
+            contentSize: result.contentSize
         ) { reply in
             reply.title = filename
             return data
         }
     }
 
-    private static func logRenderedPageDiagnostics(
-        _ page: HwpRenderedPage,
-        replyType: String,
+    private static func logPNGDiagnostics(
+        _ result: HwpRenderedPreviewPNG,
         filename: String
     ) {
-        let diagnostics = page.diagnostics
-        logger.debug("Preview \(replyType, privacy: .public) render backend file=\(filename, privacy: .public) policy=\(String(describing: diagnostics.policy), privacy: .public) backend=\(String(describing: diagnostics.backendUsed), privacy: .public) fallback=\(fallbackReasonDescription(diagnostics.fallbackReason), privacy: .public)")
-        logger.debug("Preview \(replyType, privacy: .public) render output pixel=\(Int(diagnostics.pixelSize.width), privacy: .public)x\(Int(diagnostics.pixelSize.height), privacy: .public) pngBytes=\(optionalIntDescription(diagnostics.pngBytes), privacy: .public)")
-        logger.debug("Preview \(replyType, privacy: .public) render timing totalMs=\(millisecondsDescription(diagnostics.durationMs.totalMs), privacy: .public) skiaMs=\(optionalMillisecondsDescription(diagnostics.durationMs.skiaRenderMs), privacy: .public) decodeMs=\(optionalMillisecondsDescription(diagnostics.durationMs.pngDecodeMs), privacy: .public) coreMs=\(optionalMillisecondsDescription(diagnostics.durationMs.coreGraphicsRenderMs), privacy: .public)")
+        let diagnostics = result.diagnostics
+        logger.debug("Preview PNG render backend file=\(filename, privacy: .public) requestedMode=\(diagnostics.requestedMode.identifier, privacy: .public) outputMode=\(diagnostics.outputMode.identifier, privacy: .public) backend=\(backendDescription(diagnostics.backendUsed), privacy: .public) fallback=\(optionalStringDescription(diagnostics.fallbackReason), privacy: .public)")
+        logger.debug("Preview PNG render output file=\(filename, privacy: .public) bytes=\(diagnostics.outputBytes, privacy: .public) skiaPNGBytes=\(optionalIntDescription(diagnostics.skiaPNGBytes), privacy: .public) pixel=\(optionalSizeDescription(diagnostics.pngPixelSize), privacy: .public)")
+        logger.debug("Preview PNG render timing totalMs=\(millisecondsDescription(diagnostics.durationMs.totalMs), privacy: .public) skiaMs=\(optionalMillisecondsDescription(diagnostics.durationMs.skiaRenderMs), privacy: .public) validateMs=\(optionalMillisecondsDescription(diagnostics.durationMs.pngHeaderValidateMs), privacy: .public) decodeMs=\(optionalMillisecondsDescription(diagnostics.durationMs.pngDecodeMs), privacy: .public) encodeMs=\(optionalMillisecondsDescription(diagnostics.durationMs.pngEncodeMs), privacy: .public) coreMs=\(optionalMillisecondsDescription(diagnostics.durationMs.coreGraphicsRenderMs), privacy: .public)")
     }
 
     private static func pdfReply(_ documentContext: HwpPreviewDocumentContext) throws -> QLPreviewReply {
@@ -137,18 +138,22 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
         return "\(type(of: error))(domain=\(nsError.domain), code=\(nsError.code))"
     }
 
-    private static func fallbackReasonDescription(_ reason: HwpPageRenderFallbackReason?) -> String {
-        guard let reason else {
-            return "none"
-        }
-        return String(describing: reason)
-    }
-
     private static func optionalIntDescription(_ value: Int?) -> String {
         guard let value else {
             return "none"
         }
         return String(value)
+    }
+
+    private static func optionalStringDescription(_ value: String?) -> String {
+        value ?? "none"
+    }
+
+    private static func optionalSizeDescription(_ value: CGSize?) -> String {
+        guard let value else {
+            return "none"
+        }
+        return "\(Int(value.width))x\(Int(value.height))"
     }
 
     private static func optionalMillisecondsDescription(_ value: Double?) -> String {
@@ -160,5 +165,16 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
 
     private static func millisecondsDescription(_ value: Double) -> String {
         String(format: "%.3f", value)
+    }
+
+    private static func backendDescription(_ backend: HwpPageRenderBackend) -> String {
+        switch backend {
+        case .coreGraphics:
+            return "coreGraphics"
+        case .skia:
+            return "skia"
+        case .embeddedThumbnail:
+            return "embeddedThumbnail"
+        }
     }
 }

--- a/Sources/QLExtension/HwpQuickLookPNGReplyModeResolver.swift
+++ b/Sources/QLExtension/HwpQuickLookPNGReplyModeResolver.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+enum HwpQuickLookPNGReplyModeResolver {
+    static let environmentKey = "ALHANGEUL_QUICKLOOK_PNG_REPLY_MODE"
+
+    static func resolve(
+        environment: [String: String]? = nil
+    ) -> HwpPreviewPNGReplyMode {
+#if DEBUG
+        let environment = environment ?? ProcessInfo.processInfo.environment
+        guard let rawValue = environment[environmentKey] else {
+            return .coreGraphics
+        }
+
+        switch normalizedValue(rawValue) {
+        case "skia", "skiadecode", "skiaoptin":
+            return .skiaDecode
+        case "direct", "skiadirect":
+            return .skiaDirect
+        case "coregraphics", "coregraphicsonly":
+            return .coreGraphics
+        default:
+            return .coreGraphics
+        }
+#else
+        return .coreGraphics
+#endif
+    }
+
+    static func identifier(for mode: HwpPreviewPNGReplyMode) -> String {
+        mode.identifier
+    }
+
+    private static func normalizedValue(_ value: String) -> String {
+        value
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+            .replacingOccurrences(of: "-", with: "")
+            .replacingOccurrences(of: "_", with: "")
+    }
+}

--- a/Sources/Shared/HwpPreviewPNGRenderer.swift
+++ b/Sources/Shared/HwpPreviewPNGRenderer.swift
@@ -1,0 +1,269 @@
+import CoreGraphics
+import Foundation
+
+enum HwpPreviewPNGReplyMode: Equatable {
+    case coreGraphics
+    case skiaDecode
+    case skiaDirect
+
+    var identifier: String {
+        switch self {
+        case .coreGraphics:
+            return "coreGraphics"
+        case .skiaDecode:
+            return "skiaDecode"
+        case .skiaDirect:
+            return "skiaDirect"
+        }
+    }
+}
+
+struct HwpPreviewPNGDuration {
+    let skiaRenderMs: Double?
+    let pngHeaderValidateMs: Double?
+    let pngDecodeMs: Double?
+    let pngEncodeMs: Double?
+    let coreGraphicsRenderMs: Double?
+    let totalMs: Double
+}
+
+struct HwpPreviewPNGDiagnostics {
+    let requestedMode: HwpPreviewPNGReplyMode
+    let outputMode: HwpPreviewPNGReplyMode
+    let backendUsed: HwpPageRenderBackend
+    let fallbackReason: String?
+    let outputBytes: Int
+    let skiaPNGBytes: Int?
+    let pngPixelSize: CGSize?
+    let durationMs: HwpPreviewPNGDuration
+}
+
+struct HwpRenderedPreviewPNG {
+    let data: Data
+    let contentSize: CGSize
+    let diagnostics: HwpPreviewPNGDiagnostics
+}
+
+enum HwpPreviewPNGRenderer {
+    static func render(
+        context: HwpPreviewDocumentContext,
+        mode: HwpPreviewPNGReplyMode = .coreGraphics
+    ) throws -> HwpRenderedPreviewPNG {
+        guard context.pageCount == 1 else {
+            throw HwpRenderError.pageOutOfRange
+        }
+
+        switch mode {
+        case .coreGraphics:
+            return try renderEncodedPage(
+                context: context,
+                requestedMode: mode,
+                policy: .coreGraphicsOnly
+            )
+        case .skiaDecode:
+            return try renderEncodedPage(
+                context: context,
+                requestedMode: mode,
+                policy: .skiaOptIn
+            )
+        case .skiaDirect:
+            return try renderDirectSkiaPNG(context: context)
+        }
+    }
+
+    private static func renderDirectSkiaPNG(
+        context: HwpPreviewDocumentContext
+    ) throws -> HwpRenderedPreviewPNG {
+        let skiaStart = DispatchTime.now().uptimeNanoseconds
+        let png = context.document.renderPagePNG(
+            at: 0,
+            scale: 1,
+            maxDimension: 0
+        )
+        let skiaRenderMs = elapsedMilliseconds(since: skiaStart)
+
+        guard png.status == .ok, png.byteCount > 0 else {
+            return try renderEncodedPage(
+                context: context,
+                requestedMode: .skiaDirect,
+                policy: .coreGraphicsOnly,
+                fallbackReason: directFallbackReason(for: png.status),
+                skiaRenderMs: skiaRenderMs,
+                skiaPNGBytes: png.byteCount > 0 ? png.byteCount : nil
+            )
+        }
+
+        let validateStart = DispatchTime.now().uptimeNanoseconds
+        guard let pixelSize = pngPixelSize(from: png.data) else {
+            let validateMs = elapsedMilliseconds(since: validateStart)
+            return try renderEncodedPage(
+                context: context,
+                requestedMode: .skiaDirect,
+                policy: .coreGraphicsOnly,
+                fallbackReason: "invalidPNGHeader",
+                skiaRenderMs: skiaRenderMs,
+                pngHeaderValidateMs: validateMs,
+                skiaPNGBytes: png.byteCount
+            )
+        }
+        let validateMs = elapsedMilliseconds(since: validateStart)
+
+        return HwpRenderedPreviewPNG(
+            data: png.data,
+            contentSize: context.contentSize,
+            diagnostics: HwpPreviewPNGDiagnostics(
+                requestedMode: .skiaDirect,
+                outputMode: .skiaDirect,
+                backendUsed: .skia,
+                fallbackReason: nil,
+                outputBytes: png.byteCount,
+                skiaPNGBytes: png.byteCount,
+                pngPixelSize: pixelSize,
+                durationMs: HwpPreviewPNGDuration(
+                    skiaRenderMs: skiaRenderMs,
+                    pngHeaderValidateMs: validateMs,
+                    pngDecodeMs: nil,
+                    pngEncodeMs: nil,
+                    coreGraphicsRenderMs: nil,
+                    totalMs: skiaRenderMs + validateMs
+                )
+            )
+        )
+    }
+
+    private static func renderEncodedPage(
+        context: HwpPreviewDocumentContext,
+        requestedMode: HwpPreviewPNGReplyMode,
+        policy: HwpPageRenderPolicy,
+        fallbackReason: String? = nil,
+        skiaRenderMs: Double? = nil,
+        pngHeaderValidateMs: Double? = nil,
+        skiaPNGBytes: Int? = nil
+    ) throws -> HwpRenderedPreviewPNG {
+        let page = try HwpPageImageRenderer.renderPage(
+            document: context.document,
+            pageIndex: 0,
+            policy: policy
+        )
+
+        let encodeStart = DispatchTime.now().uptimeNanoseconds
+        let data = try HwpPageImageRenderer.encodePNG(page.image)
+        let encodeMs = elapsedMilliseconds(since: encodeStart)
+
+        let renderDiagnostics = page.diagnostics
+        let outputMode = encodedOutputMode(
+            requestedMode: requestedMode,
+            diagnostics: renderDiagnostics
+        )
+        let externalSkiaRenderMs = skiaRenderMs
+        let resolvedSkiaRenderMs = skiaRenderMs ?? renderDiagnostics.durationMs.skiaRenderMs
+        let resolvedFallback = fallbackReason ?? renderDiagnostics.fallbackReason.map { String(describing: $0) }
+        let totalMs = (externalSkiaRenderMs ?? 0)
+            + (pngHeaderValidateMs ?? 0)
+            + renderDiagnostics.durationMs.totalMs
+            + encodeMs
+
+        return HwpRenderedPreviewPNG(
+            data: data,
+            contentSize: context.contentSize,
+            diagnostics: HwpPreviewPNGDiagnostics(
+                requestedMode: requestedMode,
+                outputMode: outputMode,
+                backendUsed: renderDiagnostics.backendUsed,
+                fallbackReason: resolvedFallback,
+                outputBytes: data.count,
+                skiaPNGBytes: skiaPNGBytes ?? renderDiagnostics.pngBytes,
+                pngPixelSize: renderDiagnostics.pixelSize,
+                durationMs: HwpPreviewPNGDuration(
+                    skiaRenderMs: resolvedSkiaRenderMs,
+                    pngHeaderValidateMs: pngHeaderValidateMs,
+                    pngDecodeMs: renderDiagnostics.durationMs.pngDecodeMs,
+                    pngEncodeMs: encodeMs,
+                    coreGraphicsRenderMs: renderDiagnostics.durationMs.coreGraphicsRenderMs,
+                    totalMs: totalMs
+                )
+            )
+        )
+    }
+
+    private static func encodedOutputMode(
+        requestedMode: HwpPreviewPNGReplyMode,
+        diagnostics: HwpPageRenderDiagnostics
+    ) -> HwpPreviewPNGReplyMode {
+        if requestedMode == .skiaDirect {
+            return .coreGraphics
+        }
+        if requestedMode == .skiaDecode, diagnostics.backendUsed == .skia {
+            return .skiaDecode
+        }
+        return .coreGraphics
+    }
+
+    private static func directFallbackReason(for status: RhwpPagePNGStatus) -> String {
+        switch status {
+        case .ok:
+            return "skiaRenderFailure"
+        case .invalidHandle:
+            return "invalidDocumentHandle"
+        case .invalidOutput:
+            return "ffiUnavailable"
+        case .invalidPageIndex:
+            return "invalidPageIndex"
+        case .invalidOptions:
+            return "invalidRenderOptions"
+        case .failure:
+            return "skiaRenderFailure"
+        }
+    }
+
+    private static func pngPixelSize(from data: Data) -> CGSize? {
+        data.withUnsafeBytes { rawBuffer -> CGSize? in
+            let bytes = rawBuffer.bindMemory(to: UInt8.self)
+            guard bytes.count >= 33 else {
+                return nil
+            }
+
+            let signature: [UInt8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+            for (index, expectedByte) in signature.enumerated() where bytes[index] != expectedByte {
+                return nil
+            }
+
+            let ihdrLength = readUInt32BE(bytes, offset: 8)
+            guard
+                ihdrLength == 13,
+                bytes[12] == 0x49,
+                bytes[13] == 0x48,
+                bytes[14] == 0x44,
+                bytes[15] == 0x52
+            else {
+                return nil
+            }
+
+            let width = readUInt32BE(bytes, offset: 16)
+            let height = readUInt32BE(bytes, offset: 20)
+            guard width > 0, height > 0 else {
+                return nil
+            }
+
+            return CGSize(width: CGFloat(width), height: CGFloat(height))
+        }
+    }
+
+    private static func readUInt32BE(
+        _ bytes: UnsafeBufferPointer<UInt8>,
+        offset: Int
+    ) -> UInt32 {
+        (UInt32(bytes[offset]) << 24)
+            | (UInt32(bytes[offset + 1]) << 16)
+            | (UInt32(bytes[offset + 2]) << 8)
+            | UInt32(bytes[offset + 3])
+    }
+
+    private static func elapsedMilliseconds(since start: UInt64) -> Double {
+        let end = DispatchTime.now().uptimeNanoseconds
+        guard end >= start else {
+            return 0
+        }
+        return Double(end - start) / 1_000_000
+    }
+}

--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #392 | Thumbnail Skia maxDimension mapping 실험 | 완료 | 완료: 18:48, Stage 5 최종 보고와 기술 문서 반영 완료, PR 게시 준비 |
-| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, Stage 3 opt-in direct PNG 구현과 smoke 보강 완료 후 승인 대기 |
+| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, Stage 4 대표 샘플 비교 측정 완료 후 승인 대기 |

--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #392 | Thumbnail Skia maxDimension mapping 실험 | 완료 | 완료: 18:48, Stage 5 최종 보고와 기술 문서 반영 완료, PR 게시 준비 |
-| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -5,3 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #392 | Thumbnail Skia maxDimension mapping 실험 | 완료 | 완료: 18:48, Stage 5 최종 보고와 기술 문서 반영 완료, PR 게시 준비 |
+| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #392 | Thumbnail Skia maxDimension mapping 실험 | 완료 | 완료: 18:48, Stage 5 최종 보고와 기술 문서 반영 완료, PR 게시 준비 |
-| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, Stage 1 baseline inventory 완료 후 승인 대기 |
+| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, Stage 2 direct PNG reply contract 설계 완료 후 승인 대기 |

--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #392 | Thumbnail Skia maxDimension mapping 실험 | 완료 | 완료: 18:48, Stage 5 최종 보고와 기술 문서 반영 완료, PR 게시 준비 |
-| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, Stage 2 direct PNG reply contract 설계 완료 후 승인 대기 |
+| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, Stage 3 opt-in direct PNG 구현과 smoke 보강 완료 후 승인 대기 |

--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #392 | Thumbnail Skia maxDimension mapping 실험 | 완료 | 완료: 18:48, Stage 5 최종 보고와 기술 문서 반영 완료, PR 게시 준비 |
-| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, Stage 4 대표 샘플 비교 측정 완료 후 승인 대기 |
+| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 완료 | 완료: 20:27, Stage 5 최종 보고와 기술 문서 반영 완료, PR 게시 준비 |

--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #392 | Thumbnail Skia maxDimension mapping 실험 | 완료 | 완료: 18:48, Stage 5 최종 보고와 기술 문서 반영 완료, PR 게시 준비 |
-| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |
+| #393 | Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험 | 진행중 | M020, Stage 1 baseline inventory 완료 후 승인 대기 |

--- a/mydocs/plans/task_m020_393.md
+++ b/mydocs/plans/task_m020_393.md
@@ -1,0 +1,137 @@
+# Task M020 #393 수행계획서
+
+## 목적
+
+Quick Look 단일 페이지 preview에서 Skia opt-in 경로가 이미 PNG bytes를 만들고 있음에도 Swift에서 `CGImage`로 decode한 뒤 다시 PNG로 encode하는 round-trip을 거치는지 확인하고, 진단 전용 direct PNG reply fast path를 실험한다.
+
+목표는 production default를 바꾸는 것이 아니라, 단일 페이지 Quick Look의 `skiaOptIn`에서 `RhwpDocument.renderPagePNG` 결과를 `QLPreviewReply(dataOfContentType: .png)`로 직접 반환할 수 있는지, 실패 시 기존 CoreGraphics PNG reply fallback이 유지되는지, 그리고 기존 decode path 대비 latency/bytes가 어떻게 달라지는지 기록하는 것이다.
+
+## 배경
+
+#390은 `rhwp v0.7.17` 기준 Quick Look Skia readiness를 재측정했고, 단일 페이지 `request.hwp`에서는 Skia latency와 visual 결과가 CoreGraphics보다 나은 신호를 보였다. 반면 `KTX.hwp` visual regression은 Skia default 전환 blocker로 남았다.
+
+#392는 Thumbnail surface에서 `maximumPixelSize -> maxDimension` mapping을 실험했다. 그 결과 Thumbnail의 1px drift는 대부분 줄었지만 `request.hwp` underfill risk가 남아 default 전환 근거로는 부족했다. #393은 Thumbnail이 아니라 Quick Look 단일 페이지 PNG reply의 별도 surface 실험이다.
+
+현재 `scripts/smoke-quicklook-skia-policy.sh`의 단일 페이지 측정은 다음 경로다.
+
+1. `HwpPageImageRenderer.renderPage(..., policy: .skiaOptIn)`
+2. Skia PNG bytes 생성
+3. Swift `CGImageSource` decode
+4. `HwpPageImageRenderer.encodePNG` 재인코딩
+
+단일 페이지 Quick Look reply의 최종 output이 PNG라면 3-4단계를 피할 수 있다.
+
+## 범위
+
+포함:
+
+- Quick Look 단일 페이지에 한한 `skiaOptIn` direct PNG reply 설계와 실험
+- `RhwpDocument.renderPagePNG`를 직접 사용하는 Quick Look 전용 helper 검토
+- direct path diagnostics: requested backend, used backend, fallback reason, PNG bytes, render time, direct reply 여부
+- direct PNG 실패 시 기존 CoreGraphics PNG reply fallback 유지
+- 기존 decode path와 direct path의 latency/output bytes 비교 smoke 보강
+- #390/#392 결과와 #259 readiness gate로 넘길 판단 근거 문서화
+
+제외:
+
+- Thumbnail direct PNG path
+- Quick Look 다중 페이지 PDF direct path
+- Skia release/default 전환
+- user-facing preference 또는 UI 추가
+- upstream `rhwp` 수정
+- `Rhwp.xcframework` 재생성
+
+## 설계 방향
+
+production/default Quick Look은 계속 CoreGraphics 경로로 둔다. Direct PNG fast path는 DEBUG/internal opt-in 또는 smoke helper가 명시하는 policy에서만 사용한다.
+
+Source 변경은 `QLExtension` surface에 좁게 둔다. Shared `HwpPageImageRenderer`는 기존 decode/fallback contract를 유지하고, direct PNG reply는 Quick Look provider 또는 Quick Look 전용 helper에서 `RhwpDocument.renderPagePNG`를 직접 호출하는 쪽을 우선 검토한다. 실패 시에는 text fallback으로 바로 내려가지 않고 기존 CoreGraphics PNG reply shape을 재사용한다.
+
+Smoke는 같은 단일 페이지 샘플에서 세 경로를 비교할 수 있어야 한다.
+
+- CoreGraphics PNG reply
+- 기존 Skia decode path
+- Skia direct PNG reply
+
+다중 페이지 문서는 이번 작업에서 direct path를 적용하지 않고 기존 PDF path 유지 여부와 fallback/비적용 진단만 확인한다.
+
+## 예상 변경 파일
+
+- `mydocs/plans/task_m020_393.md`
+- `mydocs/plans/task_m020_393_impl.md`
+- `mydocs/working/task_m020_393_stage*.md`
+- `mydocs/report/task_m020_393_report.md`
+- `mydocs/orders/20260703.md`
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- 필요 시 `Sources/Shared/HwpPageImageRenderer.swift`
+- 필요 시 `Sources/Shared/HwpPreviewPDFRenderer.swift`
+- 필요 시 `scripts/quicklook_skia_policy_smoke.swift`
+- 필요 시 `scripts/smoke-quicklook-skia-policy.sh`
+- 필요 시 `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- 필요 시 `mydocs/tech/skia_preview_renderer_baseline.md`
+
+## 잠정 단계
+
+1. Stage 1: 현행 Quick Look PNG reply inventory
+   - `HwpPreviewProvider`, `HwpPageImageRenderer`, `RhwpDocument.renderPagePNG`, `smoke-quicklook-skia-policy.sh`의 현재 단일 페이지 경로를 읽고 decode/encode round-trip을 문서화한다.
+   - #390 Quick Look smoke 결과와 현재 브랜치 quick smoke baseline을 고정한다.
+2. Stage 2: direct PNG reply contract 설계
+   - direct path의 적용 조건, fallback shape, diagnostics field, smoke 비교 표를 확정한다.
+   - Quick Look 단일 페이지와 다중 페이지 PDF의 경계를 문서화한다.
+3. Stage 3: opt-in direct PNG 구현과 smoke 보강
+   - Quick Look 단일 페이지 Skia direct PNG helper를 구현한다.
+   - direct 실패 시 기존 CoreGraphics PNG reply로 fallback한다.
+   - smoke helper가 direct/decode/CoreGraphics 경로를 비교 가능하게 보강한다.
+4. Stage 4: 대표 샘플 비교 측정
+   - `request.hwp`, `KTX.hwp`, `복학원서.hwp` 등 단일 페이지 샘플에서 direct/decode/CoreGraphics latency, bytes, fallback을 비교한다.
+   - 다중 페이지 샘플은 direct path가 적용되지 않는지 확인한다.
+5. Stage 5: 최종 보고와 문서 반영
+   - direct PNG fast path의 효과와 남은 visual/default blocker를 최종 보고서와 기술 문서에 기록한다.
+   - 오늘할일 완료 처리와 PR 게시 준비를 수행한다.
+
+## 검증 계획
+
+기본 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+git diff --check
+```
+
+빌드 검증 후보:
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask393 CODE_SIGNING_ALLOWED=NO build
+```
+
+Quick Look smoke 후보:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-quicklook-policy \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+필요 시 visual readiness 연결:
+
+```bash
+./scripts/preview-renderer-baseline.sh build.noindex/task393-baseline-quick --suite quick
+```
+
+## 리스크
+
+- Quick Look provider가 `QLPreviewReply` closure에서 async/diagnostic 값을 다루는 방식에 제약이 있을 수 있다.
+- Skia direct PNG bytes가 Quick Look 표시에는 적합해도 기존 `HwpRenderedPage` diagnostics 구조와 다르게 흘러갈 수 있다.
+- `KTX.hwp` visual regression은 direct PNG로 해결되는 성격이 아닐 가능성이 높다. Direct path는 encode/decode 비용 실험이지 visual default 판단은 아니다.
+- 단일 페이지 fast path가 다중 페이지 PDF path와 섞이면 regression 위험이 크므로 조건 분리를 강하게 유지해야 한다.
+- latency는 로컬 환경 변동을 받으므로 절대값보다 같은 smoke run 안의 상대 비교와 fallback 여부를 우선 해석한다.
+
+## 승인 요청 사항
+
+- 기준 브랜치는 `devel`, 작업 브랜치는 `local/task393`으로 진행한다.
+- 이 작업은 #387 추적 이슈의 Quick Look direct PNG 후속 #393으로 진행한다.
+- 수행계획서 승인 후 구현계획서를 작성하고 Stage 1 inventory부터 시작한다.
+- production default는 CoreGraphics 유지, direct PNG 변경은 DEBUG/internal opt-in diagnostic 경로의 Quick Look 단일 페이지 실험에 한정한다.

--- a/mydocs/plans/task_m020_393_impl.md
+++ b/mydocs/plans/task_m020_393_impl.md
@@ -1,0 +1,281 @@
+# Task M020 #393 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_393.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #393 `Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험`
+- 추적 이슈: #387 Preview/Thumbnail Skia readiness 후속 개선 추적
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task393`
+- 목표: Quick Look 단일 페이지 `skiaOptIn` 진단 경로에서 Skia PNG bytes를 Swift `CGImage` decode와 PNG 재인코딩 없이 `QLPreviewReply`로 직접 반환할 수 있는지 실험하고, 기존 decode path와 latency/bytes/fallback을 비교한다.
+
+## 구현 원칙
+
+- production default는 계속 `.coreGraphicsOnly`다.
+- Skia default 전환, Thumbnail direct PNG, Quick Look 다중 페이지 PDF direct path, upstream `rhwp` 변경은 하지 않는다.
+- direct PNG path는 Quick Look 단일 페이지에만 한정한다.
+- Skia direct render 실패 또는 invalid PNG 결과는 Quick Look text fallback으로 바로 내려가지 않고 기존 CoreGraphics PNG reply shape으로 fallback한다.
+- `Sources/RhwpCoreBridge`에는 AppKit/UIKit 의존을 추가하지 않는다.
+- `project.yml`이 Xcode project 원본이다. 새 Swift source 추가가 필요하면 `project.yml` 변경과 `xcodegen generate`를 함께 처리한다. 가능하면 기존 source 안에서 좁게 구현한다.
+- smoke helper는 같은 입력 파일에서 CoreGraphics, 기존 Skia decode path, Skia direct path를 비교 가능하게 남긴다.
+- visual/default 판단은 #259 readiness gate로 넘기고, 이번 작업은 direct path의 비용과 fallback contract 실험으로 제한한다.
+
+## Stage 1. 현행 Quick Look PNG reply inventory
+
+### 목표
+
+현재 Quick Look 단일 페이지 경로가 `Skia PNG -> CGImage decode -> PNG encode` round-trip을 거친다는 사실을 코드와 smoke output으로 고정한다.
+
+### 대상
+
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/Shared/HwpPreviewPDFRenderer.swift`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `scripts/smoke-quicklook-skia-policy.sh`
+- `scripts/quicklook_skia_policy_smoke.swift`
+- `mydocs/report/task_m020_390_report.md`
+- `mydocs/report/task_m020_392_report.md`
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+
+### 작업
+
+1. `HwpPreviewProvider.pngReply`가 현재 production/default에서 `.coreGraphicsOnly`만 호출하는지 확인한다.
+2. `HwpPageImageRenderer.renderPage(..., policy: .skiaOptIn)`가 Skia PNG bytes를 decode해서 `HwpRenderedPage`로 바꾸는 흐름을 정리한다.
+3. `quicklook_skia_policy_smoke.swift`가 단일 페이지에서 기존 Skia decode path를 어떻게 측정하는지 정리한다.
+4. 현재 브랜치에서 quick smoke를 실행해 #390 기준과 비교 가능한 baseline을 고정한다.
+5. Stage 2에서 필요한 direct path source surface와 diagnostics field 후보를 확정한다.
+
+### 검증
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-stage1-quicklook-baseline \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+rg -n "pngReply|renderPagePNG|decodePNGImage|encodePNG|skiaOptIn|coreGraphicsOnly|SkiaBytes|SkiaPNGBytes|Reply" \
+  Sources/QLExtension/HwpPreviewProvider.swift Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/quicklook_skia_policy_smoke.swift build.noindex/task393-stage1-quicklook-baseline \
+  mydocs/working/task_m020_393_stage1.md
+git diff --check
+```
+
+### 완료 조건
+
+- 현재 Quick Look 단일 페이지 Skia smoke가 decode/encode round-trip 경로임이 문서화되어 있다.
+- quick smoke baseline에서 reply type, output bytes, PNG bytes, backend pages, fallback, elapsed seconds가 정리되어 있다.
+- Stage 2 설계 입력이 충분하다.
+
+### 커밋 메시지
+
+```text
+Task #393 Stage 1: Quick Look PNG reply baseline inventory
+```
+
+## Stage 2. direct PNG reply contract 설계
+
+### 목표
+
+Quick Look 단일 페이지 direct PNG fast path의 적용 조건, fallback shape, diagnostics, smoke output contract를 확정한다.
+
+### 대상
+
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `scripts/quicklook_skia_policy_smoke.swift`
+- `mydocs/working/task_m020_393_stage2.md`
+
+### 작업
+
+1. provider opt-in 조건을 설계한다.
+   - production default는 `.coreGraphicsOnly`
+   - DEBUG/internal 진단 조건에서만 direct Skia path 후보 사용
+   - env key를 추가할지, smoke helper 전용 direct path로 둘지 판단
+2. direct render helper contract를 정한다.
+   - 입력: `HwpPreviewDocumentContext`, page index 0, policy/direct option
+   - 성공: PNG bytes, page size, backend `.skia`, pngBytes, renderMs, direct flag
+   - 실패: fallback reason과 Skia render timing을 보존한 뒤 CoreGraphics PNG reply로 fallback
+3. `HwpPageRenderDiagnostics`를 확장할지, Quick Look 전용 diagnostics 구조를 만들지 판단한다.
+4. 다중 페이지 PDF에는 direct path가 적용되지 않도록 조건을 명시한다.
+5. smoke summary/detail column 후보를 정한다.
+   - reply mode: `coreGraphics`, `skiaDecode`, `skiaDirect`
+   - direct 여부
+   - output bytes
+   - skia PNG bytes
+   - render/decode/encode/total seconds
+   - fallback reason
+
+### 검증
+
+```bash
+rg -n "QLPreviewReply|renderPagePNG|HwpPageRenderDiagnostics|HwpPreview|quicklook|direct|skiaOptIn|fallback" \
+  Sources/QLExtension/HwpPreviewProvider.swift Sources/Shared/HwpPageImageRenderer.swift \
+  Sources/RhwpCoreBridge/RhwpDocument.swift scripts/quicklook_skia_policy_smoke.swift \
+  mydocs/working/task_m020_393_stage2.md
+git diff --check
+```
+
+### 완료 조건
+
+- source 변경 전 direct path contract가 문서화되어 있다.
+- fallback과 diagnostics의 책임 경계가 확정되어 있다.
+- Stage 3 구현 범위가 source 단위로 명확하다.
+
+### 커밋 메시지
+
+```text
+Task #393 Stage 2: Quick Look direct PNG contract 설계
+```
+
+## Stage 3. opt-in direct PNG 구현과 smoke 보강
+
+### 목표
+
+Quick Look 단일 페이지 Skia direct PNG path를 opt-in으로 구현하고, 기존 decode path와 직접 비교 가능한 smoke output을 만든다.
+
+### 대상
+
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- 필요 시 `Sources/Shared/HwpPageImageRenderer.swift`
+- 필요 시 `Sources/Shared/HwpPreviewPDFRenderer.swift`
+- `scripts/quicklook_skia_policy_smoke.swift`
+- 필요 시 `scripts/smoke-quicklook-skia-policy.sh`
+- `mydocs/working/task_m020_393_stage3.md`
+
+### 작업
+
+1. Quick Look 단일 페이지 direct PNG helper를 구현한다.
+2. direct path 성공 시 `QLPreviewReply(dataOfContentType: .png)`가 Skia PNG bytes를 그대로 반환하도록 한다.
+3. direct path 실패 시 기존 CoreGraphics PNG reply로 fallback한다.
+4. production/default provider path가 계속 CoreGraphics인지 확인한다.
+5. smoke helper에 direct path 측정을 추가한다.
+6. quick smoke로 direct/decode/CoreGraphics path의 output bytes, PNG bytes, timing, fallback을 비교한다.
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-stage3-quicklook-direct \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+rg -n "direct|skiaOptIn|coreGraphicsOnly|Reply|Bytes|Fallback|RenderMs|Decode|Encode|OK|FAIL" \
+  build.noindex/task393-stage3-quicklook-direct Sources scripts mydocs/working/task_m020_393_stage3.md
+git diff --check
+```
+
+가능하면 build 검증:
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask393Stage3 CODE_SIGNING_ALLOWED=NO build
+```
+
+### 완료 조건
+
+- 단일 페이지 opt-in direct path가 Skia PNG bytes를 decode/encode 없이 reply data로 반환한다.
+- direct 실패 시 CoreGraphics fallback reply가 유지된다.
+- 다중 페이지 PDF path에는 direct path가 적용되지 않는다.
+- smoke 결과가 direct/decode/CoreGraphics 경로를 같은 summary에서 비교 가능하게 남긴다.
+
+### 커밋 메시지
+
+```text
+Task #393 Stage 3: Quick Look Skia direct PNG opt-in 적용
+```
+
+## Stage 4. 대표 샘플 비교 측정
+
+### 목표
+
+대표 샘플에서 CoreGraphics, 기존 Skia decode path, Skia direct path의 latency/bytes/fallback 결과를 비교하고 #259로 넘길 결론을 정리한다.
+
+### 대상
+
+- `build.noindex/task393-stage1-quicklook-baseline/`
+- `build.noindex/task393-stage3-quicklook-direct/`
+- `build.noindex/task393-quicklook-policy-representative/`
+- `mydocs/working/task_m020_393_stage4.md`
+- 필요 시 `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+
+### 작업
+
+1. 기본 검증 command를 실행한다.
+2. 대표 샘플 smoke를 실행한다.
+3. 단일 페이지 샘플에서 direct/decode/CoreGraphics latency와 bytes를 표로 정리한다.
+4. 다중 페이지 샘플이 direct path 비적용 상태로 기존 PDF path를 유지하는지 확인한다.
+5. `KTX.hwp` visual regression이 direct PNG 실험으로 해결된 것이 아니라는 점을 분리한다.
+6. #259 readiness gate로 넘길 direct path 성능/리스크 입력을 정리한다.
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-quicklook-policy-representative \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+rg -n "OK|FAIL|coreGraphicsOnly|skiaOptIn|direct|decode|png|pdf|Fallback|Bytes|Seconds|RenderMs" \
+  build.noindex/task393-quicklook-policy-representative mydocs/working/task_m020_393_stage4.md
+git diff --check
+```
+
+### 완료 조건
+
+- 대표 샘플 결과가 존재하고 direct path 효과를 해석할 수 있다.
+- 단일/다중 페이지 경계가 검증되어 있다.
+- direct path의 유효성, 한계, 후속 판단이 정리되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #393 Stage 4: Quick Look direct PNG 대표 샘플 검증
+```
+
+## Stage 5. 최종 보고와 문서 반영
+
+### 목표
+
+#393 실험 결과를 최종 보고서와 기술 문서에 반영하고 PR 게시 준비를 완료한다.
+
+### 대상
+
+- `mydocs/report/task_m020_393_report.md`
+- `mydocs/orders/20260703.md`
+- `mydocs/tech/skia_quicklook_thumbnail_backend.md`
+- 필요 시 `mydocs/tech/skia_preview_renderer_baseline.md`
+
+### 작업
+
+1. 최종 보고서에 direct PNG fast path 정책, smoke 결과, 비교 결론을 정리한다.
+2. 기술 문서의 Quick Look single-page direct PNG opt-in 기준과 남은 blocker를 갱신한다.
+3. 오늘할일 #393 상태를 완료 처리한다.
+4. #387, #390, #392, #259와의 후속 관계를 정리한다.
+5. PR body 초안에 들어갈 변경 요약과 검증 결과를 정리한다.
+
+### 검증
+
+```bash
+rg -n "#393|#387|#390|#392|#259|Quick Look|direct PNG|Skia|CoreGraphics|fallback|smoke|readiness" \
+  mydocs/report/task_m020_393_report.md mydocs/orders/20260703.md \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/tech/skia_preview_renderer_baseline.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task393
+```
+
+### 완료 조건
+
+- #393 최종 결론과 잔여 risk가 문서화되어 있다.
+- 오늘할일이 완료 처리되어 있다.
+- PR 게시에 필요한 변경 요약과 검증 결과가 정리되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #393 Stage 5: 최종 보고서와 문서 반영
+```

--- a/mydocs/report/task_m020_393_report.md
+++ b/mydocs/report/task_m020_393_report.md
@@ -1,0 +1,228 @@
+# Task M020 #393 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | #393 `Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험` |
+| 추적 이슈 | #387 `Preview/Thumbnail Skia readiness 후속 개선 추적` |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 작업 브랜치 | `local/task393` |
+| 단계 수 | 5 |
+
+Quick Look 단일 페이지 PNG reply에서 Skia PNG bytes를 Swift `CGImage`로 decode한 뒤 다시 PNG로 encode하던 진단 경로와 별도로, DEBUG/internal opt-in `skiaDirect` reply mode를 추가했다. Production/default는 계속 CoreGraphics PNG reply다.
+
+핵심 결과:
+
+- `ALHANGEUL_QUICKLOOK_PNG_REPLY_MODE` DEBUG resolver를 추가했다. missing/empty/invalid 값과 Release build는 `coreGraphics`로 수렴한다.
+- `skiaDirect`는 Quick Look 단일 페이지에서 `RhwpDocument.renderPagePNG(at: 0, scale: 1, maxDimension: 0)` 결과 PNG bytes를 header/IHDR 검증 후 그대로 반환한다.
+- direct 실패 시 Quick Look text fallback으로 가지 않고 CoreGraphics PNG reply shape으로 fallback한다.
+- 대표 5개 샘플 smoke에서 단일 페이지 3개 샘플 모두 direct fallback 0건, 다중 페이지 2개 샘플은 의도대로 `skiaDirect=N/A`였다.
+- 단일 페이지 3개 샘플에서 `skiaDirect`는 기존 `skiaDecode`보다 빨랐다.
+- `KTX.hwp` Skia visual regression은 해결되지 않았다. direct path는 같은 Skia output을 더 직접 반환하는 fast path일 뿐, Skia quality gate를 우회하지 않는다.
+
+## 변경 파일과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `Sources/Shared/HwpPreviewPNGRenderer.swift` | Quick Look PNG reply helper, `coreGraphics`/`skiaDecode`/`skiaDirect` mode, PNG header/IHDR validation, timing diagnostics 추가 |
+| `Sources/QLExtension/HwpQuickLookPNGReplyModeResolver.swift` | DEBUG/internal `ALHANGEUL_QUICKLOOK_PNG_REPLY_MODE` resolver 추가 |
+| `Sources/QLExtension/HwpPreviewProvider.swift` | 단일 페이지 PNG reply에서 resolver와 `HwpPreviewPNGRenderer` 사용. 다중 PDF path는 유지 |
+| `scripts/smoke-quicklook-skia-policy.sh` | smoke compile list에 신규 helper/resolver 추가, DEBUG resolver contract 검증 |
+| `scripts/quicklook_skia_policy_smoke.swift` | `coreGraphics`, `skiaDecode`, `skiaDirect` 측정과 resolver contract summary/detail 추가 |
+| `Alhangeul.xcodeproj/project.pbxproj` | `xcodegen generate`로 신규 Swift source 반영 |
+| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | #393 direct PNG opt-in 결과와 default blocker 반영 |
+| `mydocs/tech/skia_preview_renderer_baseline.md` | #393 결과를 visual suite를 대체하지 않는 성능 입력으로 연결 |
+| `mydocs/plans/task_m020_393.md` | 수행계획서 |
+| `mydocs/plans/task_m020_393_impl.md` | 단계별 구현계획서 |
+| `mydocs/working/task_m020_393_stage1.md` | 현행 PNG reply inventory |
+| `mydocs/working/task_m020_393_stage2.md` | direct PNG reply contract 설계 |
+| `mydocs/working/task_m020_393_stage3.md` | opt-in direct PNG 구현과 smoke 보강 |
+| `mydocs/working/task_m020_393_stage4.md` | 대표 샘플 비교 측정 |
+| `mydocs/working/task_m020_393_stage5.md` | Stage 5 완료 보고 |
+| `mydocs/report/task_m020_393_report.md` | 최종 보고서 |
+| `mydocs/orders/20260703.md` | #393 완료 처리 |
+
+Thumbnail, Quick Look 다중 페이지 PDF direct path, Skia default 전환, user-facing preference, upstream `rhwp`, `Rhwp.xcframework`는 변경하지 않았다.
+
+## 구현 계약
+
+`HwpPreviewPNGReplyMode`:
+
+| mode | 동작 | output |
+|------|------|--------|
+| `coreGraphics` | `HwpPageImageRenderer.renderPage(... .coreGraphicsOnly)` 후 PNG encode | CoreGraphics encoded PNG |
+| `skiaDecode` | `HwpPageImageRenderer.renderPage(... .skiaOptIn)` 후 PNG encode | Skia PNG를 CGImage로 decode 후 재인코딩한 PNG |
+| `skiaDirect` | `RhwpDocument.renderPagePNG(at: 0, scale: 1, maxDimension: 0)` 직접 호출 | upstream Skia PNG bytes |
+
+`skiaDirect` 성공 조건:
+
+1. Quick Look 단일 페이지 context.
+2. `renderPagePNG` status가 `.ok`.
+3. PNG bytes가 non-empty.
+4. PNG 8-byte signature가 유효.
+5. 첫 chunk가 `IHDR`, length 13, width/height가 1 이상.
+
+ImageIO decode는 direct path 검증에 사용하지 않는다. direct path의 목적은 `CGImageSource` decode와 `CGImageDestination` PNG 재인코딩 비용을 제거하는 것이다.
+
+Resolver contract:
+
+| 입력 | DEBUG 결과 | Release 결과 |
+|------|------------|--------------|
+| missing/empty/invalid | `coreGraphics` | `coreGraphics` |
+| `coreGraphics`, `coreGraphicsOnly` | `coreGraphics` | `coreGraphics` |
+| `skia`, `skiaDecode`, `skiaOptIn` | `skiaDecode` | `coreGraphics` |
+| `direct`, `skiaDirect` | `skiaDirect` | `coreGraphics` |
+
+## 대표 smoke 결과
+
+실행:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-quicklook-policy-representative \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+결과:
+
+- resolver contract: `OK`
+- 5개 샘플 load/render: 모두 `OK`
+- 단일 페이지 3개 샘플: `skiaDirect` backend `skia`, fallback 0
+- 다중 페이지 2개 샘플: `skiaDirect` status `N/A`
+- `복학원서.hwp` 처리 중 기존 layout overflow warning 2줄이 stderr에 출력됐지만 render status는 모두 `OK`
+
+| File | Reply | CGSec | SkiaDecodeSec | SkiaDirectSec | Direct vs Decode | DirectFallback |
+|------|------|------:|---------------:|---------------:|------------------|----------------|
+| `request.hwp` | png | 1.167163 | 0.062005 | 0.023481 | 0.038524초 감소, 약 62.1% 단축 | 0 |
+| `KTX.hwp` | png | 0.073884 | 0.055980 | 0.042532 | 0.013448초 감소, 약 24.0% 단축 | 0 |
+| `복학원서.hwp` | png | 0.051353 | 0.063517 | 0.051415 | 0.012102초 감소, 약 19.1% 단축 | 0 |
+| `hwp-multi-001.hwp` | pdf | 0.443835 | 0.505146 | N/A | - | - |
+| `hwpx-01.hwpx` | pdf | 0.412582 | 0.633081 | N/A | - | - |
+
+Bytes:
+
+| File | CGBytes | SkiaDecodeBytes | SkiaDecodePNGBytes | SkiaDirectBytes | DirectPixel |
+|------|--------:|----------------:|-------------------:|----------------:|-------------|
+| `request.hwp` | 90472 | 84098 | 87027 | 87027 | 567x794 |
+| `KTX.hwp` | 543472 | 181314 | 166247 | 166247 | 1123x794 |
+| `복학원서.hwp` | 223309 | 196405 | 198675 | 198675 | 794x1123 |
+
+`skiaDirect` output bytes는 항상 upstream Skia PNG bytes와 같다. `skiaDecode` output bytes는 Skia PNG를 decode한 뒤 ImageIO가 다시 encode한 결과라 원본 PNG bytes와 다를 수 있다.
+
+## 단계 요약
+
+| Stage | 커밋 | 요약 |
+|------|------|------|
+| 계획 | `4225112` | 수행계획서 작성과 오늘할일 갱신 |
+| 구현계획 | `a86ede2` | 단계별 구현계획서 작성 |
+| Stage 1 | `5d88e75` | Quick Look PNG reply baseline inventory |
+| Stage 2 | `ec7e43c` | Quick Look direct PNG contract 설계 |
+| Stage 3 | `f8054ee` | Quick Look Skia direct PNG opt-in 적용 |
+| Stage 4 | `3188adf` | Quick Look direct PNG 대표 샘플 검증 |
+| Stage 5 | 이번 커밋 | 최종 보고서와 기술 문서 반영 |
+
+## 후속 이슈 관계
+
+| 이슈 | 관계 |
+|------|------|
+| #387 | #393은 Preview/Thumbnail Skia readiness 추적 중 Quick Look 단일 PNG fast path 실험이다 |
+| #390 | `KTX.hwp` visual regression 때문에 Skia default 보류 결론을 유지한다. #393은 그 결론을 바꾸지 않는다 |
+| #392 | Thumbnail maxDimension/underfill 판단과 별도 surface다. #393은 Thumbnail path를 변경하지 않는다 |
+| #396 | visual suite가 Skia quality gate를 담당한다. #393 direct PNG 결과는 visual suite를 대체하지 않는다 |
+| #259 | release/default readiness gate다. #393 결과는 단일 PNG opt-in 성능 입력으로만 넘긴다 |
+
+## 검증 결과
+
+실행한 주요 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-stage1-quicklook-baseline \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-stage3-quicklook-direct \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-quicklook-policy-representative \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask393Stage3 CODE_SIGNING_ALLOWED=NO build
+```
+
+결과:
+
+- `check-no-appkit.sh`: 성공.
+- `verify-rhwp-core-build-info.sh`: 성공.
+- `verify-rhwp-studio-assets.sh`: 성공.
+- Stage 1 baseline smoke: 성공. 5개 샘플 모두 `OK`, fallback 0건.
+- Stage 3 direct smoke: 성공. resolver contract `OK`, 단일 페이지 direct fallback 0건, 다중 페이지 direct `N/A`.
+- Stage 4 representative smoke: 성공. 5개 샘플 모두 `OK`.
+- `xcodegen generate`: 성공.
+- `xcodebuild ... QLExtension ... build`: 첫 sandbox 실행은 Sparkle package fetch DNS/network 실패, 네트워크 허용 재실행에서 `BUILD SUCCEEDED`.
+- `git diff --check`: 각 단계에서 성공.
+
+최종 보고서 검증:
+
+```bash
+rg -n "#393|#387|#390|#392|#259|Quick Look|direct PNG|Skia|CoreGraphics|fallback|smoke|readiness" \
+  mydocs/report/task_m020_393_report.md mydocs/orders/20260703.md \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/tech/skia_preview_renderer_baseline.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task393
+```
+
+## 잔여 위험
+
+| 항목 | 상태 | 처리 |
+|------|------|------|
+| `KTX.hwp` Skia visual regression | 잔여 | #396/#259 visual readiness gate에서 default blocker로 유지 |
+| direct fallback 강제 fixture | 없음 | 정상 샘플 fallback 0은 확인. 실패 주입 fixture는 별도 후속 후보 |
+| Release resolver smoke | source `#if DEBUG`로 env opt-in 차단 | 필요 시 review follow-up에서 별도 Release compile smoke 추가 |
+| latency 절대값 | 로컬 단일 실행값 | 같은 smoke run 안의 상대 비교와 fallback 여부 중심으로 해석 |
+| 다중 PDF Skia latency | 여전히 CoreGraphics보다 느림 | direct PNG 범위 밖. #259 readiness 입력으로 유지 |
+
+## PR 게시 준비 메모
+
+권장 PR 제목:
+
+```text
+Task #393: Quick Look Skia direct PNG opt-in fast path 실험
+```
+
+권장 PR 본문 요약:
+
+```text
+## Summary
+- Add a Quick Look single-page PNG reply helper with coreGraphics, skiaDecode, and skiaDirect modes.
+- Add a DEBUG-only ALHANGEUL_QUICKLOOK_PNG_REPLY_MODE resolver; Release resolves to CoreGraphics.
+- Return upstream Skia PNG bytes directly for skiaDirect after PNG signature/IHDR validation, with CoreGraphics PNG fallback.
+- Extend the Quick Look Skia policy smoke to compare CoreGraphics, Skia decode/re-encode, and Skia direct paths.
+- Document that direct PNG is an opt-in fast path and does not bypass the Skia visual readiness gate.
+
+## Verification
+- ./scripts/check-no-appkit.sh
+- ./scripts/verify-rhwp-core-build-info.sh
+- ./scripts/verify-rhwp-studio-assets.sh
+- ./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-quicklook-policy-representative samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+- xcodegen generate
+- xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask393Stage3 CODE_SIGNING_ALLOWED=NO build
+- git diff --check
+```
+
+리뷰 포인트:
+
+- Release/default가 계속 CoreGraphics인지
+- `skiaDirect`가 Quick Look 단일 페이지 PNG reply에만 적용되는지
+- direct failure가 text fallback이 아니라 CoreGraphics PNG reply로 fallback하는지
+- PNG validation이 ImageIO decode 없이 signature/IHDR 수준으로 제한된 것이 fast path 목적과 맞는지
+- `KTX.hwp` visual regression을 default blocker로 계속 남긴 문서 판단이 적절한지
+
+## 작업지시자 승인 요청
+
+Task #393의 구현, 검증, 최종 보고서 작성을 완료했다. PR 게시 단계 진입 여부를 승인 요청한다.

--- a/mydocs/tech/skia_preview_renderer_baseline.md
+++ b/mydocs/tech/skia_preview_renderer_baseline.md
@@ -173,3 +173,4 @@ Task #396 Stage 4 기준 quick suite는 CoreGraphics/Skia 양쪽 모두 exit 0�
 - Thumbnail/Finder cache 판단은 visual suite만으로 완료하지 않는다. #389에서 provider diagnostic path, resolver contract, internal thumbnail cache signature separation smoke는 확보했다.
 - #392에서 `maximumPixelSize -> Skia maxDimension` mapping을 적용한 결과, 대표 5개 중 4개는 1px thumbnail drift가 해소됐다.
 - `request-basic-quick`은 Skia maxDimension path에서 `567x794`로 낮아지는 underfill risk가 확인됐다. 따라서 Thumbnail surface 판단은 size drift 해소만으로 끝내지 않고, visual/thumbnail readiness에서 underfill과 구조 누락 여부를 함께 본다.
+- #393에서 Quick Look 단일 페이지 `skiaDirect`는 대표 3개 단일 샘플에서 fallback 없이 성공했고 기존 `skiaDecode`보다 빨랐다. 다만 direct PNG는 같은 Skia output을 더 직접 반환하는 opt-in fast path이므로 `KTX.hwp` 같은 visual regression sentinel과 default quality gate를 대체하지 않는다.

--- a/mydocs/tech/skia_quicklook_thumbnail_backend.md
+++ b/mydocs/tech/skia_quicklook_thumbnail_backend.md
@@ -90,6 +90,17 @@ Quick Look은 사용자에게 문서 내용을 크게 보여주는 surface이므
 
 Quick Look에서 Skia가 직접 PNG bytes를 반환하는 장점은 단일 페이지 PNG reply에서 Swift `CGImage` 생성과 PNG 재인코딩을 줄일 수 있다는 점이다. 반면 다중 페이지 PDF는 `CGImage` decode가 필요하므로 초기 성능 이득을 단정하지 않는다.
 
+2026-07-03 #393 Quick Look direct PNG opt-in 실험 결과:
+
+- Provider default는 계속 `coreGraphics`다.
+- `HwpQuickLookPNGReplyModeResolver`는 `ALHANGEUL_QUICKLOOK_PNG_REPLY_MODE`를 DEBUG/internal 진단 경로에서만 해석한다. missing/empty/invalid 값과 Release build는 모두 `coreGraphics`로 수렴한다.
+- 허용 값은 `coreGraphics`/`coreGraphicsOnly`, `skia`/`skiaDecode`/`skiaOptIn`, `direct`/`skiaDirect`다. `skia` 계열은 기존 decode/re-encode path, `direct` 계열은 Skia PNG bytes 직접 반환 path다.
+- `skiaDirect`는 단일 페이지 context에서 `RhwpDocument.renderPagePNG(at: 0, scale: 1, maxDimension: 0)`을 호출하고, PNG signature와 IHDR만 검증한 뒤 `QLPreviewReply` PNG data로 반환한다.
+- direct 실패는 Quick Look text fallback으로 바로 내려가지 않고 CoreGraphics PNG reply로 fallback한다.
+- 대표 smoke 결과는 단일 페이지 3개 샘플 `request.hwp`, `KTX.hwp`, `복학원서.hwp` 모두 `skiaDirect` backend `skia`, fallback 0건이었다. direct latency는 각각 `0.023481s`, `0.042532s`, `0.051415s`로 기존 `skiaDecode`보다 빨랐다.
+- 다중 페이지 2개 샘플 `hwp-multi-001.hwp`, `hwpx-01.hwpx`는 `skiaDirect=N/A`로 기록되어 direct path가 적용되지 않았다.
+- 이 결과는 Quick Look 단일 PNG opt-in fast path 후보가 유효하다는 입력이다. `KTX.hwp` Skia visual regression은 direct PNG로 해결되지 않으므로 #259/#396 quality gate를 우회하지 않는다.
+
 ## Thumbnail 정책
 
 Thumbnail은 작은 bitmap을 빠르게 제공하는 surface이므로 latency, memory, cache 안정성을 우선한다.
@@ -107,7 +118,7 @@ Thumbnail은 Quick Look보다 `max_dimension` 입력 경계가 명확하다. 다
 
 | 입력 | CoreGraphics 현재 처리 | Skia 후보 매핑 |
 |---|---|---|
-| Quick Look 단일 페이지 | page size 기준 1x bitmap 후 PNG encode | `scale = 1.0`부터 시작. 이후 target size 정책이 생기면 scale 계산 |
+| Quick Look 단일 페이지 | page size 기준 1x bitmap 후 PNG encode | `skiaDecode`는 `scale = 1.0` PNG decode 후 재인코딩. `skiaDirect`는 DEBUG opt-in에서 upstream PNG bytes 직접 반환 |
 | Quick Look 다중 페이지 | page size 기준 page별 bitmap을 PDF에 draw | 초기 opt-in에서는 CoreGraphics 유지. 별도 flag에서 page별 `scale = 1.0` 검증 |
 | Thumbnail maximum size/scale | `maximumPixelSize` bucket 계산 후 renderScale 산출 | 긴 변을 `PngExportOptions.max_dimension`에 매핑 |
 | file size > 50 MB | render 전 거절 | Skia 호출 전 동일하게 거절 |

--- a/mydocs/working/task_m020_393_stage1.md
+++ b/mydocs/working/task_m020_393_stage1.md
@@ -1,0 +1,194 @@
+# Task M020 #393 Stage 1 보고서
+
+## 단계 목적
+
+현행 Quick Look 단일 페이지 PNG reply가 production/default에서는 CoreGraphics만 사용하고, `skiaOptIn` 진단 smoke에서는 `Skia PNG bytes -> CGImage decode -> PNG encode` round-trip을 거친다는 사실을 코드와 smoke output으로 고정했다.
+
+이번 단계는 source 변경 없이 inventory와 quick smoke baseline만 수행했다.
+
+## 산출물
+
+| 파일/산출물 | 내용 |
+|------|------|
+| `Sources/QLExtension/HwpPreviewProvider.swift` | Quick Look 단일 PNG/PDF reply 선택과 production CoreGraphics policy 확인 |
+| `Sources/Shared/HwpPageImageRenderer.swift` | `skiaOptIn` render, Skia PNG decode, CoreGraphics fallback, PNG encode helper 확인 |
+| `Sources/Shared/HwpPreviewPDFRenderer.swift` | 다중 페이지 PDF가 page별 `HwpRenderedPage`를 `CGContext`에 draw하는 구조 확인 |
+| `Sources/RhwpCoreBridge/RhwpDocument.swift` | `renderPagePNG(at:scale:maxDimension:)`가 direct PNG bytes를 이미 반환할 수 있음을 확인 |
+| `scripts/quicklook_skia_policy_smoke.swift` | 단일 페이지 smoke가 policy별 `renderPage` 후 `encodePNG`로 output bytes를 측정함을 확인 |
+| `scripts/smoke-quicklook-skia-policy.sh` | Swift smoke helper compile/run path 확인 |
+| `build.noindex/task393-stage1-quicklook-baseline/summary.txt` | #393 Stage 1 Quick Look baseline smoke summary |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+제품 source는 변경하지 않았다. 새로 추가한 문서는 이 Stage 1 보고서뿐이고, 오늘할일 상태만 갱신했다.
+
+## Inventory 결과
+
+### Quick Look provider
+
+`HwpPreviewProvider.createPreview`는 `HwpPreviewPDFRenderer.load`로 문서를 읽은 뒤 page count가 1이면 `pngReply`, 2 이상이면 `pdfReply`를 선택한다.
+
+현재 production/default 단일 PNG reply는 다음 순서다.
+
+1. `HwpPageImageRenderer.renderPage(document:pageIndex:policy:)`를 `policy: .coreGraphicsOnly`로 호출한다.
+2. `logRenderedPageDiagnostics`로 backend/fallback/pixel/pngBytes/timing을 기록한다.
+3. `HwpPageImageRenderer.encodePNG(page.image)`로 `CGImage`를 PNG로 인코딩한다.
+4. `QLPreviewReply(dataOfContentType: .png, contentSize: contentSize)`에 encoded PNG data를 반환한다.
+
+따라서 현재 사용자 기본 Quick Look 단일 페이지는 Skia를 호출하지 않는다.
+
+다중 페이지 PDF reply도 `HwpPreviewPDFRenderer.render(context:policy:.coreGraphicsOnly)`를 호출하므로 현재 production/default는 CoreGraphics다.
+
+### Shared renderer
+
+`HwpPageImageRenderer.renderPage`의 policy는 두 가지다.
+
+| policy | 현재 동작 |
+|------|------|
+| `.coreGraphicsOnly` | `renderCoreGraphicsPage`로 `PageRenderTree`를 Swift/CoreGraphics에서 draw |
+| `.skiaOptIn` | `renderSkiaPage`를 먼저 시도하고, 실패하면 CoreGraphics fallback |
+
+`renderSkiaPage`는 `RhwpDocument.renderPagePNG`를 호출해 upstream Skia PNG bytes를 받은 뒤, 성공 상태와 non-empty bytes를 확인한다. 이후 현재 shared contract인 `HwpRenderedPage`를 만들기 위해 `decodePNGImage(png.data)`로 `CGImage`를 생성한다.
+
+즉 현재 `skiaOptIn` 성공 경로는 다음과 같다.
+
+```text
+rhwp_render_page_png
+-> Swift Data copy
+-> CGImageSourceCreateWithData
+-> CGImageSourceCreateImageAtIndex
+-> HwpRenderedPage(image: CGImage, diagnostics: pngBytes)
+```
+
+그리고 단일 Quick Look smoke/helper는 이 `CGImage`를 다시 PNG로 encode한다. 따라서 현재 smoke의 `SkiaPNGBytes`는 upstream Skia 원본 PNG bytes이고, `SkiaBytes`는 decode 후 재인코딩된 Quick Look reply 후보 bytes다.
+
+### RustBridge wrapper
+
+`RhwpDocument.renderPagePNG(at:scale:maxDimension:)`는 이미 Swift에서 PNG bytes를 직접 받을 수 있는 wrapper다.
+
+입력 guard:
+
+- page index는 0 이상이어야 한다.
+- `scale`은 finite이며 0 이상이어야 한다.
+- `maxDimension`은 0 이상, `UInt32.max` 이하이어야 한다.
+
+FFI 호출 성공 시 `Data(bytes: pngPtr, count: Int(outLen))`로 Rust-owned buffer를 복사한 뒤 `rhwp_free_bytes`로 해제한다. 따라서 Stage 3의 direct path는 신규 Rust ABI 없이 이 wrapper를 재사용할 수 있다.
+
+### PDF renderer
+
+`HwpPreviewPDFRenderer.render`는 page별로 `HwpPageImageRenderer.renderPage`를 호출하고, 반환된 `CGImage`를 `CGContext` PDF page에 draw한다. 이 구조에서는 Skia PNG bytes를 PDF에 넣기 위해서도 `CGImage` decode가 필요하다.
+
+따라서 이번 task의 direct PNG 실험은 Quick Look 단일 페이지 PNG reply에만 한정하는 것이 맞고, 다중 페이지 PDF는 Stage 3에서 직접 PNG data 반환 대상이 아니다.
+
+### Smoke helper
+
+`quicklook_skia_policy_smoke.swift`는 단일 페이지에서 policy별로 다음 경로를 탄다.
+
+```text
+HwpPageImageRenderer.renderPage(document: pageIndex: 0, policy: policy)
+-> HwpPageImageRenderer.encodePNG(page.image)
+-> outputBytes = encoded PNG bytes
+```
+
+다중 페이지에서는 `HwpPreviewPDFRenderer.render(context:policy:collectDiagnostics:true)`를 호출하고 PDF bytes를 측정한다.
+
+결론적으로 Stage 1 smoke는 현행 decode/re-encode 경로의 baseline으로 사용할 수 있지만, Skia direct PNG reply의 latency/bytes는 아직 측정하지 않는다.
+
+## Baseline smoke 결과
+
+실행:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-stage1-quicklook-baseline \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+결과: 5개 샘플 모두 load/render `OK`, fallback 0건.
+
+stderr에는 기존 layout overflow warning 2줄이 출력됐지만 smoke 실패로 이어지지 않았다.
+
+| File | Reply | Pages | CGBackend | CGBytes | CGSeconds | SkiaBackend | SkiaBytes | SkiaPNGBytes | SkiaSeconds | Fallback |
+|------|------|------:|------|------:|------:|------|------:|------:|------:|------|
+| `request.hwp` | png | 1 | `skia:0,cg:1,embedded:0` | 90472 | 1.208144 | `skia:1,cg:0,embedded:0` | 84098 | 87027 | 0.090322 | 0 |
+| `KTX.hwp` | png | 1 | `skia:0,cg:1,embedded:0` | 543472 | 0.077545 | `skia:1,cg:0,embedded:0` | 181314 | 166247 | 0.060733 | 0 |
+| `복학원서.hwp` | png | 1 | `skia:0,cg:1,embedded:0` | 223309 | 0.055824 | `skia:1,cg:0,embedded:0` | 196405 | 198675 | 0.067626 | 0 |
+| `hwp-multi-001.hwp` | pdf | 9 | `skia:0,cg:9,embedded:0` | 1398731 | 0.391512 | `skia:9,cg:0,embedded:0` | 1102131 | 1297323 | 0.474950 | 0 |
+| `hwpx-01.hwpx` | pdf | 9 | `skia:0,cg:9,embedded:0` | 1377385 | 0.369959 | `skia:9,cg:0,embedded:0` | 1093637 | 1314854 | 0.498662 | 0 |
+
+해석:
+
+- 단일 페이지 3개 샘플에서 `skiaOptIn`은 fallback 없이 Skia backend로 성공했다.
+- 단일 페이지 `SkiaBytes`와 `SkiaPNGBytes`가 서로 다르다. 이 차이가 현재 smoke가 direct PNG bytes가 아니라 decode 후 재인코딩된 bytes를 output으로 삼는다는 증거다.
+- `request.hwp`, `KTX.hwp`는 이번 실행에서 Skia path elapsed가 CoreGraphics보다 짧았다.
+- `복학원서.hwp`는 이번 실행에서 CoreGraphics path elapsed가 Skia path보다 짧았다.
+- 다중 페이지 2개 샘플은 Skia fallback은 없지만 elapsed 기준으로 CoreGraphics가 더 빠르다. direct PNG 실험 대상에서 제외한다.
+
+## #390 기준과의 관계
+
+#390 최종 보고서의 Quick Look smoke와 같은 대표 샘플 세트를 사용했다. 절대 latency는 로컬 실행마다 변동하지만 방향은 유지된다.
+
+| 샘플 | #390 CG/Skia sec | #393 Stage 1 CG/Skia sec | 해석 |
+|------|------|------|------|
+| `request.hwp` | 1.188107 / 0.068532 | 1.208144 / 0.090322 | Skia latency 우위 유지 |
+| `KTX.hwp` | 0.072109 / 0.059391 | 0.077545 / 0.060733 | Skia latency 우위 유지 |
+| `복학원서.hwp` | 0.049888 / 0.063096 | 0.055824 / 0.067626 | CoreGraphics latency 우위 유지 |
+| `hwp-multi-001.hwp` | 0.420672 / 0.482924 | 0.391512 / 0.474950 | 다중 PDF는 CoreGraphics 우위 유지 |
+| `hwpx-01.hwpx` | 0.376054 / 0.514870 | 0.369959 / 0.498662 | 다중 PDF는 CoreGraphics 우위 유지 |
+
+#390의 최종 판단인 `CoreGraphics default + Skia opt-in diagnostic backend`를 바꿀 근거는 Stage 1에 없다. 이번 작업은 default 전환이 아니라 단일 PNG opt-in direct reply 비용 비교로 제한한다.
+
+## Stage 2 입력
+
+Stage 2에서는 다음 contract를 확정해야 한다.
+
+1. direct path 적용 범위는 Quick Look 단일 페이지 PNG reply로 제한한다.
+2. production/default `pngReply`는 계속 `.coreGraphicsOnly`로 유지한다.
+3. opt-in direct path는 `RhwpDocument.renderPagePNG(at:0, scale:1, maxDimension:0)`를 직접 호출하는 후보를 우선 검토한다.
+4. 성공 조건은 `status == .ok`와 non-empty PNG bytes다. PNG header validation을 할지, `CGImageSource` decode validation을 피할지 결정해야 한다.
+5. direct path 실패 시 text fallback으로 바로 가지 않고 기존 CoreGraphics PNG reply shape으로 fallback한다.
+6. direct diagnostics는 기존 `HwpPageRenderDiagnostics`를 확장할지, Quick Look 전용 측정 구조로 둘지 결정한다.
+7. smoke summary에는 최소한 `skiaDecode`와 `skiaDirect`를 분리해 `outputBytes`, 원본 `pngBytes`, render/decode/encode/total seconds, fallback reason을 비교할 수 있어야 한다.
+8. 다중 페이지 PDF는 direct PNG data return 대상이 아니며, Stage 3 구현에서도 기존 PDF path를 유지해야 한다.
+
+## 검증 결과
+
+구현계획서 Stage 1 검증:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-stage1-quicklook-baseline \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+결과: 성공. 5개 샘플 모두 `OK`, fallback 0건.
+
+추가 점검:
+
+```bash
+rg -n "pngReply|renderPagePNG|decodePNGImage|encodePNG|skiaOptIn|coreGraphicsOnly|SkiaBytes|SkiaPNGBytes|Reply" \
+  Sources/QLExtension/HwpPreviewProvider.swift Sources/Shared/HwpPageImageRenderer.swift \
+  scripts/quicklook_skia_policy_smoke.swift build.noindex/task393-stage1-quicklook-baseline \
+  mydocs/working/task_m020_393_stage1.md
+git diff --check
+```
+
+`rg`는 provider, shared renderer, smoke helper, baseline output, Stage 1 문서의 관련 지점을 확인하는 용도로 사용했다. `git diff --check`는 Stage 1 문서 작성 후 통과시킨다.
+
+## 잔여 위험
+
+| 항목 | 상태 | 다음 처리 |
+|------|------|------|
+| direct PNG validation | 아직 미확정 | Stage 2에서 non-empty/status만 볼지 PNG signature를 볼지 결정 |
+| diagnostics 책임 경계 | 아직 미확정 | Stage 2에서 shared diagnostics 확장 또는 Quick Look 전용 구조 결정 |
+| visual 품질 | 이번 Stage 범위 밖 | #396/#259 readiness 판단으로 유지 |
+| 다중 PDF latency | Skia가 여전히 느림 | 이번 task direct path 범위에서 제외 |
+| latency 절대값 | 로컬 실행 변동 가능 | Stage 4에서 대표 샘플 상대 비교 중심으로 해석 |
+
+## 다음 단계 영향
+
+Stage 2는 source 변경 전 설계 단계다. direct path를 provider에 좁게 둘지, Shared renderer에 direct PNG helper를 둘지 결정하고, smoke helper가 `coreGraphics`, 기존 `skiaDecode`, 신규 `skiaDirect`를 한 summary에서 비교할 수 있는 출력 계약을 정한다.
+
+## 승인 요청
+
+Stage 1 inventory와 Quick Look PNG reply baseline 고정을 완료했다. Stage 2 `direct PNG reply contract 설계`로 진행 승인해 달라.

--- a/mydocs/working/task_m020_393_stage2.md
+++ b/mydocs/working/task_m020_393_stage2.md
@@ -1,0 +1,276 @@
+# Task M020 #393 Stage 2 보고서
+
+## 단계 목적
+
+Quick Look 단일 페이지 Skia direct PNG fast path의 적용 조건, fallback shape, diagnostics, smoke output contract를 source 변경 전에 확정했다.
+
+이번 단계는 설계 고정 단계다. 제품 source는 변경하지 않았다.
+
+## 산출물
+
+| 파일/산출물 | 내용 |
+|------|------|
+| `mydocs/working/task_m020_393_stage2.md` | direct PNG reply contract 설계 |
+| `mydocs/orders/20260703.md` | #393 진행 상태를 Stage 2 완료 후 승인 대기로 갱신 |
+
+## 설계 결론
+
+Stage 3 구현은 Quick Look 단일 페이지 PNG reply 전용 helper를 추가하는 방향으로 진행한다. 기존 `HwpPageRenderPolicy`는 `CGImage`를 반환하는 shared renderer 정책으로 유지하고, direct PNG는 Quick Look PNG reply mode로 분리한다.
+
+핵심 결정:
+
+| 항목 | 결정 |
+|------|------|
+| default | production/default provider는 계속 CoreGraphics PNG reply |
+| opt-in 경계 | DEBUG/internal env opt-in에서만 provider direct mode 사용 가능 |
+| direct 범위 | Quick Look 단일 페이지 PNG reply만 대상 |
+| 비대상 | Thumbnail, Quick Look 다중 PDF, HostApp viewer/editor, upstream `rhwp` |
+| direct 성공 | Skia PNG status OK, non-empty bytes, PNG signature/IHDR validation 성공 |
+| direct 실패 | Quick Look text fallback이 아니라 CoreGraphics PNG reply로 fallback |
+| diagnostics | 기존 `HwpPageRenderDiagnostics`는 유지하고 Quick Look PNG 전용 diagnostics를 추가 |
+| smoke | `coreGraphics`, `skiaDecode`, `skiaDirect`를 같은 summary/detail에서 비교 |
+
+## Provider opt-in contract
+
+새 resolver 후보:
+
+```swift
+enum HwpQuickLookPNGReplyMode {
+    case coreGraphics
+    case skiaDecode
+    case skiaDirect
+}
+
+enum HwpQuickLookPNGReplyModeResolver {
+    static let environmentKey = "ALHANGEUL_QUICKLOOK_PNG_REPLY_MODE"
+}
+```
+
+resolver 동작:
+
+| 입력 | DEBUG 결과 | Release 결과 |
+|------|------------|--------------|
+| missing/empty/invalid | `.coreGraphics` | `.coreGraphics` |
+| `coreGraphics`, `coreGraphicsOnly` | `.coreGraphics` | `.coreGraphics` |
+| `skia`, `skiaDecode`, `skiaOptIn` | `.skiaDecode` | `.coreGraphics` |
+| `direct`, `skiaDirect` | `.skiaDirect` | `.coreGraphics` |
+
+값 비교는 Thumbnail resolver와 같은 방식으로 trim, lowercase, `-`/`_` 제거 후 수행한다. `resolve(environment:)` 기본 인자는 `nil`로 두고, DEBUG에서만 `ProcessInfo.processInfo.environment`를 평가한다. Release에서는 환경변수 딕셔너리를 읽지 않고 항상 `.coreGraphics`를 반환한다.
+
+Provider 적용:
+
+1. `HwpPreviewProvider.createPreview`는 page count가 1인 경우에만 resolver를 호출한다.
+2. missing/invalid env에서는 지금과 동일하게 CoreGraphics PNG reply를 생성한다.
+3. `.skiaDecode`는 기존 diagnostic path와 같은 `HwpPageImageRenderer.renderPage(..., policy: .skiaOptIn) -> encodePNG` 경로를 provider에서 직접 확인할 수 있게 둔다.
+4. `.skiaDirect`는 Skia PNG bytes를 `QLPreviewReply(dataOfContentType: .png)` data block에 그대로 반환한다.
+5. page count가 2 이상이면 resolver 결과와 무관하게 기존 PDF reply path를 유지한다.
+
+환경 key를 새로 두는 이유:
+
+- 기존 Thumbnail env key인 `ALHANGEUL_THUMBNAIL_RENDER_POLICY`와 surface를 분리한다.
+- `HwpPageRenderPolicy.skiaOptIn`은 `CGImage` 기반 shared renderer policy이고, direct PNG는 reply data mode이므로 같은 enum에 넣지 않는다.
+- `skia` 값을 기존 decode path로 해석하고, direct path는 `direct` 또는 `skiaDirect`를 요구해 우발적 direct 활성화를 피한다.
+
+## Direct render helper contract
+
+새 shared helper 후보:
+
+```swift
+struct HwpRenderedPreviewPNG {
+    let data: Data
+    let contentSize: CGSize
+    let diagnostics: HwpPreviewPNGDiagnostics
+}
+
+struct HwpPreviewPNGDiagnostics {
+    let requestedMode: HwpQuickLookPNGReplyMode
+    let outputMode: HwpQuickLookPNGReplyMode
+    let backendUsed: HwpPageRenderBackend
+    let fallbackReason: String?
+    let outputBytes: Int
+    let skiaPNGBytes: Int?
+    let pngPixelSize: CGSize?
+    let durationMs: HwpPreviewPNGDuration
+}
+```
+
+helper 위치는 `Sources/Shared/HwpPreviewPNGRenderer.swift`를 우선한다. 이 파일은 QuickLookUI에 의존하지 않고 `Foundation`, `CoreGraphics`만 사용한다. provider는 이 helper 결과를 `QLPreviewReply`로 감싸고, smoke helper도 같은 helper를 호출해 product path와 측정 path의 contract를 맞춘다.
+
+Mode별 동작:
+
+| mode | 동작 | output data |
+|------|------|-------------|
+| `.coreGraphics` | `HwpPageImageRenderer.renderPage(... .coreGraphicsOnly)` 후 `encodePNG` | CoreGraphics encoded PNG |
+| `.skiaDecode` | `HwpPageImageRenderer.renderPage(... .skiaOptIn)` 후 `encodePNG` | Skia decoded CGImage를 재인코딩한 PNG |
+| `.skiaDirect` | `RhwpDocument.renderPagePNG(at: 0, scale: 1, maxDimension: 0)` 직접 호출 | upstream Skia PNG bytes |
+
+`.skiaDirect` 성공 조건:
+
+1. page index는 0으로 고정한다.
+2. `context.pageCount == 1`에서만 호출한다.
+3. `renderPagePNG` 결과가 `status == .ok`여야 한다.
+4. PNG bytes가 비어 있지 않아야 한다.
+5. PNG 8-byte signature가 유효해야 한다.
+6. IHDR chunk를 읽어 width/height가 1 이상인지 확인한다.
+
+PNG validation은 ImageIO decode를 사용하지 않는다. 목적은 direct path가 `CGImageSourceCreateImageAtIndex`와 `CGImageDestinationFinalize` 비용을 피하는지 확인하는 것이므로, direct 성공 검증은 bytes/header 수준에 한정한다.
+
+## Fallback contract
+
+`.skiaDirect` 실패 시 흐름:
+
+```text
+Skia direct PNG attempt
+-> status/bytes/header 실패
+-> CoreGraphics PNG reply fallback
+-> fallback도 실패하면 기존 provider catch에서 text fallback 또는 throw
+```
+
+fallback reason 문자열 후보:
+
+| reason | 의미 |
+|------|------|
+| `skiaRenderFailure` | upstream status failure 또는 empty bytes |
+| `invalidPNGHeader` | PNG signature 또는 IHDR validation 실패 |
+| `coreGraphicsFallbackFailure` | direct 실패 후 CoreGraphics fallback도 실패 |
+
+기존 `HwpPageRenderFallbackReason` enum은 Stage 3에서 확장하지 않는다. 이유는 direct path가 `HwpRenderedPage`를 반환하지 않고 PNG reply data를 직접 반환하기 때문이다. direct path 전용 실패 이유는 `HwpPreviewPNGDiagnostics.fallbackReason` 문자열로 남기고, shared renderer fallback enum은 기존 decode path와 Thumbnail/PDF에서만 사용한다.
+
+CoreGraphics fallback shape:
+
+- reply content type은 `.png` 유지
+- content size는 `HwpPreviewDocumentContext.contentSize` 유지
+- title은 기존 filename 유지
+- fallback output bytes는 CoreGraphics encoded PNG bytes
+- diagnostics에는 requested mode `.skiaDirect`, output mode `.coreGraphics`, backend `.coreGraphics`, direct fallback reason을 남김
+
+## Diagnostics contract
+
+`HwpPreviewPNGDuration` 후보:
+
+```swift
+struct HwpPreviewPNGDuration {
+    let skiaRenderMs: Double?
+    let pngHeaderValidateMs: Double?
+    let pngDecodeMs: Double?
+    let pngEncodeMs: Double?
+    let coreGraphicsRenderMs: Double?
+    let totalMs: Double
+}
+```
+
+Mode별 값:
+
+| mode | skiaRenderMs | headerValidateMs | decodeMs | encodeMs | coreGraphicsRenderMs |
+|------|--------------|------------------|----------|----------|----------------------|
+| `coreGraphics` | nil | nil | nil | PNG encode 별도 측정 | render diagnostics의 coreGraphics render |
+| `skiaDecode` | render diagnostics의 skia render | nil | render diagnostics의 decode | PNG encode 별도 측정 | fallback이면 값 존재 |
+| `skiaDirect` 성공 | direct `renderPagePNG` 측정 | PNG header/IHDR validation 측정 | nil | nil | nil |
+| `skiaDirect` fallback | direct attempt 측정 | 실패 지점까지 측정 | nil | fallback PNG encode 측정 | fallback render 측정 |
+
+Stage 3에서 encode time을 분리하려면 `HwpPageImageRenderer.encodePNG` 호출 주위에서 시간을 잰다. 기존 `HwpPageRenderDiagnostics.durationMs`에는 PNG encode 시간이 포함되지 않으므로, Quick Look PNG reply helper가 별도 측정해야 한다.
+
+로그 후보:
+
+- `mode`: requested/output mode
+- `backend`: `coreGraphics` 또는 `skia`
+- `fallback`: 없으면 `-`
+- `outputBytes`
+- `skiaPNGBytes`
+- `pngPixelSize`
+- `totalMs`
+- `skiaRenderMs`
+- `decodeMs`
+- `encodeMs`
+
+## Smoke output contract
+
+`scripts/quicklook_skia_policy_smoke.swift`는 Stage 3에서 다음 구조로 확장한다.
+
+단일 페이지:
+
+- `coreGraphics`: CoreGraphics PNG reply 후보
+- `skiaDecode`: 기존 Skia decode + encode path
+- `skiaDirect`: 신규 Skia direct PNG path
+
+다중 페이지:
+
+- 기존처럼 `coreGraphics`와 `skiaDecode` PDF path만 측정한다.
+- `skiaDirect`는 `-` 또는 `notApplicable`로 기록한다.
+
+summary column 후보:
+
+| column | 의미 |
+|------|------|
+| `File` | 입력 파일 basename |
+| `Load` | load status |
+| `Reply` | `png` 또는 `pdf` |
+| `Pages` | page count |
+| `CGStatus`, `CGBytes`, `CGSeconds` | CoreGraphics 결과 |
+| `SkiaDecodeStatus`, `SkiaDecodeBytes`, `SkiaDecodePNGBytes`, `SkiaDecodeSeconds` | 기존 decode path 결과 |
+| `SkiaDirectStatus`, `SkiaDirectBytes`, `SkiaDirectPNGBytes`, `SkiaDirectSeconds` | direct path 결과 |
+| `SkiaDirectFallback` | direct fallback reason |
+| `SkiaDirectPixel` | PNG IHDR pixel size |
+
+detail file에는 mode별 timing breakdown을 기록한다.
+
+resolver contract 검증:
+
+- smoke script는 `-DDEBUG`로 compile해 resolver DEBUG opt-in behavior를 확인한다.
+- 별도 Release resolver 확인은 Stage 3 또는 review follow-up에서 필요 시 추가한다.
+- provider env resolver 검증과 smoke mode별 직접 측정은 구분한다. smoke는 env를 바꿔 측정하지 않고 helper를 직접 mode별 호출한다.
+
+## Source 변경 범위
+
+Stage 3 예상 source:
+
+| 파일 | 변경 |
+|------|------|
+| `Sources/Shared/HwpPreviewPNGRenderer.swift` | 신규 PNG reply renderer/helper, diagnostics, PNG header parser |
+| `Sources/QLExtension/HwpQuickLookPNGReplyModeResolver.swift` | 신규 DEBUG/internal resolver |
+| `Sources/QLExtension/HwpPreviewProvider.swift` | 단일 페이지 PNG reply에서 resolver와 helper 사용 |
+| `scripts/quicklook_skia_policy_smoke.swift` | `coreGraphics`, `skiaDecode`, `skiaDirect` 측정으로 확장 |
+| `scripts/smoke-quicklook-skia-policy.sh` | 신규 Swift source compile list와 `-DDEBUG` 반영 |
+| `Alhangeul.xcodeproj/project.pbxproj` | 신규 Swift source 반영을 위해 `xcodegen generate` 실행 시 변경 가능 |
+
+`project.yml`은 이미 `Sources/QLExtension`과 `Sources/Shared` directory source를 포함한다. 신규 Swift source가 실제 Xcode project에 반영되도록 Stage 3에서 `xcodegen generate`를 실행한다.
+
+## 비변경 범위
+
+- `RhwpDocument.renderPagePNG` ABI와 Rust wrapper는 변경하지 않는다.
+- `HwpPageRenderPolicy` enum은 변경하지 않는다.
+- Thumbnail source와 cache signature는 변경하지 않는다.
+- Quick Look 다중 페이지 PDF renderer는 direct mode를 적용하지 않는다.
+- Skia default 전환 판단은 하지 않는다.
+
+## 검증 결과
+
+구현계획서 Stage 2 검증:
+
+```bash
+rg -n "QLPreviewReply|renderPagePNG|HwpPageRenderDiagnostics|HwpPreview|quicklook|direct|skiaOptIn|fallback" \
+  Sources/QLExtension/HwpPreviewProvider.swift Sources/Shared/HwpPageImageRenderer.swift \
+  Sources/RhwpCoreBridge/RhwpDocument.swift scripts/quicklook_skia_policy_smoke.swift \
+  mydocs/working/task_m020_393_stage2.md
+git diff --check
+```
+
+`rg`는 provider, shared renderer, RustBridge wrapper, smoke helper, Stage 2 문서의 contract 지점을 확인하는 용도로 사용한다. `git diff --check`는 Stage 2 문서 작성 후 통과시킨다.
+
+## 잔여 위험
+
+| 항목 | 상태 | 다음 처리 |
+|------|------|------|
+| PNG header parser 구현 | 아직 미구현 | Stage 3에서 signature/IHDR parser를 작게 추가 |
+| provider direct path 실제 실행 | 아직 미구현 | Stage 3에서 DEBUG env opt-in으로 연결 |
+| Release resolver 검증 | 설계상 Release 차단 | Stage 3 이후 필요 시 별도 Release smoke 추가 |
+| visual 품질 | direct path가 해결하지 않음 | Stage 4/#259에서 별도 판단 |
+| 다중 PDF latency | Skia decode path가 느린 상태 | 이번 task direct 범위 밖 |
+
+## 다음 단계 영향
+
+Stage 3는 source 구현 단계다. 구현 순서는 `HwpPreviewPNGRenderer` 추가, provider resolver 추가, provider 연결, smoke helper 확장, smoke/build 검증 순서가 적절하다.
+
+## 승인 요청
+
+Stage 2 direct PNG reply contract 설계를 완료했다. Stage 3 `opt-in direct PNG 구현과 smoke 보강`으로 진행 승인해 달라.

--- a/mydocs/working/task_m020_393_stage3.md
+++ b/mydocs/working/task_m020_393_stage3.md
@@ -1,0 +1,159 @@
+# Task M020 #393 Stage 3 보고서
+
+## 단계 목적
+
+Quick Look 단일 페이지 Skia direct PNG path를 DEBUG/internal opt-in으로 구현하고, 기존 CoreGraphics PNG reply 및 Skia decode/re-encode path와 같은 smoke summary에서 비교 가능하게 만들었다.
+
+## 변경 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `Sources/Shared/HwpPreviewPNGRenderer.swift` | 신규 Quick Look PNG reply helper. `coreGraphics`, `skiaDecode`, `skiaDirect` mode와 PNG header/IHDR validation, timing diagnostics 추가 |
+| `Sources/QLExtension/HwpQuickLookPNGReplyModeResolver.swift` | 신규 DEBUG/internal resolver. `ALHANGEUL_QUICKLOOK_PNG_REPLY_MODE` env를 DEBUG에서만 해석 |
+| `Sources/QLExtension/HwpPreviewProvider.swift` | 단일 페이지 PNG reply에서 resolver와 `HwpPreviewPNGRenderer` 사용. 다중 PDF path는 유지 |
+| `scripts/smoke-quicklook-skia-policy.sh` | smoke compile list에 신규 helper/resolver 추가, resolver contract 검증을 위해 `-DDEBUG` compile |
+| `scripts/quicklook_skia_policy_smoke.swift` | `coreGraphics`, `skiaDecode`, `skiaDirect` 측정과 resolver contract summary/detail 추가 |
+| `Alhangeul.xcodeproj/project.pbxproj` | `xcodegen generate`로 신규 Swift source를 target source phase에 반영 |
+| `mydocs/orders/20260703.md` | #393 상태를 Stage 3 완료 후 승인 대기로 갱신 |
+
+## 구현 계약
+
+### Reply mode
+
+`HwpPreviewPNGReplyMode`를 Shared에 추가했다.
+
+| mode | 동작 |
+|------|------|
+| `coreGraphics` | `HwpPageImageRenderer.renderPage(... .coreGraphicsOnly)` 후 PNG encode |
+| `skiaDecode` | `HwpPageImageRenderer.renderPage(... .skiaOptIn)` 후 PNG encode |
+| `skiaDirect` | `RhwpDocument.renderPagePNG(at: 0, scale: 1, maxDimension: 0)` 결과 PNG bytes를 직접 반환 |
+
+기존 `HwpPageRenderPolicy`는 변경하지 않았다. direct PNG는 `CGImage` 기반 shared renderer policy가 아니라 Quick Look PNG reply data mode로 분리했다.
+
+### Resolver
+
+`ALHANGEUL_QUICKLOOK_PNG_REPLY_MODE` env key를 추가했다.
+
+| 입력 | DEBUG 결과 | Release 결과 |
+|------|------------|--------------|
+| missing/empty/invalid | `coreGraphics` | `coreGraphics` |
+| `coreGraphics`, `coreGraphicsOnly` | `coreGraphics` | `coreGraphics` |
+| `skia`, `skiaDecode`, `skiaOptIn` | `skiaDecode` | `coreGraphics` |
+| `direct`, `skiaDirect` | `skiaDirect` | `coreGraphics` |
+
+Stage 3 smoke는 DEBUG resolver contract를 검증한다. Release는 source의 `#if DEBUG` 경계로 env opt-in을 차단하며, 별도 Release smoke는 이번 단계에서 수행하지 않았다.
+
+### Direct validation과 fallback
+
+`skiaDirect` 성공 조건:
+
+1. Quick Look 단일 페이지 context.
+2. `renderPagePNG` status가 `.ok`.
+3. PNG bytes가 non-empty.
+4. PNG 8-byte signature가 유효.
+5. 첫 chunk가 `IHDR`, length 13, width/height가 1 이상.
+
+ImageIO decode는 direct path 검증에 사용하지 않았다. direct 실패 시 text fallback으로 가지 않고 CoreGraphics PNG reply shape으로 fallback한다. fallback diagnostics는 `HwpPreviewPNGDiagnostics.fallbackReason` 문자열에 남긴다.
+
+## Smoke 결과
+
+실행:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-stage3-quicklook-direct \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+결과:
+
+- resolver contract: `OK`
+- 5개 샘플 load/render: 모두 `OK`
+- 단일 페이지 3개 샘플: `skiaDirect` fallback 0건
+- 다중 페이지 2개 샘플: `skiaDirect`는 `N/A`
+- `복학원서.hwp` 처리 중 기존 layout overflow warning 2줄이 stderr에 출력됐지만 render status는 모두 `OK`
+
+요약:
+
+| File | Reply | CGBytes/Sec | SkiaDecodeBytes/Sec | SkiaDirectBytes/Sec | SkiaDirectPNGBytes | DirectPixel | DirectFallback |
+|------|------|-------------|---------------------|---------------------|--------------------|-------------|----------------|
+| `request.hwp` | png | 90472 / 1.199618 | 84098 / 0.063675 | 87027 / 0.024707 | 87027 | 567x794 | 0 |
+| `KTX.hwp` | png | 543472 / 0.075807 | 181314 / 0.056624 | 166247 / 0.047337 | 166247 | 1123x794 | 0 |
+| `복학원서.hwp` | png | 223309 / 0.047160 | 196405 / 0.062583 | 198675 / 0.053175 | 198675 | 794x1123 | 0 |
+| `hwp-multi-001.hwp` | pdf | 1398731 / 0.413798 | 1102131 / 0.493192 | N/A | N/A | - | - |
+| `hwpx-01.hwpx` | pdf | 1377385 / 0.356351 | 1093637 / 0.480660 | N/A | N/A | - | - |
+
+해석:
+
+- direct path는 단일 페이지에서 output bytes와 Skia PNG bytes가 같다.
+- direct path는 `PNGDecodeMs`와 `PNGEncodeMs`가 `-`로 남아 decode/re-encode를 생략한다.
+- `request.hwp`, `KTX.hwp`, `복학원서.hwp` 모두 direct path가 fallback 없이 성공했다.
+- 다중 PDF는 direct mode가 적용되지 않아 Stage 2 범위를 지켰다.
+
+## Build/project 결과
+
+`xcodegen generate`를 실행해 신규 Swift source를 Xcode project에 반영했다.
+
+`project.pbxproj` 반영:
+
+- `HwpPreviewPNGRenderer.swift`: Shared source이므로 HostApp, ThumbnailExtension, QLExtension source phase에 추가됨.
+- `HwpQuickLookPNGReplyModeResolver.swift`: QLExtension source phase에만 추가됨.
+
+QLExtension Debug build:
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask393Stage3 CODE_SIGNING_ALLOWED=NO build
+```
+
+첫 실행은 sandbox 네트워크 제한 때문에 Sparkle package fetch에서 실패했다.
+
+```text
+Could not resolve host: github.com
+```
+
+동일 명령을 네트워크 허용으로 재실행했고 `BUILD SUCCEEDED`로 완료했다. CoreSimulator version warning은 출력됐지만 macOS build 실패로 이어지지 않았다.
+
+## 검증 결과
+
+실행한 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-stage3-quicklook-direct \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask393Stage3 CODE_SIGNING_ALLOWED=NO build
+rg -n "direct|skiaOptIn|coreGraphicsOnly|Reply|Bytes|Fallback|RenderMs|Decode|Encode|OK|FAIL" \
+  build.noindex/task393-stage3-quicklook-direct Sources scripts
+git diff --check
+```
+
+결과:
+
+- `check-no-appkit.sh`: 성공.
+- Quick Look Skia policy smoke: 성공. resolver contract `OK`, 5개 샘플 모두 `OK`.
+- `xcodegen generate`: 성공.
+- `xcodebuild`: sandbox 첫 실행은 network fetch 실패, 네트워크 허용 재실행에서 `BUILD SUCCEEDED`.
+- `rg`: direct/decode/CoreGraphics mode, resolver contract, smoke output, fallback/timing field 확인.
+- `git diff --check`: 성공.
+
+## 잔여 위험
+
+| 항목 | 상태 | 다음 처리 |
+|------|------|------|
+| Release resolver smoke | source상 `#if DEBUG`로 차단 | 필요 시 review follow-up 또는 Stage 4에서 별도 Release compile smoke 추가 |
+| direct path visual 품질 | 이번 Stage는 bytes/timing/fallback 검증 | Stage 4에서 대표 비교로 정리 |
+| PNG header validation | signature/IHDR만 확인 | 의도적으로 ImageIO decode를 피함. invalid PNG fixture는 없음 |
+| direct fallback 강제 fixture | 없음 | 정상 샘플 기준 fallback 0 확인. 실패 주입은 별도 이슈 후보 |
+| 다중 PDF Skia latency | 여전히 CoreGraphics보다 느림 | direct PNG 범위 밖, #259 readiness 입력으로 유지 |
+
+## 다음 단계 영향
+
+Stage 4에서는 대표 샘플 결과를 재실행하거나 Stage 3 산출물을 기반으로 `coreGraphics`, `skiaDecode`, `skiaDirect`의 latency/bytes/fallback을 비교하고, #259 readiness gate로 넘길 direct path 판단을 정리한다.
+
+## 승인 요청
+
+Stage 3 opt-in direct PNG 구현과 smoke 보강을 완료했다. Stage 4 `대표 샘플 비교 측정`으로 진행 승인해 달라.

--- a/mydocs/working/task_m020_393_stage4.md
+++ b/mydocs/working/task_m020_393_stage4.md
@@ -1,0 +1,170 @@
+# Task M020 #393 Stage 4 보고서
+
+## 단계 목적
+
+대표 샘플에서 CoreGraphics, 기존 Skia decode path, 신규 Skia direct path의 latency/bytes/fallback 결과를 비교하고, #259 Skia readiness gate로 넘길 판단 입력을 정리했다.
+
+이번 단계는 source 변경 없이 Stage 3 구현 결과를 대표 smoke로 재측정하고 문서화했다.
+
+## 산출물
+
+| 파일/산출물 | 내용 |
+|------|------|
+| `build.noindex/task393-quicklook-policy-representative/summary.txt` | 대표 5개 샘플 Quick Look policy smoke summary |
+| `build.noindex/task393-quicklook-policy-representative/resolver-contract.txt` | DEBUG resolver contract 결과 |
+| `build.noindex/task393-quicklook-policy-representative/*-quicklook-skia-policy.txt` | 파일별 mode detail |
+| `mydocs/working/task_m020_393_stage4.md` | Stage 4 비교 보고서 |
+| `mydocs/orders/20260703.md` | #393 상태를 Stage 4 완료 후 승인 대기로 갱신 |
+
+## 검증 명령
+
+기본 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+```
+
+결과:
+
+- `check-no-appkit.sh`: 성공.
+- `verify-rhwp-core-build-info.sh`: 성공.
+- `verify-rhwp-studio-assets.sh`: 성공.
+
+대표 smoke:
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-quicklook-policy-representative \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+```
+
+결과:
+
+- resolver contract: `OK`.
+- 5개 샘플 모두 load/render `OK`.
+- 단일 페이지 3개 샘플 모두 `skiaDirect` backend `skia`, fallback 0.
+- 다중 페이지 2개 샘플은 `skiaDirect` status `N/A`.
+- `복학원서.hwp` 처리 중 기존 layout overflow warning 2줄이 stderr에 출력됐지만 render status는 모두 `OK`.
+
+## Resolver contract
+
+`ALHANGEUL_QUICKLOOK_PNG_REPLY_MODE` DEBUG resolver contract:
+
+| Case | RawValue | Expected | Resolved | Status |
+|------|----------|----------|----------|--------|
+| missing | `<missing>` | `coreGraphics` | `coreGraphics` | OK |
+| empty |  | `coreGraphics` | `coreGraphics` | OK |
+| invalid | `banana` | `coreGraphics` | `coreGraphics` | OK |
+| `coreGraphics` | `coreGraphics` | `coreGraphics` | `coreGraphics` | OK |
+| `coreGraphicsOnly` | `coreGraphicsOnly` | `coreGraphics` | `coreGraphics` | OK |
+| `skia` | `skia` | `skiaDecode` | `skiaDecode` | OK |
+| `skiaDecode` | `skiaDecode` | `skiaDecode` | `skiaDecode` | OK |
+| `skiaOptIn` | `skiaOptIn` | `skiaDecode` | `skiaDecode` | OK |
+| `direct` | `direct` | `skiaDirect` | `skiaDirect` | OK |
+| `skiaDirect` | `skiaDirect` | `skiaDirect` | `skiaDirect` | OK |
+
+Release에서는 source `#if DEBUG` 경계로 env opt-in이 `coreGraphics`로 수렴한다. 이번 Stage 4에서는 별도 Release smoke를 추가하지 않았다.
+
+## 대표 smoke summary
+
+| File | Reply | Pages | CGBytes | CGSec | SkiaDecodeBytes | SkiaDecodePNGBytes | SkiaDecodeSec | SkiaDirectBytes | SkiaDirectPNGBytes | SkiaDirectSec | DirectPixel | DirectFallback |
+|------|------|------:|--------:|------:|----------------:|-------------------:|---------------:|----------------:|-------------------:|--------------:|-------------|----------------|
+| `request.hwp` | png | 1 | 90472 | 1.167163 | 84098 | 87027 | 0.062005 | 87027 | 87027 | 0.023481 | 567x794 | 0 |
+| `KTX.hwp` | png | 1 | 543472 | 0.073884 | 181314 | 166247 | 0.055980 | 166247 | 166247 | 0.042532 | 1123x794 | 0 |
+| `복학원서.hwp` | png | 1 | 223309 | 0.051353 | 196405 | 198675 | 0.063517 | 198675 | 198675 | 0.051415 | 794x1123 | 0 |
+| `hwp-multi-001.hwp` | pdf | 9 | 1398731 | 0.443835 | 1102131 | 1297323 | 0.505146 | N/A | N/A | N/A | - | - |
+| `hwpx-01.hwpx` | pdf | 9 | 1377385 | 0.412582 | 1093637 | 1314854 | 0.633081 | N/A | N/A | N/A | - | - |
+
+## 단일 페이지 direct 효과
+
+### Latency
+
+| File | CGSec | SkiaDecodeSec | SkiaDirectSec | Direct vs Decode | Direct vs CG |
+|------|------:|---------------:|---------------:|------------------|--------------|
+| `request.hwp` | 1.167163 | 0.062005 | 0.023481 | 0.038524초 감소, 약 62.1% 단축 | 1.143682초 감소 |
+| `KTX.hwp` | 0.073884 | 0.055980 | 0.042532 | 0.013448초 감소, 약 24.0% 단축 | 0.031352초 감소 |
+| `복학원서.hwp` | 0.051353 | 0.063517 | 0.051415 | 0.012102초 감소, 약 19.1% 단축 | 거의 동일, direct가 0.000062초 느림 |
+
+해석:
+
+- direct path는 단일 페이지 3개 샘플 모두에서 기존 `skiaDecode`보다 빠르다.
+- `request.hwp`, `KTX.hwp`에서는 CoreGraphics보다도 빠르다.
+- `복학원서.hwp`는 CoreGraphics와 사실상 같은 수준이며, 로컬 단일 실행값으로 우열을 단정하기 어렵다.
+
+### Bytes
+
+| File | CGBytes | SkiaDecodeBytes | SkiaDirectBytes | 해석 |
+|------|--------:|----------------:|----------------:|------|
+| `request.hwp` | 90472 | 84098 | 87027 | direct는 Skia 원본 PNG. decode 재인코딩보다 2929 bytes 큼 |
+| `KTX.hwp` | 543472 | 181314 | 166247 | direct가 decode 재인코딩보다 15067 bytes 작음 |
+| `복학원서.hwp` | 223309 | 196405 | 198675 | direct가 decode 재인코딩보다 2270 bytes 큼 |
+
+해석:
+
+- direct path의 output bytes는 항상 `SkiaDirectPNGBytes`와 같다.
+- decode path의 output bytes는 Skia 원본 PNG를 `CGImage`로 decode한 뒤 ImageIO가 다시 encode한 결과라 원본 PNG bytes와 다를 수 있다.
+- bytes 차이는 성능과 품질 판단의 보조 신호일 뿐이며 visual correctness를 대체하지 않는다.
+
+## 다중 페이지 경계
+
+다중 페이지 샘플 2개는 `Reply=pdf`이고 `skiaDirect`가 `N/A`로 기록됐다.
+
+| File | Pages | CGSec | SkiaDecodeSec | SkiaDirect |
+|------|------:|------:|---------------:|------------|
+| `hwp-multi-001.hwp` | 9 | 0.443835 | 0.505146 | N/A |
+| `hwpx-01.hwpx` | 9 | 0.412582 | 0.633081 | N/A |
+
+이 결과는 Stage 2 범위인 "direct PNG path는 Quick Look 단일 페이지에만 한정" 조건을 만족한다. 다중 PDF는 여전히 기존 bitmap PDF path이며, Skia decode path는 두 샘플 모두 CoreGraphics보다 느리다.
+
+## #259 readiness 입력
+
+이번 결과가 주는 긍정 신호:
+
+1. Quick Look 단일 페이지에서 direct path가 fallback 없이 성공한다.
+2. direct path는 decode/re-encode 비용을 제거해 `skiaDecode`보다 일관되게 빠르다.
+3. direct path의 output bytes가 upstream Skia PNG bytes와 같아 data-copy/validation 중심의 단순 경로가 가능하다.
+4. 다중 PDF와 Thumbnail surface에는 영향을 주지 않는다.
+
+이번 결과가 해결하지 않는 문제:
+
+1. `KTX.hwp`의 기존 Skia visual regression은 direct PNG로 해결된 것이 아니다. 같은 Skia renderer output을 더 직접 반환할 뿐이다.
+2. Skia default 전환 판단은 visual suite와 release readiness gate가 필요하다.
+3. direct fallback 강제 fixture는 아직 없다.
+4. Release resolver 동작은 source 경계로 보장하지만 별도 Release smoke는 이번 단계에서 추가하지 않았다.
+
+Stage 4 결론:
+
+- `skiaDirect`는 Quick Look 단일 PNG opt-in fast path 후보로 유효하다.
+- default 전환 근거로 쓰기에는 부족하다. visual correctness, 특히 `KTX.hwp` Skia regression은 #259/#396 계열 판단으로 남긴다.
+- Stage 5에서는 기술 문서에 "Quick Look 단일 PNG direct path는 opt-in fast path로 가능하지만 Skia quality gate를 우회하지 않는다"는 결론을 반영한다.
+
+## 검증 결과
+
+구현계획서 Stage 4 검증:
+
+```bash
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-quicklook-policy-representative \
+  samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp \
+  samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx
+rg -n "OK|FAIL|coreGraphicsOnly|skiaOptIn|direct|decode|png|pdf|Fallback|Bytes|Seconds|RenderMs" \
+  build.noindex/task393-quicklook-policy-representative mydocs/working/task_m020_393_stage4.md
+git diff --check
+```
+
+결과:
+
+- `check-no-appkit.sh`: 성공.
+- `verify-rhwp-core-build-info.sh`: 성공.
+- `verify-rhwp-studio-assets.sh`: 성공.
+- representative smoke: 성공. resolver contract `OK`, 5개 샘플 모두 `OK`.
+- `rg`: smoke output과 Stage 4 문서에서 mode/status/bytes/timing/fallback 항목 확인.
+- `git diff --check`: 통과.
+
+## 승인 요청
+
+Stage 4 대표 샘플 비교 측정을 완료했다. Stage 5 `최종 보고와 문서 반영`으로 진행 승인해 달라.

--- a/mydocs/working/task_m020_393_stage5.md
+++ b/mydocs/working/task_m020_393_stage5.md
@@ -1,0 +1,56 @@
+# Task M020 #393 Stage 5 완료 보고서
+
+## 단계 목적
+
+#393 direct PNG opt-in 실험 결과를 최종 보고서와 기술 문서에 반영하고 PR 게시 준비 상태로 만든다.
+
+## 산출물
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/report/task_m020_393_report.md` | #393 최종 보고서 |
+| `mydocs/working/task_m020_393_stage5.md` | Stage 5 완료 보고서 |
+| `mydocs/tech/skia_quicklook_thumbnail_backend.md` | Quick Look 단일 PNG direct opt-in 기준과 남은 blocker 반영 |
+| `mydocs/tech/skia_preview_renderer_baseline.md` | #393 결과를 visual suite를 대체하지 않는 성능 입력으로 연결 |
+| `mydocs/orders/20260703.md` | #393 완료 처리 |
+
+## 정리 내용
+
+- Quick Look 단일 페이지 `skiaDirect`는 upstream Skia PNG bytes를 decode/re-encode 없이 반환하는 DEBUG/internal opt-in fast path로 정리했다.
+- Production/default와 Release resolver는 계속 CoreGraphics로 수렴한다고 기록했다.
+- direct 실패 시 Quick Look text fallback이 아니라 CoreGraphics PNG reply로 fallback하는 계약을 최종 보고서에 남겼다.
+- 대표 smoke에서 단일 페이지 3개 샘플 direct fallback 0건, 다중 페이지 2개 샘플 direct `N/A`였음을 기록했다.
+- `skiaDirect`가 기존 `skiaDecode`보다 빠르지만 `KTX.hwp` visual regression을 해결하지 않는다는 결론을 기술 문서와 최종 보고서에 반영했다.
+- #387, #390, #392, #396, #259와의 관계를 PR 게시 준비 메모에 정리했다.
+
+## 검증
+
+실행 대상:
+
+```bash
+rg -n "#393|#387|#390|#392|#259|Quick Look|direct PNG|Skia|CoreGraphics|fallback|smoke|readiness" \
+  mydocs/report/task_m020_393_report.md mydocs/orders/20260703.md \
+  mydocs/tech/skia_quicklook_thumbnail_backend.md mydocs/tech/skia_preview_renderer_baseline.md \
+  mydocs/working/task_m020_393_stage5.md
+git diff --check
+git status --short --branch
+git log --oneline devel..local/task393
+```
+
+결과:
+
+- `rg`: 최종 보고서, 오늘할일, 기술 문서, Stage 5 보고서에서 #393/#387/#390/#392/#259와 direct PNG/Skia/CoreGraphics/fallback/readiness 키워드를 확인했다.
+- `git diff --check`: 통과.
+- `git status --short --branch`: Stage 5 문서/기술 문서/오늘할일 변경만 남아 있음을 확인했다.
+- `git log --oneline devel..local/task393`: 계획, Stage 1-4 커밋이 예상 순서로 존재함을 확인했다.
+
+## 완료 판단
+
+- 최종 보고서가 존재하고 #393의 구현 계약, smoke 결과, 잔여 risk를 설명한다.
+- 기술 문서가 direct PNG opt-in fast path와 quality gate 분리를 포함한다.
+- 오늘할일 #393이 완료 상태로 갱신된다.
+- PR 게시 준비에 필요한 summary와 검증 명령이 정리되어 있다.
+
+## 승인 요청
+
+Stage 5는 완료했다. 최종 보고서 검토 후 PR 게시 단계 진행 여부를 승인 요청한다.

--- a/scripts/quicklook_skia_policy_smoke.swift
+++ b/scripts/quicklook_skia_policy_smoke.swift
@@ -10,8 +10,9 @@ struct Timed<Value> {
     let seconds: Double
 }
 
-struct PolicyMeasurement {
-    let policyName: String
+struct ModeMeasurement {
+    let modeName: String
+    let outputModeName: String?
     let status: String
     let error: String?
     let outputBytes: Int?
@@ -21,9 +22,40 @@ struct PolicyMeasurement {
     let coreGraphicsPages: Int
     let embeddedThumbnailPages: Int
     let fallbackPages: Int
-    let pngBytes: Int
-    let renderMs: Double
+    let pngBytes: Int?
+    let renderMs: Double?
     let firstFallback: String?
+    let pixelSize: CGSize?
+    let skiaRenderMs: Double?
+    let pngHeaderValidateMs: Double?
+    let pngDecodeMs: Double?
+    let pngEncodeMs: Double?
+    let coreGraphicsRenderMs: Double?
+
+    static func notApplicable(modeName: String) -> ModeMeasurement {
+        ModeMeasurement(
+            modeName: modeName,
+            outputModeName: nil,
+            status: "N/A",
+            error: nil,
+            outputBytes: nil,
+            outputPages: nil,
+            elapsedSeconds: nil,
+            skiaPages: 0,
+            coreGraphicsPages: 0,
+            embeddedThumbnailPages: 0,
+            fallbackPages: 0,
+            pngBytes: nil,
+            renderMs: nil,
+            firstFallback: nil,
+            pixelSize: nil,
+            skiaRenderMs: nil,
+            pngHeaderValidateMs: nil,
+            pngDecodeMs: nil,
+            pngEncodeMs: nil,
+            coreGraphicsRenderMs: nil
+        )
+    }
 }
 
 struct FileMeasurement {
@@ -35,8 +67,30 @@ struct FileMeasurement {
     let pageCount: Int?
     let replyType: String?
     let firstPageSize: CGSize?
-    let coreGraphics: PolicyMeasurement?
-    let skiaOptIn: PolicyMeasurement?
+    let coreGraphics: ModeMeasurement?
+    let skiaDecode: ModeMeasurement?
+    let skiaDirect: ModeMeasurement?
+}
+
+struct ResolverCaseResult {
+    let label: String
+    let rawValue: String?
+    let expected: HwpPreviewPNGReplyMode
+    let resolved: HwpPreviewPNGReplyMode
+
+    var status: String {
+        expected == resolved ? "OK" : "FAIL"
+    }
+}
+
+struct ResolverContractResult {
+    let build: String
+    let environmentKey: String
+    let cases: [ResolverCaseResult]
+
+    var status: String {
+        cases.allSatisfy { $0.status == "OK" } ? "OK" : "FAIL"
+    }
 }
 
 @main
@@ -51,6 +105,9 @@ struct QuickLookSkiaPolicySmoke {
         let inputs = args.dropFirst().map { absoluteURL($0) }
         try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
 
+        let resolverContract = makeResolverContract()
+        try writeResolverContract(resolverContract, outputDir: outputDir)
+
         var measurements: [FileMeasurement] = []
         for inputURL in inputs {
             let measurement = measure(inputURL: inputURL)
@@ -59,7 +116,11 @@ struct QuickLookSkiaPolicySmoke {
             print("\(measurement.loadStatus) \(measurement.fileName): \(rowSummary(measurement))")
         }
 
-        try writeSummary(measurements, outputDir: outputDir)
+        try writeSummary(
+            measurements,
+            resolverContract: resolverContract,
+            outputDir: outputDir
+        )
     }
 
     private static func measure(inputURL: URL) -> FileMeasurement {
@@ -69,16 +130,12 @@ struct QuickLookSkiaPolicySmoke {
         do {
             let context = try HwpPreviewPDFRenderer.load(fileURL: inputURL)
             let replyType = context.pageCount == 1 ? "png" : "pdf"
-            let coreGraphics = measurePolicy(
-                context: context,
-                policyName: "coreGraphicsOnly",
-                policy: .coreGraphicsOnly
-            )
-            let skiaOptIn = measurePolicy(
-                context: context,
-                policyName: "skiaOptIn",
-                policy: .skiaOptIn
-            )
+            let coreGraphics = measureMode(context: context, mode: .coreGraphics)
+            let skiaDecode = measureMode(context: context, mode: .skiaDecode)
+            let skiaDirect = context.pageCount == 1
+                ? measureMode(context: context, mode: .skiaDirect)
+                : ModeMeasurement.notApplicable(modeName: HwpPreviewPNGReplyMode.skiaDirect.identifier)
+
             return FileMeasurement(
                 fileName: fileName,
                 filePath: inputURL.path,
@@ -89,7 +146,8 @@ struct QuickLookSkiaPolicySmoke {
                 replyType: replyType,
                 firstPageSize: context.contentSize,
                 coreGraphics: coreGraphics,
-                skiaOptIn: skiaOptIn
+                skiaDecode: skiaDecode,
+                skiaDirect: skiaDirect
             )
         } catch {
             return FileMeasurement(
@@ -102,51 +160,52 @@ struct QuickLookSkiaPolicySmoke {
                 replyType: nil,
                 firstPageSize: nil,
                 coreGraphics: nil,
-                skiaOptIn: nil
+                skiaDecode: nil,
+                skiaDirect: nil
             )
         }
     }
 
-    private static func measurePolicy(
+    private static func measureMode(
         context: HwpPreviewDocumentContext,
-        policyName: String,
-        policy: HwpPageRenderPolicy
-    ) -> PolicyMeasurement {
+        mode: HwpPreviewPNGReplyMode
+    ) -> ModeMeasurement {
         do {
-            let timedResult = try timed {
-                if context.pageCount == 1 {
-                    let page = try HwpPageImageRenderer.renderPage(
-                        document: context.document,
-                        pageIndex: 0,
-                        policy: policy
-                    )
-                    let png = try HwpPageImageRenderer.encodePNG(page.image)
-                    return policyResult(
-                        outputBytes: png.count,
-                        outputPages: 1,
-                        diagnostics: [
-                            HwpPreviewPDFPageDiagnostics(
-                                pageIndex: 0,
-                                diagnostics: page.diagnostics
-                            )
-                        ]
+            if context.pageCount == 1 {
+                let timedResult = try timed {
+                    try HwpPreviewPNGRenderer.render(
+                        context: context,
+                        mode: mode
                     )
                 }
+                return pngMeasurement(
+                    modeName: mode.identifier,
+                    result: timedResult.value,
+                    elapsedSeconds: timedResult.seconds
+                )
+            }
 
+            guard mode != .skiaDirect else {
+                return .notApplicable(modeName: mode.identifier)
+            }
+
+            let policy: HwpPageRenderPolicy = mode == .coreGraphics ? .coreGraphicsOnly : .skiaOptIn
+            let timedResult = try timed {
                 let pdf = try HwpPreviewPDFRenderer.render(
                     context: context,
                     policy: policy,
                     collectDiagnostics: true
                 )
-                return policyResult(
+                return pdfPolicyResult(
                     outputBytes: pdf.data.count,
                     outputPages: pdfPageCount(data: pdf.data) ?? pdf.pageCount,
                     diagnostics: pdf.pageDiagnostics
                 )
             }
             let result = timedResult.value
-            return PolicyMeasurement(
-                policyName: policyName,
+            return ModeMeasurement(
+                modeName: mode.identifier,
+                outputModeName: mode.identifier,
                 status: "OK",
                 error: nil,
                 outputBytes: result.outputBytes,
@@ -158,11 +217,18 @@ struct QuickLookSkiaPolicySmoke {
                 fallbackPages: result.fallbackPages,
                 pngBytes: result.pngBytes,
                 renderMs: result.renderMs,
-                firstFallback: result.firstFallback
+                firstFallback: result.firstFallback,
+                pixelSize: nil,
+                skiaRenderMs: nil,
+                pngHeaderValidateMs: nil,
+                pngDecodeMs: nil,
+                pngEncodeMs: nil,
+                coreGraphicsRenderMs: nil
             )
         } catch {
-            return PolicyMeasurement(
-                policyName: policyName,
+            return ModeMeasurement(
+                modeName: mode.identifier,
+                outputModeName: nil,
                 status: "FAIL",
                 error: String(describing: error),
                 outputBytes: nil,
@@ -172,14 +238,50 @@ struct QuickLookSkiaPolicySmoke {
                 coreGraphicsPages: 0,
                 embeddedThumbnailPages: 0,
                 fallbackPages: 0,
-                pngBytes: 0,
-                renderMs: 0,
-                firstFallback: nil
+                pngBytes: nil,
+                renderMs: nil,
+                firstFallback: nil,
+                pixelSize: nil,
+                skiaRenderMs: nil,
+                pngHeaderValidateMs: nil,
+                pngDecodeMs: nil,
+                pngEncodeMs: nil,
+                coreGraphicsRenderMs: nil
             )
         }
     }
 
-    private struct PolicyResult {
+    private static func pngMeasurement(
+        modeName: String,
+        result: HwpRenderedPreviewPNG,
+        elapsedSeconds: Double
+    ) -> ModeMeasurement {
+        let diagnostics = result.diagnostics
+        return ModeMeasurement(
+            modeName: modeName,
+            outputModeName: diagnostics.outputMode.identifier,
+            status: "OK",
+            error: nil,
+            outputBytes: diagnostics.outputBytes,
+            outputPages: 1,
+            elapsedSeconds: elapsedSeconds,
+            skiaPages: diagnostics.backendUsed == .skia ? 1 : 0,
+            coreGraphicsPages: diagnostics.backendUsed == .coreGraphics ? 1 : 0,
+            embeddedThumbnailPages: diagnostics.backendUsed == .embeddedThumbnail ? 1 : 0,
+            fallbackPages: diagnostics.fallbackReason == nil ? 0 : 1,
+            pngBytes: diagnostics.skiaPNGBytes,
+            renderMs: diagnostics.durationMs.totalMs,
+            firstFallback: diagnostics.fallbackReason,
+            pixelSize: diagnostics.pngPixelSize,
+            skiaRenderMs: diagnostics.durationMs.skiaRenderMs,
+            pngHeaderValidateMs: diagnostics.durationMs.pngHeaderValidateMs,
+            pngDecodeMs: diagnostics.durationMs.pngDecodeMs,
+            pngEncodeMs: diagnostics.durationMs.pngEncodeMs,
+            coreGraphicsRenderMs: diagnostics.durationMs.coreGraphicsRenderMs
+        )
+    }
+
+    private struct PDFPolicyResult {
         let outputBytes: Int
         let outputPages: Int
         let skiaPages: Int
@@ -191,11 +293,11 @@ struct QuickLookSkiaPolicySmoke {
         let firstFallback: String?
     }
 
-    private static func policyResult(
+    private static func pdfPolicyResult(
         outputBytes: Int,
         outputPages: Int,
         diagnostics: [HwpPreviewPDFPageDiagnostics]
-    ) -> PolicyResult {
+    ) -> PDFPolicyResult {
         var skiaPages = 0
         var coreGraphicsPages = 0
         var embeddedThumbnailPages = 0
@@ -224,7 +326,7 @@ struct QuickLookSkiaPolicySmoke {
             renderMs += page.diagnostics.durationMs.totalMs
         }
 
-        return PolicyResult(
+        return PDFPolicyResult(
             outputBytes: outputBytes,
             outputPages: outputPages,
             skiaPages: skiaPages,
@@ -254,14 +356,21 @@ struct QuickLookSkiaPolicySmoke {
         return document.numberOfPages
     }
 
-    private static func writeSummary(_ measurements: [FileMeasurement], outputDir: URL) throws {
+    private static func writeSummary(
+        _ measurements: [FileMeasurement],
+        resolverContract: ResolverContractResult,
+        outputDir: URL
+    ) throws {
         var lines: [String] = []
         lines.append("# Quick Look Skia Policy Smoke")
         lines.append("")
         lines.append("GeneratedAt: \(ISO8601DateFormatter().string(from: Date()))")
+        lines.append("ResolverBuild: \(resolverContract.build)")
+        lines.append("ResolverEnvKey: \(resolverContract.environmentKey)")
+        lines.append("ResolverContract: \(resolverContract.status)")
         lines.append("")
-        lines.append("| File | Load | Reply | Pages | Size | CGStatus | CGBackend | CGFallback | CGBytes | CGSeconds | SkiaStatus | SkiaBackend | SkiaFallback | SkiaBytes | SkiaPNGBytes | SkiaSeconds |")
-        lines.append("|------|------|-------|-------|------|----------|-----------|------------|---------|-----------|------------|-------------|--------------|-----------|--------------|-------------|")
+        lines.append("| File | Load | Reply | Pages | Size | CGStatus | CGBackend | CGFallback | CGBytes | CGSeconds | SkiaDecodeStatus | SkiaDecodeBackend | SkiaDecodeFallback | SkiaDecodeBytes | SkiaDecodePNGBytes | SkiaDecodeSeconds | SkiaDirectStatus | SkiaDirectBackend | SkiaDirectFallback | SkiaDirectBytes | SkiaDirectPNGBytes | SkiaDirectSeconds | SkiaDirectPixel |")
+        lines.append("|------|------|-------|-------|------|----------|-----------|------------|---------|-----------|------------------|-------------------|--------------------|----------------|-------------------|-------------------|------------------|-------------------|--------------------|----------------|-------------------|-------------------|-----------------|")
 
         for measurement in measurements {
             lines.append([
@@ -275,22 +384,37 @@ struct QuickLookSkiaPolicySmoke {
                 fallbackSummary(measurement.coreGraphics),
                 optionalInt(measurement.coreGraphics?.outputBytes),
                 secondsString(measurement.coreGraphics?.elapsedSeconds),
-                measurement.skiaOptIn?.status ?? "-",
-                backendSummary(measurement.skiaOptIn),
-                fallbackSummary(measurement.skiaOptIn),
-                optionalInt(measurement.skiaOptIn?.outputBytes),
-                optionalInt(measurement.skiaOptIn?.pngBytes),
-                secondsString(measurement.skiaOptIn?.elapsedSeconds)
+                measurement.skiaDecode?.status ?? "-",
+                backendSummary(measurement.skiaDecode),
+                fallbackSummary(measurement.skiaDecode),
+                optionalInt(measurement.skiaDecode?.outputBytes),
+                optionalInt(measurement.skiaDecode?.pngBytes),
+                secondsString(measurement.skiaDecode?.elapsedSeconds),
+                measurement.skiaDirect?.status ?? "-",
+                backendSummary(measurement.skiaDirect),
+                fallbackSummary(measurement.skiaDirect),
+                optionalInt(measurement.skiaDirect?.outputBytes),
+                optionalInt(measurement.skiaDirect?.pngBytes),
+                secondsString(measurement.skiaDirect?.elapsedSeconds),
+                sizeString(measurement.skiaDirect?.pixelSize)
             ].joined(separator: " | ").wrappedTableRow)
         }
 
-        let failed = measurements.filter { $0.loadStatus == "FAIL" || $0.coreGraphics?.status == "FAIL" || $0.skiaOptIn?.status == "FAIL" }
-        if !failed.isEmpty {
+        let failed = measurements.filter {
+            $0.loadStatus == "FAIL"
+                || isFailure($0.coreGraphics)
+                || isFailure($0.skiaDecode)
+                || isFailure($0.skiaDirect)
+        }
+        if !failed.isEmpty || resolverContract.status == "FAIL" {
             lines.append("")
             lines.append("## Failures")
             lines.append("")
+            if resolverContract.status == "FAIL" {
+                lines.append("- resolver contract failed; see `resolver-contract.txt`")
+            }
             for measurement in failed {
-                lines.append("- `\(measurement.fileName)`: load=\(measurement.loadError ?? "-") cg=\(measurement.coreGraphics?.error ?? "-") skia=\(measurement.skiaOptIn?.error ?? "-")")
+                lines.append("- `\(measurement.fileName)`: load=\(measurement.loadError ?? "-") cg=\(measurement.coreGraphics?.error ?? "-") skiaDecode=\(measurement.skiaDecode?.error ?? "-") skiaDirect=\(measurement.skiaDirect?.error ?? "-")")
             }
         }
 
@@ -316,49 +440,151 @@ struct QuickLookSkiaPolicySmoke {
         lines.append("ReplyType: \(measurement.replyType ?? "-")")
         lines.append("PageCount: \(optionalInt(measurement.pageCount))")
         lines.append("FirstPageSize: \(sizeString(measurement.firstPageSize))")
-        appendPolicy(measurement.coreGraphics, name: "CoreGraphics", lines: &lines)
-        appendPolicy(measurement.skiaOptIn, name: "SkiaOptIn", lines: &lines)
+        appendMode(measurement.coreGraphics, name: "CoreGraphics", lines: &lines)
+        appendMode(measurement.skiaDecode, name: "SkiaDecode", lines: &lines)
+        appendMode(measurement.skiaDirect, name: "SkiaDirect", lines: &lines)
         try lines.joined(separator: "\n").write(to: detailURL, atomically: true, encoding: .utf8)
     }
 
-    private static func appendPolicy(_ policy: PolicyMeasurement?, name: String, lines: inout [String]) {
+    private static func appendMode(_ mode: ModeMeasurement?, name: String, lines: inout [String]) {
         lines.append("")
         lines.append("[\(name)]")
-        guard let policy else {
+        guard let mode else {
             lines.append("Status: -")
             return
         }
-        lines.append("Status: \(policy.status)")
-        if let error = policy.error {
+        lines.append("Mode: \(mode.modeName)")
+        lines.append("OutputMode: \(mode.outputModeName ?? "-")")
+        lines.append("Status: \(mode.status)")
+        if let error = mode.error {
             lines.append("Error: \(error)")
         }
-        lines.append("OutputBytes: \(optionalInt(policy.outputBytes))")
-        lines.append("OutputPages: \(optionalInt(policy.outputPages))")
-        lines.append("ElapsedSeconds: \(secondsString(policy.elapsedSeconds))")
-        lines.append("SkiaPages: \(policy.skiaPages)")
-        lines.append("CoreGraphicsPages: \(policy.coreGraphicsPages)")
-        lines.append("EmbeddedThumbnailPages: \(policy.embeddedThumbnailPages)")
-        lines.append("FallbackPages: \(policy.fallbackPages)")
-        lines.append("FirstFallback: \(policy.firstFallback ?? "-")")
-        lines.append("PNGBytes: \(policy.pngBytes)")
-        lines.append("RenderMs: \(formatMilliseconds(policy.renderMs))")
+        lines.append("OutputBytes: \(optionalInt(mode.outputBytes))")
+        lines.append("OutputPages: \(optionalInt(mode.outputPages))")
+        lines.append("ElapsedSeconds: \(secondsString(mode.elapsedSeconds))")
+        lines.append("Backend: \(backendSummary(mode))")
+        lines.append("SkiaPages: \(mode.skiaPages)")
+        lines.append("CoreGraphicsPages: \(mode.coreGraphicsPages)")
+        lines.append("EmbeddedThumbnailPages: \(mode.embeddedThumbnailPages)")
+        lines.append("FallbackPages: \(mode.fallbackPages)")
+        lines.append("FirstFallback: \(mode.firstFallback ?? "-")")
+        lines.append("PNGBytes: \(optionalInt(mode.pngBytes))")
+        lines.append("PixelSize: \(sizeString(mode.pixelSize))")
+        lines.append("RenderMs: \(millisecondsString(mode.renderMs))")
+        lines.append("SkiaRenderMs: \(millisecondsString(mode.skiaRenderMs))")
+        lines.append("PNGHeaderValidateMs: \(millisecondsString(mode.pngHeaderValidateMs))")
+        lines.append("PNGDecodeMs: \(millisecondsString(mode.pngDecodeMs))")
+        lines.append("PNGEncodeMs: \(millisecondsString(mode.pngEncodeMs))")
+        lines.append("CoreGraphicsRenderMs: \(millisecondsString(mode.coreGraphicsRenderMs))")
+    }
+
+    private static func makeResolverContract() -> ResolverContractResult {
+        let key = HwpQuickLookPNGReplyModeResolver.environmentKey
+        let cases: [(label: String, rawValue: String?, expected: HwpPreviewPNGReplyMode)] = [
+            ("missing", nil, .coreGraphics),
+            ("empty", "", .coreGraphics),
+            ("invalid", "banana", .coreGraphics),
+            ("coreGraphics", "coreGraphics", .coreGraphics),
+            ("coreGraphicsOnly", "coreGraphicsOnly", .coreGraphics),
+            ("skia", "skia", expectedSkiaMode()),
+            ("skiaDecode", "skiaDecode", expectedSkiaMode()),
+            ("skiaOptIn", "skiaOptIn", expectedSkiaMode()),
+            ("direct", "direct", expectedDirectMode()),
+            ("skiaDirect", "skiaDirect", expectedDirectMode())
+        ]
+
+        let results = cases.map { item in
+            let environment: [String: String]
+            if let rawValue = item.rawValue {
+                environment = [key: rawValue]
+            } else {
+                environment = [:]
+            }
+            return ResolverCaseResult(
+                label: item.label,
+                rawValue: item.rawValue,
+                expected: item.expected,
+                resolved: HwpQuickLookPNGReplyModeResolver.resolve(environment: environment)
+            )
+        }
+
+        return ResolverContractResult(
+            build: resolverBuildString(),
+            environmentKey: key,
+            cases: results
+        )
+    }
+
+    private static func writeResolverContract(
+        _ contract: ResolverContractResult,
+        outputDir: URL
+    ) throws {
+        var lines: [String] = []
+        lines.append("ResolverBuild: \(contract.build)")
+        lines.append("ResolverEnvKey: \(contract.environmentKey)")
+        lines.append("ResolverContract: \(contract.status)")
+        lines.append("")
+        lines.append("| Case | RawValue | Expected | Resolved | Status |")
+        lines.append("|------|----------|----------|----------|--------|")
+        for item in contract.cases {
+            lines.append([
+                item.label,
+                item.rawValue ?? "<missing>",
+                item.expected.identifier,
+                item.resolved.identifier,
+                item.status
+            ].joined(separator: " | ").wrappedTableRow)
+        }
+        try lines.joined(separator: "\n").write(
+            to: outputDir.appendingPathComponent("resolver-contract.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+    }
+
+    private static func expectedSkiaMode() -> HwpPreviewPNGReplyMode {
+#if DEBUG
+        .skiaDecode
+#else
+        .coreGraphics
+#endif
+    }
+
+    private static func expectedDirectMode() -> HwpPreviewPNGReplyMode {
+#if DEBUG
+        .skiaDirect
+#else
+        .coreGraphics
+#endif
+    }
+
+    private static func resolverBuildString() -> String {
+#if DEBUG
+        "DEBUG"
+#else
+        "RELEASE"
+#endif
     }
 
     private static func rowSummary(_ measurement: FileMeasurement) -> String {
         guard measurement.loadStatus == "OK" else {
             return measurement.loadError ?? "load failed"
         }
-        return "reply=\(measurement.replyType ?? "-") pages=\(optionalInt(measurement.pageCount)) cg=\(backendSummary(measurement.coreGraphics)) skia=\(backendSummary(measurement.skiaOptIn)) fallback=\(fallbackSummary(measurement.skiaOptIn))"
+        return "reply=\(measurement.replyType ?? "-") pages=\(optionalInt(measurement.pageCount)) cg=\(backendSummary(measurement.coreGraphics)) skiaDecode=\(backendSummary(measurement.skiaDecode)) skiaDirect=\(backendSummary(measurement.skiaDirect)) directFallback=\(fallbackSummary(measurement.skiaDirect))"
     }
 
-    private static func backendSummary(_ measurement: PolicyMeasurement?) -> String {
+    private static func isFailure(_ measurement: ModeMeasurement?) -> Bool {
+        measurement?.status == "FAIL"
+    }
+
+    private static func backendSummary(_ measurement: ModeMeasurement?) -> String {
         guard let measurement, measurement.status == "OK" else {
             return "-"
         }
         return "skia:\(measurement.skiaPages),cg:\(measurement.coreGraphicsPages),embedded:\(measurement.embeddedThumbnailPages)"
     }
 
-    private static func fallbackSummary(_ measurement: PolicyMeasurement?) -> String {
+    private static func fallbackSummary(_ measurement: ModeMeasurement?) -> String {
         guard let measurement, measurement.status == "OK" else {
             return "-"
         }
@@ -388,8 +614,9 @@ struct QuickLookSkiaPolicySmoke {
         return String(format: "%.6f", value)
     }
 
-    private static func formatMilliseconds(_ value: Double) -> String {
-        String(format: "%.3f", value)
+    private static func millisecondsString(_ value: Double?) -> String {
+        guard let value else { return "-" }
+        return String(format: "%.3f", value)
     }
 
     private static func sizeString(_ size: CGSize?) -> String {

--- a/scripts/smoke-quicklook-skia-policy.sh
+++ b/scripts/smoke-quicklook-skia-policy.sh
@@ -49,6 +49,7 @@ rm -rf "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
 mkdir -p "$SWIFT_MODULE_CACHE" "$CLANG_MODULE_CACHE"
 
 swiftc -parse-as-library \
+  -DDEBUG \
   -module-cache-path "$SWIFT_MODULE_CACHE" \
   -Xcc -fmodules-cache-path="$CLANG_MODULE_CACHE" \
   -I "$MODULEMAP_DIR" \
@@ -61,6 +62,8 @@ swiftc -parse-as-library \
   "$ROOT/Sources/Shared/HwpPageImageRenderer.swift" \
   "$ROOT/Sources/Shared/HwpNativePageCompositor.swift" \
   "$ROOT/Sources/Shared/HwpPreviewPDFRenderer.swift" \
+  "$ROOT/Sources/Shared/HwpPreviewPNGRenderer.swift" \
+  "$ROOT/Sources/QLExtension/HwpQuickLookPNGReplyModeResolver.swift" \
   "$ROOT/scripts/quicklook_skia_policy_smoke.swift" \
   "$LIB" \
   -framework CoreGraphics \


### PR DESCRIPTION
## 요약

- 대상 타스크: #393 Quick Look 단일 페이지 Skia direct PNG opt-in fast path 실험
- 왜: 기존 Skia 진단 경로가 upstream PNG를 `CGImage`로 decode한 뒤 다시 PNG로 encode해 단일 PNG reply 비용을 추가로 만든다.
- 무엇: DEBUG/internal `skiaDirect` reply mode, resolver, PNG header validation, CoreGraphics fallback, smoke 비교 출력을 추가했다.
- 리뷰 포인트: Release/default가 CoreGraphics로 유지되고, direct path가 Quick Look 단일 페이지에만 적용되며, Skia visual gate를 우회하지 않는지 확인한다.

## PR base

- base: `devel`

## 변경 내역

- **[계획](https://github.com/postmelee/alhangeul-macos/blob/9a1a82f944fc4ddfb24c93374f3abc44cb0beb55/mydocs/plans/task_m020_393.md)** ([4225112](https://github.com/postmelee/alhangeul-macos/commit/4225112ce6aac7786739cc84a1d7491c5dd02ffa)): 수행계획서와 오늘할일을 정리했다.
- **[구현계획](https://github.com/postmelee/alhangeul-macos/blob/9a1a82f944fc4ddfb24c93374f3abc44cb0beb55/mydocs/plans/task_m020_393_impl.md)** ([a86ede2](https://github.com/postmelee/alhangeul-macos/commit/a86ede29dbb6cab8c89fc27f9e1236706fc4b288)): Stage별 목표, 범위, 검증 명령을 고정했다.
- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/9a1a82f944fc4ddfb24c93374f3abc44cb0beb55/mydocs/working/task_m020_393_stage1.md)** ([5d88e75](https://github.com/postmelee/alhangeul-macos/commit/5d88e75c3debce4ce7c5a926e7c15ecf781fe75a)): 현행 Quick Look PNG reply가 Skia decode/re-encode 경로임을 inventory와 baseline smoke로 고정했다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/9a1a82f944fc4ddfb24c93374f3abc44cb0beb55/mydocs/working/task_m020_393_stage2.md)** ([ec7e43c](https://github.com/postmelee/alhangeul-macos/commit/ec7e43cd3e4d0683bd7d59c4eb939e1cf1acbb62)): direct PNG reply mode, resolver, fallback, diagnostics contract를 설계했다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/9a1a82f944fc4ddfb24c93374f3abc44cb0beb55/mydocs/working/task_m020_393_stage3.md)** ([f8054ee](https://github.com/postmelee/alhangeul-macos/commit/f8054eee40d4b77785957b745d4c05d19962cfbf)): `HwpPreviewPNGRenderer`, Quick Look resolver, provider 연결, smoke 보강을 구현했다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/9a1a82f944fc4ddfb24c93374f3abc44cb0beb55/mydocs/working/task_m020_393_stage4.md)** ([3188adf](https://github.com/postmelee/alhangeul-macos/commit/3188adf86d4a2ec7d0f51d7e26f81dacfffaf49b)): 대표 샘플에서 direct/decode/CoreGraphics latency, bytes, fallback을 비교했다.
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/9a1a82f944fc4ddfb24c93374f3abc44cb0beb55/mydocs/working/task_m020_393_stage5.md)** ([9a1a82f](https://github.com/postmelee/alhangeul-macos/commit/9a1a82f944fc4ddfb24c93374f3abc44cb0beb55)): 최종 보고서와 기술 문서에 결론을 반영했다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| Quick Look PNG reply | `coreGraphics`, `skiaDecode`, `skiaDirect` helper 추가 | direct 성공/실패 계약과 CoreGraphics fallback |
| QLExtension resolver | `ALHANGEUL_QUICKLOOK_PNG_REPLY_MODE` DEBUG 해석 추가 | Release/default가 `coreGraphics`로 수렴 |
| Smoke | `coreGraphics`, `skiaDecode`, `skiaDirect` 비교와 resolver contract 출력 | 다중 페이지 direct `N/A`, fallback 0 기록 |
| 문서 | 최종 보고서와 Skia backend/baseline 문서 보강 | direct PNG가 quality gate를 대체하지 않는 결론 |

- 수행 계획서: [task_m020_393.md](https://github.com/postmelee/alhangeul-macos/blob/9a1a82f944fc4ddfb24c93374f3abc44cb0beb55/mydocs/plans/task_m020_393.md)
- 구현 계획서: [task_m020_393_impl.md](https://github.com/postmelee/alhangeul-macos/blob/9a1a82f944fc4ddfb24c93374f3abc44cb0beb55/mydocs/plans/task_m020_393_impl.md)
- 최종 보고서: [task_m020_393_report.md](https://github.com/postmelee/alhangeul-macos/blob/9a1a82f944fc4ddfb24c93374f3abc44cb0beb55/mydocs/report/task_m020_393_report.md)

## 핵심 리뷰 포인트

- Release/default Quick Look PNG reply가 계속 CoreGraphics인지
- `skiaDirect`가 Quick Look 단일 페이지 PNG reply에만 적용되고 다중 PDF/Thumbnail을 건드리지 않는지
- direct PNG가 `KTX.hwp` Skia visual regression 같은 quality gate를 우회하지 않는다는 문서 판단이 충분한지

## 검증

- `./scripts/check-no-appkit.sh`
- `./scripts/verify-rhwp-core-build-info.sh`
- `./scripts/verify-rhwp-studio-assets.sh`
- `./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-stage1-quicklook-baseline samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx`
- `./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-stage3-quicklook-direct samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx`
- `./scripts/smoke-quicklook-skia-policy.sh build.noindex/task393-quicklook-policy-representative samples/basic/request.hwp samples/basic/KTX.hwp samples/복학원서.hwp samples/hwp-multi-001.hwp samples/hwpx/hwpx-01.hwpx`
- `xcodegen generate`
- `xcodebuild -project Alhangeul.xcodeproj -scheme QLExtension -configuration Debug -derivedDataPath build.noindex/DerivedDataTask393Stage3 CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

## 관련 이슈

- #387 Preview/Thumbnail Skia readiness 후속 개선 추적
- #390 `rhwp v0.7.17` 기준 Skia readiness gate 재측정
- #392 Thumbnail Skia maxDimension mapping 실험
- #396 업스트림 renderer baseline 방식을 Quick Look/Thumbnail Skia 품질 검증에 이식
- #259 Skia release/default readiness gate

## 후속 이슈 제안

- direct fallback 강제 fixture 또는 실패 주입 smoke가 필요하면 별도 follow-up으로 분리한다.
- Release resolver compile smoke가 리뷰에서 필요하면 별도 follow-up으로 분리한다.

## 남은 리스크

- `KTX.hwp` Skia visual regression은 direct PNG로 해결되지 않는다.
- latency는 로컬 단일 실행값이므로 같은 smoke run 안의 상대 비교와 fallback 여부 중심으로 해석해야 한다.
- 다중 PDF Skia decode path는 여전히 CoreGraphics보다 느려 direct PNG 범위 밖의 #259 판단 입력으로 남긴다.
