### PR TITLE
Task #391: filename/external image context ABI 조사와 bridge 설계

### DIFF
--- a/mydocs/orders/20260705.md
+++ b/mydocs/orders/20260705.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #404 | upstream 렌더 PR 대표 샘플 diff 측정 | 완료 | M020, 완료: 18:48, PR 게시 승인 완료 |
-| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, 구현계획서 작성 후 Stage 1 승인 대기 |
+| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, Stage 1 완료 후 Stage 2 승인 대기 |

--- a/mydocs/orders/20260705.md
+++ b/mydocs/orders/20260705.md
@@ -5,3 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #404 | upstream 렌더 PR 대표 샘플 diff 측정 | 완료 | M020, 완료: 18:48, PR 게시 승인 완료 |
+| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260705.md
+++ b/mydocs/orders/20260705.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #404 | upstream 렌더 PR 대표 샘플 diff 측정 | 완료 | M020, 완료: 18:48, PR 게시 승인 완료 |
-| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, 구현계획서 작성 후 Stage 1 승인 대기 |

--- a/mydocs/orders/20260710.md
+++ b/mydocs/orders/20260710.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, Stage 4 완료 후 Stage 5 승인 대기 |
+| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, Stage 5 최종 보고서 완료 후 PR 게시 승인 대기 |

--- a/mydocs/orders/20260710.md
+++ b/mydocs/orders/20260710.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 7월 10일
+
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, Stage 2 완료 후 Stage 3 승인 대기 |

--- a/mydocs/orders/20260710.md
+++ b/mydocs/orders/20260710.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, Stage 3 완료 후 Stage 4 승인 대기 |
+| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, Stage 4 완료 후 Stage 5 승인 대기 |

--- a/mydocs/orders/20260710.md
+++ b/mydocs/orders/20260710.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, Stage 2 완료 후 Stage 3 승인 대기 |
+| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, Stage 3 완료 후 Stage 4 승인 대기 |

--- a/mydocs/orders/20260710.md
+++ b/mydocs/orders/20260710.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #391 | filename/external image context ABI 조사 및 bridge 설계 | 진행중 | M020, Stage 5 최종 보고서 완료 후 PR 게시 승인 대기 |
+| #391 | filename/external image context ABI 조사 및 bridge 설계 | 완료 | M020, 완료: 02:12 |

--- a/mydocs/plans/task_m020_391.md
+++ b/mydocs/plans/task_m020_391.md
@@ -1,0 +1,127 @@
+# Task M020 #391 수행계획서
+
+## 목적
+
+`filename/external image context ABI 조사 및 bridge 설계`를 수행한다.
+
+현재 Swift `RhwpDocument(data:filename:)`는 filename 인자를 받지만 Rust FFI는 `rhwp_open(data, len)`만 호출한다. 또한 `rhwp-ffi-symbols.txt`에는 filename context, external image reference discovery, external bytes injection, missing image diagnostic 관련 symbol이 없다. 이 작업은 구현 전에 현재 pinned `rhwp v0.7.17`와 upstream 관련 변경을 조사하고, 알한글 macOS 앱이 소유해야 할 RustBridge C ABI와 Swift/macOS shell 책임 경계를 설계한다.
+
+## 배경
+
+#404에서 external/large image data 축은 local proxy sample에서는 hard fail이 없었지만 exact external BinData Link, large BinData, placeholder 보존 fixture는 미측정으로 남았다. Stage 4 최종 분류는 external image/filename context 판단을 #391 설계 작업으로 넘겼다.
+
+현재 코드 상태는 다음과 같다.
+
+- `RhwpDocument(data:filename:)`는 filename을 error message 용도로만 사용하고 `rhwp_open(data, len)`에 전달하지 않는다.
+- `RustBridge/src/lib.rs`의 `rhwp_open`은 `DocumentCore::from_bytes(bytes)`만 호출한다.
+- Swift image renderer는 `ImageNode.bin_data_id`로 `rhwp_image_data(handle, binDataId, &len)`를 조회한다.
+- `rhwp-ffi-symbols.txt`의 공개 symbol은 render/page/image data 조회 중심이며 filename/external resource context symbol은 없다.
+
+따라서 external image가 core/studio/Skia path에서는 context를 통해 해석되지만 Swift/CoreGraphics path에서는 bytes가 없거나 missing 상태가 deterministic하게 드러나지 않는 경우, bridge ABI와 sandbox/file access policy를 먼저 설계해야 한다.
+
+## 범위
+
+포함:
+
+- 현재 pinned `rhwp v0.7.17` 기준 filename/external image 관련 native API 존재 여부 확인
+- upstream `edwardkim/rhwp` 관련 PR/issue 조사
+- filename context가 native Skia/PageLayerTree path와 `rhwp-studio` path에서 어떤 의미를 갖는지 정리
+- external image reference discovery, missing/injected 상태 진단, bytes injection 가능성 조사
+- RustBridge C ABI 후보 작성
+- Swift wrapper와 Quick Look/Thumbnail sandbox/file access 책임 경계 설계
+- 구현이 필요한 경우 후속 ABI 구현 이슈 초안 작성
+
+제외:
+
+- RustBridge ABI 구현
+- generated `Rhwp.xcframework` 재생성
+- `rhwp-core.lock` 변경
+- upstream `rhwp` 수정
+- external resource file access policy를 renderer backend에 직접 넣는 작업
+- Skia default 전환
+- HostApp native viewer/editor 전환
+
+## 설계 방향
+
+조사는 세 층으로 나눠 진행한다.
+
+1. 현재 앱 ABI 표면: Swift wrapper, RustBridge C ABI, `rhwp-ffi-symbols.txt`, render tree image node 계약을 확인한다.
+2. upstream core/studio 표면: `rhwp v0.7.17`와 upstream 관련 issue/PR에서 filename context, document context, external image resource contract가 어떻게 쓰이는지 확인한다.
+3. macOS shell 책임: Quick Look/Thumbnail extension sandbox, file URL security scope, package-relative external resource lookup, deterministic diagnostic reporting의 경계를 정한다.
+
+ABI 설계는 즉시 구현 가능한 함수명 나열보다 책임 경계를 우선한다. renderer backend가 임의로 filesystem access를 수행하지 않도록 하고, Swift/macOS shell이 허용된 파일과 bytes를 명시적으로 core에 전달하는 구조를 기본 가정으로 둔다.
+
+후속 구현 후보는 다음 단위로 분리한다.
+
+- filename context open API 또는 document context setter
+- external image reference list/discovery API
+- external image bytes injection API
+- missing/injected/embedded image diagnostic API
+- Quick Look/Thumbnail sandbox resource resolver
+
+## 예상 변경 파일
+
+이번 수행계획서 단계의 실제 변경 파일은 다음으로 제한한다.
+
+- `mydocs/orders/20260705.md`
+- `mydocs/plans/task_m020_391.md`
+
+이후 단계의 예상 산출물:
+
+- `mydocs/plans/task_m020_391_impl.md`
+- `mydocs/working/task_m020_391_stage*.md`
+- `mydocs/report/task_m020_391_report.md`
+- 필요 시 `mydocs/tech/` 하위 ABI 설계 문서 후보
+
+제품 Swift/Rust source와 generated framework는 이번 타스크에서 변경하지 않는다.
+
+## 잠정 단계
+
+1. Stage 1: current app ABI와 renderer image data 계약 inventory
+2. Stage 2: upstream `rhwp v0.7.17` 및 관련 PR/issue의 filename/external resource contract 조사
+3. Stage 3: external image diagnostic과 bytes injection C ABI 후보 설계
+4. Stage 4: Swift/macOS shell, Quick Look/Thumbnail sandbox, security scope 책임 경계 설계
+5. Stage 5: 후속 구현 이슈 초안과 최종 보고서 정리
+
+## 검증 계획
+
+기본 검증:
+
+```bash
+git diff --check
+rg -n "filename|external|BinData|rhwp_open|rhwp_image_data|ABI|sandbox|diagnostic" \
+  mydocs/plans/task_m020_391.md mydocs/orders/20260705.md
+```
+
+조사 단계 후보 명령:
+
+```bash
+rg -n "filename|external|BinData|image_data|rhwp_open|DocumentCore::from_bytes|context" \
+  Sources RustBridge rhwp-ffi-symbols.txt mydocs
+gh issue view 391 --repo postmelee/alhangeul-macos --json number,title,body,state,labels,milestone,url
+gh issue view 1141 --repo edwardkim/rhwp --json number,title,body,state,url
+gh pr list --repo edwardkim/rhwp --search "external image filename context BinData" \
+  --state all --limit 20 --json number,title,state,url
+```
+
+후속 설계 검증:
+
+```bash
+rg -n "C ABI|Swift wrapper|Quick Look|Thumbnail|sandbox|security scope|missing|injected|embedded" \
+  mydocs/working/task_m020_391_stage*.md
+git diff --check
+```
+
+## 리스크
+
+- upstream `rhwp`의 relevant API가 `v0.7.17`에는 없고 unreleased commit에만 있을 수 있다. 이 경우 release pin 반영과 설계 관찰을 분리해야 한다.
+- external resource access는 Quick Look/Thumbnail sandbox와 보안 범위에 민감하다. renderer backend가 직접 filesystem access를 하지 않도록 책임 경계를 명확히 해야 한다.
+- external image fixture가 로컬에 없으면 설계는 API/diagnostic 중심으로 끝나고 구현 검증은 후속 fixture 이슈로 넘어갈 수 있다.
+- bytes injection ABI를 좁게 설계하면 HWP/HWPX package-relative path, filename context, duplicate resource id, missing placeholder 상태를 구분하지 못할 수 있다.
+- ABI 구현은 `Rhwp.xcframework` 재생성과 symbol/provenance 검증이 필요하므로 이번 조사 타스크에서 섞지 않는다.
+
+## 승인 요청 사항
+
+- 기준 브랜치는 `devel`, 작업 브랜치는 `local/task391`로 진행한다.
+- 이 작업은 #387 추적 흐름의 하위 architecture/design 작업 #391로 진행한다.
+- 수행계획서 승인 후 Stage 1 구현 계획서를 작성하고, 실제 조사와 설계 문서화는 그 다음 단계에서 수행한다.

--- a/mydocs/plans/task_m020_391_impl.md
+++ b/mydocs/plans/task_m020_391_impl.md
@@ -1,0 +1,260 @@
+# Task M020 #391 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_391.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #391 `filename/external image context ABI 조사 및 bridge 설계`
+- 추적 이슈: #387 Preview/Thumbnail Skia readiness 후속 개선 추적
+- 관련 완료 조사: #404 upstream 렌더 PR 대표 샘플 diff 측정
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task391`
+- 목표: 현재 Swift/RustBridge가 파일명과 외부 이미지 리소스를 어떤 수준까지 전달할 수 있는지 확인하고, upstream `rhwp v0.7.17` 및 최근 external image 관련 변경을 근거로 future C ABI와 Swift/macOS 책임 경계를 설계한다.
+
+## 구현 원칙
+
+- #391은 조사와 설계 작업이다. RustBridge ABI 구현, `Rhwp.xcframework` 재생성, renderer backend 동작 변경, Skia 기본 전환은 수행하지 않는다.
+- `rhwp-core.lock`의 pinned `v0.7.17`과 upstream unreleased 변경을 구분해서 기록한다. unreleased PR/issue는 future compatibility 관찰 대상으로만 취급한다.
+- renderer backend가 임의의 파일 시스템 접근 권한을 갖는 설계는 피한다. macOS shell이 허용된 파일과 byte payload를 판정하고 RustBridge는 명시적으로 전달된 context만 사용한다.
+- Quick Look Preview, Finder Thumbnail, HostApp/WKWebView, future native viewer의 파일 접근 조건을 분리한다.
+- external fixture가 없거나 upstream API가 아직 확정되지 않은 항목은 구현을 보류하고 follow-up issue 후보로 정리한다.
+- 기존 ABI와 JSON shape를 깨지 않는 additive 설계를 우선 검토한다. breaking change가 필요하면 별도 migration 단계와 symbol versioning 필요성을 명시한다.
+
+## 관련 맥락
+
+| 축 | 관련 항목 | #391 확인 포인트 |
+|----|-----------|------------------|
+| 현재 filename 전달 | `RhwpDocument(data:filename:)`, `rhwp_open(data,len)` | Swift가 받은 filename이 RustBridge에 전달되지 않는 현재 구조와 에러 메시지 용도만 문서화한다. |
+| embedded image bytes | `ImageNode.bin_data_id`, `rhwp_image_data` | render tree image node와 BinData byte 조회 계약, nil image 처리 경로를 확인한다. |
+| external/large image data | upstream `edwardkim/rhwp#1913`, `#1924`, `#1917`, `#1930`, issue `#1141` | 외부 BinData Link, placeholder 보존, 대형 BinData 처리, missing image diagnostic 필요성을 조사한다. |
+| macOS sandbox | Quick Look, Thumbnail, HostApp | file URL, sibling resource, package-relative path, security-scoped access 책임이 어느 layer에 있어야 하는지 분리한다. |
+| future ABI | RustBridge C ABI, Swift wrapper | open context, external refs enumeration, injected bytes, diagnostics JSON 후보를 설계한다. |
+
+## Stage 1. 현재 app ABI와 image data 계약 inventory
+
+### 목표
+
+현재 알한글 downstream에서 filename과 image data가 지나가는 경로를 정리하고, external image context가 들어갈 수 없는 지점을 명확히 표시한다.
+
+### 대상
+
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+- `Sources/RhwpCoreBridge/PageOverlayImages.swift`
+- `Sources/PreviewRenderer/CGTreeRenderer.swift`
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+- `RustBridge/src/lib.rs`
+- `rhwp-ffi-symbols.txt`
+- `rhwp-core.lock`
+- `mydocs/working/task_m020_391_stage1.md`
+
+### 작업
+
+1. Swift wrapper에서 `filename`이 사용되는 위치와 RustBridge로 전달되지 않는 지점을 확인한다.
+2. `rhwp_open`, `rhwp_image_data`, render tree `ImageNode.bin_data_id`의 current contract를 정리한다.
+3. CoreGraphics renderer가 image byte nil 또는 decode 실패를 어떻게 처리하는지 확인한다.
+4. Quick Look/Thumbnail entry point가 file URL, Data, filename을 어떤 순서로 전달하는지 정리한다.
+5. current ABI로는 external image discovery/injection/diagnostic이 불가능한 부분을 evidence 중심으로 기록한다.
+
+### 검증
+
+```bash
+rg -n "filename|external|BinData|bin_data_id|rhwp_open|rhwp_image_data|imageData|DocumentCore::from_bytes|pageOverlay|overlay|sandbox|security" \
+  Sources RustBridge rhwp-ffi-symbols.txt rhwp-core.lock mydocs/plans/task_m020_391_impl.md
+git diff --check
+```
+
+### 완료 조건
+
+- current Swift/RustBridge call graph와 image data contract가 Stage 1 보고서에 정리되어 있다.
+- filename이 현재 ABI로 전달되지 않는다는 근거가 파일/라인 중심으로 기록되어 있다.
+- Stage 2에서 확인할 upstream contract 질문 목록이 도출되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #391 Stage 1: current ABI와 image data 계약 inventory
+```
+
+## Stage 2. upstream rhwp/studio external resource contract 조사
+
+### 목표
+
+pinned `rhwp v0.7.17`와 upstream 최근 이슈/PR에서 filename context, external image link, placeholder, large BinData가 어떤 contract로 다뤄지는지 조사한다.
+
+### 대상
+
+- `rhwp-core.lock`
+- upstream `edwardkim/rhwp` issue/PR metadata
+- 필요 시 upstream `v0.7.17` source snapshot
+- `mydocs/working/task_m020_391_stage2.md`
+
+### 작업
+
+1. `rhwp-core.lock`의 release tag/commit 기준을 다시 확인하고 pinned core의 public path를 조사한다.
+2. upstream issue `edwardkim/rhwp#1141`과 external image, filename context, BinData 관련 PR 목록을 조회한다.
+3. #404에서 분류된 external/large image data 축의 PR `#1913`, `#1924`, `#1917`, `#1930`이 #391 설계에 주는 의미를 분리한다.
+4. rhwp-studio 또는 upstream CLI가 filename/base path를 사용하는지, render tree 또는 SVG export에 missing image signal을 남기는지 확인한다.
+5. pinned release에서 즉시 사용할 수 있는 API와 future ABI로만 고려해야 하는 API를 분리한다.
+
+### 검증
+
+```bash
+gh issue view 1141 --repo edwardkim/rhwp --json number,title,body,state,url
+gh pr list --repo edwardkim/rhwp --search "external image filename context BinData" --state all --limit 20 --json number,title,state,url
+gh pr list --repo edwardkim/rhwp --search "document context external resource" --state all --limit 20 --json number,title,state,url
+gh pr view 1913 --repo edwardkim/rhwp --json number,title,body,files,state,url
+gh pr view 1924 --repo edwardkim/rhwp --json number,title,body,files,state,url
+gh pr view 1917 --repo edwardkim/rhwp --json number,title,body,files,state,url
+gh pr view 1930 --repo edwardkim/rhwp --json number,title,body,files,state,url
+rg -n "external|filename|BinData|context|resource|missing|injected|placeholder|large" \
+  mydocs/working/task_m020_391_stage2.md
+git diff --check
+```
+
+### 완료 조건
+
+- pinned `v0.7.17`에서 가능한 것과 upstream unreleased 변경의 기대 효과가 구분되어 있다.
+- filename context가 upstream parser/render path에서 필요한지, 또는 downstream shell responsibility인지 판단 근거가 있다.
+- Stage 3 ABI 후보에 반영할 external image state 목록이 정리되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #391 Stage 2: upstream external resource contract 조사
+```
+
+## Stage 3. external image C ABI 후보 설계
+
+### 목표
+
+기존 C ABI와 JSON shape를 가능한 유지하면서 external image discovery, bytes injection, diagnostics를 지원할 후보 API를 설계한다.
+
+### 대상
+
+- `rhwp-ffi-symbols.txt`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `RustBridge/src/lib.rs`
+- `mydocs/working/task_m020_391_stage3.md`
+
+### 작업
+
+1. `rhwp_open_with_context` 또는 context setter 방식의 장단점을 비교한다.
+2. 외부 리소스 목록을 JSON으로 열람하는 `rhwp_external_image_refs` 계열 후보를 설계한다.
+3. Swift shell이 허용한 bytes를 주입하는 `rhwp_inject_external_image_bytes` 계열 후보를 설계한다.
+4. embedded, external, missing, placeholder, injected, decode_failed 같은 diagnostic 상태 enum 또는 JSON shape를 설계한다.
+5. UTF-8 path, relative path normalization, byte buffer ownership, handle lifecycle, thread-safety, additive symbol export 정책을 정리한다.
+6. legacy client가 새 symbol 없이도 기존 embedded image 렌더를 유지하는 fallback 조건을 명시한다.
+
+### 검증
+
+```bash
+rg -n "rhwp_open_with|context setter|external.*ref|inject|diagnostic|missing|embedded|placeholder|injected|decode_failed|lifetime|UTF-8|C ABI" \
+  mydocs/working/task_m020_391_stage3.md
+git diff --check
+```
+
+### 완료 조건
+
+- 최소 2개 이상의 C ABI 설계안과 선택 기준이 기록되어 있다.
+- Swift/RustBridge memory ownership과 error reporting 정책이 포함되어 있다.
+- 실제 구현을 위한 follow-up issue로 쪼갤 수 있는 단위가 표시되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #391 Stage 3: external image ABI 후보 설계
+```
+
+## Stage 4. Swift/macOS shell 책임 경계 설계
+
+### 목표
+
+Quick Look, Thumbnail, HostApp에서 filename/external resource context를 수집하고 RustBridge에 넘기는 책임 경계를 설계한다.
+
+### 대상
+
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- `Sources/ThumbnailExtension/HwpThumbnailProvider.swift`
+- `Sources/Shared/HwpPageImageRenderer.swift`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `mydocs/working/task_m020_391_stage4.md`
+
+### 작업
+
+1. Quick Look Preview와 Thumbnail extension이 문서 URL, file data, display filename을 얻는 방식을 비교한다.
+2. HostApp/WKWebView와 future native viewer에서 파일 접근 및 external resource resolver가 달라지는 지점을 분리한다.
+3. sandbox, security-scoped resource, package-relative path, sibling file lookup, network path 금지 정책을 정리한다.
+4. RustBridge에 전달할 context object의 Swift API 후보를 설계한다.
+5. missing external image를 Swift renderer에서 placeholder/fallback으로 그릴지, core render tree diagnostic으로 표현할지 판단 기준을 제안한다.
+6. #390 Skia policy, #404 measurement 결과, #391 ABI 설계가 만나는 rollout sequence를 정리한다.
+
+### 검증
+
+```bash
+rg -n "Quick Look|Thumbnail|HostApp|sandbox|security scope|resource resolver|filename context|file access|diagnostic|placeholder|Skia|#390|#404" \
+  mydocs/working/task_m020_391_stage4.md
+git diff --check
+```
+
+### 완료 조건
+
+- surface별 파일 접근 책임과 금지 경로가 분리되어 있다.
+- Swift wrapper API 후보와 RustBridge C ABI 후보의 mapping이 정리되어 있다.
+- 구현 전에 필요한 upstream/core 선행 조건과 downstream-only 가능 작업이 분리되어 있다.
+
+### 커밋 메시지
+
+```text
+Task #391 Stage 4: macOS external resource 책임 경계 설계
+```
+
+## Stage 5. 후속 이슈 초안과 최종 보고서
+
+### 목표
+
+조사 결과를 최종 보고서로 정리하고, 실제 downstream 적용 작업을 후속 이슈 단위로 나눈다.
+
+### 대상
+
+- `mydocs/report/task_m020_391_report.md`
+- `mydocs/orders/20260705.md`
+- 필요 시 GitHub issue draft text
+
+### 작업
+
+1. Stage 1-4 결과를 current state, upstream dependency, recommended ABI, Swift responsibility, rollout order로 요약한다.
+2. 후속 이슈 후보를 implementation, fixture/test, upstream coordination, Quick Look/Thumbnail policy로 분리한다.
+3. #387, #390, #404와 중복되거나 선행/후행 관계가 있는 항목을 표시한다.
+4. 오늘할일의 #391 상태를 완료 대기 상태로 갱신한다.
+5. 최종 검증 결과와 잔여 리스크를 기록한다.
+
+### 검증
+
+```bash
+rg -n "#391|filename|external|BinData|C ABI|Swift wrapper|Quick Look|Thumbnail|후속|residual|#387|#390|#404" \
+  mydocs/report/task_m020_391_report.md mydocs/orders
+git diff --check
+git status --short
+```
+
+### 완료 조건
+
+- #391 최종 보고서가 있고 실제 구현 follow-up을 등록할 수 있는 수준의 초안이 있다.
+- 현재 downstream에서 바로 적용 가능한 작업과 upstream/core 변경 대기 작업이 구분되어 있다.
+- 작업지시자 승인 후 final report 절차 또는 PR 게시 절차로 넘길 수 있다.
+
+### 커밋 메시지
+
+```text
+Task #391 Stage 5 + 최종 보고서: external image ABI 설계 정리
+```
+
+## 승인 요청 사항
+
+이 구현계획서 승인 후 Stage 1 `현재 app ABI와 image data 계약 inventory`를 시작한다.

--- a/mydocs/report/task_m020_391_report.md
+++ b/mydocs/report/task_m020_391_report.md
@@ -180,7 +180,17 @@ v1 path resolver 정책:
 
 ## 후속 이슈 초안
 
-아래 초안은 즉시 등록하지 않는다. 작업지시자 승인 후 GitHub Issue로 분리 등록한다.
+작업지시자 승인 후 parent issue #407 및 native sub-issue #408-#413으로 등록했다.
+
+| 이슈 | 제목 | 성격 |
+|------|------|------|
+| #407 | external image context ABI 후속 구현 추적 | parent/umbrella |
+| #408 | RustBridge external image context C ABI 구현 | RustBridge ABI |
+| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | Swift wrapper/Quick Look |
+| #410 | CoreGraphics `ImageNode.externalPath`와 missing/decode diagnostic 보강 | Swift renderer |
+| #411 | Thumbnail external resource cache signature와 prepared request 적용 | Finder Thumbnail cache |
+| #412 | external/large image fixture suite와 visual regression 측정 | fixture/verification |
+| #413 | HostApp WKWebView external image bridge 설계 | viewer-app 후속 설계 |
 
 ### 1. RustBridge external image context C ABI 구현
 
@@ -447,9 +457,9 @@ PR 게시 전 상태:
 - Stage 1-4 조사/설계 보고서 작성 완료
 - Stage 5 최종 보고서 작성 완료
 - 제품 코드 변경 없음
-- 후속 구현 이슈는 초안만 작성했고 등록하지 않음
-- PR 게시에는 작업지시자 승인 후 `publish/task391` 브랜치와 PR 생성 단계가 필요
+- 후속 구현 이슈는 #407 parent와 #408-#413 native sub-issue로 등록 완료
+- 작업지시자 승인 후 `publish/task391` 브랜치와 PR 생성 단계로 진행
 
 ## 작업지시자 승인 요청
 
-Task #391의 filename/external image context ABI 조사와 bridge 설계를 완료했다. PR 게시 단계 진입 여부와 후속 구현 이슈 등록 여부를 승인해 달라.
+Task #391의 filename/external image context ABI 조사와 bridge 설계를 완료했고, 후속 구현 이슈도 #407 parent와 #408-#413 native sub-issue로 등록했다. PR 게시 단계에서 본 결과를 제출한다.

--- a/mydocs/report/task_m020_391_report.md
+++ b/mydocs/report/task_m020_391_report.md
@@ -1,0 +1,455 @@
+# Task #391 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | #391 `filename/external image context ABI 조사 및 bridge 설계` |
+| 연결 이슈 | #404 upstream 렌더 PR 대표 샘플 diff 측정, #396 visual suite, #387 Skia readiness |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 단계 수 | 5 |
+| 작업 브랜치 | `local/task391` |
+
+`edwardkim/rhwp` upstream의 filename context, external image refs, external bytes injection 계약을 조사하고, 알한글 Quick Look/Thumbnail/HostApp native 경로에 필요한 RustBridge C ABI와 Swift/macOS 책임 경계를 설계했다.
+
+최종 판단은 "upstream 개선만으로는 자동 반영되지 않는다"이다. upstream에는 `HwpDocument` 기준 filename 설정, external reference JSON, key-based injection API가 있으나, 현재 다운스트림 RustBridge C ABI는 `rhwp_open(data,len)`, `rhwp_render_tree_json`, `rhwp_image_data(binDataId)`만 노출한다. Swift 모델도 `ImageNode.externalPath`를 decode하지 않고, bytes가 없거나 decode에 실패한 image는 CoreGraphics renderer에서 조용히 생략될 수 있다.
+
+따라서 후속 구현은 `RustBridge additive ABI`와 `Swift resolver/renderer/cache`를 분리해 진행하는 것이 안전하다. Quick Look Preview는 cache 구조 영향이 작으므로 1차 적용 후보이고, Finder Thumbnail은 external resource signature가 cache key에 들어간 뒤 resolver를 켜야 한다. WKWebView bundled `rhwp-studio` 경로는 native ABI 적용과 다른 host bridge 이슈로 분리한다.
+
+제품 Swift/Rust source, `rhwp-core.lock`, sample fixture, build artifact는 변경하지 않았다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/plans/task_m020_391.md` | #391 수행계획서 |
+| `mydocs/plans/task_m020_391_impl.md` | Stage 1-5 구현계획서 |
+| `mydocs/working/task_m020_391_stage1.md` | current ABI와 image data 계약 inventory |
+| `mydocs/working/task_m020_391_stage2.md` | upstream external resource contract 조사 |
+| `mydocs/working/task_m020_391_stage3.md` | external image ABI 후보 설계 |
+| `mydocs/working/task_m020_391_stage4.md` | macOS external resource 책임 경계 설계 |
+| `mydocs/report/task_m020_391_report.md` | 본 최종 보고서와 후속 이슈 초안 |
+| `mydocs/orders/20260710.md` | #391 오늘할일 상태 갱신 |
+
+최종 diff는 문서 변경만 포함한다.
+
+## 단계 요약
+
+| Stage | 커밋 | 요약 |
+|------|------|------|
+| 계획 | `4c85fa3`, `0fa15da` | 수행계획서, 오늘할일, 구현계획서 작성 |
+| Stage 1 | `e3afbba` | current ABI와 Swift image render 계약 inventory |
+| Stage 2 | `3421a32` | upstream filename/external image refs/injection 계약 조사 |
+| Stage 3 | `daa245f` | RustBridge additive C ABI와 Swift wrapper 후보 설계 |
+| Stage 4 | `3fa98dd` | Quick Look/Thumbnail/HostApp 책임 경계와 resolver/cache 정책 설계 |
+| Stage 5 | 이번 커밋 | 최종 보고서 작성과 후속 이슈 초안 정리 |
+
+## 핵심 결론
+
+| 질문 | 최종 판단 |
+|------|-----------|
+| upstream parser/renderer가 external image를 더 잘 처리하면 다운스트림도 자동 반영되는가 | current ABI에서는 제한적이다. embedded `binDataId -> bytes`가 기존 shape로 들어오는 경우만 자동 반영 후보이며, external refs/injection은 C ABI에 없다. |
+| filename context가 필요한가 | 필요하다. upstream `HwpDocument`는 filename context와 external refs cache invalidation을 제공하지만, 현재 `rhwp_open(data,len)` 호출에는 filename이 들어가지 않는다. |
+| external image bytes는 누가 찾고 읽어야 하는가 | Swift/macOS shell이 source URL 권한, path policy, bytes read, cache signature를 소유해야 한다. RustBridge/core가 product path에서 filesystem을 직접 읽지 않는다. |
+| Swift renderer 보강이 필요한가 | 필요하다. `ImageNode.externalPath` additive decode, missing external placeholder, decode failure diagnostic이 필요하다. |
+| Thumbnail에 바로 resolver를 켜도 되는가 | 안 된다. current cache key에 external file state가 없으므로 stale thumbnail 위험이 있다. prepared request 또는 external refs cache bypass가 선행되어야 한다. |
+| WKWebView `rhwp-studio`에도 같은 방식으로 적용되는가 | 아니다. bundled studio WASM에는 upstream API가 있지만 macOS host가 external bytes를 전달하는 JS bridge가 없으므로 별도 이슈가 필요하다. |
+
+## Stage 1 current ABI inventory
+
+확인한 current downstream 계약은 다음과 같다.
+
+| 영역 | 현 상태 | 영향 |
+|------|---------|------|
+| Swift open API | `RhwpDocument(data:filename:)` | filename은 Swift error/title/log context로만 쓰이고 FFI에는 전달되지 않는다. |
+| RustBridge handle | `DocumentCore` opaque handle | upstream `wasm_api::HwpDocument`의 filename/external refs/injection API를 직접 쓸 수 없다. |
+| C ABI | `rhwp_open(data,len)` | source filename, base directory, external resource context가 없다. |
+| image data lookup | `rhwp_image_data(handle, binDataId)` | bytes nil 이유가 embedded missing인지 external missing인지 decode failure인지 구분되지 않는다. |
+| Swift render tree | `ImageNode.binDataId` 중심 | `externalPath` 필드가 모델에 없다. |
+| CoreGraphics renderer | bytes nil/decode fail 시 image 생략 가능 | visual diff나 diagnostic 없이는 누락이 조용히 지나갈 수 있다. |
+| Quick Look/Thumbnail | main file URL에서 bytes만 읽어 document open | sibling/external image lookup과 injection 지점이 없다. |
+| Thumbnail cache | main file path/mtime/size/pixel/render signature | external file 변경을 cache key가 반영하지 못한다. |
+
+## Stage 2 upstream contract
+
+현재 lock 기준은 `rhwp v0.7.17`, commit `03351190ec35436e58cbfee0aa9278a8fdc04a59`, feature `native-skia`다.
+
+external resource와 관련해 확인한 upstream 흐름은 다음과 같다.
+
+| upstream PR/흐름 | 내용 | 다운스트림 의미 |
+|------------------|------|-----------------|
+| #1174 | filename context와 cache invalidation | C ABI에 filename setter 또는 open context가 필요하다. |
+| #1175 | external refs JSON: `key`, `binDataId`, `originalPath`, `basename`, `extension`, `loaded` | Swift resolver가 읽을 reference list의 기준 shape다. |
+| #1185 | `injectExternalImageByKey`와 missing/injected diagnostic | Swift가 bytes를 읽은 뒤 core state에 명시 주입해야 한다. |
+| #1913 | external BinData Link roundtrip preservation | external image 문서가 더 정확히 보존될 가능성이 높아진다. 다운스트림 ABI 없이는 render에는 반영되지 않는다. |
+| #1917/#1924 | large BinData limit 확대 | large image fixture와 size cap 정책을 downstream에서 별도 검증해야 한다. |
+| #1927 | BinData load failure placeholder pic preservation | missing placeholder와 diagnostic을 Swift renderer가 표현할 준비가 필요하다. |
+| #1930 | `imgDim` preservation | image geometry가 더 정확해질 수 있으나 renderer replay 정합성 검증이 필요하다. |
+| #2040 | BinData storage id max+1, position과 storage id 분리 | `binDataId`를 storage id로 오해하지 말고 render lookup id로 취급해야 한다. |
+
+중요한 설계 포인트는 upstream의 public API가 `wasm_api::HwpDocument`에 이미 모여 있다는 점이다. current RustBridge가 `DocumentCore`를 handle로 들고 있어 이 surface를 노출하지 못하는 것이 downstream gap이다.
+
+## Stage 3 ABI 설계 결론
+
+권장 후보는 `RhwpHandle` 내부를 `DocumentCore`에서 `rhwp::wasm_api::HwpDocument`로 전환하고, additive C ABI를 노출하는 방식이다.
+
+후보 C ABI:
+
+```c
+RhwpExternalImageStatus rhwp_set_file_name_utf8(
+    RhwpHandle *handle,
+    const uint8_t *name,
+    uintptr_t name_len
+);
+
+char *rhwp_external_image_refs_json(RhwpHandle *handle);
+
+RhwpExternalImageStatus rhwp_inject_external_image_by_key(
+    RhwpHandle *handle,
+    const uint8_t *key,
+    uintptr_t key_len,
+    const uint8_t *data,
+    uintptr_t data_len,
+    const uint8_t *display_path,
+    uintptr_t display_path_len
+);
+
+char *rhwp_image_state_json(RhwpHandle *handle, uint32_t bin_data_id);
+```
+
+보조 후보:
+
+| 후보 | 판단 |
+|------|------|
+| `rhwp_open_with_context` | filename 전달에는 유용하지만 external bytes injection을 대체하지 못하므로 보조 API다. |
+| `rhwp_populate_external_images_from_dir` 직접 노출 | core가 filesystem을 읽게 되므로 macOS sandbox, privacy, cache 책임 경계와 맞지 않아 제품 기본 경로에서 제외한다. |
+| `DocumentCore` public API upstream 요청 | `HwpDocument` handle 전환이 어렵다는 compile spike 결과가 있을 때만 후순위로 검토한다. |
+
+Swift wrapper 후보:
+
+- `RhwpExternalImageReference`
+- `RhwpExternalImageStatus`
+- `RhwpDocumentOpenContext`
+- `RhwpExternalResourceResolution`
+- `RhwpExternalResourceReport`
+- `ImageNode.externalPath` additive decode
+
+상태 구분은 Rust/core가 `embedded`, `external`, `missing`, `injected`를 보고하고, Swift renderer가 `decodeFailed`를 별도로 보고하는 구조가 적절하다.
+
+## Stage 4 macOS 책임 경계
+
+최종 책임 분리는 다음과 같이 고정한다.
+
+| 계층 | 책임 |
+|------|------|
+| Swift/macOS shell | source URL 권한, external path policy, sibling candidate resolution, bytes read, cache signature, privacy-safe logging |
+| RustBridge/core | filename context, external refs enumeration, explicit bytes injection, render tree/image data export |
+| Swift renderer | injected document state replay, `externalPath` placeholder, decode failure diagnostic |
+| Thumbnail cache | external resource signature 포함 또는 external refs 문서 cache bypass |
+| WKWebView host bridge | bundled studio에 external bytes를 전달하는 별도 JS/native bridge |
+
+v1 path resolver 정책:
+
+1. `sourceURL`이 없으면 resolver disabled.
+2. file URL이 아니면 resolver disabled.
+3. `reference.basename` 또는 `originalPath`에서 basename만 추출한다.
+4. 빈 이름, `.`, `..`, path separator 포함 이름은 reject한다.
+5. 후보는 source document parent directory의 sibling file 하나로 제한한다.
+6. standardized/resolved path가 source parent 밖으로 나가면 reject한다.
+7. directory와 size cap 초과 file은 reject한다.
+8. read 성공 bytes만 `rhwp_inject_external_image_by_key`로 주입한다.
+
+명시 금지:
+
+- `originalPath` absolute path를 그대로 열지 않는다.
+- Windows drive path, UNC/network path, URL string을 접근 경로로 해석하지 않는다.
+- symlink traversal로 source parent 밖 파일을 읽지 않는다.
+- renderer나 RustBridge가 filesystem에 직접 접근하지 않는다.
+
+## 기존 다운스트림 보정 후보와의 연결
+
+#404에서 정리한 upstream 렌더 후보 축 중 #391은 `external/large image data` 축을 구체화한 작업이다. 나머지 축은 관련 맥락으로 유지하되 #391 구현 범위에는 넣지 않는다.
+
+| 후보 축 | 관련 upstream/관찰 | #391과의 관계 |
+|---------|--------------------|---------------|
+| RawSvg/차트 | upstream #1890 계열. Swift `RawSvg`는 단일 raster image data URL 중심이고 일반 SVG vector는 fallback risk가 있다. | external image ABI와 별개다. chart가 external image bytes를 참조하는 exact fixture가 확인될 때만 resolver와 함께 측정한다. |
+| HWP3 group/shape/transform | upstream #1905 계열. Swift `GroupNode`에는 group transform 필드가 없고 renderer도 group-level transform을 적용하지 않는다. | external image ABI와 별개다. image bbox/clip과 겹칠 수 있으므로 visual suite에서만 함께 관찰한다. |
+| 미주 배치/구분선 | upstream #1875 계열. core가 Line/TextRun 좌표로 내보내면 자동 반영 후보지만 order/clip 확인이 필요하다. | external image ABI 범위 밖이다. diagnostic/report 구조만 공유 가능하다. |
+| 그림 wrap/TAC 높이/글리프 가드 | upstream #1881 계열. layout 좌표는 자동 반영 후보지만 CoreText/clip/table cell slack 차이가 남을 수 있다. | image fixture에서 clip과 external missing이 동시에 나타날 수 있어 #396 visual suite에서 교차 검증한다. |
+| PDF font option/수식 SVG font | upstream #1895 계열. 알한글 Quick Look/Thumbnail에는 직접 반영되지 않지만 equation SVG parser와 font fallback 검증은 필요하다. | external image ABI와 별개다. Swift renderer diagnostic 방식만 재사용 가능하다. |
+
+## 후속 이슈 초안
+
+아래 초안은 즉시 등록하지 않는다. 작업지시자 승인 후 GitHub Issue로 분리 등록한다.
+
+### 1. RustBridge external image context C ABI 구현
+
+목적:
+
+- upstream `HwpDocument`의 filename context, external refs, key-based injection을 macOS Swift에서 호출 가능한 C ABI로 노출한다.
+
+배경:
+
+- current `RhwpHandle`은 `DocumentCore`를 들고 있어 `setFileName`, `getExternalImageRefs`, `injectExternalImageByKey` 계열 upstream API를 노출하지 못한다.
+- #1913, #1927 등 upstream external BinData preservation 개선은 이 ABI 없이는 Quick Look/Thumbnail native render에 충분히 반영되지 않는다.
+
+범위:
+
+- `RhwpHandle` 내부 타입을 `HwpDocument`로 전환하는 compile spike와 regression 확인
+- `rhwp_set_file_name_utf8`
+- `rhwp_external_image_refs_json`
+- `rhwp_inject_external_image_by_key`
+- optional `rhwp_image_state_json`
+- generated C header와 `rhwp-ffi-symbols.txt` 갱신
+- Swift wrapper가 소비할 status enum과 memory ownership 문서화
+
+검증:
+
+- RustBridge build/test
+- C header generation
+- symbol list diff
+- Swift package/app compile
+- embedded image 기존 fixture regression 없음
+
+제외:
+
+- Swift path resolver 구현
+- Quick Look/Thumbnail UI 변경
+- upstream API 변경 요청
+
+### 2. Swift external image wrapper/resolver와 Quick Look Preview 적용
+
+목적:
+
+- Quick Look Preview에서 source document sibling external image를 안전하게 찾아 RustBridge에 injection한다.
+
+배경:
+
+- Preview는 `QLFilePreviewRequest.fileURL`을 갖고 있고, document open 직후 page count/size/render 전에 resolver를 실행할 수 있어 1차 적용 surface로 적합하다.
+
+범위:
+
+- `RhwpDocumentOpenContext`
+- `RhwpExternalImageReference` JSON decode
+- `RhwpExternalResourceResolution`과 report summary
+- v1 basename-only sibling resolver
+- `RhwpDocument(data:context:)` 또는 동등한 open helper
+- `HwpPreviewPDFRenderer.load(fileURL:)` 적용
+- permission denied, missing, invalid basename, too large diagnostic
+
+검증:
+
+- external image fixture Preview smoke
+- source URL 없음 또는 dropped bytes resolver disabled
+- privacy-safe log 확인
+- page count/page size/render가 injection 후 호출되는지 확인
+
+제외:
+
+- Thumbnail cache 변경
+- HostApp WKWebView bridge
+- directory recursive lookup
+
+### 3. CoreGraphics `ImageNode.externalPath`와 missing/decode diagnostic 보강
+
+목적:
+
+- render tree에 external image metadata가 남는 경우 Swift renderer가 missing external image와 decode failure를 구분해 표현한다.
+
+배경:
+
+- current Swift `ImageNode`는 `binDataId` 중심이고 `externalPath`를 decode하지 않는다.
+- `rhwp_image_data`가 nil이면 embedded missing과 external missing을 구분할 수 없고, decode 실패도 render 결과에서 조용히 누락될 수 있다.
+
+범위:
+
+- `ImageNode.externalPath` additive decode
+- bytes nil + `externalPath != nil` placeholder
+- bytes 있음 + decode failure diagnostic
+- user-facing placeholder에서 full original path 숨김
+- render diagnostics에 external missing/decode failed count 추가
+
+검증:
+
+- embedded image 기존 fixture regression 없음
+- missing external fixture placeholder 확인
+- decode failure fixture가 render 전체 실패로 올라가지 않는지 확인
+- visual suite metric에 non-white/placeholder sanity 추가
+
+제외:
+
+- full SVG engine 도입
+- Skia placeholder rendering 변경
+
+### 4. Thumbnail external resource cache signature와 prepared request 적용
+
+목적:
+
+- Finder Thumbnail에서 external resource 변경이 stale cache로 남지 않도록 cache key와 render flow를 조정한다.
+
+배경:
+
+- current `HwpThumbnailCacheKey`는 main file path/mtime/size/pixel/render signature만 포함한다.
+- external resolver를 이 상태에서 켜면 sibling image 변경 후에도 오래된 thumbnail이 재사용될 수 있다.
+
+범위:
+
+- document open + external refs enumeration 이후 cache lookup하는 prepared request flow 검토
+- `RhwpExternalResourceCacheSignature`
+- decision, basename, file size, mtime 기반 v1 signature
+- external refs 문서 cache bypass fallback 정책
+- cache log/diagnostic에 external signature 요약 추가
+
+검증:
+
+- external file mtime/size 변경 시 cache miss
+- external refs 없는 문서는 기존 cache behavior 유지
+- missing/rejected 상태도 cache key에 반영
+- Thumbnail smoke 8회 request 안정성 유지
+
+제외:
+
+- byte hash 필수화
+- directory mtime broad key
+- recursive lookup
+
+### 5. external/large image fixture suite와 visual regression 측정
+
+목적:
+
+- upstream external/large image 개선이 알한글 native render에 실제로 반영되는지 fixture 기반으로 측정한다.
+
+배경:
+
+- #404에서 external BinData Link, large BinData, placeholder exact fixture는 미측정으로 남았다.
+- #1913, #1917/#1924, #1927, #1930, #2040 변화는 ABI 구현 전후 regression suite가 필요하다.
+
+범위:
+
+- external BinData Link exact fixture 확보
+- large BinData fixture size cap 정책
+- missing placeholder fixture
+- sparse/storage id와 render `binDataId` 분리 fixture
+- CoreGraphics/Skia/SVG render-debug 비교
+- Quick Look/Thumbnail smoke 편입
+
+검증:
+
+- injected/missing 상태별 visual artifact 생성
+- `binDataId`를 storage id로 오해하지 않는 lookup 검증
+- large image memory/latency smoke
+- #396 visual suite에 metric 연결
+
+제외:
+
+- fixture 라이선스/개인정보 확인 전 repository 편입
+- upstream sample 무조건 vendoring
+
+### 6. HostApp WKWebView external image bridge 설계
+
+목적:
+
+- bundled `rhwp-studio` WASM 경로에서도 external refs를 native host permission model과 연결할 수 있는지 설계한다.
+
+배경:
+
+- upstream studio JS API에는 filename/external refs/injection이 있으나, current HostApp document scheme은 main document bytes만 제공하고 resource scheme은 bundled assets만 제공한다.
+- native Quick Look/Thumbnail ABI와 WKWebView JS bridge는 적용 지점이 다르다.
+
+범위:
+
+- WKScriptMessageHandler 또는 custom scheme 기반 external refs request 설계
+- security-scoped URL 보유 문서와 dropped bytes 문서 분리
+- native resolver report를 JS에 전달하는 shape
+- full path privacy와 user-facing permission UX
+
+검증:
+
+- opened file 경로에서 sibling external image injection
+- dropped bytes resolver disabled
+- no network/no arbitrary file access 확인
+
+제외:
+
+- #391 1차 native Quick Look/Thumbnail 구현 범위
+- bundled `rhwp-studio` 대규모 수정
+
+## 구현 권장 순서
+
+1. RustBridge additive ABI 구현 spike
+2. Swift wrapper와 `RhwpDocumentOpenContext` 추가
+3. Quick Look Preview resolver 적용
+4. CoreGraphics `externalPath` placeholder/diagnostic 적용
+5. Thumbnail prepared request 또는 cache bypass 선택 후 cache signature 반영
+6. HostApp native PDF export에 source URL context 전달
+7. external/large fixture suite와 visual regression 측정
+8. WKWebView external image bridge 별도 설계
+
+Quick Look Preview를 먼저 잡는 이유는 cache correctness 부담이 작고, single opened document에 injected state를 유지하기 쉽기 때문이다. Thumbnail은 cache key 설계 없이는 제품 품질을 해칠 수 있으므로 별도 단계가 필요하다.
+
+## 잔여 위험과 처리
+
+| 항목 | 상태 | 처리 |
+|------|------|------|
+| `HwpDocument` handle 전환 compile risk | 잔여 | RustBridge ABI 구현 이슈에서 spike로 먼저 검증 |
+| upstream API shape drift | 잔여 | `rhwp-core.lock` 갱신 시 external refs JSON contract 재검증 |
+| Thumbnail stale cache | 중요한 잔여 | resolver 적용 전 external cache signature 선행 |
+| path privacy/logging | 중요한 잔여 | full original path는 user-facing surface와 public log에서 숨김 |
+| sandbox permission variation | 잔여 | Quick Look/Thumbnail/HostApp surface별 smoke 필요 |
+| exact external fixture 부재 | 잔여 | fixture suite 이슈에서 확보 후 측정 |
+| large image memory/latency | 잔여 | size cap과 byte hash 비용을 별도 측정 |
+| `binDataId` storage id 오해 | 잔여 | #2040 반영 fixture로 render lookup id 기준 검증 |
+| WKWebView 적용 범위 | 후속 | native ABI와 별도 bridge 이슈로 분리 |
+
+## 지금 하지 않을 작업
+
+| 항목 | 이유 |
+|------|------|
+| RustBridge ABI 구현 | #391은 조사/설계 이슈다. 구현은 후속 이슈로 분리한다. |
+| Swift renderer 수정 | externalPath shape와 ABI가 확정된 뒤 적용한다. |
+| Thumbnail resolver 즉시 적용 | current cache key가 external file state를 반영하지 못한다. |
+| HostApp WKWebView bridge 구현 | native Quick Look/Thumbnail path와 적용 방식이 달라 별도 설계가 필요하다. |
+| Skia default 전환 | #387/#390/#404 판단에 따라 CoreGraphics default + Skia opt-in diagnostic 상태를 유지한다. |
+| upstream exact fixture 편입 | 라이선스, 크기, 개인정보, 재현성 검토와 작업지시자 승인이 먼저 필요하다. |
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| current ABI/source `rg` 조사 | 통과. Swift open path, RustBridge handle, image lookup, renderer nil 처리, Thumbnail cache key 확인 |
+| upstream PR/API `gh pr view`와 source 조사 | 통과. #1174/#1175/#1185, #1913/#1917/#1924/#1927/#1930/#2040 연결 확인 |
+| `gh issue view` 계열 | 통과. #387/#390/#404/#396/#392/#389 연결 맥락 확인 |
+| Stage 3 ABI 후보 문서 검토 | 통과. `HwpDocument` handle 전환 + additive C ABI를 권장안으로 확정 |
+| Stage 4 macOS surface inventory | 통과. Quick Look, Thumbnail, HostApp WKWebView/native export 책임 경계 확인 |
+| `rg -n "#391\|filename\|external\|BinData\|C ABI\|Swift wrapper\|Quick Look\|Thumbnail\|후속\|residual\|#387\|#390\|#404" ...` | 통과. 최종 보고서와 오늘할일에 핵심 키워드/연결 이슈 반영 확인 |
+| `rg -n "RustBridge\|HwpDocument\|externalPath\|cache signature\|prepared request\|WKWebView\|fixture\|resolver\|placeholder\|decodeFailed\|binDataId" ...` | 통과. ABI, Swift wrapper, renderer, cache, fixture 후속 항목 반영 확인 |
+| `git diff --check` | 통과 |
+
+## PR 게시 준비 메모
+
+권장 PR 제목:
+
+```text
+Task #391: filename/external image context ABI 조사와 bridge 설계
+```
+
+권장 리뷰 포인트:
+
+- upstream external image 개선이 current downstream ABI에 자동 반영되지 않는다는 판단이 타당한지
+- `HwpDocument` handle 전환 + additive C ABI를 1차 후보로 두는 설계가 적절한지
+- Swift/macOS shell이 path policy와 bytes read를 소유하고 RustBridge/core는 명시 injection만 담당하는 책임 경계가 맞는지
+- Quick Look Preview를 1차 적용, Thumbnail은 cache signature 선행으로 분리하는 순서가 안전한지
+- WKWebView bundled `rhwp-studio` bridge를 native ABI 적용과 별도 이슈로 분리하는 정렬이 적절한지
+- 후속 이슈 초안 6개가 구현 단위로 과도하게 크거나 작지 않은지
+
+PR 게시 전 상태:
+
+- Stage 1-4 조사/설계 보고서 작성 완료
+- Stage 5 최종 보고서 작성 완료
+- 제품 코드 변경 없음
+- 후속 구현 이슈는 초안만 작성했고 등록하지 않음
+- PR 게시에는 작업지시자 승인 후 `publish/task391` 브랜치와 PR 생성 단계가 필요
+
+## 작업지시자 승인 요청
+
+Task #391의 filename/external image context ABI 조사와 bridge 설계를 완료했다. PR 게시 단계 진입 여부와 후속 구현 이슈 등록 여부를 승인해 달라.

--- a/mydocs/working/task_m020_391_stage1.md
+++ b/mydocs/working/task_m020_391_stage1.md
@@ -1,0 +1,188 @@
+# Task M020 #391 Stage 1 보고서
+
+단계: Stage 1 `현재 app ABI와 image data 계약 inventory`
+
+## 요약
+
+- 현재 Swift shell은 문서 `fileURL`을 알고 있지만 RustBridge에는 문서 bytes와 `filename` 중 bytes만 전달한다.
+- `RhwpDocument(data:filename:)`의 `filename`은 parse 실패 에러 메시지, Quick Look title/log, HostApp display name에만 쓰이고 `rhwp_open` 호출에는 들어가지 않는다.
+- RustBridge current open ABI는 `rhwp_open(data,len)`뿐이며 내부에서 `DocumentCore::from_bytes(bytes)`를 호출한다. base path, absolute path, package URL, resource resolver, diagnostic channel은 없다.
+- Swift render tree image model은 `ImageNode.bin_data_id`를 중심으로 `rhwp_image_data(handle, bin_data_id, out_len)`를 조회한다. external path/ref/status를 담는 필드는 없다.
+- CoreGraphics renderer는 image byte가 없거나 decode에 실패하면 해당 이미지를 조용히 생략한다. overlay image도 base64 payload 또는 `bin_data_id` bytes가 없으면 fallback을 타지만, fallback 역시 동일한 `rhwp_image_data` 계약에 묶인다.
+- Quick Look/Thumbnail extension은 sandbox + user-selected read-only entitlement를 갖고 main file URL을 읽는다. sibling/external resource 탐색, injection, cache signature 반영은 현재 없다.
+
+## Current call graph
+
+### Quick Look Preview
+
+1. `HwpPreviewProvider.providePreview`가 `QLFilePreviewRequest.fileURL`을 받는다.
+2. `HwpPreviewPDFRenderer.load(fileURL:)`이 main file을 읽고 `RhwpDocument`를 만든다.
+3. 단일 페이지는 PNG reply, 복수 페이지는 PDF reply로 갈라지지만 같은 `HwpPreviewDocumentContext.document`를 사용한다.
+4. native render path는 `HwpPageImageRenderer.renderPage(document:pageIndex:)`로 들어간다.
+
+근거:
+
+- `Sources/QLExtension/HwpPreviewProvider.swift:12-19` request의 `fileURL`에서 preview context를 생성한다.
+- `Sources/QLExtension/HwpPreviewProvider.swift:41-60` PNG reply title에는 `filename`을 쓰지만 render 입력은 이미 열린 context다.
+- `Sources/QLExtension/HwpPreviewProvider.swift:74-92` PDF reply도 title/log 용도로 `filename`을 사용한다.
+- `Sources/Shared/HwpPreviewPDFRenderer.swift:173-181` main file을 `Data(contentsOf:)`로 읽고 `fileURL.lastPathComponent`를 `RhwpDocument(data:filename:)`에 넘긴다.
+- `Sources/Shared/HwpPreviewPDFRenderer.swift:120-124` PDF 각 페이지 render는 `HwpPageImageRenderer.renderPage(document:pageIndex:)`를 호출한다.
+
+### Finder Thumbnail
+
+1. `HwpThumbnailProvider.provideThumbnail`이 `QLFileThumbnailRequest.fileURL`을 받는다.
+2. `HwpThumbnailRenderRequest`는 cache key에 path, mtime, file size, requested pixel bucket, renderer signature를 넣는다.
+3. cache miss 시 `HwpPageImageRenderer.renderFirstPage(fileURL:)`가 main file을 읽고 `RhwpDocument(data:filename:)`를 만든다.
+
+근거:
+
+- `Sources/ThumbnailExtension/HwpThumbnailProvider.swift:12-25` request file URL과 maximum size를 render request로 만든다.
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift:19-36` cache key는 main file path, modification time, file size, pixel bucket, render signature로 구성된다.
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift:190-197` cache miss render는 `HwpPageImageRenderer.renderFirstPage(fileURL:...)`로 위임한다.
+- `Sources/Shared/HwpPageImageRenderer.swift:120-141` main file을 `Data(contentsOf:)`로 읽고 `fileURL.lastPathComponent`를 wrapper에 전달한다.
+
+### HostApp
+
+1. `DocumentViewerStore.loadDocument(from:)`는 file URL에 대해 security-scoped access를 시작하고 main file bytes를 읽는다.
+2. store state는 `RhwpStudioDocumentPayload(data, filename, revision)`만 보관한다.
+3. 현재 MVP viewer는 bundled `rhwp-studio` WKWebView 중심이다. native PDF export만 `RhwpDocument(data:filename:)`를 직접 사용한다.
+
+근거:
+
+- `Sources/HostApp/Stores/DocumentViewerStore.swift:43-64` HostApp은 URL에 대해 `startAccessingSecurityScopedResource()` 후 `Data(contentsOf:)`를 읽고 basename만 보존한다.
+- `Sources/HostApp/Stores/DocumentViewerStore.swift:188-203` store payload는 `data`, `filename`, `revision`만 갖는다.
+- `Sources/HostApp/Services/RhwpStudioDocumentPayload.swift:3-7` payload model에 source URL/base directory는 없다.
+- `Sources/HostApp/Services/RhwpStudioPDFExportController.swift:49-65` native PDF export는 payload data와 filename으로 `RhwpDocument`를 다시 연다.
+
+## Current RustBridge ABI
+
+| Symbol | 역할 | filename/external context 관점 |
+|--------|------|--------------------------------|
+| `rhwp_open(data,len)` | bytes에서 `DocumentCore` 생성 | filename/base path 인자가 없다. |
+| `rhwp_render_page_tree(handle,page)` | page render tree JSON 반환 | image node가 external ref/status를 표현하는지는 upstream JSON shape에 전적으로 의존한다. |
+| `rhwp_page_overlay_images(handle,page)` | overlay compact JSON 반환 | compact JSON 자체에는 `binDataId`가 없고 Swift가 render tree supplement로 보강한다. |
+| `rhwp_image_data(handle,bin_data_id,out_len)` | embedded BinData bytes 조회 | 1-indexed id 조회만 가능하다. missing 이유는 구분하지 않는다. |
+| `rhwp_render_page_png(handle,page,...)` | Skia PNG export | export options에 font paths만 있고 document filename/resource context는 없다. |
+
+근거:
+
+- `rhwp-ffi-symbols.txt:1-12` exported symbol 목록에는 open context, external refs, bytes injection, diagnostic API가 없다.
+- `RustBridge/src/lib.rs:101-116` `rhwp_open`은 data pointer/length만 검사하고 `DocumentCore::from_bytes(bytes)`를 호출한다.
+- `RustBridge/src/lib.rs:151-163` render tree JSON은 `build_page_render_tree(page)` 결과의 root만 문자열화한다.
+- `RustBridge/src/lib.rs:165-174` overlay compact JSON은 `get_page_overlay_images_native(page)` 결과를 그대로 반환한다.
+- `RustBridge/src/lib.rs:215-225` Skia PNG export options에는 scale, max_dimension, `font_paths`만 있으며 document file context는 없다.
+- `RustBridge/src/lib.rs:247-271` image data는 `bin_data_id == 0`을 invalid로 보고 `(bin_data_id - 1)` index로 `get_bin_data`를 조회한다.
+- `rhwp-core.lock:3-8` 현재 core는 release tag `v0.7.17`, commit `03351190ec35436e58cbfee0aa9278a8fdc04a59`, feature `native-skia` 기준이다.
+
+## Swift image data contract
+
+### Render tree image node
+
+`RenderTree.swift`의 `ImageNode`는 embedded BinData id와 render 속성을 담는다. Stage 1 기준으로 path, URI, external link target, missing reason, resource id 같은 필드는 없다.
+
+근거:
+
+- `Sources/RhwpCoreBridge/RenderTree.swift:303-328` `ImageNode`는 `bin_data_id`, section/para/control index, fill/effect/brightness/contrast/textWrap/transform/crop 등을 디코딩한다.
+- `Sources/RhwpCoreBridge/RenderTree.swift:386-395` `PlaceholderNode`는 label과 색상만 있고 image missing diagnostic과 연결되는 필드는 없다.
+
+### `RhwpDocument.imageData`
+
+Swift wrapper는 `rhwp_image_data`가 반환한 pointer를 즉시 Swift `Data`로 복사한다. pointer ownership은 Rust `DocumentCore` 내부 lifetime에 의존하고 Swift가 free하지 않는다.
+
+근거:
+
+- `Sources/RhwpCoreBridge/RhwpDocument.swift:194-200` `imageData(binDataId:)`는 pointer와 길이를 받아 `Data(bytes:count:)`로 복사한다.
+- `Sources/RhwpCoreBridge/RhwpDocument.swift:203-213` availability 확인도 같은 `rhwp_image_data` call 결과가 nil/0인지로만 판단한다.
+
+### Overlay image path
+
+Overlay compact JSON은 base64 image bytes를 직접 담을 수 있지만, compact payload에는 `binDataId`가 없다. Swift는 render tree를 순회해 layer+bbox로 supplement를 붙인다.
+
+근거:
+
+- `Sources/RhwpCoreBridge/PageOverlayImages.swift:81-94` overlay source는 `data`, `base64Length`, optional `binDataId`, optional `binDataAvailable`만 갖는다.
+- `Sources/RhwpCoreBridge/PageOverlayImages.swift:166-183` compact JSON decode가 실패하거나 없으면 render tree supplement만으로 fallback image set을 만든다.
+- `Sources/RhwpCoreBridge/PageOverlayImages.swift:245-257` compact payload model은 base64를 `Data`로 decode하며 `binDataId`는 nil로 둔다.
+- `Sources/RhwpCoreBridge/PageOverlayImages.swift:316-340` supplement는 render tree `ImageNode.binDataId`와 `document.hasImageData`로 availability를 계산한다.
+- `Sources/RhwpCoreBridge/PageOverlayImages.swift:352-369` compact overlay JSON에는 `binDataId`가 없어 bbox/layer 매칭으로 보강한다는 주석과 구현이 있다.
+
+## Renderer missing data behavior
+
+### 일반 ImageNode
+
+CoreGraphics renderer는 `binDataId == 0`, document 없음, `rhwp_image_data` nil, image decode 실패를 모두 "그리지 않음"으로 처리한다. 사용자에게 보이는 placeholder 또는 diagnostic은 이 레이어에서 생성하지 않는다.
+
+근거:
+
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:756-767` `renderImage`는 `doc.imageData` 또는 `decodeImage` 실패 시 즉시 return한다.
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:851-857` decode는 ImageIO 또는 PCX decode만 시도한다.
+
+### Overlay image
+
+Overlay compositor는 renderable overlay가 있으면 `renderOverlayImages`를 먼저 시도하고 draw count가 0이면 render tree page overlay layer로 fallback한다. 그러나 fallback layer의 image drawing도 결국 `renderImage`와 같은 `rhwp_image_data` 계약을 사용한다.
+
+근거:
+
+- `Sources/Shared/HwpNativePageCompositor.swift:55-84` renderable overlay가 없거나 draw count가 0이면 page overlay layer를 render tree로 다시 그린다.
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:828-849` overlay image decode는 inline data를 먼저 보고, 없으면 `binDataId`로 `document.imageData`를 조회한다.
+
+### RawSvg
+
+RawSvg는 external image ABI와 별개지만 #404 downstream 보정 후보와 연결된다. Swift renderer는 single image data URL만 decode하고 일반 SVG vector나 SVG image reference는 fallback 박스로 간다.
+
+근거:
+
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:1519-1531` RawSvg 크기/limit 검사 또는 single image decode 실패 시 fallback을 그린다.
+- `Sources/RhwpCoreBridge/CGTreeRenderer.swift:1539-1559` data URL이 `image/*`이면서 `image/svg+xml`이 아니고 base64인 경우만 image data로 decode한다.
+
+## Sandbox and file access observations
+
+- Quick Look과 Thumbnail extension entitlements는 app sandbox와 user-selected read-only만 선언한다.
+- extension 코드에는 external sibling file lookup, security-scoped resource open/close, relative path resolver가 없다.
+- HostApp은 user-selected file URL에 대해 security-scoped access를 시작하지만, 현재 source URL/base directory를 document payload나 RustBridge handle에 유지하지 않는다.
+- Thumbnail cache key는 main file path/mtime/file size만 보므로 future external image context가 들어오면 external resource signature 또는 injected bytes signature가 cache key에 추가되어야 한다.
+
+근거:
+
+- `Sources/QLExtension/QLExtension.entitlements:5-8` Quick Look extension sandbox와 read-only file entitlement.
+- `Sources/ThumbnailExtension/ThumbnailExtension.entitlements:5-8` Thumbnail extension sandbox와 read-only file entitlement.
+- `Sources/HostApp/Stores/DocumentViewerStore.swift:50-64` HostApp open path는 security-scoped access 안에서 main file만 읽는다.
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift:29-36` thumbnail cache key에는 external resource 상태가 없다.
+
+## Current limitations
+
+1. Filename context 부재
+   - Swift wrapper initializer는 `filename`을 받지만 FFI call에는 넣지 않는다.
+   - RustBridge handle은 `DocumentCore`만 보관한다.
+   - 따라서 core가 relative external resource를 열려면 필요한 base directory나 original filename을 알 수 없다.
+
+2. External resource identity 부재
+   - render tree `ImageNode`는 `bin_data_id`만 표현한다.
+   - Swift model에는 external link target, package-relative path, URI, original BinData name, placeholder reason이 없다.
+
+3. Missing image diagnostic 부재
+   - `rhwp_image_data` nil은 invalid id, missing embedded data, unsupported external link, decode failure 이전 단계 등을 구분하지 않는다.
+   - CoreGraphics renderer는 nil/decode failure를 생략 처리하므로 native PNG에서 조용한 누락이 생길 수 있다.
+
+4. Bytes injection 부재
+   - Swift shell이 sibling file이나 security-scoped file을 읽더라도 RustBridge handle에 주입할 API가 없다.
+   - injection이 생기면 `imageCache` key와 document lifetime, cache invalidation도 같이 설계해야 한다.
+
+5. Surface별 권한 경계 부재
+   - Quick Look/Thumbnail은 Finder가 준 request URL 중심이고 HostApp은 security-scoped URL을 다룬다.
+   - current bridge ABI가 URL을 받지 않으므로 surface별 권한 차이를 표현할 channel도 없다.
+
+## Stage 2 확인 질문
+
+- pinned `rhwp v0.7.17`에 `DocumentCore::from_path`, document context, external resource resolver, BinData link metadata 접근 API가 있는가?
+- upstream issue `edwardkim/rhwp#1141`과 PR `#1913`, `#1924`, `#1917`, `#1930`은 external image를 render tree, SVG, Skia PNG, overlay JSON 중 어디에 표현하는가?
+- upstream이 missing external image를 `PlaceholderNode`로 내보내는가, 아니면 `ImageNode.bin_data_id`만 유지하고 byte data를 비워 두는가?
+- `get_page_overlay_images_native`의 compact JSON에 external/missing 상태를 추가할 계획이 있는가, 아니면 render tree supplement가 계속 필요할까?
+- Skia PNG export는 external resource bytes를 core 내부에서 해결해야 하는가, 아니면 downstream이 injected bytes를 준비해야 하는가?
+- downstream ABI는 filename/base URL만 넘겨도 되는가, 아니면 external refs enumeration + explicit bytes injection이 필요한가?
+
+## Stage 1 판정
+
+현재 downstream ABI만으로는 filename/external image context를 자동 반영할 수 없다. upstream parser가 embedded BinData bytes와 기존 `bin_data_id`/JSON shape를 더 잘 채우는 변경은 자동 반영될 수 있지만, external link를 보존하거나 missing placeholder/diagnostic을 내보내는 변경은 Swift model, C ABI, renderer fallback 정책 중 적어도 하나의 downstream 보강이 필요하다.
+
+Stage 2에서는 pinned release와 upstream external image 관련 이슈/PR을 조사해 "core update만으로 해결되는 embedded/placeholder 개선"과 "downstream context ABI가 필요한 external resource 해결"을 분리한다.

--- a/mydocs/working/task_m020_391_stage2.md
+++ b/mydocs/working/task_m020_391_stage2.md
@@ -1,0 +1,203 @@
+# Task M020 #391 Stage 2 보고서
+
+단계: Stage 2 `upstream rhwp/studio external resource contract 조사`
+
+## 요약
+
+- 현재 pinned core는 `rhwp v0.7.17` / commit `03351190ec35436e58cbfee0aa9278a8fdc04a59` / feature `native-skia` 기준이다.
+- upstream `#1141` 체인은 filename context, external image reference discovery, external image bytes injection을 이미 merged 상태로 제공한다.
+- bundled `rhwp-studio` WASM wrapper도 `setFileName`, `getExternalImageReferences`, `getExternalImageBasenames`, `injectExternalImage`, `injectExternalImageByKey`를 노출한다.
+- pinned source의 native `wasm_api::HwpDocument`에는 위 API가 있지만, 알한글 RustBridge handle은 현재 `DocumentCore`를 직접 보관하므로 C ABI에서는 해당 contract를 사용할 수 없다.
+- upstream render tree `ImageNode`에는 `external_path`가 있고 SVG/WebCanvas/CanvasKit/Skia 계열은 missing external image placeholder 또는 diagnostic을 표현한다. Swift `ImageNode` 모델과 CoreGraphics renderer는 Stage 1 기준으로 이 정보를 받지 못한다.
+- 최근 PR `#1913`, `#1924`, `#1927`, `#1930`, `#2040`은 BinData 보존, 대형 embedded image, placeholder 구조, storage id 정합을 개선한다. embedded bytes가 기존 `bin_data_id`로 채워지는 경우는 core pin update만으로 좋아질 수 있지만, external link bytes 해결과 native placeholder/diagnostic은 downstream C ABI와 Swift renderer 보강이 필요하다.
+
+## 조사 기준
+
+| 항목 | 확인 결과 |
+|------|-----------|
+| downstream pin | `rhwp-core.lock` 기준 `release-tag v0.7.17`, commit `03351190ec35436e58cbfee0aa9278a8fdc04a59`, `native-skia` |
+| Cargo dependency | `RustBridge/Cargo.toml`은 `rhwp` tag `v0.7.17`와 `native-skia` feature를 사용 |
+| bundled studio | `Sources/HostApp/Resources/rhwp-studio/`의 WASM JS binding에 external image/filename API 존재 |
+| upstream 확인일 | 2026-07-10, GitHub CLI로 개별 issue/PR 상태 재확인 |
+| 범위 | 조사/설계 문서화만 수행. RustBridge ABI 구현, framework 재생성, core pin 변경은 제외 |
+
+## Upstream contract 체인
+
+| 항목 | 상태 | #391 의미 |
+|------|------|-----------|
+| `edwardkim/rhwp#1141` | CLOSED | filename context, external image reference discovery, bytes injection/resource resolver 책임 경계를 묶은 parent issue다. 파일 접근 정책은 consumer 책임, core는 명시 전달된 상태만 반영한다는 방향이다. |
+| PR `#1174` | MERGED, 2026-05-30 | `DocumentCore.file_name -> LayoutEngine.set_file_name -> PageRenderTree/PageLayerTree` 경로를 정리하고 filename 변경 시 render tree cache를 무효화한다. |
+| PR `#1175` | MERGED, 2026-05-30 | `getExternalImageReferences()` contract를 추가한다. key, binDataId, originalPath, basename, extension, loaded 상태를 JSON으로 노출한다. |
+| PR `#1185` | MERGED, 2026-05-31 | `injectExternalImageByKey(key,data,displayPath)`와 legacy basename injection을 추가한다. injection 후 cache를 무효화하고 CanvasKit diagnostic에서 external missing/injected 상태를 구분한다. |
+
+### 책임 경계
+
+upstream contract의 핵심은 renderer backend가 임의로 filesystem을 탐색하지 않는다는 점이다.
+
+- consumer: 파일 선택, 권한, path policy, bytes 준비
+- core: discovery key와 BinData id 기준으로 document state 갱신
+- renderer backend: document state를 replay하고 missing/injected 상태를 표현
+
+알한글 macOS에 그대로 적용하면 Quick Look/Thumbnail/HostApp shell이 external resource 후보를 읽고, RustBridge C ABI는 발견 목록과 bytes injection만 받아야 한다. renderer가 sibling path를 직접 열거나 sandbox 밖 파일을 추정해서 읽는 구조는 Stage 3 설계 기본안에서 제외한다.
+
+## Pinned `v0.7.17` source 관찰
+
+### `wasm_api::HwpDocument`
+
+pinned source checkout에서 `src/wasm_api.rs`는 native build에서도 `HwpDocument::from_bytes(data)`를 제공하고 `DocumentCore`로 `Deref/DerefMut`된다. 즉 RustBridge가 handle 내부 타입을 `wasm_api::HwpDocument`로 바꾸면 기존 page/render API를 유지하면서 upstream external API를 감쌀 가능성이 있다.
+
+확인된 public surface:
+
+- `ExternalImageReference` JSON field: `key`, `binDataId`, `originalPath`, `basename`, `extension`, `loaded`
+- `get_external_image_references() -> String`
+- `get_external_image_basenames() -> String`
+- `inject_external_image(basename,data,display_path) -> u32`
+- `inject_external_image_by_key(key,data,display_path) -> u32`
+- `set_file_name(name)`
+
+`injectExternalImageByKey`의 key는 `binData:N` 형태를 지원하고, invalid key, 존재하지 않는 reference, 이미 loaded 상태인 reference는 실패로 취급된다. injection 성공 시 document의 BinData content가 채워지고 display path가 diagnostic/debug용으로 갱신된다.
+
+### `DocumentCore`
+
+현재 알한글 RustBridge가 직접 보관하는 `DocumentCore`에는 Stage 2 기준 다음 차이가 있다.
+
+- public `populate_external_images_from_dir(base_dir)`는 존재한다.
+- filename setter와 structured external reference JSON API는 public `DocumentCore` surface로 보이지 않는다.
+- `Document::inject_external_image_data`는 model 내부 helper이고 RustBridge crate가 직접 호출할 수 있는 public API가 아니다.
+
+따라서 Stage 3 설계안은 세 갈래를 비교해야 한다.
+
+1. RustBridge handle을 `DocumentCore`에서 `wasm_api::HwpDocument`로 바꾸고 public wrapper API를 감싼다.
+2. `DocumentCore::populate_external_images_from_dir`만 C ABI로 노출한다.
+3. upstream에 public `DocumentCore` filename/external refs/injection API를 요청하거나 반영한 뒤 RustBridge handle 구조를 유지한다.
+
+2번은 core가 directory를 직접 읽는 형태라 macOS sandbox 책임 경계와 충돌하기 쉽다. Stage 3의 기본 후보는 1번 또는 3번을 중심으로 잡는 것이 맞다.
+
+## Bundled `rhwp-studio` 관찰
+
+`Sources/HostApp/Resources/rhwp-studio/rhwp_bg.wasm.d.ts`와 `rhwp.js`는 다음 binding을 이미 노출한다.
+
+- `hwpdocument_setFileName`
+- `hwpdocument_getExternalImageBasenames`
+- `hwpdocument_getExternalImageReferences`
+- `hwpdocument_injectExternalImage`
+- `hwpdocument_injectExternalImageByKey`
+
+`rhwp.js`의 high-level method도 같은 이름으로 제공된다. 즉 HostApp WKWebView 기반 MVP는 upstream studio 쪽 API를 쓸 준비가 되어 있지만, native Quick Look/Thumbnail의 Swift CoreGraphics path는 RustBridge C ABI에 같은 symbol이 없어서 동일 contract에 접근하지 못한다.
+
+## Render tree와 missing image 표현
+
+pinned `v0.7.17` source의 render tree `ImageNode`에는 `external_path: Option<String>`이 있다. upstream 주석은 `data`가 없고 `external_path`가 있으면 placeholder 표시가 가능하다는 방향을 명시한다.
+
+backend별 관찰:
+
+- SVG renderer는 image data가 없고 external path가 있으면 placeholder rect와 external path label을 그리는 경로가 있다.
+- WebCanvas renderer도 external path가 있는 missing image를 dashed placeholder로 표현한다.
+- CanvasKit policy는 `externalImage;missingImageData`와 `externalImage;injectedImageData` diagnostic을 구분한다.
+- Skia renderer 계열은 invalid/missing image placeholder를 그리는 테스트와 경로가 있다.
+
+downstream Swift는 Stage 1 기준으로 다음 정보가 빠져 있다.
+
+- `RenderTree.ImageNode`에 `externalPath` field 없음
+- `rhwp_render_page_tree` JSON decode 후 external missing 상태를 Swift model에 보존하지 않음
+- `CGTreeRenderer.renderImage`는 image byte nil/decode failure를 조용히 return 처리
+- `PlaceholderNode`는 차트/OLE 같은 별도 placeholder label용이며 image missing diagnostic과 연결되어 있지 않음
+
+따라서 upstream core가 render tree에 `external_path`를 이미 내보내더라도 Swift JSON model이 해당 field를 보존하지 않으면 native Quick Look/Thumbnail에는 자동 반영되지 않는다.
+
+## 최근 external/large image 관련 PR
+
+| 항목 | 상태 | 영향 범주 | #391 판정 |
+|------|------|-----------|-----------|
+| PR `#1913` | MERGED, 2026-07-05 | HWPX external BinData Link 왕복 보존 | external link 구조가 core에 더 잘 남는다. 하지만 bytes가 비어 있으면 native renderer는 C ABI discovery/injection 없이는 해결할 수 없다. |
+| issue `#1917` | CLOSED | HWPX 64MB BinData load 거부와 pic control 소실 | large embedded image가 core에서 더 잘 열리면 기존 `bin_data_id` path로 자동 개선될 수 있다. |
+| PR `#1924` | MERGED, 2026-07-05 | HWPX BinData limit 64MB -> 512MB | embedded large image load 개선이다. downstream에는 memory/thumbnail cache policy 검토가 남지만 external ABI 자체는 아니다. |
+| PR `#1927` | MERGED, 2026-07-05 | BinData load 실패 placeholder pic 보존 | 구조 보존은 core update 효과다. 시각적 placeholder를 Swift에서 표시하려면 render tree field/diagnostic을 받아야 한다. |
+| PR `#1930` | MERGED, 2026-07-05 | HWP5 그림 `imgDim` 원본 크기 roundtrip 보존 | original image dimension metadata 보존 성격이다. external resource C ABI와 직접 연결되지는 않는다. |
+| PR `#2040` | MERGED, 2026-07-08 | BinData storage id를 위치와 분리해 max+1 채번 | `ImageAttr.bin_data_id`는 여전히 위치 기반 1-based 의미를 유지한다. C ABI는 storage id와 render lookup id를 혼동하지 않도록 `binDataId`를 upstream JSON 의미 그대로 다뤄야 한다. |
+
+`#2040` 본문은 `inject_external_image_data`의 위치 기반 id 재작성은 범위 외라고 명시한다. 따라서 external injection ABI 설계에서는 `binDataId`를 "렌더 lookup용 1-based 위치 id"로 보고, 저장소 stream id 또는 `BinData.storage_id`와 섞지 않는 원칙이 필요하다.
+
+## Stage 1 질문에 대한 답
+
+### `DocumentCore::from_path` 또는 document context API가 있는가?
+
+Stage 2 기준으로 알한글이 쓰는 `DocumentCore` public surface에는 filename setter, structured external refs, explicit bytes injection API가 충분히 노출되어 있지 않다. native directory population API는 있으나, 이는 core가 filesystem을 직접 읽는 형태라 macOS shell 책임 경계와 맞지 않는다.
+
+### upstream은 external image를 어디에 표현하는가?
+
+external reference discovery는 WASM/native wrapper API에서 JSON으로 노출된다. render tree `ImageNode`에도 `external_path`가 남을 수 있고, backend별 placeholder/diagnostic 경로가 존재한다. 다만 알한글 Swift model이 `external_path`를 디코딩하지 않으므로 현재 native CoreGraphics path에서는 이 정보가 소실된다.
+
+### missing external image는 `PlaceholderNode`인가, `ImageNode`인가?
+
+upstream render tree 관찰상 image 자체는 `ImageNode`에 남고 `data == None`, `external_path == Some` 조합으로 placeholder 표시가 가능하다. Swift의 `PlaceholderNode`와는 별개로 취급해야 한다.
+
+### overlay compact JSON도 external/missing 상태를 갖는가?
+
+Stage 2에서 확인한 downstream current path는 overlay compact JSON이 base64 image data 중심이고 `binDataId`도 Swift supplement로 보강한다. upstream external reference contract는 render tree와 document-level API 쪽에 더 명확하게 존재한다. 따라서 Stage 3 설계는 overlay JSON 확장보다 document-level refs/injection과 render tree `externalPath` 보존을 우선한다.
+
+### Skia PNG export는 core 내부에서 external bytes를 해결해야 하는가?
+
+upstream contract의 바람직한 경계는 consumer가 bytes를 준비하고 core에 주입한 뒤 renderer가 그 상태를 replay하는 것이다. Skia PNG export가 좋아지려면 Swift/macOS shell이 injection을 먼저 수행하거나, 제한된 directory population을 명시 정책으로 호출해야 한다.
+
+### downstream ABI는 filename/base URL만 넘기면 되는가?
+
+filename context만으로는 부족하다. filename은 field rendering과 일부 context에는 필요하지만, external image 해결에는 reference discovery와 explicit bytes injection이 필요하다. base URL/direct directory population은 sandbox와 cache signature를 흐리게 하므로 기본 ABI로 삼기 어렵다.
+
+## Stage 3 설계 입력
+
+Stage 3에서 최소로 다뤄야 할 state:
+
+- `embedded`: 기존 `rhwp_image_data`로 bytes 존재
+- `externalMissing`: external reference는 있으나 bytes 없음
+- `externalInjected`: external reference가 injection으로 loaded
+- `placeholderPreserved`: bytes load 실패 또는 roundtrip 보존용 placeholder 구조 존재
+- `decodeFailed`: bytes는 있으나 Swift/CoreGraphics decode 실패
+- `invalidBinDataId`: render tree id 또는 caller id가 유효하지 않음
+
+Stage 3에서 비교할 ABI 후보:
+
+- `rhwp_set_file_name(handle, utf8_name)`
+- `rhwp_external_image_refs(handle) -> JSON`
+- `rhwp_inject_external_image_by_key(handle, key, bytes, display_path) -> status`
+- `rhwp_image_state(handle, bin_data_id) -> enum 또는 JSON`
+- `rhwp_render_page_tree` JSON model에 `externalPath` additive decode
+- `rhwp_open_with_context(data, len, filename, optional_display_path)` 또는 open 후 setter 방식
+
+memory/lifetime 원칙:
+
+- C ABI는 caller-provided bytes를 즉시 Rust-owned `Vec<u8>`로 복사한다.
+- Rust가 반환하는 JSON string은 기존 `rhwp_free_string` lifecycle을 따른다.
+- external refs key는 stable string으로 Swift cache key에 들어갈 수 있어야 한다.
+- cache invalidation은 injection 성공, filename setter 변경, image state 변경 시 명시적으로 발생해야 한다.
+
+## Stage 2 판정
+
+upstream `rhwp`는 external resource contract 자체를 이미 상당히 갖고 있다. 문제는 downstream 알한글 native path가 그 contract를 C ABI로 받지 못하고, Swift render tree model도 `external_path`와 missing/injected diagnostic을 보존하지 않는다는 점이다.
+
+따라서 #391의 실제 downstream 적용 작업은 core pin update만으로 끝나지 않는다. embedded large image와 일부 parser/roundtrip 보존은 upstream 발전을 따라 자동 개선될 수 있지만, Quick Look/Thumbnail의 external image 정합성은 다음 downstream 작업이 필요하다.
+
+1. RustBridge C ABI에서 filename setter 또는 open context, external refs enumeration, bytes injection을 additive symbol로 노출한다.
+2. Swift `RhwpDocument`가 external refs를 조회하고 shell이 허용한 bytes를 주입할 수 있게 한다.
+3. Swift `ImageNode`가 upstream `external_path`를 보존하고 CoreGraphics renderer가 missing external image를 생략 대신 placeholder/diagnostic으로 처리할지 정책화한다.
+4. Thumbnail cache signature에 injected resource 상태 또는 resolver signature를 반영한다.
+5. storage id와 render `binDataId`를 혼동하지 않도록 ABI 문서와 테스트 fixture를 분리한다.
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| `gh issue view 1141 --repo edwardkim/rhwp --json number,title,state,url` | 통과: CLOSED 확인 |
+| `gh pr view 1174/1175/1185 --repo edwardkim/rhwp --json number,title,state,mergedAt,url` | 통과: 모두 MERGED 확인 |
+| `gh pr view 1913/1924/1927/1930/2040 --repo edwardkim/rhwp --json number,title,state,mergedAt,url` | 통과: 모두 MERGED 확인 |
+| `gh pr list --repo edwardkim/rhwp --search "external image"` | 통과: `#1175`, `#1185`, `#1913`, `#2040` 등 관련 PR 확인 |
+| `rg -n "ExternalImageReference|get_external_image_references|get_external_image_basenames|inject_external_image|set_file_name|populate_external_images_from_dir" ...` | 통과: pinned source의 wrapper/API 위치 확인 |
+| `rg -n "external_path|placeholder|missingImageData|injectedImageData" ...` | 통과: render tree/backend diagnostic 위치 확인 |
+
+## 다음 단계 영향
+
+Stage 3에서는 제품 코드를 수정하지 않고 external image C ABI 후보를 설계한다. 특히 `wasm_api::HwpDocument` handle 전환안과 `DocumentCore` public API 확장안을 비교하고, Swift wrapper가 사용할 JSON/status shape를 정한다.
+
+## 승인 요청
+
+Stage 2 결과에 따라 Stage 3 `external image C ABI 후보 설계`로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_391_stage3.md
+++ b/mydocs/working/task_m020_391_stage3.md
@@ -1,0 +1,379 @@
+# Task M020 #391 Stage 3 보고서
+
+단계: Stage 3 `external image C ABI 후보 설계`
+
+## 요약
+
+- 기존 `rhwp_open`, `rhwp_image_data`, `rhwp_render_page_tree` 계약은 유지하고 external image context는 additive C symbol로 확장하는 방향이 맞다.
+- 우선 후보는 `RhwpHandle` 내부 타입을 `DocumentCore`에서 `rhwp::wasm_api::HwpDocument`로 전환하고, upstream `setFileName`, `getExternalImageReferences`, `injectExternalImageByKey`를 RustBridge C ABI로 감싸는 방식이다.
+- `rhwp_open_with_context`는 보조 후보로 둘 수 있지만, filename만 open 시점에 넣어도 external image bytes 해결은 되지 않는다. open-time context 단독 설계는 불충분하다.
+- `populate_external_images_from_dir`를 C ABI로 노출하는 방식은 구현은 작지만 core가 filesystem을 직접 읽게 되어 Quick Look/Thumbnail sandbox 책임 경계와 맞지 않는다. 제품 기본 경로 후보에서 제외한다.
+- Swift/CoreGraphics의 `decodeFailed`는 RustBridge가 알 수 없는 상태다. RustBridge는 embedded/external/missing/injected를 보고하고, Swift renderer가 decode 실패를 별도 diagnostic으로 보강해야 한다.
+
+## Current ABI constraints
+
+현재 RustBridge의 C ABI는 다음 패턴을 갖는다.
+
+| 패턴 | current symbol | 설계 영향 |
+|------|----------------|-----------|
+| opaque handle | `struct RhwpHandle *rhwp_open(...)` | handle 내부 Rust 타입 변경은 C ABI에 드러나지 않는다. |
+| borrowed document bytes | `const uint8_t *rhwp_image_data(..., out_len)` | 반환 pointer는 handle lifetime에 묶이고 Swift는 즉시 `Data`로 복사한다. |
+| owned bytes 반환 | `rhwp_extract_thumbnail`, `rhwp_render_page_png` + `rhwp_free_bytes` | Rust가 새 buffer를 할당해 caller가 free한다. |
+| owned string 반환 | `rhwp_render_page_tree`, `rhwp_page_overlay_images` + `rhwp_free_string` | JSON 반환은 기존 string lifecycle을 재사용할 수 있다. |
+| status enum | `RhwpRenderStatus` | injection처럼 실패 원인 구분이 필요한 API는 enum이 적합하다. |
+| symbol snapshot | `rhwp-ffi-symbols.txt` | symbol 추가 시 generated header, symbol snapshot, lock metadata 검증이 필요하다. |
+
+현재 ABI에는 input string symbol이 없다. filename, key, display path 같은 새 문자열 입력은 null-terminated C string보다 UTF-8 pointer+length 형태가 낫다. path나 document string 자체에 NUL이 들어갈 수는 없지만, pointer+length가 Swift `Data`/`String.UTF8View`와 Rust `std::str::from_utf8` 검증을 명확히 분리한다.
+
+## 후보 A: `HwpDocument` handle 전환 + additive symbols
+
+### 개요
+
+`RhwpHandle` 내부를 다음처럼 바꾸는 후보이다.
+
+```rust
+pub struct RhwpHandle {
+    doc: rhwp::wasm_api::HwpDocument,
+}
+```
+
+pinned `v0.7.17`에서 `rhwp::wasm_api`는 public module이고 `HwpDocument::from_bytes`가 native CLI에서도 사용된다. `HwpDocument`는 `DocumentCore`로 `Deref/DerefMut`되므로 기존 page count, render tree, SVG, PNG export 호출은 대부분 같은 형태로 유지할 가능성이 높다.
+
+### C ABI 후보
+
+```c
+typedef enum RhwpExternalImageStatus {
+  RHWP_EXTERNAL_OK = 0,
+  RHWP_EXTERNAL_INVALID_HANDLE = 1,
+  RHWP_EXTERNAL_INVALID_INPUT = 2,
+  RHWP_EXTERNAL_INVALID_UTF8 = 3,
+  RHWP_EXTERNAL_NOT_FOUND = 4,
+  RHWP_EXTERNAL_ALREADY_LOADED = 5,
+  RHWP_EXTERNAL_FAILURE = 6,
+} RhwpExternalImageStatus;
+
+RhwpExternalImageStatus rhwp_set_file_name_utf8(
+  struct RhwpHandle *handle,
+  const uint8_t *name,
+  uintptr_t name_len
+);
+
+char *rhwp_external_image_refs_json(
+  const struct RhwpHandle *handle
+);
+
+RhwpExternalImageStatus rhwp_inject_external_image_by_key(
+  struct RhwpHandle *handle,
+  const uint8_t *key,
+  uintptr_t key_len,
+  const uint8_t *data,
+  uintptr_t data_len,
+  const uint8_t *display_path,
+  uintptr_t display_path_len
+);
+
+char *rhwp_image_state_json(
+  const struct RhwpHandle *handle,
+  uint16_t bin_data_id
+);
+```
+
+### JSON shape
+
+`rhwp_external_image_refs_json`은 upstream WASM shape를 그대로 따른다.
+
+```json
+[
+  {
+    "key": "binData:3",
+    "binDataId": 3,
+    "originalPath": "C:\\sample\\linked.png",
+    "basename": "linked.png",
+    "extension": "png",
+    "loaded": false
+  }
+]
+```
+
+`rhwp_image_state_json`은 Swift renderer diagnostic과 cache key 생성을 위한 보조 API다. 최소 shape는 다음을 후보로 둔다.
+
+```json
+{
+  "binDataId": 3,
+  "key": "binData:3",
+  "source": "external",
+  "state": "externalMissing",
+  "loaded": false,
+  "byteLength": 0,
+  "externalPath": "C:\\sample\\linked.png"
+}
+```
+
+상태 후보:
+
+| state | 의미 | 산출 layer |
+|-------|------|------------|
+| `embeddedAvailable` | external ref가 아니고 bytes가 있다 | RustBridge |
+| `embeddedMissing` | external ref가 아니지만 bytes가 없다 | RustBridge |
+| `externalMissing` | external ref는 있으나 bytes가 없다 | RustBridge |
+| `externalInjected` | external ref가 있고 bytes가 주입되어 있다 | RustBridge |
+| `invalidBinDataId` | `bin_data_id == 0` 또는 lookup 불가 | RustBridge |
+| `decodeFailed` | bytes는 있으나 CoreGraphics decode 실패 | Swift renderer |
+| `placeholderPreserved` | core가 구조 보존용 placeholder를 유지 | RustBridge가 알 수 있으면 JSON, 아니면 render tree/Swift 정책 |
+
+`decodeFailed`는 Rust가 판단하지 않는다. Swift `CGTreeRenderer.decodeImage`가 실패했을 때 overlay diagnostic 또는 debug counter에 붙이는 상태로 둔다.
+
+### 장점
+
+- upstream `#1141/#1175/#1185` contract와 가장 직접적으로 정렬된다.
+- 기존 `rhwp_open` symbol과 Swift call site를 유지하면서 handle 내부 구현만 바꿀 수 있다.
+- `rhwp_external_image_refs_json`은 기존 JSON string 반환/free 패턴을 재사용한다.
+- injection 성공 시 upstream `HwpDocument`가 page tree cache invalidation을 수행한다.
+- `setFileName`은 filename field rendering과 cache invalidation을 upstream 방식으로 맞춘다.
+
+### 리스크
+
+- `HwpDocument`가 RustBridge staticlib build에서 필요한 feature 조합으로 컴파일되는지 실제 구현 단계에서 확인해야 한다.
+- `HwpDocument` public API 일부가 `wasm_bindgen` 중심이라 native C ABI wrapper에서 borrow/mutability 문제가 생길 수 있다.
+- handle 내부 타입 변경 후 기존 `DocumentCore` method 호출이 모두 `Deref`로 통과하는지 build 검증이 필요하다.
+- `rhwp_image_data`는 현재 `DocumentCore::get_bin_data(index)`의 0-based index 조회를 쓴다. `HwpDocument` 전환 후에도 동일 lookup 의미를 유지해야 한다.
+
+### 판정
+
+1순위 후보로 둔다. 구현 follow-up에서는 가장 먼저 이 전환안으로 compile spike를 수행하고, 실패하면 후보 D로 upstream `DocumentCore` public API 확장을 요청한다.
+
+## 후보 B: open-time context API 추가
+
+### 개요
+
+`rhwp_open_with_context`를 추가해 parse 직후 filename을 설정하는 방식이다.
+
+```c
+struct RhwpHandle *rhwp_open_with_context(
+  const uint8_t *data,
+  uintptr_t len,
+  const uint8_t *file_name,
+  uintptr_t file_name_len
+);
+```
+
+### 장점
+
+- Swift `RhwpDocument(data:filename:)`가 이미 filename 인자를 받으므로 call site 의미가 직관적이다.
+- filename field가 첫 render tree build 전에 설정된다.
+- 기존 `rhwp_open`은 유지하고 새 initializer만 추가하면 ABI breaking이 없다.
+
+### 한계
+
+- external image reference discovery와 bytes injection은 별도 symbol이 여전히 필요하다.
+- filename만으로는 base directory, sibling resource, sandbox permission, package-relative lookup을 해결할 수 없다.
+- open 시점 context를 늘리기 시작하면 이후 base path, security token, resolver option을 계속 붙이고 싶어지는 압력이 생긴다.
+
+### 판정
+
+단독안으로는 부족하다. 후보 A의 `rhwp_set_file_name_utf8`를 먼저 구현하고, filename이 반드시 첫 layout 전에 필요하다는 fixture가 나오면 `rhwp_open_with_context`를 보조 API로 추가한다.
+
+## 후보 C: directory population API 노출
+
+### 개요
+
+upstream `DocumentCore::populate_external_images_from_dir(base_dir)`를 C ABI로 노출하는 방식이다.
+
+```c
+uint32_t rhwp_populate_external_images_from_dir(
+  struct RhwpHandle *handle,
+  const uint8_t *base_dir,
+  uintptr_t base_dir_len
+);
+```
+
+### 장점
+
+- Rust 구현량이 작다.
+- upstream native CLI와 비슷한 동작을 만들 수 있다.
+- external path basename만 필요한 단순 HWP3 sample에는 빠르게 효과가 날 수 있다.
+
+### 문제
+
+- core/RustBridge가 filesystem을 직접 읽는다.
+- Quick Look/Thumbnail sandbox, security-scoped URL, network path 금지, symlink traversal 정책을 RustBridge 내부로 끌어들인다.
+- 어떤 external file을 읽었는지 Swift thumbnail cache signature에 반영하기 어렵다.
+- 실패 원인이 permission인지 missing file인지 policy reject인지 Swift가 정밀하게 알기 어렵다.
+
+### 판정
+
+제품 기본 경로로 채택하지 않는다. 내부 CLI/debug smoke 전용으로는 검토할 수 있지만 Quick Look/Thumbnail의 downstream contract에는 맞지 않는다.
+
+## 후보 D: upstream `DocumentCore` public API 확장
+
+### 개요
+
+RustBridge handle을 `DocumentCore`로 유지하고 upstream에 다음 public API를 추가하거나 반영한 뒤 C ABI를 감싸는 방식이다.
+
+- `DocumentCore::set_file_name`
+- `DocumentCore::external_image_references_json`
+- `DocumentCore::inject_external_image_by_key`
+- `DocumentCore::image_state`
+
+### 장점
+
+- RustBridge 내부 타입을 바꾸지 않는다.
+- domain API가 `wasm_api` wrapper가 아니라 core layer에 자리 잡는다.
+- WASM/native/CLI 모두 같은 implementation을 공유하기 쉽다.
+
+### 한계
+
+- upstream PR 또는 core pin update가 선행되어야 한다.
+- #391 이후 바로 downstream 구현을 착수하기 어렵다.
+- 이미 `HwpDocument` wrapper에 구현된 contract와 중복될 수 있다.
+
+### 판정
+
+후보 A가 compile 또는 API 안정성 문제로 막히면 선택한다. 장기적으로는 upstream에 core-level public API를 두는 편이 더 깨끗하지만, downstream Quick Look/Thumbnail 보정의 첫 구현 경로는 후보 A가 더 빠르다.
+
+## 선택 기준
+
+| 기준 | 후보 A | 후보 B | 후보 C | 후보 D |
+|------|--------|--------|--------|--------|
+| 기존 ABI compatibility | 좋음 | 좋음 | 좋음 | 좋음 |
+| external refs/injection 완성도 | 좋음 | 낮음 | 중간 | 좋음 |
+| sandbox 책임 경계 | 좋음 | 중간 | 낮음 | 좋음 |
+| 구현 착수 가능성 | 높음 | 높음 | 높음 | 낮음 |
+| upstream contract 정합 | 높음 | 일부 | 일부 | 높음 |
+| cache invalidation 명확성 | 높음 | 낮음 | 중간 | 높음 |
+
+Stage 3 권고는 후보 A를 우선 구현 후보로 삼고, 후보 B는 filename-first fixture가 필요할 때 보조로 추가, 후보 C는 제품 기본 경로에서 제외, 후보 D는 upstream 정리 또는 후보 A 실패 시 대체 경로로 둔다.
+
+## Swift wrapper mapping
+
+후속 구현에서 Swift wrapper는 다음 API를 후보로 둔다.
+
+```swift
+struct RhwpExternalImageReference: Decodable, Hashable {
+    let key: String
+    let binDataId: UInt16
+    let originalPath: String
+    let basename: String
+    let extension: String
+    let loaded: Bool
+}
+
+enum RhwpExternalImageStatus: Equatable {
+    case ok
+    case invalidHandle
+    case invalidInput
+    case invalidUTF8
+    case notFound
+    case alreadyLoaded
+    case failure
+}
+
+extension RhwpDocument {
+    func setFileNameContext(_ name: String) -> RhwpExternalImageStatus
+    func externalImageReferences() -> [RhwpExternalImageReference]
+    func injectExternalImage(key: String, data: Data, displayPath: String) -> RhwpExternalImageStatus
+    func imageState(binDataId: UInt16) -> RhwpImageState?
+}
+```
+
+`RhwpDocument(data:filename:)`는 open 성공 직후 `setFileNameContext`를 호출하도록 바꿀 수 있다. 이 변경은 parse failure error message와 별개로 document rendering context를 core에 전달한다.
+
+`RenderTree.ImageNode`에는 다음 field를 additive decode한다.
+
+```swift
+let externalPath: String?
+```
+
+`externalPath` decode는 기존 JSON에 field가 없어도 nil이므로 backward compatible하다. Swift `CGTreeRenderer.renderImage`는 image bytes가 없고 `externalPath != nil`이면 생략 대신 placeholder 정책을 적용할 수 있다. placeholder 실제 디자인과 surface별 노출 여부는 Stage 4에서 결정한다.
+
+## Memory ownership
+
+- `rhwp_external_image_refs_json`과 `rhwp_image_state_json`은 Rust-owned C string을 반환하고 caller가 `rhwp_free_string`으로 해제한다.
+- `rhwp_inject_external_image_by_key`의 `data` pointer는 호출 중에만 유효하다. RustBridge는 성공 여부와 무관하게 caller buffer를 보관하지 않고, 성공 시 Rust-owned `Vec<u8>`로 복사한다.
+- `display_path`는 diagnostic용 문자열이다. core가 이 값을 외부 파일 접근에 사용하지 않는다는 전제를 문서화해야 한다.
+- `rhwp_image_data`의 borrowed pointer는 handle 내부 storage에 묶인다. injection 같은 mutation 후에는 과거 pointer를 재사용하면 안 된다. Swift current wrapper는 즉시 `Data`로 복사하므로 이 원칙과 맞는다.
+- `RhwpDocument` handle은 thread-safe로 선언하지 않는다. 같은 handle에서 render와 injection을 동시에 호출하지 않는 것을 Swift wrapper contract로 둔다.
+
+## Error reporting
+
+`rhwp_inject_external_image_by_key`는 upstream WASM이 `u32` count를 반환하지만, C ABI에서는 다음 원인 구분이 필요하다.
+
+| status | 사용 조건 |
+|--------|-----------|
+| `RHWP_EXTERNAL_OK` | injection 또는 setter 성공 |
+| `RHWP_EXTERNAL_INVALID_HANDLE` | handle null |
+| `RHWP_EXTERNAL_INVALID_INPUT` | key/data/name pointer와 length 조합이 부적절 |
+| `RHWP_EXTERNAL_INVALID_UTF8` | key/name/display path가 UTF-8이 아님 |
+| `RHWP_EXTERNAL_NOT_FOUND` | key에 해당하는 external reference 없음 |
+| `RHWP_EXTERNAL_ALREADY_LOADED` | reference는 있으나 이미 bytes가 있음 |
+| `RHWP_EXTERNAL_FAILURE` | panic, serialization 실패, upstream helper false 등 기타 실패 |
+
+다만 upstream `inject_external_image_by_key` public method가 현재 `0/1`만 반환하므로 `NOT_FOUND`와 `ALREADY_LOADED`를 정확히 구분하려면 RustBridge가 injection 전에 refs JSON 또는 helper logic으로 reference 상태를 조회해야 한다. 이 구분이 구현을 과하게 만들면 v1은 `OK/INVALID/FAILURE` 중심으로 시작하고 `rhwp_image_state_json`으로 상세 원인을 보완하는 단계화를 허용한다.
+
+## `binDataId` naming rule
+
+Stage 2에서 확인한 `#2040`과 upstream `find_bin_data` 규칙 때문에 다음 원칙을 고정한다.
+
+- C ABI와 Swift model의 `binDataId`는 render lookup id다.
+- 기본 해석은 1-based `bin_data_content` 위치다.
+- upstream renderer는 위치 lookup 실패 시 storage id fallback을 쓸 수 있지만, downstream ABI는 storage id를 직접 의미하지 않는다.
+- external refs key `binData:N`의 `N`도 render lookup id로 취급한다.
+- 후속 테스트 fixture는 sparse storage id, storage id collision, external injected image를 분리해서 잡는다.
+
+## Rollout proposal
+
+후속 구현은 한 PR에 모두 넣지 않고 다음 단위로 나누는 것이 좋다.
+
+1. RustBridge additive ABI spike
+   - `RhwpHandle` 내부 `HwpDocument` 전환 compile 검증
+   - `rhwp_set_file_name_utf8`
+   - `rhwp_external_image_refs_json`
+   - `rhwp_inject_external_image_by_key`
+   - `rhwp-ffi-symbols.txt`, generated header, lock metadata 갱신
+
+2. Swift wrapper와 JSON model
+   - `RhwpExternalImageReference`, `RhwpExternalImageStatus`, `RhwpImageState`
+   - `RhwpDocument(data:filename:)`의 filename context setter 호출
+   - external refs/injection unit tests 또는 smoke harness
+
+3. Render tree external path 보존
+   - `ImageNode.externalPath`
+   - missing external image placeholder/fallback policy
+   - CoreGraphics decode failure diagnostic
+
+4. macOS shell resolver
+   - Quick Look/Thumbnail/HostApp별 file access policy
+   - allowed sibling/package-relative resource lookup
+   - thumbnail cache signature에 external resource 상태 반영
+
+5. Fixture and regression
+   - exact external BinData Link sample
+   - large BinData sample
+   - storage id sparse/collision sample
+   - native CG vs Skia/SVG missing/injected image comparison
+
+## Stage 3 판정
+
+downstream 적용은 "filename만 넘기기"로는 부족하다. 최소 구현 단위는 filename setter, external refs JSON, key 기반 bytes injection, image state diagnostic, Swift `externalPath` decode의 조합이다.
+
+제품 경로의 기본 선택은 후보 A다. 이 안은 upstream contract를 재사용하고, macOS shell이 bytes와 권한 정책을 소유하며, RustBridge는 명시적으로 전달된 context만 document state에 반영한다. 후보 C처럼 RustBridge가 directory를 직접 읽는 방식은 sandbox와 cache 설계를 흐리므로 기본안에서 제외한다.
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| `sed -n '1,340p' RustBridge/src/lib.rs` | 통과: current handle, string/bytes free, render status 패턴 확인 |
+| `sed -n '1,280p' Sources/RhwpCoreBridge/RhwpDocument.swift` | 통과: Swift wrapper ownership과 filename 미전달 확인 |
+| `sed -n '1,120p' rhwp-ffi-symbols.txt` | 통과: external context symbol 없음 확인 |
+| `sed -n '1,220p' Frameworks/generated_rhwp.h` | 통과: generated C surface current shape 확인 |
+| `rg -n "pub mod wasm_api|HwpDocument::from_bytes" ...` | 통과: pinned core의 public `wasm_api`와 native usage 확인 |
+| `sed -n '2588,2714p' .../src/wasm_api.rs` | 통과: upstream refs/injection API shape 확인 |
+| `sed -n '250,330p' .../src/model/document.rs` | 통과: external loaded/injection helper와 position-first lookup 확인 |
+
+## 다음 단계 영향
+
+Stage 4에서는 이 ABI 후보를 전제로 Swift/macOS shell 책임을 설계한다. 특히 Quick Look/Thumbnail이 어떤 external file을 읽을 수 있는지, resolver가 어떤 path를 거부해야 하는지, injected resource signature를 thumbnail cache에 어떻게 반영할지 결정해야 한다.
+
+## 승인 요청
+
+Stage 3 결과에 따라 Stage 4 `macOS external resource 책임 경계 설계`로 진행해도 되는지 승인 요청한다.

--- a/mydocs/working/task_m020_391_stage4.md
+++ b/mydocs/working/task_m020_391_stage4.md
@@ -1,0 +1,317 @@
+# Task M020 #391 Stage 4 보고서
+
+단계: Stage 4 `macOS external resource 책임 경계 설계`
+
+## 요약
+
+- Quick Look Preview, Finder Thumbnail, HostApp native export는 모두 Swift/macOS shell이 source URL 권한과 external resource bytes를 판정하고, RustBridge에는 명시적으로 filename context와 bytes만 전달하는 구조로 설계한다.
+- RustBridge/core가 directory를 직접 읽는 `populate_external_images_from_dir` 방식은 제품 기본 경로에서 제외한다.
+- external path의 `originalPath`는 신뢰할 수 있는 접근 경로가 아니라 reference metadata다. resolver는 basename과 source document 위치를 기준으로 제한된 후보만 만든다.
+- Quick Look/Thumbnail extension은 read-only sandbox 환경이므로 sibling file lookup도 conservative opt-in으로 두고, 실패 시 missing placeholder/diagnostic으로 degrade해야 한다.
+- Thumbnail은 external resource 상태가 cache key에 들어가야 한다. 현재 key는 main file path/mtime/size/render signature뿐이므로 resolver 적용 전 cache 구조 조정이 필요하다.
+- HostApp은 security-scoped bookmark를 이미 갖지만 `RhwpStudioDocumentPayload`에는 URL이 없다. future native viewer/export resolver는 source URL 또는 resolved bookmark를 별도 context로 전달해야 한다.
+
+## Current surface inventory
+
+| Surface | current input | current retention | Stage 4 의미 |
+|---------|---------------|-------------------|--------------|
+| Quick Look Preview | `QLFilePreviewRequest.fileURL` | `HwpPreviewDocumentContext`에 `RhwpDocument`, filename, page info만 유지 | request URL은 load 시점에만 쓰인다. resolver도 load 직후 실행해야 한다. |
+| Finder Thumbnail | `QLFileThumbnailRequest.fileURL`, maximum size, scale | `HwpThumbnailCacheKey`에 path/mtime/size/pixel bucket/render signature | external resource signature가 cache key에 없다. |
+| HostApp WKWebView | user-selected URL 또는 dropped bytes | `RhwpStudioDocumentPayload(data, filename, revision)` | source URL/base directory가 payload에 없다. dropped bytes는 external lookup 불가로 취급해야 한다. |
+| HostApp native PDF export | payload data + filename | 새 `RhwpDocument`를 열어 PDF render | source URL context가 없어 external injection 불가. |
+
+근거:
+
+- `Sources/QLExtension/HwpPreviewProvider.swift:12-19` Preview request URL을 받아 `HwpPreviewPDFRenderer.load(fileURL:)`로 위임한다.
+- `Sources/Shared/HwpPreviewPDFRenderer.swift:173-181` Preview load는 main file bytes와 basename으로 `RhwpDocument`를 연다.
+- `Sources/ThumbnailExtension/HwpThumbnailProvider.swift:12-21` Thumbnail request URL로 render request를 만든다.
+- `Sources/ThumbnailExtension/HwpThumbnailRenderCache.swift:19-35` Thumbnail cache key는 main file mtime/size와 renderer signature만 포함한다.
+- `Sources/Shared/HwpPageImageRenderer.swift:128-141` Thumbnail render path도 main file bytes와 basename만 `RhwpDocument`에 넘긴다.
+- `Sources/HostApp/Stores/DocumentViewerStore.swift:50-63` HostApp은 security-scoped access 안에서 main file을 읽지만 payload에는 data/filename만 전달한다.
+- `Sources/HostApp/Services/RhwpStudioDocumentPayload.swift:3-6` payload model은 `data`, `filename`, `revision`만 갖는다.
+- `Sources/HostApp/Services/RhwpStudioPDFExportController.swift:49-50` native PDF export는 payload data와 filename으로 새 `RhwpDocument`를 연다.
+
+## Entitlement and permission boundary
+
+| Surface | entitlement | resolver policy |
+|---------|-------------|-----------------|
+| Quick Look Preview | app sandbox + user-selected read-only | main file와 같은 directory의 basename match 후보만 허용한다. 권한 실패는 missing으로 degrade한다. |
+| Finder Thumbnail | app sandbox + user-selected read-only | Preview와 같은 read-only policy를 쓰되, cache signature를 먼저 해결해야 한다. |
+| HostApp open/export | app sandbox + user-selected read-write + security-scoped bookmark | source URL을 가진 문서에 한해 security scope를 열고 resolver를 실행한다. dropped bytes는 resolver disabled다. |
+| WKWebView bundled studio | custom `alhangeul-studio`/`alhangeul-document` scheme | 현재는 bundled asset과 document bytes만 제공한다. external file serving은 별도 host bridge/permission 설계 없이는 추가하지 않는다. |
+
+근거:
+
+- `Sources/QLExtension/QLExtension.entitlements:5-8`, `Sources/ThumbnailExtension/ThumbnailExtension.entitlements:5-8`는 sandbox + user-selected read-only다.
+- `Sources/HostApp/HostApp.entitlements:5-16`은 sandbox, user-selected read-write, network client, print entitlement를 갖는다.
+- `Sources/HostApp/Services/RecentDocumentStore.swift:21-41`는 security-scoped bookmark를 저장/복원한다.
+- `Sources/HostApp/Services/RhwpStudioDocumentSchemeHandler.swift:88-113`는 WKWebView에 current document bytes만 response로 보낸다.
+- `Sources/HostApp/Services/RhwpStudioResourceSchemeHandler.swift:73-93`는 bundled `rhwp-studio` resource만 resolve한다.
+
+## Shared resolver model
+
+Stage 3 ABI 후보를 전제로 Swift layer에는 다음 shared model을 둔다.
+
+```swift
+struct RhwpDocumentOpenContext {
+    let filename: String
+    let sourceURL: URL?
+    let surface: RhwpDocumentSurface
+    let externalResourcePolicy: RhwpExternalResourcePolicy
+}
+
+enum RhwpDocumentSurface {
+    case quickLookPreview
+    case finderThumbnail
+    case hostAppViewer
+    case hostAppPDFExport
+    case droppedDocument
+}
+
+struct RhwpExternalResourceResolution {
+    let reference: RhwpExternalImageReference
+    let decision: RhwpExternalResourceDecision
+    let displayPath: String?
+    let data: Data?
+    let cacheComponent: RhwpExternalResourceCacheComponent?
+}
+```
+
+resolver 실행 순서:
+
+1. main file bytes를 읽는다.
+2. `RhwpDocument(data:filename:)`를 열고 filename context를 설정한다.
+3. `rhwp_external_image_refs_json`으로 external references를 얻는다.
+4. Swift resolver가 surface policy에 따라 candidate file을 찾고 bytes를 읽는다.
+5. 허용된 bytes만 `rhwp_inject_external_image_by_key`로 주입한다.
+6. resolution report와 cache signature를 render diagnostics에 보관한다.
+7. page count/page size/render tree를 조회한다.
+
+`pageCount`와 `pageSize`는 injection 이후에 조회하는 것을 기본으로 둔다. 대부분 그림 geometry는 control property에 들어 있지만, external bytes가 layout/image metadata에 영향을 줄 가능성을 배제하지 않는 편이 안전하다.
+
+## Path resolution policy
+
+external reference의 `originalPath`는 다음 용도로만 쓴다.
+
+- basename 추출
+- extension 참고
+- privacy-safe diagnostic 표시
+
+access path로 직접 사용하지 않는다.
+
+v1 후보 resolution:
+
+1. `sourceURL`이 없으면 resolver disabled.
+2. `sourceURL.isFileURL == false`면 resolver disabled.
+3. `reference.basename` 또는 `originalPath`에서 basename을 추출한다.
+4. basename이 비어 있거나 `.`, `..`, path separator를 포함하면 policy reject.
+5. candidate URL은 `sourceURL.deletingLastPathComponent().appendingPathComponent(basename)` 하나만 만든다.
+6. standardized/resolved path가 source parent 밖으로 나가면 reject.
+7. candidate가 directory면 reject.
+8. file size가 policy cap을 넘으면 reject.
+9. read 성공 시 bytes를 injection한다.
+
+명시 금지:
+
+- `originalPath`가 absolute path여도 그대로 열지 않는다.
+- Windows drive path, UNC/network path를 열지 않는다.
+- `http`, `https`, `file://` string을 `originalPath`에서 파싱해 접근하지 않는다.
+- symlink traversal로 source parent 밖 파일을 읽지 않는다.
+- renderer 또는 RustBridge가 filesystem을 직접 읽지 않는다.
+
+extension은 allow-list 보조 신호로만 쓴다. Swift CoreGraphics는 ImageIO + PCX decode를 쓰지만, injection 자체는 renderer backend가 해석할 수 있는 bytes를 core state에 넣는 일이다. 따라서 v1에서는 upstream reference extension과 file size/read success를 우선하고, decode failure는 Swift renderer diagnostic으로 분리한다.
+
+## Surface-specific design
+
+### Quick Look Preview
+
+Preview는 `HwpPreviewPDFRenderer.load(fileURL:)`에서 document를 한 번 열고 단일 PNG 또는 PDF reply를 만든다. 따라서 external resolver 삽입 지점은 `loadDocument(fileURL:)` 안의 `RhwpDocument` 생성 직후가 적절하다.
+
+후속 API 후보:
+
+```swift
+let context = RhwpDocumentOpenContext(
+    filename: fileURL.lastPathComponent,
+    sourceURL: fileURL,
+    surface: .quickLookPreview,
+    externalResourcePolicy: .quickLookReadOnly
+)
+let document = try RhwpDocument(data: data, context: context)
+```
+
+정책:
+
+- main file size gate는 현행 유지.
+- external image read는 read-only sibling basename 후보만 시도.
+- resolver 실패는 preview failure가 아니라 missing placeholder/diagnostic으로 남긴다.
+- full original path는 Quick Look title/log/placeholder에 노출하지 않는다.
+- multi-page PDF는 같은 opened document와 injected state를 모든 page에 재사용한다.
+
+### Finder Thumbnail
+
+Thumbnail은 cache lookup 전에 key가 필요하므로 가장 주의가 필요하다. 현재 `HwpThumbnailRenderRequest`는 file URL resource values만으로 key를 만든 뒤 cache hit를 판단한다. external resource를 반영하려면 다음 중 하나를 선택해야 한다.
+
+| 후보 | 설명 | 판단 |
+|------|------|------|
+| Prepared request | worker에서 document open + refs enumeration + resolver signature 산출 후 full cache key로 lookup | 권장. 정확하지만 cache flow refactor가 필요하다. |
+| External refs cache bypass | external refs가 있는 문서는 memory cache를 쓰지 않고 매번 render | 안전한 v1 fallback. 성능 손해가 있다. |
+| Directory mtime broad key | source parent directory mtime를 key에 넣는다 | 부정확하다. sibling file 변경을 놓칠 수 있어 기본안에서 제외한다. |
+| Main file key 유지 | current key 유지 | external file 변경 시 stale thumbnail이 생겨 제외한다. |
+
+권장 구조:
+
+1. `HwpThumbnailRenderRequest`는 current preflight key가 아니라 source file/pixel/policy만 담는 lightweight request로 둔다.
+2. worker queue에서 document를 열고 external refs를 조회한다.
+3. resolver가 `RhwpExternalResourceCacheSignature`를 만든다.
+4. `HwpThumbnailCacheKey`에 external signature를 포함해 cache lookup/store를 수행한다.
+
+cache signature 후보:
+
+```swift
+struct RhwpExternalResourceCacheSignature: Hashable {
+    let policyVersion: String
+    let components: [RhwpExternalResourceCacheComponent]
+}
+
+struct RhwpExternalResourceCacheComponent: Hashable {
+    let key: String
+    let decision: String
+    let basename: String
+    let fileSize: Int?
+    let modificationTime: TimeInterval?
+}
+```
+
+주입을 위해 bytes를 이미 읽었다면 후속 구현에서 byte hash를 포함할 수 있다. 다만 hashing cost가 large image와 충돌할 수 있으므로 v1은 file size + mtime + decision을 기본 후보로 둔다.
+
+### HostApp WKWebView
+
+bundled `rhwp-studio`는 upstream WASM API를 갖지만 macOS host가 external file bytes를 제공하는 bridge는 없다. 현재 WKWebView document scheme은 current document bytes만 서빙하고, resource scheme은 bundled `rhwp-studio` asset만 서빙한다.
+
+Stage 4 판단:
+
+- WKWebView MVP path는 이번 #391 downstream native ABI 적용의 직접 대상에서 제외한다.
+- external image injection을 WKWebView에도 맞추려면 JS host bridge가 external refs를 읽고 native host에 resource request를 보낸 뒤 bytes를 WASM에 inject하는 별도 이슈가 필요하다.
+- HostApp native PDF export는 Swift/RustBridge path이므로 #391 ABI 적용 대상이다.
+
+### HostApp native viewer/export
+
+HostApp은 opened URL에 대해 security-scoped access를 시작하고 recent document bookmark도 저장한다. 그러나 current payload에는 source URL이 없다.
+
+후속 설계:
+
+- `RhwpStudioDocumentPayload`에 source URL을 직접 넣기보다, native render/export 호출에 `RhwpDocumentOpenContext`를 별도로 전달한다.
+- opened document는 `sourceDocument.resolvedURL()` 또는 current open URL을 통해 security scope를 render/export 작업 동안 연다.
+- dropped document는 `sourceURL == nil`이므로 external resolver disabled.
+- save-as 이후 `recordSavedDocument(at:)`가 source document를 갱신하므로 이후 export/viewer resolver는 새 URL 기준으로 동작한다.
+
+## Swift renderer placeholder policy
+
+Stage 3에서 `ImageNode.externalPath` additive decode를 후보로 잡았다. Stage 4에서는 missing external image 시각 정책을 다음처럼 둔다.
+
+| 상황 | Swift CoreGraphics 동작 후보 |
+|------|-----------------------------|
+| `binDataId > 0`, bytes 있음, decode 성공 | 현재처럼 이미지 렌더 |
+| bytes 있음, decode 실패 | 이미지 bbox에 decode failure placeholder 또는 diagnostic count. render 전체 실패로 올리지 않음 |
+| bytes 없음, `externalPath != nil` | external missing placeholder를 그림 |
+| bytes 없음, `externalPath == nil` | 기존 embedded missing. placeholder 여부는 debug policy와 함께 결정 |
+
+Quick Look/Thumbnail은 path privacy가 중요하므로 placeholder label은 full path가 아니라 `image` 또는 basename 정도로 제한한다. `originalPath` 전체는 user-facing preview에 표시하지 않는다.
+
+Skia PNG path는 injection된 document state를 core가 replay하므로 Swift placeholder와 별개다. 단, Skia missing placeholder와 Swift missing placeholder가 visual diff에서 크게 갈라지지 않도록 #396 visual suite에 external fixture를 넣어야 한다.
+
+## Diagnostics and logging
+
+필요한 diagnostic shape:
+
+```swift
+struct RhwpExternalResourceReport {
+    let referenceCount: Int
+    let injectedCount: Int
+    let missingCount: Int
+    let rejectedCount: Int
+    let decisions: [RhwpExternalResourceResolution]
+}
+```
+
+logging 원칙:
+
+- public log에는 filename, counts, decision kind만 남긴다.
+- full resolved path는 privacy private 또는 debug artifact에만 남긴다.
+- permission denied, file missing, too large, invalid basename, policy rejected를 구분한다.
+- external resolver 실패는 render fallback reason과 분리한다. renderer backend fallback과 resource missing은 다른 축이다.
+
+`HwpPageRenderDiagnostics`에는 external resource counts 또는 optional report summary를 추가하는 후보를 둔다. 전체 per-resource report는 Thumbnail cache key와 debug smoke 산출물에만 사용하고, user-facing log에는 축약한다.
+
+## #390/#404 연결
+
+| 이슈 | Stage 4 반영 |
+|------|--------------|
+| #390 | Skia default는 보류다. external resolver는 CoreGraphics default와 Skia opt-in 모두 같은 injected document state를 쓰도록 설계한다. |
+| #404 | external/large image exact fixture가 미측정이다. ABI 구현 전후 검증에 external BinData Link, large BinData, placeholder fixture가 필요하다. |
+| #396 | external fixture를 visual suite에 포함해야 Skia/SVG/CoreGraphics missing/injected placeholder 차이를 추적할 수 있다. |
+| #392/#389 | Thumbnail cache signature와 diagnostic logging 변경은 external resolver 적용 시 같이 확장되어야 한다. |
+
+## Downstream-only and upstream-dependent work
+
+downstream-only 가능:
+
+- Swift `RhwpDocumentOpenContext`와 resolver policy model 설계/구현
+- Quick Look/Thumbnail/HostApp native render entry point에 context 전달
+- Swift `ImageNode.externalPath` additive decode
+- CoreGraphics missing external placeholder
+- Thumbnail cache key external signature 확장
+- resolver diagnostic/reporting
+
+upstream/core 또는 ABI 선행 필요:
+
+- `rhwp_set_file_name_utf8`
+- `rhwp_external_image_refs_json`
+- `rhwp_inject_external_image_by_key`
+- `rhwp_image_state_json`
+- generated header, `rhwp-ffi-symbols.txt`, `rhwp-core.lock` artifact metadata 갱신
+- exact external/large fixture로 injected/missing state 검증
+
+## Rollout order
+
+1. RustBridge additive ABI 구현 spike
+2. Swift wrapper에 filename setter, refs, injection API 추가
+3. shared resolver model과 Quick Look Preview 적용
+4. CoreGraphics `externalPath` decode와 missing placeholder 적용
+5. Thumbnail prepared request 또는 cache bypass 선택 후 cache signature 반영
+6. HostApp native export에 context 전달
+7. WKWebView external image host bridge 별도 검토
+8. #396 visual suite에 external/large image fixture 추가
+
+Quick Look Preview를 Thumbnail보다 먼저 적용하는 이유는 cache 구조 변경이 없고, opened document context 하나에 injection state를 유지하기 쉽기 때문이다. Thumbnail은 cache correctness가 제품 품질에 직접 영향을 주므로 별도 단계로 분리한다.
+
+## Stage 4 판정
+
+#391의 macOS 책임 경계는 다음으로 고정한다.
+
+1. Swift/macOS shell이 source URL 권한, path policy, bytes read, cache signature를 소유한다.
+2. RustBridge는 filename context, external refs enumeration, explicit bytes injection만 수행한다.
+3. renderer backend는 document state를 replay하고 missing/injected 상태를 표현한다.
+4. external path는 access path가 아니라 metadata다.
+5. Thumbnail은 external resource signature 없이는 resolver를 켜지 않는다.
+6. dropped bytes 문서는 external resolver disabled가 기본이다.
+
+이 설계는 Stage 3 후보 A와 정합된다. Stage 5에서는 실제 후속 구현 이슈를 `RustBridge ABI`, `Swift wrapper/resolver`, `Thumbnail cache`, `fixture/visual suite`, `WKWebView bridge` 단위로 나누는 것이 적절하다.
+
+## 검증 결과
+
+| 명령 | 결과 |
+|------|------|
+| `rg -n "providePreview|load(fileURL|Data(contentsOf|RhwpDocument(data|renderPage" ...` | 통과: Preview/Shared render entry point 확인 |
+| `rg -n "provideThumbnail|HwpThumbnailRenderRequest|HwpThumbnailCacheKey|renderSignature" ...` | 통과: Thumbnail cache key current shape 확인 |
+| `rg -n "startAccessingSecurityScopedResource|bookmarkData|RhwpStudioDocumentPayload" ...` | 통과: HostApp security scope, bookmark, payload 확인 |
+| `rg -n "app-sandbox|user-selected|network.client|print" ...entitlements` | 통과: surface별 entitlement 확인 |
+| `rg -n "Skia|Quick Look|Thumbnail|external|#391" mydocs/working/task_m020_390_stage4.md mydocs/working/task_m020_404_stage4.md` | 통과: #390/#404 연결 근거 확인 |
+
+## 다음 단계 영향
+
+Stage 5에서는 #391 최종 보고서와 후속 이슈 초안을 작성한다. 후속 구현을 바로 시작하려면 최소 `RustBridge additive ABI`, `Swift resolver + Quick Look`, `Thumbnail cache signature`, `external fixture suite`를 분리해 등록하는 편이 안전하다.
+
+## 승인 요청
+
+Stage 4 결과에 따라 Stage 5 `후속 이슈 초안과 최종 보고서`로 진행해도 되는지 승인 요청한다.


### PR DESCRIPTION
## 요약

- 대상 타스크: #391 filename/external image context ABI 조사 및 bridge 설계
- 왜: upstream external image 개선이 current downstream ABI에는 자동 반영되지 않는 gap을 구현 전에 확정해야 했다.
- 무엇: current ABI inventory, upstream refs/injection contract, RustBridge additive C ABI 후보, macOS resolver/cache 책임 경계, 후속 parent/sub-issue를 문서화했다.
- 리뷰 포인트: `HwpDocument` handle 전환 후보, Swift/macOS shell의 path/bytes 책임, Quick Look 우선 적용과 Thumbnail cache 선행 분리 판단이다.

## PR base

- base: `devel`

## 변경 내역

- **[수행 계획](https://github.com/postmelee/alhangeul-macos/blob/0b54aad66a5f17ca34e52b22cf17764354562c8a/mydocs/plans/task_m020_391.md)** ([4c85fa3](https://github.com/postmelee/alhangeul-macos/commit/4c85fa3)): #391 범위, 제외 항목, 검증 기준을 정리했다.
- **[구현 계획](https://github.com/postmelee/alhangeul-macos/blob/0b54aad66a5f17ca34e52b22cf17764354562c8a/mydocs/plans/task_m020_391_impl.md)** ([0fa15da](https://github.com/postmelee/alhangeul-macos/commit/0fa15da)): Stage 1-5 조사/설계 순서를 고정했다.
- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/0b54aad66a5f17ca34e52b22cf17764354562c8a/mydocs/working/task_m020_391_stage1.md)** ([e3afbba](https://github.com/postmelee/alhangeul-macos/commit/e3afbba)): current ABI와 Swift image render 계약을 inventory했다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/0b54aad66a5f17ca34e52b22cf17764354562c8a/mydocs/working/task_m020_391_stage2.md)** ([3421a32](https://github.com/postmelee/alhangeul-macos/commit/3421a32)): upstream filename/external refs/injection contract를 조사했다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/0b54aad66a5f17ca34e52b22cf17764354562c8a/mydocs/working/task_m020_391_stage3.md)** ([daa245f](https://github.com/postmelee/alhangeul-macos/commit/daa245f)): RustBridge additive C ABI와 Swift wrapper 후보를 설계했다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/0b54aad66a5f17ca34e52b22cf17764354562c8a/mydocs/working/task_m020_391_stage4.md)** ([3fa98dd](https://github.com/postmelee/alhangeul-macos/commit/3fa98dd)): Quick Look, Thumbnail, HostApp surface별 external resource 책임 경계를 정리했다.
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/0b54aad66a5f17ca34e52b22cf17764354562c8a/mydocs/report/task_m020_391_report.md)** ([2f935c6](https://github.com/postmelee/alhangeul-macos/commit/2f935c6), [0b54aad](https://github.com/postmelee/alhangeul-macos/commit/0b54aad)): 최종 보고서, 후속 issue registration 결과, 오늘할일 완료 상태를 정리했다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| 문서 | #391 계획/단계/최종 보고서 추가 | 제품 코드 변경 없이 조사와 설계만 포함한다. |
| ABI 설계 | `HwpDocument` handle 전환과 additive C ABI 후보 정리 | current `DocumentCore` handle 유지 시 upstream API 노출 gap이 남는지 확인한다. |
| macOS 책임 경계 | Swift resolver/cache/diagnostic 책임 분리 | renderer나 RustBridge가 filesystem을 직접 읽지 않는 정책이 타당한지 확인한다. |
| 후속 추적 | #407 parent와 #408-#413 native sub-issue 등록 | 구현 단위와 milestone 분리가 적절한지 확인한다. |

- 수행 계획서: [task_m020_391.md](https://github.com/postmelee/alhangeul-macos/blob/0b54aad66a5f17ca34e52b22cf17764354562c8a/mydocs/plans/task_m020_391.md)
- 구현 계획서: [task_m020_391_impl.md](https://github.com/postmelee/alhangeul-macos/blob/0b54aad66a5f17ca34e52b22cf17764354562c8a/mydocs/plans/task_m020_391_impl.md)
- 최종 보고서: [task_m020_391_report.md](https://github.com/postmelee/alhangeul-macos/blob/0b54aad66a5f17ca34e52b22cf17764354562c8a/mydocs/report/task_m020_391_report.md)

## 핵심 리뷰 포인트

- upstream external image 개선이 current downstream ABI에 자동 반영되지 않는다는 판단이 맞는지
- `HwpDocument` handle 전환 + additive C ABI를 1차 구현 후보로 두는 설계가 적절한지
- Quick Look Preview를 먼저 적용하고 Thumbnail은 external cache signature 선행으로 분리한 순서가 안전한지

## 검증

- `rg -n "#391|filename|external|BinData|C ABI|Swift wrapper|Quick Look|Thumbnail|후속|residual|#387|#390|#404" mydocs/report/task_m020_391_report.md mydocs/orders/20260710.md`
- `rg -n "RustBridge|HwpDocument|externalPath|cache signature|prepared request|WKWebView|fixture|resolver|placeholder|decodeFailed|binDataId" mydocs/report/task_m020_391_report.md`
- `git diff --check`
- `git diff --cached --check`
- `gh issue list` / `gh api` live 조회로 milestone, label, duplicate, native sub-issue 연결 확인
- `scripts/validate-github-body.sh /private/tmp/task391-pr-body.md`

## 관련 이슈

- #404 upstream 렌더 PR 대표 샘플 diff 측정
- #396 visual suite
- #387 Preview/Thumbnail Skia readiness 후속 개선 추적
- #283 rhwp-studio 문서 열기 normalization external image parity 영향 조사

## 후속 이슈 제안

- #407 external image context ABI 후속 구현 추적
- #408 RustBridge external image context C ABI 구현
- #409 Swift external image wrapper/resolver와 Quick Look Preview 적용
- #410 CoreGraphics `ImageNode.externalPath`와 missing/decode diagnostic 보강
- #411 Thumbnail external resource cache signature와 prepared request 적용
- #412 external/large image fixture suite와 visual regression 측정
- #413 HostApp WKWebView external image bridge 설계

## 남은 리스크

- `HwpDocument` handle 전환 compile risk는 #408 구현 spike에서 검증해야 한다.
- external/large exact fixture는 아직 repository에 없으며 #412 작업에서 라이선스와 재현성을 확인해야 한다.
- Thumbnail resolver는 #411 cache signature 정리 전에는 켜면 stale cache risk가 있다.
- WKWebView external image bridge는 native Quick Look/Thumbnail path와 별도 설계가 필요하다.
