### PR TITLE
Task #408: RustBridge external image context C ABI 구현

### DIFF
--- a/RustBridge/README.md
+++ b/RustBridge/README.md
@@ -24,7 +24,7 @@
 
 ## Core dependency 기준
 
-현재 v0.1.0 목표는 Demo/Preview release이며, `RustBridge/Cargo.toml`은 `git` + `rev`로 commit pin 상태다. Stable은 release tag가 필요한 bridge API를 포함할 때만 별도 승격하고, branch/floating ref는 사용하지 않는다.
+현재 `rhwp-core.lock`과 `RustBridge/Cargo.toml`은 release tag `v0.7.17`, resolved commit `03351190ec35436e58cbfee0aa9278a8fdc04a59`, feature `native-skia`를 기준으로 한다. Stable 기준은 release tag와 resolved commit을 함께 고정하며 branch/floating ref는 사용하지 않는다.
 
 채널별 dependency 기준, lock 필드, compatibility gate 상세는 [`core_release_compatibility.md`](../mydocs/tech/core_release_compatibility.md)를 참조한다.
 
@@ -43,12 +43,35 @@ core 기준을 바꿀 때는 저장소 루트에서 다음 스크립트를 사�
 ./scripts/update-rhwp-core.sh --channel stable --tag <release-tag>
 ```
 
+## External image context ABI
+
+RustBridge는 external image 파일을 직접 찾거나 읽지 않는다. Swift/macOS shell이 source URL 권한, basename-only resolver, size 제한과 bytes read를 소유하고, 허용된 context와 bytes만 다음 ABI로 전달한다.
+
+| ABI | 역할 |
+|-----|------|
+| `rhwp_set_file_name_utf8` | UTF-8 filename context를 document에 설정한다. |
+| `rhwp_external_image_refs_json` | `key`, `binDataId`, `originalPath`, `basename`, `extension`, `loaded`를 포함한 upstream JSON 배열을 반환한다. |
+| `rhwp_inject_external_image_by_key` | refs JSON의 key로 caller가 읽은 image bytes를 document에 주입한다. |
+
+세터와 injection은 `RhwpExternalImageStatus`를 반환한다. status는 성공, invalid handle/input/UTF-8, reference 미존재, 이미 loaded, 일반 failure를 구분한다.
+
+메모리와 수명 규칙:
+
+- filename, key, data, display path 입력 pointer는 caller-owned이며 호출 동안만 빌려 쓴다.
+- `rhwp_external_image_refs_json` 반환 문자열은 Rust-owned이며 `rhwp_free_string`으로 해제한다.
+- injection에 성공하면 upstream document가 image bytes를 복사해 소유한다.
+- `rhwp_image_data` 반환 pointer는 document-owned이므로 caller는 즉시 복사하고 setter/injection 같은 mutable 호출을 넘겨 보관하지 않는다.
+- `originalPath`와 `display_path`는 bridge가 filesystem 접근 경로로 해석하지 않는다.
+
+pinned public API에는 embedded/external/missing/injected 전체 image 상태를 반환하는 함수가 없어 `rhwp_image_state_json`은 제공하지 않는다. External 상태는 refs JSON의 `loaded`로 전달하고 renderer missing/decode diagnostic은 downstream renderer 이슈에서 별도로 다룬다.
+
 ## 경계 규칙
 
 - core API 변경은 먼저 `edwardkim/rhwp` 저장소에 반영한다.
 - 앱 저장소 안에서 core source를 직접 수정하지 않는다.
 - `rhwp_*` ABI 변경 시 `rhwp-ffi-symbols.txt`, generated header, Swift bridge 호출부, `rhwp-core.lock` 정합성을 함께 확인한다.
 - Rust가 Swift에 넘긴 문자열과 byte buffer는 지정된 free 함수로 해제해야 한다.
+- external resource 권한·탐색·bytes read는 Swift/macOS shell이 소유하며 RustBridge가 filesystem을 직접 탐색하지 않는다.
 
 관련 상세 문서:
 

--- a/RustBridge/cbindgen.toml
+++ b/RustBridge/cbindgen.toml
@@ -5,6 +5,7 @@ include_guard = "RHWP_MAC_BRIDGE_H"
 [export]
 include = [
   "RhwpHandle",
+  "RhwpExternalImageStatus",
   "RhwpPageSize",
   "RhwpRenderStatus",
 ]

--- a/RustBridge/examples/svg_pdf_benchmark.rs
+++ b/RustBridge/examples/svg_pdf_benchmark.rs
@@ -95,7 +95,11 @@ fn parse_args(args: Vec<String>) -> Result<Config, String> {
         return Err("missing input files".to_string());
     }
 
-    Ok(Config { output_dir, runs, inputs })
+    Ok(Config {
+        output_dir,
+        runs,
+        inputs,
+    })
 }
 
 fn usage() -> String {
@@ -110,7 +114,9 @@ fn measure(input: &Path, output_dir: &Path, run: usize) -> Measurement {
         .unwrap_or("input")
         .to_string();
     let file_path = input.display().to_string();
-    let file_bytes = fs::metadata(input).map(|metadata| metadata.len()).unwrap_or(0);
+    let file_bytes = fs::metadata(input)
+        .map(|metadata| metadata.len())
+        .unwrap_or(0);
 
     match measure_ok(input, output_dir, run) {
         Ok(mut measurement) => {
@@ -144,7 +150,9 @@ fn measure_ok(input: &Path, output_dir: &Path, run: usize) -> Result<Measurement
         .unwrap_or("input")
         .to_string();
     let file_path = input.display().to_string();
-    let file_bytes = fs::metadata(input).map_err(|error| error.to_string())?.len();
+    let file_bytes = fs::metadata(input)
+        .map_err(|error| error.to_string())?
+        .len();
 
     let data_read_start = Instant::now();
     let data = fs::read(input).map_err(|error| error.to_string())?;
@@ -168,7 +176,8 @@ fn measure_ok(input: &Path, output_dir: &Path, run: usize) -> Result<Measurement
     let svg_seconds = svg_start.elapsed().as_secs_f64();
 
     let pdf_start = Instant::now();
-    let pdf_bytes = rhwp::renderer::pdf::svgs_to_pdf(&svg_pages).map_err(|error| error.to_string())?;
+    let pdf_bytes =
+        rhwp::renderer::pdf::svgs_to_pdf(&svg_pages).map_err(|error| error.to_string())?;
     let pdf_seconds = pdf_start.elapsed().as_secs_f64();
 
     let stem = input
@@ -204,14 +213,18 @@ fn write_outputs(output_dir: &Path, measurements: &[Measurement]) -> Result<(), 
         tsv.push_str(&measurement.to_tsv());
         tsv.push('\n');
     }
-    fs::write(output_dir.join("svg_pdf_measurements.tsv"), tsv).map_err(|error| error.to_string())?;
+    fs::write(output_dir.join("svg_pdf_measurements.tsv"), tsv)
+        .map_err(|error| error.to_string())?;
 
     let mut summary = String::new();
     summary.push_str("# rhwp SVG PDF Benchmark\n\n");
     summary.push_str("| File | Runs | Status | Pages | AvgTotalSeconds | MinTotalSeconds | MaxTotalSeconds | AvgPDFSeconds | AvgPDFBytes |\n");
     summary.push_str("|------|------|--------|-------|-----------------|-----------------|-----------------|---------------|-------------|\n");
 
-    let mut files: Vec<&str> = measurements.iter().map(|measurement| measurement.file_name.as_str()).collect();
+    let mut files: Vec<&str> = measurements
+        .iter()
+        .map(|measurement| measurement.file_name.as_str())
+        .collect();
     files.sort_unstable();
     files.dedup();
 
@@ -221,14 +234,19 @@ fn write_outputs(output_dir: &Path, measurements: &[Measurement]) -> Result<(), 
             .filter(|measurement| measurement.file_name == file && measurement.status == "OK")
             .collect();
         if rows.is_empty() {
-            summary.push_str(&format!("| `{file}` | 0 | FAIL | - | - | - | - | - | - |\n"));
+            summary.push_str(&format!(
+                "| `{file}` | 0 | FAIL | - | - | - | - | - | - |\n"
+            ));
             continue;
         }
 
         let runs = rows.len();
         let pages = rows[0].page_count;
         let avg_total = average(rows.iter().map(|row| row.total_seconds));
-        let min_total = rows.iter().map(|row| row.total_seconds).fold(f64::INFINITY, f64::min);
+        let min_total = rows
+            .iter()
+            .map(|row| row.total_seconds)
+            .fold(f64::INFINITY, f64::min);
         let max_total = rows.iter().map(|row| row.total_seconds).fold(0.0, f64::max);
         let avg_pdf = average(rows.iter().map(|row| row.pdf_seconds));
         let avg_pdf_bytes = average(rows.iter().map(|row| row.pdf_bytes as f64));

--- a/RustBridge/src/lib.rs
+++ b/RustBridge/src/lib.rs
@@ -3,7 +3,7 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::ptr;
 
 use rhwp::document_core::queries::rendering::PngExportOptions;
-use rhwp::DocumentCore;
+use rhwp::wasm_api::HwpDocument;
 
 macro_rules! ffi_guard {
     ($handle:expr, $default:expr, $body:expr) => {{
@@ -18,7 +18,7 @@ macro_rules! ffi_guard {
 }
 
 pub struct RhwpHandle {
-    doc: DocumentCore,
+    doc: HwpDocument,
 }
 
 #[repr(C)]
@@ -106,7 +106,7 @@ pub extern "C" fn rhwp_open(data: *const u8, len: usize) -> *mut RhwpHandle {
 
     let result = catch_unwind(AssertUnwindSafe(|| {
         let bytes = unsafe { std::slice::from_raw_parts(data, len) };
-        match DocumentCore::from_bytes(bytes) {
+        match HwpDocument::from_bytes(bytes) {
             Ok(doc) => Box::into_raw(Box::new(RhwpHandle { doc })),
             Err(_) => ptr::null_mut(),
         }
@@ -126,7 +126,10 @@ pub extern "C" fn rhwp_page_count(handle: *const RhwpHandle) -> u32 {
 
 #[no_mangle]
 pub extern "C" fn rhwp_page_size(handle: *const RhwpHandle, page: u32) -> RhwpPageSize {
-    const ZERO: RhwpPageSize = RhwpPageSize { width_pt: 0.0, height_pt: 0.0 };
+    const ZERO: RhwpPageSize = RhwpPageSize {
+        width_pt: 0.0,
+        height_pt: 0.0,
+    };
     ffi_guard!(handle, ZERO, {
         let h = unsafe { &*handle };
         let json = match h.doc.get_page_info_native(page) {
@@ -224,7 +227,10 @@ pub extern "C" fn rhwp_render_page_png(
             font_paths: Vec::new(),
         };
 
-        match h.doc.render_page_png_native_with_export_options(page, &options) {
+        match h
+            .doc
+            .render_page_png_native_with_export_options(page, &options)
+        {
             Ok(bytes) if !bytes.is_empty() => {
                 let mut owned = bytes.into_boxed_slice();
                 let owned_len = owned.len();
@@ -252,7 +258,9 @@ pub extern "C" fn rhwp_image_data(
 ) -> *const u8 {
     if handle.is_null() || out_len.is_null() || bin_data_id == 0 {
         if !out_len.is_null() {
-            unsafe { *out_len = 0; }
+            unsafe {
+                *out_len = 0;
+            }
         }
         return ptr::null();
     }
@@ -260,11 +268,15 @@ pub extern "C" fn rhwp_image_data(
     let idx = (bin_data_id - 1) as usize;
     match h.doc.get_bin_data(idx) {
         Some(data) => {
-            unsafe { *out_len = data.len(); }
+            unsafe {
+                *out_len = data.len();
+            }
             data.as_ptr()
         }
         None => {
-            unsafe { *out_len = 0; }
+            unsafe {
+                *out_len = 0;
+            }
             ptr::null()
         }
     }
@@ -273,21 +285,27 @@ pub extern "C" fn rhwp_image_data(
 #[no_mangle]
 pub extern "C" fn rhwp_free_string(ptr: *mut c_char) {
     if !ptr.is_null() {
-        unsafe { drop(CString::from_raw(ptr)); }
+        unsafe {
+            drop(CString::from_raw(ptr));
+        }
     }
 }
 
 #[no_mangle]
 pub extern "C" fn rhwp_free_bytes(ptr: *mut u8, len: usize) {
     if !ptr.is_null() {
-        unsafe { drop(Vec::from_raw_parts(ptr, len, len)); }
+        unsafe {
+            drop(Vec::from_raw_parts(ptr, len, len));
+        }
     }
 }
 
 #[no_mangle]
 pub extern "C" fn rhwp_close(handle: *mut RhwpHandle) {
     if !handle.is_null() {
-        unsafe { drop(Box::from_raw(handle)); }
+        unsafe {
+            drop(Box::from_raw(handle));
+        }
     }
 }
 

--- a/RustBridge/src/lib.rs
+++ b/RustBridge/src/lib.rs
@@ -40,6 +40,19 @@ pub enum RhwpRenderStatus {
     RHWP_RENDER_FAILURE = 5,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[allow(non_camel_case_types)]
+pub enum RhwpExternalImageStatus {
+    RHWP_EXTERNAL_IMAGE_OK = 0,
+    RHWP_EXTERNAL_IMAGE_INVALID_HANDLE = 1,
+    RHWP_EXTERNAL_IMAGE_INVALID_INPUT = 2,
+    RHWP_EXTERNAL_IMAGE_INVALID_UTF8 = 3,
+    RHWP_EXTERNAL_IMAGE_REFERENCE_NOT_FOUND = 4,
+    RHWP_EXTERNAL_IMAGE_ALREADY_LOADED = 5,
+    RHWP_EXTERNAL_IMAGE_FAILURE = 6,
+}
+
 #[no_mangle]
 pub extern "C" fn rhwp_extract_thumbnail(
     data: *const u8,
@@ -113,6 +126,89 @@ pub extern "C" fn rhwp_open(data: *const u8, len: usize) -> *mut RhwpHandle {
     }));
 
     result.unwrap_or(ptr::null_mut())
+}
+
+#[no_mangle]
+pub extern "C" fn rhwp_set_file_name_utf8(
+    handle: *mut RhwpHandle,
+    name: *const u8,
+    name_len: usize,
+) -> RhwpExternalImageStatus {
+    if handle.is_null() {
+        return RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_HANDLE;
+    }
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let name = match unsafe { borrowed_input_utf8(name, name_len, true) } {
+            Ok(name) => name,
+            Err(status) => return status,
+        };
+        let h = unsafe { &mut *handle };
+        h.doc.set_file_name(name);
+        RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_OK
+    }));
+
+    result.unwrap_or(RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_FAILURE)
+}
+
+#[no_mangle]
+pub extern "C" fn rhwp_external_image_refs_json(handle: *const RhwpHandle) -> *mut c_char {
+    ffi_guard!(handle, ptr::null_mut(), {
+        let h = unsafe { &*handle };
+        string_to_c(h.doc.get_external_image_references())
+    })
+}
+
+#[no_mangle]
+pub extern "C" fn rhwp_inject_external_image_by_key(
+    handle: *mut RhwpHandle,
+    key: *const u8,
+    key_len: usize,
+    data: *const u8,
+    data_len: usize,
+    display_path: *const u8,
+    display_path_len: usize,
+) -> RhwpExternalImageStatus {
+    if handle.is_null() {
+        return RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_HANDLE;
+    }
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let key = match unsafe { borrowed_input_utf8(key, key_len, false) } {
+            Ok(key) => key,
+            Err(status) => return status,
+        };
+        let data = match unsafe { borrowed_input_bytes(data, data_len, false) } {
+            Ok(data) => data,
+            Err(status) => return status,
+        };
+        let display_path =
+            match unsafe { borrowed_input_utf8(display_path, display_path_len, true) } {
+                Ok(display_path) => display_path,
+                Err(status) => return status,
+            };
+
+        let h = unsafe { &mut *handle };
+        let refs_json = h.doc.get_external_image_references();
+        let loaded = match external_image_reference_loaded(&refs_json, key) {
+            Ok(Some(loaded)) => loaded,
+            Ok(None) => {
+                return RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_REFERENCE_NOT_FOUND;
+            }
+            Err(()) => return RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_FAILURE,
+        };
+        if loaded {
+            return RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_ALREADY_LOADED;
+        }
+
+        if h.doc.inject_external_image_by_key(key, data, display_path) == 1 {
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_OK
+        } else {
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_FAILURE
+        }
+    }));
+
+    result.unwrap_or(RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_FAILURE)
 }
 
 #[no_mangle]
@@ -316,10 +412,238 @@ fn string_to_c(value: String) -> *mut c_char {
     }
 }
 
+fn external_image_reference_loaded(refs_json: &str, key: &str) -> Result<Option<bool>, ()> {
+    let refs: serde_json::Value = serde_json::from_str(refs_json).map_err(|_| ())?;
+    let references = refs.as_array().ok_or(())?;
+    let Some(reference) = references
+        .iter()
+        .find(|reference| reference.get("key").and_then(|value| value.as_str()) == Some(key))
+    else {
+        return Ok(None);
+    };
+    let loaded = reference
+        .get("loaded")
+        .and_then(|value| value.as_bool())
+        .ok_or(())?;
+    Ok(Some(loaded))
+}
+
+/// Borrows a caller-owned FFI buffer for the duration of the current call.
+///
+/// # Safety
+/// When `len > 0`, `data` must point to at least `len` readable bytes that
+/// remain valid for the returned lifetime.
+unsafe fn borrowed_input_bytes<'a>(
+    data: *const u8,
+    len: usize,
+    allow_empty: bool,
+) -> Result<&'a [u8], RhwpExternalImageStatus> {
+    if len == 0 {
+        return if allow_empty {
+            Ok(&[])
+        } else {
+            Err(RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_INPUT)
+        };
+    }
+    if data.is_null() {
+        return Err(RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_INPUT);
+    }
+
+    Ok(unsafe { std::slice::from_raw_parts(data, len) })
+}
+
+unsafe fn borrowed_input_utf8<'a>(
+    data: *const u8,
+    len: usize,
+    allow_empty: bool,
+) -> Result<&'a str, RhwpExternalImageStatus> {
+    let bytes = unsafe { borrowed_input_bytes(data, len, allow_empty) }?;
+    std::str::from_utf8(bytes)
+        .map_err(|_| RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_UTF8)
+}
+
 fn page_size_from_json(json: &str) -> Option<RhwpPageSize> {
     let value: serde_json::Value = serde_json::from_str(json).ok()?;
     Some(RhwpPageSize {
         width_pt: value.get("width")?.as_f64()?,
         height_pt: value.get("height")?.as_f64()?,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CStr;
+    use std::fs;
+    use std::path::PathBuf;
+
+    struct TestHandle(*mut RhwpHandle);
+
+    impl Drop for TestHandle {
+        fn drop(&mut self) {
+            rhwp_close(self.0);
+        }
+    }
+
+    fn open_fixture() -> TestHandle {
+        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../samples/basic/KTX.hwp");
+        let data = fs::read(fixture).expect("KTX fixture should be readable");
+        let handle = rhwp_open(data.as_ptr(), data.len());
+        assert!(!handle.is_null());
+        TestHandle(handle)
+    }
+
+    #[test]
+    fn filename_context_validates_handle_and_utf8() {
+        assert_eq!(
+            rhwp_set_file_name_utf8(ptr::null_mut(), ptr::null(), 0),
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_HANDLE
+        );
+
+        let handle = open_fixture();
+        assert_eq!(
+            rhwp_set_file_name_utf8(handle.0, ptr::null(), 0),
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_OK
+        );
+
+        let name = b"KTX.hwp";
+        assert_eq!(
+            rhwp_set_file_name_utf8(handle.0, name.as_ptr(), name.len()),
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_OK
+        );
+
+        let invalid_utf8 = [0xff];
+        assert_eq!(
+            rhwp_set_file_name_utf8(handle.0, invalid_utf8.as_ptr(), invalid_utf8.len()),
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_UTF8
+        );
+        assert_eq!(
+            rhwp_set_file_name_utf8(handle.0, ptr::null(), 1),
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_INPUT
+        );
+    }
+
+    #[test]
+    fn external_refs_json_has_owned_string_lifecycle() {
+        assert!(rhwp_external_image_refs_json(ptr::null()).is_null());
+
+        let handle = open_fixture();
+        assert!(rhwp_page_count(handle.0) > 0);
+        let json_ptr = rhwp_external_image_refs_json(handle.0);
+        assert!(!json_ptr.is_null());
+        let json = unsafe { CStr::from_ptr(json_ptr) }
+            .to_str()
+            .expect("external refs should be UTF-8")
+            .to_owned();
+        rhwp_free_string(json_ptr);
+
+        let value: serde_json::Value =
+            serde_json::from_str(&json).expect("external refs should be valid JSON");
+        assert!(value.is_array());
+    }
+
+    #[test]
+    fn injection_validates_inputs_and_missing_reference() {
+        let key = b"not-a-reference";
+        let data = [0_u8];
+        assert_eq!(
+            rhwp_inject_external_image_by_key(
+                ptr::null_mut(),
+                key.as_ptr(),
+                key.len(),
+                data.as_ptr(),
+                data.len(),
+                ptr::null(),
+                0,
+            ),
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_HANDLE
+        );
+
+        let handle = open_fixture();
+        assert_eq!(
+            rhwp_inject_external_image_by_key(
+                handle.0,
+                ptr::null(),
+                0,
+                data.as_ptr(),
+                data.len(),
+                ptr::null(),
+                0,
+            ),
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_INPUT
+        );
+        assert_eq!(
+            rhwp_inject_external_image_by_key(
+                handle.0,
+                key.as_ptr(),
+                key.len(),
+                ptr::null(),
+                0,
+                ptr::null(),
+                0,
+            ),
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_INPUT
+        );
+
+        let invalid_utf8 = [0xff];
+        assert_eq!(
+            rhwp_inject_external_image_by_key(
+                handle.0,
+                invalid_utf8.as_ptr(),
+                invalid_utf8.len(),
+                data.as_ptr(),
+                data.len(),
+                ptr::null(),
+                0,
+            ),
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_UTF8
+        );
+        assert_eq!(
+            rhwp_inject_external_image_by_key(
+                handle.0,
+                key.as_ptr(),
+                key.len(),
+                data.as_ptr(),
+                data.len(),
+                invalid_utf8.as_ptr(),
+                invalid_utf8.len(),
+            ),
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_INVALID_UTF8
+        );
+        assert_eq!(
+            rhwp_inject_external_image_by_key(
+                handle.0,
+                key.as_ptr(),
+                key.len(),
+                data.as_ptr(),
+                data.len(),
+                ptr::null(),
+                0,
+            ),
+            RhwpExternalImageStatus::RHWP_EXTERNAL_IMAGE_REFERENCE_NOT_FOUND
+        );
+    }
+
+    #[test]
+    fn external_reference_lookup_reads_loaded_state() {
+        let refs = r#"[
+            {"key":"binData:1","loaded":false},
+            {"key":"binData:2","loaded":true}
+        ]"#;
+
+        assert_eq!(
+            external_image_reference_loaded(refs, "binData:1"),
+            Ok(Some(false))
+        );
+        assert_eq!(
+            external_image_reference_loaded(refs, "binData:2"),
+            Ok(Some(true))
+        );
+        assert_eq!(external_image_reference_loaded(refs, "binData:3"), Ok(None));
+        assert_eq!(
+            external_image_reference_loaded(r#"[{"key":"binData:1"}]"#, "binData:1"),
+            Err(())
+        );
+        assert_eq!(external_image_reference_loaded("{}", "binData:1"), Err(()));
+    }
 }

--- a/mydocs/orders/20260710.md
+++ b/mydocs/orders/20260710.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #391 | filename/external image context ABI 조사 및 bridge 설계 | 완료 | M020, 완료: 02:12 |
-| #408 | RustBridge external image context C ABI 구현 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #408 | RustBridge external image context C ABI 구현 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260710.md
+++ b/mydocs/orders/20260710.md
@@ -5,4 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #391 | filename/external image context ABI 조사 및 bridge 설계 | 완료 | M020, 완료: 02:12 |
-| #408 | RustBridge external image context C ABI 구현 | 진행중 | M020, 구현계획서 작성 후 승인 대기 |
+| #408 | RustBridge external image context C ABI 구현 | 진행중 | M020, Stage 1 완료, Stage 2 승인 대기 |

--- a/mydocs/orders/20260710.md
+++ b/mydocs/orders/20260710.md
@@ -5,3 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #391 | filename/external image context ABI 조사 및 bridge 설계 | 완료 | M020, 완료: 02:12 |
+| #408 | RustBridge external image context C ABI 구현 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260711.md
+++ b/mydocs/orders/20260711.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 7월 11일
+
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #408 | RustBridge external image context C ABI 구현 | 진행중 | M020, Stage 2 완료, Stage 3 승인 대기 |

--- a/mydocs/orders/20260711.md
+++ b/mydocs/orders/20260711.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #408 | RustBridge external image context C ABI 구현 | 진행중 | M020, Stage 4 완료, Stage 5 승인 대기 |
+| #408 | RustBridge external image context C ABI 구현 | 완료 | M020, 최종 보고 승인 대기, 완료: 22:20 |

--- a/mydocs/orders/20260711.md
+++ b/mydocs/orders/20260711.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #408 | RustBridge external image context C ABI 구현 | 진행중 | M020, Stage 3 완료, Stage 4 승인 대기 |
+| #408 | RustBridge external image context C ABI 구현 | 진행중 | M020, Stage 4 완료, Stage 5 승인 대기 |

--- a/mydocs/orders/20260711.md
+++ b/mydocs/orders/20260711.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #408 | RustBridge external image context C ABI 구현 | 진행중 | M020, Stage 2 완료, Stage 3 승인 대기 |
+| #408 | RustBridge external image context C ABI 구현 | 진행중 | M020, Stage 3 완료, Stage 4 승인 대기 |

--- a/mydocs/plans/task_m020_408.md
+++ b/mydocs/plans/task_m020_408.md
@@ -1,0 +1,181 @@
+# Task M020 #408 수행계획서
+
+## 목적
+
+`RustBridge external image context C ABI 구현`을 수행한다.
+
+현재 pinned `rhwp v0.7.17`의 `HwpDocument`가 제공하는 filename context, external image reference 조회, key 기반 bytes injection 기능을 macOS Swift 계층에서 호출할 수 있는 additive C ABI로 노출한다. 기존 embedded image, page count/size, render tree, SVG, Skia PNG, image data ABI는 그대로 유지하고, Quick Look Preview가 후속 #409에서 안전한 external resource resolver를 연결할 수 있는 bridge 기반을 만든다.
+
+## 배경
+
+#391 조사 결과 current downstream은 upstream external image 개선을 자동으로 충분히 반영하지 못한다. upstream `HwpDocument`에는 filename context와 external refs/injection API가 있지만, 현재 `RustBridge/src/lib.rs`의 `RhwpHandle`은 `DocumentCore`를 직접 보관하고 `rhwp_open(data, len)` 이후 filename이나 external bytes를 전달할 표면이 없다.
+
+현재 기준은 다음과 같다.
+
+- `rhwp-core.lock`은 release tag `v0.7.17`, commit `03351190ec35436e58cbfee0aa9278a8fdc04a59`를 고정한다.
+- `RhwpHandle.doc`은 `DocumentCore`이며 page/render/image API가 이 타입을 직접 호출한다.
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`는 `filename`을 받지만 `rhwp_open(data, len)`만 호출한다.
+- `rhwp_image_data`는 1-indexed `bin_data_id`를 0-indexed core 조회로 변환하며, 반환 포인터는 document가 소유한다.
+- `rhwp-ffi-symbols.txt`에는 filename setter, external refs 조회, bytes injection, image state 조회 symbol이 없다.
+- #404에서는 exact external BinData Link, large BinData, missing placeholder fixture가 미측정으로 남았고, 전체 fixture/visual regression은 후속 #412가 소유한다.
+
+따라서 이 타스크는 RustBridge가 filesystem을 직접 읽지 않는다는 책임 경계를 유지하면서, Swift/macOS shell이 허용한 context와 bytes만 명시적으로 전달할 수 있도록 ABI를 추가한다.
+
+## 범위
+
+포함:
+
+- `RhwpHandle` 내부 타입을 `DocumentCore`에서 pinned core의 `HwpDocument`로 전환하는 compile spike
+- 기존 `rhwp_open`, page count/size, SVG/render tree, overlay image, Skia PNG, image data 동작 호환성 유지
+- UTF-8 filename context를 설정하는 `rhwp_set_file_name_utf8` 계열 additive ABI
+- external image reference JSON을 반환하는 `rhwp_external_image_refs_json` 계열 additive ABI
+- Swift가 읽은 bytes를 reference key 기준으로 주입하는 `rhwp_inject_external_image_by_key` 계열 additive ABI
+- pinned API가 안정적으로 제공하는 경우 image 상태를 조회하는 `rhwp_image_state_json` 계열 ABI
+- status enum, null/length 검증, panic 격리, UTF-8 오류, key 미존재, injection 실패 계약
+- 문자열·입력 bytes·document 내부 image data의 소유권과 유효 수명 문서화
+- cbindgen generated header, `rhwp-ffi-symbols.txt`, `rhwp-core.lock` artifact metadata 정합성 갱신
+- RustBridge build/test와 기존 Swift target compile/link 및 embedded image render regression 확인
+
+제외:
+
+- Swift `RhwpExternalImageReference` wrapper와 path resolver 구현
+- Quick Look Preview 또는 Finder Thumbnail 제품 동작 변경
+- external resource cache signature와 prepared request 구현
+- CoreGraphics `ImageNode.externalPath` placeholder/diagnostic 구현
+- HostApp WKWebView JS/native bridge 구현
+- RustBridge 또는 core가 directory, absolute path, URL, network resource를 직접 탐색하는 기능
+- upstream `edwardkim/rhwp` API 수정
+- core release tag/commit 변경과 Skia default 전환
+- external/large image fixture suite의 정식 편입과 전체 visual regression 측정
+
+## 설계 방향
+
+구현은 기존 ABI를 깨지 않는 additive 방식으로 진행한다.
+
+1. 먼저 pinned `v0.7.17`의 `HwpDocument` native 사용 가능 여부, 생성자, `DocumentCore` 접근 또는 위임 메서드를 compile spike로 확인한다. 기존 page/render/image 함수가 같은 의미를 유지할 수 있을 때만 handle 내부 타입을 전환한다.
+2. 기존 `rhwp_open(data, len)` signature와 opaque `RhwpHandle` ABI는 유지한다. 신규 context는 document open 이후 setter/query/injection 함수로 제공해 기존 Swift caller가 변경 없이 동작하게 한다.
+3. filename과 key는 UTF-8 pointer/length 쌍으로 받고 null pointer, 빈 값, 잘못된 UTF-8을 명시적으로 구분한다. 모든 mutation/query entrypoint는 기존 `catch_unwind` 경계를 유지한다.
+4. external refs와 optional image state는 Rust가 할당한 UTF-8 JSON C string으로 반환하고 기존 `rhwp_free_string`으로 해제한다. JSON shape는 upstream public API 결과를 불필요하게 재가공하지 않되, Swift가 안정적으로 decode할 수 있는지 검증한다.
+5. injection 입력 bytes는 호출 동안만 유효한 borrowed buffer로 받고 core가 필요한 데이터를 복사·소유하도록 한다. `rhwp_image_data`가 반환하는 document-owned pointer는 다음 mutable document 호출 전까지만 유효하다는 제약을 확인하고 문서화한다.
+6. status enum은 성공, invalid handle/input/UTF-8, key not found 또는 rejected, core failure를 Swift가 구분할 수 있는 범위로 제한한다. upstream API가 원인을 구분하지 못하면 임의 추론하지 않고 일반 failure로 매핑한다.
+7. external path를 실제 filesystem path로 해석하거나 파일을 여는 로직은 넣지 않는다. filename은 core context이고, external bytes 탐색·권한·크기 제한은 후속 #409의 Swift/macOS shell 책임으로 유지한다.
+8. optional `rhwp_image_state_json`은 pinned public API로 embedded/external/missing/injected 상태를 안정적으로 얻을 수 있을 때만 포함한다. 별도 파싱이나 내부 타입 의존이 필요하면 구현계획서에서 제외 판정을 기록하고 후속 범위로 남긴다.
+
+## 예상 변경 파일
+
+수행계획서 단계:
+
+- `mydocs/orders/20260710.md`
+- `mydocs/plans/task_m020_408.md`
+
+수행계획 승인 후 예상 소스·계약 변경:
+
+- `RustBridge/src/lib.rs`
+- `RustBridge/cbindgen.toml`
+- 필요 시 `RustBridge/tests/` 하위 external image ABI test
+- `rhwp-ffi-symbols.txt`
+- `rhwp-core.lock`
+- 필요 시 `scripts/build-rust-macos.sh`
+- `RustBridge/README.md`
+- `mydocs/tech/project_architecture.md`
+
+생성·검증 대상이지만 git commit하지 않는 산출물:
+
+- `Frameworks/generated_rhwp.h`
+- `Frameworks/generated_rhwp_symbols.txt`
+- `Frameworks/universal/librhwp.a`
+- `Frameworks/Rhwp.xcframework/**`
+- `Alhangeul.xcodeproj/**`
+- `build.noindex/**`
+
+후속 문서 산출물:
+
+- `mydocs/plans/task_m020_408_impl.md`
+- `mydocs/working/task_m020_408_stage{N}.md`
+- `mydocs/report/task_m020_408_report.md`
+
+`RustBridge/Cargo.toml`과 `RustBridge/Cargo.lock`은 current pinned dependency로 구현 가능하면 변경하지 않는다. dependency 또는 feature 변경이 필요하다고 확인되면 범위 확장 승인을 먼저 요청한다.
+
+## 잠정 단계
+
+1. Stage 1: `HwpDocument` handle 전환 compile spike와 기존 ABI 호환성 확인
+   - pinned core API를 확인하고 handle 내부 타입을 전환한다.
+   - 기존 page/render/image entrypoint의 compile 및 최소 동작 회귀를 확인한다.
+2. Stage 2: filename, external refs, key injection C ABI와 Rust 검증 구현
+   - status enum과 입력 검증, panic 경계, JSON/string ownership을 구현한다.
+   - invalid input과 가능한 external reference/injection 경로를 Rust test 또는 최소 ABI smoke로 검증한다.
+3. Stage 3: generated header, symbol lock, artifact provenance와 계약 문서 갱신
+   - cbindgen header와 symbol 목록을 갱신하고 ABI diff를 확인한다.
+   - `rhwp-core.lock` reference artifact metadata와 bridge/architecture 문서를 맞춘다.
+4. Stage 4: Swift compile/link와 embedded image/render regression 검증
+   - 기존 Swift caller가 변경 없이 compile/link되는지 확인한다.
+   - 기본 embedded image/render fixture에서 page/render/image ABI 회귀가 없는지 확인한다.
+5. Stage 5: 최종 결과 보고서와 후속 #409 handoff 정리
+   - 제공된 symbol, 보류된 optional API, ownership 제약, 검증 결과와 잔여 리스크를 정리한다.
+   - #409가 소비할 확정 C ABI contract를 명시한다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260710.md mydocs/plans/task_m020_408.md
+rg -n "#408|HwpDocument|external|filename|inject|C ABI|ownership|HwpDocument|#409" \
+  mydocs/orders/20260710.md mydocs/plans/task_m020_408.md
+```
+
+RustBridge 구현 단계 후보:
+
+```bash
+cargo fmt --manifest-path RustBridge/Cargo.toml --check
+cargo check --manifest-path RustBridge/Cargo.toml --locked
+cargo test --manifest-path RustBridge/Cargo.toml --locked
+rg -n "RhwpHandle|HwpDocument|rhwp_set_file_name|rhwp_external_image_refs|rhwp_inject_external_image|rhwp_image_state|rhwp_free_string" \
+  RustBridge/src RustBridge/tests rhwp-ffi-symbols.txt
+```
+
+generated artifact와 provenance 검증 후보:
+
+```bash
+./scripts/build-rust-macos.sh --update-lock
+./scripts/build-rust-macos.sh --verify-lock
+nm -gU Frameworks/universal/librhwp.a | rg "rhwp_(set_file_name|external_image_refs|inject_external_image|image_state)"
+git diff --check
+```
+
+Swift/renderer 회귀 검증 후보:
+
+```bash
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+./scripts/validate-stage3-render.sh
+```
+
+external exact fixture가 #408 진행 중 확보되지 않으면 invalid input, empty refs, JSON validity, 기존 embedded image 회귀까지를 이 타스크의 필수 gate로 두고, injected/missing visual 검증은 #409와 #412에서 수행한다.
+
+## 리스크
+
+- `HwpDocument`가 WASM 중심 wrapper이거나 native build에서 필요한 생성자·내부 core 접근을 제공하지 않으면 handle 전환이 기존 render API를 깨뜨릴 수 있다. Stage 1에서 확인하고, 실패하면 `DocumentCore`에 external API를 추가하는 upstream 요청 또는 dual-handle adapter를 별도 승인 대상으로 제시한다.
+- handle 전환 후 page count, render tree, SVG, Skia PNG, overlay image, `get_bin_data` 의미가 기존 `DocumentCore` 직접 호출과 달라질 수 있다.
+- injection mutation 뒤 `rhwp_image_data`가 반환한 document-owned pointer가 무효화될 수 있다. Swift는 즉시 copy해야 하며 ABI 문서에 유효 수명을 명확히 남겨야 한다.
+- upstream JSON shape를 그대로 노출하면 future field 추가에는 유연하지만 필드명 변경에는 취약하다. #409 Swift decoder는 additive field를 허용해야 한다.
+- cbindgen enum representation 또는 함수 signature가 Swift import 결과에서 의도와 다를 수 있다. generated header와 실제 Swift compile을 함께 검증한다.
+- exact external image fixture가 없으면 성공 injection의 end-to-end visual 검증이 제한된다. 이 제한은 #412 fixture 작업과 구분해 보고한다.
+- Rust static archive와 generated header 갱신은 artifact hash/size를 바꾸므로 `rhwp-core.lock`을 의도적으로 갱신하고 source provenance가 그대로인지 확인해야 한다.
+- `mydocs/manual/core_dependency_operation_guide.md`의 서술이 current `rhwp-core.lock`보다 오래된 경우, #408 범위를 벗어난 core pin 변경으로 오해하지 않도록 실제 lock을 진실 원천으로 사용한다.
+
+## 승인 요청 사항
+
+1. #408을 parent #407의 첫 구현 이슈로 진행하고, 기준 브랜치 `devel`, 작업 브랜치 `local/task408`을 사용하는 범위 승인
+2. 기존 opaque handle과 모든 기존 symbol을 유지하면서 신규 setter/query/injection symbol만 추가하는 ABI 방향 승인
+3. RustBridge가 filesystem을 읽지 않고 Swift/macOS shell이 external resource 권한·탐색·bytes read를 소유하는 경계 승인
+4. `rhwp_image_state_json`은 pinned public API로 안정적으로 구현 가능한 경우에만 포함하고, 내부 타입 의존이 필요하면 보류하는 조건 승인
+5. 위 5개 잠정 단계 승인
+
+수행계획서 승인 전에는 구현계획서 작성, RustBridge source 변경, generated artifact 갱신을 진행하지 않는다.

--- a/mydocs/plans/task_m020_408_impl.md
+++ b/mydocs/plans/task_m020_408_impl.md
@@ -1,0 +1,380 @@
+# Task M020 #408 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_408.md`
+
+각 단계 완료 후 단계 보고서를 작성하고 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #408 `RustBridge external image context C ABI 구현`
+- Parent: #407 `external image context ABI 후속 구현 추적`
+- 선행 조사: #391 `filename/external image context ABI 조사 및 bridge 설계`
+- 관련 측정: #404 `upstream 렌더 PR 대표 샘플 diff 측정`
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task408`
+- 목표: pinned `rhwp v0.7.17`의 filename context, external image references, key-based bytes injection API를 기존 ABI와 호환되는 RustBridge C ABI로 노출한다.
+
+## 구현 전 확인 결론
+
+pinned source `/Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/0335119/src/wasm_api.rs`를 기준으로 다음을 확인했다.
+
+| 항목 | pinned API | 구현 판단 |
+|------|------------|-----------|
+| native document 생성 | `HwpDocument::from_bytes(&[u8]) -> Result<HwpDocument, HwpError>` | `rhwp_open` 내부 생성 타입을 전환할 수 있다. |
+| 기존 core API 접근 | `HwpDocument: Deref<Target = DocumentCore> + DerefMut` | page/render/image 함수는 기존 호출 형태를 유지할 수 있다. |
+| filename context | `HwpDocument::set_file_name(&mut self, &str)` | UTF-8 setter C ABI로 직접 연결한다. |
+| external refs | `HwpDocument::get_external_image_references(&self) -> String` | upstream JSON을 Rust-owned C string으로 반환한다. |
+| key injection | `HwpDocument::inject_external_image_by_key(&mut self, &str, &[u8], &str) -> u32` | key/data/display path를 전달하고 결과를 status로 매핑한다. |
+| refs JSON shape | `key`, `binDataId`, `originalPath`, `basename`, `extension`, `loaded` | #409 Swift decoder가 소비할 기준 shape로 사용한다. |
+| 전체 image state | 별도 public API 없음 | optional `rhwp_image_state_json`은 이번 이슈에서 보류한다. |
+
+`get_external_image_references`의 `loaded`는 external reference의 주입 여부를 나타내지만 embedded/missing/decode-failed 전체 상태를 표현하지 않는다. 따라서 이를 확장 해석해 `rhwp_image_state_json`을 만들지 않는다. external 상태는 refs JSON으로 전달하고, renderer decode failure는 #410에서 별도로 다룬다.
+
+## 구현 원칙
+
+- 기존 opaque `RhwpHandle`, `rhwp_open(data,len)`, 기존 공개 symbol의 signature와 의미를 유지한다.
+- `RhwpHandle.doc`만 `DocumentCore`에서 `HwpDocument`로 전환하고, 기존 메서드는 `Deref/DerefMut`를 통해 호출한다.
+- 신규 ABI는 setter/query/injection 세 함수와 하나의 `#[repr(C)]` status enum으로 제한한다.
+- RustBridge는 external path를 열거나 directory를 탐색하지 않는다. Swift/macOS shell이 후속 #409에서 허용된 bytes를 읽어 주입한다.
+- 모든 FFI entrypoint는 null/length 조합을 검사하고 panic을 C 경계 밖으로 전파하지 않는다.
+- Rust가 반환한 refs JSON은 `rhwp_free_string`으로 해제한다. 입력 문자열과 bytes는 호출 동안 caller가 소유하고, upstream injection이 필요한 bytes를 document 내부로 복사한다.
+- `rhwp_image_data`의 반환 포인터는 document-owned다. Swift는 즉시 `Data`로 복사하며, 특히 setter/injection 같은 mutable 호출을 넘겨 보관하지 않는다.
+- upstream external refs JSON을 bridge 전용 shape로 재작성하지 않는다. 신규 필드 추가에 대응할 수 있도록 그대로 전달한다.
+- exact external image fixture가 없는 상태를 숨기지 않는다. C ABI의 정상 injection visual 검증은 #409/#412로 넘기고, #408에서는 bridge contract와 기존 embedded 회귀를 필수 gate로 둔다.
+- `RustBridge/Cargo.toml`, `Cargo.lock`, pinned release tag/commit은 변경하지 않는다. 추가 dependency 또는 feature가 필요해지면 해당 단계에서 범위 확장 승인을 요청한다.
+
+## ABI 확정안
+
+### Status enum
+
+```c
+typedef enum RhwpExternalImageStatus {
+  RHWP_EXTERNAL_IMAGE_OK = 0,
+  RHWP_EXTERNAL_IMAGE_INVALID_HANDLE = 1,
+  RHWP_EXTERNAL_IMAGE_INVALID_INPUT = 2,
+  RHWP_EXTERNAL_IMAGE_INVALID_UTF8 = 3,
+  RHWP_EXTERNAL_IMAGE_REFERENCE_NOT_FOUND = 4,
+  RHWP_EXTERNAL_IMAGE_ALREADY_LOADED = 5,
+  RHWP_EXTERNAL_IMAGE_FAILURE = 6,
+} RhwpExternalImageStatus;
+```
+
+| status | 의미 |
+|--------|------|
+| `OK` | filename 설정 또는 external image 주입 성공 |
+| `INVALID_HANDLE` | null document handle |
+| `INVALID_INPUT` | pointer/length 불일치, 빈 key 또는 빈 image bytes |
+| `INVALID_UTF8` | filename, key 또는 display path가 UTF-8이 아님 |
+| `REFERENCE_NOT_FOUND` | refs JSON에 전달된 key가 없음 |
+| `ALREADY_LOADED` | 해당 reference의 `loaded`가 이미 `true` |
+| `FAILURE` | refs JSON 해석 실패, upstream injection 0 반환, panic guard 실패 |
+
+### Filename setter
+
+```c
+RhwpExternalImageStatus rhwp_set_file_name_utf8(
+    struct RhwpHandle *handle,
+    const uint8_t *name,
+    uintptr_t name_len
+);
+```
+
+- `name_len == 0`은 filename context를 빈 문자열로 지우는 유효 요청이다. 이 경우 `name == NULL`을 허용한다.
+- `name_len > 0`이면 `name`은 non-null UTF-8 buffer여야 한다.
+- upstream `set_file_name`이 page tree cache를 invalidation하는 동작을 유지한다.
+
+### External refs query
+
+```c
+char *rhwp_external_image_refs_json(const struct RhwpHandle *handle);
+```
+
+- 성공 시 upstream JSON 배열 문자열을 반환한다. external ref가 없으면 `[]`이다.
+- null handle, panic, CString 생성 실패 시 `NULL`이다.
+- caller는 반환값을 `rhwp_free_string`으로 해제한다.
+
+### Key-based injection
+
+```c
+RhwpExternalImageStatus rhwp_inject_external_image_by_key(
+    struct RhwpHandle *handle,
+    const uint8_t *key,
+    uintptr_t key_len,
+    const uint8_t *data,
+    uintptr_t data_len,
+    const uint8_t *display_path,
+    uintptr_t display_path_len
+);
+```
+
+- `key`와 `data`는 non-null, non-empty여야 한다.
+- `display_path_len == 0`이면 `display_path == NULL`을 허용하고 upstream에 빈 문자열을 전달한다.
+- refs JSON에서 key를 먼저 찾아 `REFERENCE_NOT_FOUND`와 `ALREADY_LOADED`를 구분한다.
+- unloaded reference에 upstream `inject_external_image_by_key`가 `1`을 반환하면 `OK`, `0`이면 `FAILURE`다.
+- input bytes와 strings는 호출 동안만 빌려 쓰며 RustBridge가 소유권을 해제하지 않는다.
+
+### 이번 이슈에서 보류하는 ABI
+
+```c
+char *rhwp_image_state_json(struct RhwpHandle *handle, uint32_t bin_data_id);
+```
+
+pinned public API가 embedded/external/missing/injected 전체 상태를 제공하지 않으므로 구현하지 않는다. external reference 상태는 `rhwp_external_image_refs_json`의 `loaded`로 전달하고, 전체 image/renderer diagnostic은 #410에서 설계한다.
+
+## Stage 1. `HwpDocument` handle 전환과 기존 ABI 호환성
+
+### 목표
+
+opaque C handle과 기존 symbol을 바꾸지 않고 내부 document 타입만 `HwpDocument`로 전환한다.
+
+### 대상
+
+- `RustBridge/src/lib.rs`
+- `mydocs/working/task_m020_408_stage1.md`
+- `mydocs/orders/20260710.md`
+
+### 작업
+
+1. `rhwp::DocumentCore` import를 `rhwp::wasm_api::HwpDocument`로 전환한다.
+2. `RhwpHandle.doc` 타입을 `HwpDocument`로 변경한다.
+3. `rhwp_open`이 `HwpDocument::from_bytes`를 사용하도록 변경한다.
+4. `Deref/DerefMut`를 통한 기존 page count/size, SVG, render tree, overlay, Skia PNG, image data 호출이 compile되는지 확인한다.
+5. 기존 공개 함수 signature와 `rhwp-ffi-symbols.txt`는 Stage 1에서 변경하지 않는다.
+
+### 검증
+
+```bash
+cargo fmt --manifest-path RustBridge/Cargo.toml --check
+cargo check --manifest-path RustBridge/Cargo.toml --locked
+cargo test --manifest-path RustBridge/Cargo.toml --locked
+git diff --check -- RustBridge/src/lib.rs mydocs/working/task_m020_408_stage1.md mydocs/orders/20260710.md
+rg -n "HwpDocument|RhwpHandle|rhwp_open|page_count|get_page_info_native|build_page_render_tree|get_bin_data" \
+  RustBridge/src/lib.rs mydocs/working/task_m020_408_stage1.md
+```
+
+### 완료 조건
+
+- RustBridge가 pinned dependency와 lock을 유지한 채 check/test를 통과한다.
+- 기존 C 함수 signature와 symbol 목록에 변경이 없다.
+- handle 전환으로 확인된 수명·mutation 제약이 Stage 1 보고서에 기록되어 있다.
+
+### 커밋
+
+```text
+Task #408 Stage 1: HwpDocument handle 전환과 기존 ABI 호환성 확인
+```
+
+## Stage 2. External image context C ABI와 Rust 검증 구현
+
+### 목표
+
+filename setter, external refs query, key injection과 status contract를 구현한다.
+
+### 대상
+
+- `RustBridge/src/lib.rs`
+- `RustBridge/cbindgen.toml`
+- `mydocs/working/task_m020_408_stage2.md`
+- `mydocs/orders/20260710.md`
+
+### 작업
+
+1. `RhwpExternalImageStatus`를 `#[repr(C)]` enum으로 추가하고 cbindgen export 목록에 포함한다.
+2. pointer/length 쌍을 빈 값 허용 여부에 따라 안전하게 `&[u8]`와 `&str`로 변환하는 private helper를 추가한다.
+3. `rhwp_set_file_name_utf8`를 구현한다.
+4. `rhwp_external_image_refs_json`을 구현하고 기존 `string_to_c`/`rhwp_free_string` 계약을 재사용한다.
+5. refs JSON의 `key`와 `loaded`만 `serde_json::Value`로 preflight해 injection status를 구분한다. bridge 전용 DTO나 신규 serde dependency는 추가하지 않는다.
+6. `rhwp_inject_external_image_by_key`를 구현한다.
+7. `#[cfg(test)]` unit test에서 null handle, pointer/length 불일치, invalid UTF-8, empty key/data, ref 미존재, refs JSON validity를 확인한다.
+8. repository 기본 샘플을 `CARGO_MANIFEST_DIR` 기준으로 읽어 `rhwp_open -> refs query -> free -> close` lifecycle을 검증한다.
+9. exact external fixture가 발견되면 성공 injection과 `loaded: false -> true`를 추가 검증하고, 없으면 #412 의존성을 명시한다.
+
+### 검증
+
+```bash
+cargo fmt --manifest-path RustBridge/Cargo.toml --check
+cargo check --manifest-path RustBridge/Cargo.toml --locked
+cargo test --manifest-path RustBridge/Cargo.toml --locked
+rg -n "RhwpExternalImageStatus|rhwp_set_file_name_utf8|rhwp_external_image_refs_json|rhwp_inject_external_image_by_key|REFERENCE_NOT_FOUND|ALREADY_LOADED" \
+  RustBridge/src/lib.rs RustBridge/cbindgen.toml mydocs/working/task_m020_408_stage2.md
+git diff --check -- RustBridge/src/lib.rs RustBridge/cbindgen.toml mydocs/working/task_m020_408_stage2.md mydocs/orders/20260710.md
+```
+
+### 완료 조건
+
+- 세 신규 함수와 status enum이 구현되어 있다.
+- invalid input과 refs query lifecycle이 Rust test로 고정되어 있다.
+- RustBridge가 filesystem lookup을 수행하지 않는다.
+- `rhwp_image_state_json` 보류 판단이 Stage 2 보고서에 명시되어 있다.
+
+### 커밋
+
+```text
+Task #408 Stage 2: external image context C ABI 구현
+```
+
+## Stage 3. Header, symbol, provenance와 ABI 문서 갱신
+
+### 목표
+
+새 ABI를 generated header와 symbol lock에 반영하고, artifact metadata와 ownership 문서를 맞춘다.
+
+### 대상
+
+- `rhwp-ffi-symbols.txt`
+- `rhwp-core.lock`
+- `RustBridge/README.md`
+- `mydocs/tech/project_architecture.md`
+- `Frameworks/generated_rhwp.h` 및 generated artifacts
+- `mydocs/working/task_m020_408_stage3.md`
+- `mydocs/orders/20260710.md`
+
+### 작업
+
+1. `rhwp-ffi-symbols.txt`에 다음 세 symbol을 추가한다.
+   - `rhwp_set_file_name_utf8`
+   - `rhwp_external_image_refs_json`
+   - `rhwp_inject_external_image_by_key`
+2. `./scripts/build-rust-macos.sh --update-lock`으로 universal staticlib, header, xcframework를 재생성한다.
+3. generated header에서 enum 값, const/mutable handle, pointer/length 타입을 검토한다.
+4. generated symbol set과 expected symbol set이 일치하는지 확인한다.
+5. `rhwp-core.lock`의 source tag/commit/features는 유지하고 artifact hash/size와 build timestamp만 의도대로 갱신한다.
+6. `RustBridge/README.md`와 `project_architecture.md`에 신규 ABI, refs JSON, string/input/image-data ownership과 `rhwp_image_state_json` 보류를 기록한다.
+7. generated `Frameworks/**`는 검증에 사용하되 저장소 정책대로 commit하지 않는다.
+
+### 검증
+
+```bash
+./scripts/build-rust-macos.sh --update-lock
+./scripts/build-rust-macos.sh --verify-lock
+rg -n "RhwpExternalImageStatus|rhwp_set_file_name_utf8|rhwp_external_image_refs_json|rhwp_inject_external_image_by_key" \
+  Frameworks/generated_rhwp.h Frameworks/generated_rhwp_symbols.txt rhwp-ffi-symbols.txt
+nm -gU Frameworks/universal/librhwp.a | rg "rhwp_(set_file_name_utf8|external_image_refs_json|inject_external_image_by_key)"
+rg -n "v0.7.17|03351190ec35436e58cbfee0aa9278a8fdc04a59|native-skia" rhwp-core.lock
+git diff --check -- rhwp-ffi-symbols.txt rhwp-core.lock RustBridge/README.md mydocs/tech/project_architecture.md mydocs/working/task_m020_408_stage3.md mydocs/orders/20260710.md
+```
+
+### 완료 조건
+
+- generated header와 staticlib에 세 신규 symbol과 status enum이 존재한다.
+- expected/generated symbol set과 lock verification이 통과한다.
+- core source provenance는 변경되지 않고 artifact metadata만 갱신되어 있다.
+- #409가 참조할 ABI와 ownership 규칙이 저장소 문서에 기록되어 있다.
+
+### 커밋
+
+```text
+Task #408 Stage 3: external image ABI artifact와 계약 문서 갱신
+```
+
+## Stage 4. Swift compile/link와 embedded render 회귀 검증
+
+### 목표
+
+기존 Swift caller와 embedded image/render 경로가 additive ABI 변경 이후에도 정상 동작하는지 확인한다.
+
+### 대상
+
+- generated `Frameworks/Rhwp.xcframework`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift` 읽기/compile 대상
+- `samples/basic/KTX.hwp`
+- `samples/basic/request.hwp`
+- `samples/hwp-img-001.hwp`
+- `mydocs/working/task_m020_408_stage4.md`
+- `mydocs/orders/20260710.md`
+
+### 작업
+
+1. no-AppKit 경계 검사를 실행한다.
+2. `xcodegen generate` 후 HostApp Debug compile/link를 확인한다.
+3. `validate-stage3-render.sh` 기본 fixture로 page count/size/render tree/native bitmap 회귀를 확인한다.
+4. image fixture를 추가 지정해 기존 `bin_data_id` lookup과 embedded image가 누락되지 않는지 확인한다.
+5. Rust unit test와 staticlib symbol 검사를 다시 실행한다.
+6. Quick Look/Thumbnail extension 등록 smoke는 제품 경로를 바꾸지 않으므로 실행하지 않는다.
+7. #409 handoff용으로 Swift import 결과의 enum/function signature를 Stage 4 보고서에 기록한다.
+
+### 검증
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+./scripts/validate-stage3-render.sh
+./scripts/validate-stage3-render.sh build.noindex/task408-render samples/hwp-img-001.hwp
+cargo test --manifest-path RustBridge/Cargo.toml --locked
+nm -gU Frameworks/universal/librhwp.a | rg "rhwp_(open|image_data|set_file_name_utf8|external_image_refs_json|inject_external_image_by_key|close)"
+git diff --check
+```
+
+### 완료 조건
+
+- HostApp Debug compile/link가 통과한다.
+- 기본 및 image fixture render smoke가 통과한다.
+- 기존 embedded image lookup과 기존 symbol에 회귀가 없다.
+- Swift가 import한 신규 enum/function signature가 #409 구현에 충분히 기록되어 있다.
+
+### 커밋
+
+```text
+Task #408 Stage 4: Swift 호환성과 embedded image 회귀 검증
+```
+
+## Stage 5. 최종 보고서와 #409 handoff
+
+### 목표
+
+구현 결과와 검증 근거를 정리하고 후속 Swift resolver 작업이 소비할 계약을 확정한다.
+
+### 대상
+
+- `mydocs/report/task_m020_408_report.md`
+- `mydocs/orders/20260710.md`
+
+### 작업
+
+1. Stage 1-4 변경과 검증 결과를 최종 보고서에 요약한다.
+2. 최종 공개 symbol, enum 값, refs JSON shape, pointer/length 규칙, free/lifetime 규칙을 정리한다.
+3. `rhwp_image_state_json` 보류와 exact external fixture 미측정 여부를 잔여 리스크로 기록한다.
+4. #409의 Swift wrapper/resolver가 구현해야 할 mapping을 명시한다.
+5. 오늘할일을 완료로 갱신하고 task-final-report 전 최종 승인 지점으로 이동한다.
+
+### 검증
+
+```bash
+rg -n "#408|#409|RhwpExternalImageStatus|rhwp_set_file_name_utf8|rhwp_external_image_refs_json|rhwp_inject_external_image_by_key|ownership|loaded|보류" \
+  mydocs/report/task_m020_408_report.md mydocs/orders/20260710.md
+./scripts/build-rust-macos.sh --verify-lock
+cargo test --manifest-path RustBridge/Cargo.toml --locked
+git diff --check
+git log --oneline origin/devel..HEAD
+```
+
+### 완료 조건
+
+- 최종 보고서가 ABI, artifact, 검증, 잔여 리스크와 #409 handoff를 포함한다.
+- 오늘할일이 완료 처리되어 있다.
+- working tree가 clean이고 최종 PR 게시 전 승인을 요청할 수 있다.
+
+### 커밋
+
+```text
+Task #408 Stage 5 + 최종 보고서: external image C ABI 완료 정리
+```
+
+## 단계별 승인 지점
+
+1. 이 구현계획서 승인 후 Stage 1을 시작한다.
+2. Stage 1 완료보고서 승인 후 Stage 2를 시작한다.
+3. Stage 2 완료보고서 승인 후 Stage 3을 시작한다.
+4. Stage 3 완료보고서 승인 후 Stage 4를 시작한다.
+5. Stage 4 완료보고서 승인 후 Stage 5를 시작한다.
+6. 최종 결과보고서 승인 후 `task-final-report` 절차로 PR을 게시한다.
+
+구현계획서 승인 전에는 `RustBridge/src/lib.rs`, cbindgen 설정, FFI symbol lock, generated artifact를 변경하지 않는다.

--- a/mydocs/report/task_m020_408_report.md
+++ b/mydocs/report/task_m020_408_report.md
@@ -1,0 +1,371 @@
+# Task M020 #408 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | #408 `RustBridge external image context C ABI 구현` |
+| Parent | #407 `external image context ABI 후속 구현 추적` |
+| 선행 조사 | #391 filename/external image context ABI 조사, #404 upstream 렌더 diff 측정 |
+| 후속 구현 | #409 Swift wrapper/resolver와 Quick Look Preview 적용 |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 작업 브랜치 | `local/task408` |
+| 단계 수 | 수행계획/구현계획 + Stage 1-5 |
+
+현재 pinned `rhwp v0.7.17`의 `HwpDocument`가 제공하는 filename context, external image reference 조회, key-based bytes injection을 macOS Swift에서 호출할 수 있는 additive C ABI로 노출했다.
+
+기존 opaque `RhwpHandle`, open/page/render/image ABI와 `bin_data_id` lookup 계약은 유지했다. RustBridge는 external file을 직접 찾거나 읽지 않으며, 후속 #409의 Swift/macOS shell이 source URL 권한, resolver policy, size 제한과 bytes read를 소유하도록 경계를 고정했다.
+
+Quick Look/Thumbnail 제품 동작은 이번 이슈에서 변경하지 않았다. #408 완료 시점은 “external image를 해결할 bridge가 준비된 상태”이며 “Preview resolver가 실제로 동작하는 상태”는 #409 완료 후다.
+
+## 최종 결과
+
+| 수용 기준 | 결과 |
+|-----------|------|
+| `RhwpHandle`을 `HwpDocument` 기반으로 전환 | 완료 |
+| 기존 page/render/image ABI 호환성 유지 | 완료 |
+| filename context C ABI | 완료 |
+| external refs JSON C ABI | 완료 |
+| key-based bytes injection C ABI | 완료 |
+| status enum과 invalid-input taxonomy | 완료 |
+| generated header/staticlib/xcframework 반영 | 완료 |
+| expected/generated symbol lock 일치 | 완료 |
+| artifact provenance 갱신 | 완료 |
+| Swift import 및 HostApp/extension compile/link | 완료 |
+| embedded image render 회귀 없음 | 완료 |
+| RustBridge filesystem lookup 없음 | 완료 |
+| `rhwp_image_state_json` | pinned public API 부재로 보류 |
+| external injection 성공 visual fixture | exact fixture 부재로 #409/#412 이관 |
+
+## 변경 파일과 영향 범위
+
+### Product/bridge source
+
+| 파일 | 내용 |
+|------|------|
+| `RustBridge/src/lib.rs` | `HwpDocument` handle 전환, `RhwpExternalImageStatus`, 세 신규 ABI, pointer/JSON helper, unit test 4개 |
+| `RustBridge/cbindgen.toml` | external status enum export |
+| `RustBridge/examples/svg_pdf_benchmark.rs` | Stage 1 formatter gate를 위한 기존 rustfmt drift 정규화, 동작 변경 없음 |
+
+### ABI/artifact/provenance
+
+| 파일 | 내용 |
+|------|------|
+| `rhwp-ffi-symbols.txt` | expected set에 신규 symbol 세 개 추가, 총 15개 |
+| `rhwp-core.lock` | source pin 유지, staticlib/header artifact metadata 갱신 |
+| `scripts/build-rust-macos.sh` | 숫자 포함 symbol을 온전히 추출하도록 regex 보강 |
+
+### 계약 문서
+
+| 파일 | 내용 |
+|------|------|
+| `RustBridge/README.md` | external image ABI, status, ownership, filesystem 책임 경계 |
+| `mydocs/tech/project_architecture.md` | current FFI 표면과 Swift/macOS shell 경계 |
+
+### 하이퍼-워터폴 문서
+
+| 파일 | 내용 |
+|------|------|
+| `mydocs/plans/task_m020_408.md` | 수행계획서 |
+| `mydocs/plans/task_m020_408_impl.md` | 5단계 구현계획서와 ABI 확정안 |
+| `mydocs/working/task_m020_408_stage1.md` | handle 전환 및 기존 ABI 호환성 |
+| `mydocs/working/task_m020_408_stage2.md` | external context ABI와 Rust test |
+| `mydocs/working/task_m020_408_stage3.md` | generated artifact, provenance, 문서 |
+| `mydocs/working/task_m020_408_stage4.md` | Swift compile/link와 embedded render regression |
+| `mydocs/report/task_m020_408_report.md` | 본 최종 결과와 #409 handoff |
+| `mydocs/orders/20260710.md`, `20260711.md` | 착수·단계 진행·완료 상태 |
+
+Swift product source, `project.yml`, core dependency tag/commit, sample fixture는 변경하지 않았다. Generated `Frameworks/**`, `RustBridge/target/**`, `build.noindex/**`, `output/**`는 검증에 사용했지만 ignored 산출물로 commit하지 않는다.
+
+## 단계와 커밋
+
+| 구분 | 커밋 | 결과 |
+|------|------|------|
+| 수행계획 | `71c24f9` | 이슈 범위, 5단계, 검증·리스크 승인 기준 |
+| 구현계획 | `bf4c9dc` | pinned API inventory와 최종 ABI 초안 |
+| Stage 1 | `6cbe649` | `HwpDocument` handle 전환, 기존 ABI compile 호환성 |
+| Stage 2 | `3ddeb62` | status enum, 세 C ABI, unit test 4개 |
+| Stage 3 | `5a29f81` | header/symbol/artifact/provenance와 계약 문서 |
+| Stage 4 | `5af44e2` | Swift compile/link, render regression, Swift import type |
+| Stage 5 | 이번 커밋 | 최종 보고서와 #409 handoff, 오늘할일 완료 |
+
+## 최종 C ABI 계약
+
+### Status enum
+
+```c
+typedef enum RhwpExternalImageStatus {
+  RHWP_EXTERNAL_IMAGE_OK = 0,
+  RHWP_EXTERNAL_IMAGE_INVALID_HANDLE = 1,
+  RHWP_EXTERNAL_IMAGE_INVALID_INPUT = 2,
+  RHWP_EXTERNAL_IMAGE_INVALID_UTF8 = 3,
+  RHWP_EXTERNAL_IMAGE_REFERENCE_NOT_FOUND = 4,
+  RHWP_EXTERNAL_IMAGE_ALREADY_LOADED = 5,
+  RHWP_EXTERNAL_IMAGE_FAILURE = 6,
+} RhwpExternalImageStatus;
+```
+
+| rawValue | Swift mapping 권장 | 의미 |
+|----------|--------------------|------|
+| 0 | `.ok` | filename 설정 또는 injection 성공 |
+| 1 | `.invalidHandle` | null document handle |
+| 2 | `.invalidInput` | pointer/length 불일치, 빈 key/data |
+| 3 | `.invalidUTF8` | filename/key/display path UTF-8 오류 |
+| 4 | `.referenceNotFound` | refs JSON에 key 없음 |
+| 5 | `.alreadyLoaded` | 해당 external reference가 이미 loaded |
+| 6 | `.failure` | JSON shape, upstream injection 또는 panic failure |
+
+### Filename context
+
+```c
+RhwpExternalImageStatus rhwp_set_file_name_utf8(
+    RhwpHandle *handle,
+    const uint8_t *name,
+    uintptr_t name_len
+);
+```
+
+- `name_len == 0`이면 null pointer를 허용하고 빈 filename context로 설정한다.
+- `name_len > 0`이면 non-null UTF-8 buffer가 필요하다.
+- upstream `set_file_name`의 page tree cache invalidation을 유지한다.
+
+### External references
+
+```c
+char *rhwp_external_image_refs_json(const RhwpHandle *handle);
+```
+
+- 성공 시 upstream JSON 배열 문자열, external ref가 없으면 `[]`다.
+- 반환 pointer는 Rust-owned이며 `rhwp_free_string`으로 해제한다.
+- null handle/panic/CString failure는 null pointer다.
+
+기준 JSON shape:
+
+```json
+[
+  {
+    "key": "binData:1",
+    "binDataId": 1,
+    "originalPath": "C:\\source\\image.gif",
+    "basename": "image.gif",
+    "extension": "gif",
+    "loaded": false
+  }
+]
+```
+
+Swift decoder는 field 추가를 허용해야 하며 `key`, `binDataId`, `basename`, `loaded`를 필수 계약으로 취급한다. `originalPath`는 resolver가 그대로 열 경로가 아니라 diagnostic/source metadata다.
+
+### Key-based injection
+
+```c
+RhwpExternalImageStatus rhwp_inject_external_image_by_key(
+    RhwpHandle *handle,
+    const uint8_t *key,
+    uintptr_t key_len,
+    const uint8_t *data,
+    uintptr_t data_len,
+    const uint8_t *display_path,
+    uintptr_t display_path_len
+);
+```
+
+- key와 data는 non-null/non-empty다.
+- display path는 길이 0일 때 null pointer를 허용한다.
+- refs JSON preflight로 key 미존재와 already-loaded를 구분한다.
+- 성공 시 upstream document가 image bytes를 복사해 소유한다.
+- RustBridge는 key/original/display path로 filesystem을 열지 않는다.
+
+## 메모리·수명·호출 순서
+
+### Ownership
+
+| 데이터 | 소유자 | caller 규칙 |
+|--------|--------|-------------|
+| filename/key/display path 입력 | Swift caller | FFI 호출 동안 pointer/length 유효 |
+| injection image bytes | Swift caller, 호출 중 borrowed | `Data.withUnsafeBytes` 범위 안에서 호출 |
+| refs JSON 반환 | Rust | Swift 복사 후 `rhwp_free_string` |
+| injected image bytes | upstream document | injection 성공 후 document handle 수명에 종속 |
+| `rhwp_image_data` 반환 | document-owned | 즉시 `Data`로 복사, 별도 free 금지 |
+
+`rhwp_image_data` pointer를 setter/injection 같은 mutable document 호출을 넘겨 보관하지 않는다.
+
+### #409 권장 호출 순서
+
+1. main document bytes로 `rhwp_open`한다.
+2. source filename이 있으면 `rhwp_set_file_name_utf8`를 호출한다.
+3. `rhwp_external_image_refs_json`을 조회·복사·해제한다.
+4. Swift resolver가 허용한 sibling image bytes만 읽는다.
+5. 각 reference를 `rhwp_inject_external_image_by_key`로 주입한다.
+6. injection 완료 후 page count, page size, render tree/PNG/image data를 조회한다.
+
+page tree/render 전에 injection해야 cache invalidation 뒤 최신 document 상태를 렌더한다.
+
+## Swift import 결과
+
+generated `Rhwp` module을 실제 Swift compiler로 typecheck한 결과다.
+
+```swift
+RhwpExternalImageStatus(rawValue: UInt32) -> RhwpExternalImageStatus
+
+rhwp_set_file_name_utf8:
+  (OpaquePointer?, UnsafePointer<UInt8>?, UInt)
+    -> RhwpExternalImageStatus
+
+rhwp_external_image_refs_json:
+  (OpaquePointer?) -> UnsafeMutablePointer<CChar>?
+
+rhwp_inject_external_image_by_key:
+  (OpaquePointer?,
+   UnsafePointer<UInt8>?, UInt,
+   UnsafePointer<UInt8>?, UInt,
+   UnsafePointer<UInt8>?, UInt)
+    -> RhwpExternalImageStatus
+```
+
+#409 wrapper는 `RhwpExternalImageStatus.rawValue`를 downstream enum으로 매핑하고, 문자열은 UTF-8 bytes와 명시 길이로 전달해야 한다. Empty display path는 nil/0으로 전달할 수 있다.
+
+## Artifact와 provenance
+
+source 기준은 변경하지 않았다.
+
+| 필드 | 값 |
+|------|----|
+| ref kind | `release-tag` |
+| release tag | `v0.7.17` |
+| resolved commit | `03351190ec35436e58cbfee0aa9278a8fdc04a59` |
+| enabled features | `native-skia` |
+
+artifact 결과:
+
+| artifact | 이전 | 최종 | 변화 |
+|----------|------|------|------|
+| universal `librhwp.a` | 202,902,712 bytes | 202,931,144 bytes | +28,432 bytes |
+| generated header | 2,059 bytes | 3,310 bytes | +1,251 bytes |
+| expected symbol | 12개 | 15개 | +3개 |
+
+- staticlib sha256: `e454ac6b32667c84509d320ce6da7972277a5d97655f3187f19f2f5a9a8a5acd`
+- header sha256: `c4cba0728b7e443ba78541dc1184d6aa286b91b72006e423e9283d998c31d8e5`
+- architectures: `x86_64 arm64`
+- staticlib/xcframework 표시 크기: 각각 194M
+
+## 검증 결과
+
+| 검증 | 결과 | 핵심 근거 |
+|------|------|-----------|
+| Rust format/check/test | 통과 | unit test 4개, 0 failure |
+| Clippy 보강 | 통과 | 기존 raw-pointer lint만 명시 allow, 나머지 `-D warnings` |
+| cbindgen header | 통과 | enum 값 0-6, 세 C signature |
+| expected/generated symbol | 통과 | 15개 exact match |
+| universal staticlib symbol | 통과 | 기존 open/image/close + 신규 세 symbol |
+| artifact update/verify | 통과 | `--update-lock`, `--verify-lock` |
+| no-AppKit boundary | 통과 | Shared Swift 계층 AppKit/UIKit 없음 |
+| HostApp/extension compile/link | 통과 | HostApp, QLExtension, ThumbnailExtension, `-lrhwp` |
+| 기본 native render | 통과 | KTX/request/exam_kor non-blank·한글 glyph |
+| embedded image render | 통과 | `hwp-img-001.hwp`, 정부/기관 logo 시각 확인 |
+| Swift module import | 통과 | enum raw type과 세 function interface type 확인 |
+| whitespace | 통과 | `git diff --check` |
+
+주요 render metric:
+
+| fixture | bitmap | textRuns | hangulRuns | nonWhitePixels |
+|---------|--------|----------|------------|----------------|
+| `KTX.hwp` | 1123x794 | 410 | 76 | 455,061 |
+| `request.hwp` | 567x794 | 102 | 36 | 70,188 |
+| `exam_kor.hwp` | 1123x1588 | 133 | 86 | 173,981 |
+| `hwp-img-001.hwp` | 794x1123 | 66 | 35 | 57,037 |
+
+환경성 실패는 모두 회복 후 동일 gate가 통과했다.
+
+- Skia binary cache와 Sparkle package fetch: sandbox DNS 제한, 네트워크 허용 재실행 성공
+- Xcode/xcframework의 CoreSimulatorService 경고: 비치명적, exit 0
+- Swift import default module cache: sandbox 밖 cache 접근 실패, `/private/tmp` cache 지정 후 성공
+- Debug app LaunchServices: 종료 확인에서 개발 산출물 path 잔존 없음
+
+## Build gate 보정
+
+신규 함수 `rhwp_set_file_name_utf8`의 숫자 `8` 때문에 기존 symbol parser가 이름을 `rhwp_set_file_name_utf`으로 잘랐다. `scripts/build-rust-macos.sh`의 추출 regex를 다음처럼 보정했다.
+
+```diff
+-\brhwp_[a-z_]+
++\brhwp_[a-z0-9_]+
+```
+
+보정 후 generated/expected symbol set, update-lock, verify-lock이 통과했다. 이는 이번 ABI뿐 아니라 향후 숫자가 들어간 symbol의 provenance gate도 올바르게 만든다.
+
+## #409 Handoff
+
+#409는 다음 구현 단위를 바로 소비할 수 있다.
+
+### Swift model/wrapper
+
+- `RhwpExternalImageReference: Decodable`
+  - `key: String`
+  - `binDataId: UInt16`
+  - `originalPath: String`
+  - `basename: String`
+  - `extension: String`
+  - `loaded: Bool`
+- downstream `RhwpExternalImageStatus` enum과 rawValue 0-6 mapping
+- `RhwpDocument.setFileName(_:)`
+- `RhwpDocument.externalImageReferences()`
+- `RhwpDocument.injectExternalImage(key:data:displayPath:)`
+- refs JSON pointer copy와 `defer { rhwp_free_string(...) }`
+- 모든 input string을 UTF-8 pointer/length로 전달
+
+### Open context와 resolver
+
+- `RhwpDocumentOpenContext`
+  - source URL optional
+  - display filename optional
+  - max external resource bytes
+- source URL이 없거나 file URL이 아니면 resolver disabled
+- reference의 `basename`만 사용한 source parent sibling lookup
+- 빈 이름, `.`, `..`, path separator 포함 이름 reject
+- standardized/resolved candidate가 source parent 밖이면 reject
+- directory, symlink escape, size cap 초과 reject
+- network/URL/Windows absolute/UNC path 해석 금지
+- full original path를 user-facing log에 노출하지 않음
+
+### Preview 적용 순서
+
+- `HwpPreviewPDFRenderer.load(fileURL:)`에서 main bytes open
+- filename setter
+- refs 조회
+- resolver와 injection
+- 그 뒤 page count/size/render
+- resolver 실패는 document render 전체 failure로 올리지 않고 report/diagnostic에 누적
+
+### #409 검증 최소 기준
+
+- source URL 없음: resolver disabled, 기존 render 유지
+- external refs 없음: `[]`, 기존 render 유지
+- invalid basename/path escape/too large: reject status/report
+- valid sibling: injection success 후 `loaded == true`
+- page/render 호출이 injection 뒤 실행됨
+- refs JSON Rust string 해제와 image bytes caller lifetime 확인
+- privacy-safe log
+
+Thumbnail cache는 #411 전까지 resolver를 활성화하지 않는다. CoreGraphics missing/decode placeholder는 #410, exact fixture/full visual regression은 #412, WKWebView 경로는 #413이 소유한다.
+
+## 보류 및 잔여 위험
+
+| 항목 | 현재 상태 | 후속 |
+|------|-----------|------|
+| `rhwp_image_state_json` | pinned public API가 전체 image state를 제공하지 않아 미구현 | #410 또는 upstream API 확장 검토 |
+| external injection 성공 fixture | repository exact fixture 없음 | #409 최소 fixture, #412 정식 suite |
+| external missing/decode placeholder | renderer 미구현 | #410 |
+| Thumbnail stale cache | external signature 없음 | #411 |
+| large image memory/latency | 미측정 | #412 |
+| WKWebView external bridge | native ABI와 별도 경로 | #413 |
+| safe Rust raw-pointer lint | current C ABI 전체가 safe extern wrapper 정책 | 별도 FFI safety 정리 시 검토 |
+
+## 최종 판단
+
+#391에서 설계한 RustBridge downstream 보정 중 #408 범위는 완료됐다. Upstream `HwpDocument`의 filename/external refs/injection 기능이 이제 macOS Swift에서 호출 가능한 ABI로 노출되고 generated artifact와 provenance gate까지 일치한다.
+
+다만 실제 Quick Look에서 external image가 보이기 위한 작업은 끝나지 않았다. #409가 Swift wrapper와 resolver를 연결해야 하며, renderer placeholder/cache/fixture는 #410-#412에서 각각 완료해야 parent #407의 전체 목표가 충족된다.
+
+## 작업지시자 승인 요청
+
+#408 Stage 1-5와 최종 결과보고서가 완료됐다. 최종 보고 승인 후 `task-final-report` 절차를 호출해 `publish/task408` push와 `devel` 대상 PR 게시를 진행한다.

--- a/mydocs/tech/project_architecture.md
+++ b/mydocs/tech/project_architecture.md
@@ -175,10 +175,15 @@ mydocs/                       # hyper-waterfall 작업 문서와 운영 매뉴�
 
 - `rhwp_open`
 - `rhwp_close`
+- `rhwp_set_file_name_utf8`
+- `rhwp_external_image_refs_json`
+- `rhwp_inject_external_image_by_key`
 - `rhwp_page_count`
 - `rhwp_page_size`
 - `rhwp_render_page_svg`
 - `rhwp_render_page_tree`
+- `rhwp_page_overlay_images`
+- `rhwp_render_page_png`
 - `rhwp_image_data`
 - `rhwp_extract_thumbnail`
 - `rhwp_free_string`
@@ -192,18 +197,26 @@ mydocs/                       # hyper-waterfall 작업 문서와 운영 매뉴�
 - `rhwp_render_page_tree`: 상세 render tree JSON 반환
 - `rhwp_image_data`: `bin_data_id`에 대응하는 이미지 바이트 조회
 - `rhwp_extract_thumbnail`: embedded thumbnail 바이트와 메타데이터 조회
+- `rhwp_set_file_name_utf8`: filename context를 document에 설정
+- `rhwp_external_image_refs_json`: external image reference와 loaded 상태를 upstream JSON 배열로 조회
+- `rhwp_inject_external_image_by_key`: Swift/macOS shell이 읽은 image bytes를 reference key로 주입
 - `rhwp_close`: 문서 핸들 해제
 - `rhwp_free_string`: Rust가 할당한 문자열 해제
 - `rhwp_free_bytes`: Rust가 소유권을 넘긴 byte buffer 해제
 
 `rhwp_render_page_svg`는 현재 HostApp/extension의 주 렌더링 경로는 아니지만, 진단/호환성 관점에서 ABI에 포함되어 있다. core SVG와 native renderer 비교 절차는 [`render_core_native_compare_guide.md`](../manual/render_core_native_compare_guide.md)를 따른다.
 
+External image context ABI는 #409 Swift wrapper/Quick Look 적용 전까지 제품 경로에서 직접 호출하지 않는다. RustBridge는 external path를 열지 않으며 source URL 권한, resolver policy, bytes read와 cache signature는 Swift/macOS shell 책임이다. `rhwp_image_state_json`은 pinned public API가 전체 image 상태를 제공하지 않아 현재 ABI에 포함하지 않는다.
+
 ## FFI 안전성 규칙
 
 - null pointer 입력은 Rust와 Swift 양쪽에서 방어한다.
 - `RhwpDocument`의 수명은 내부 `OpaquePointer` handle 수명과 일치해야 한다.
 - `rhwp_render_page_tree`와 `rhwp_render_page_svg`가 반환한 문자열은 반드시 `rhwp_free_string`으로 해제한다.
+- `rhwp_external_image_refs_json`이 반환한 문자열도 반드시 `rhwp_free_string`으로 해제한다.
+- filename, external key, image bytes, display path 입력 pointer는 caller-owned이며 FFI 호출 동안 유효해야 한다.
 - `rhwp_image_data`는 내부 문서 버퍼를 가리키므로, Swift에서는 즉시 `Data`로 복사해 사용한다.
+- `rhwp_image_data` pointer는 filename setter나 external image injection 같은 mutable 호출을 넘겨 보관하지 않는다.
 - `rhwp_extract_thumbnail`이 반환한 byte buffer는 Swift에서 복사 후 `rhwp_free_bytes`로 해제한다.
 - 이미지 조회의 `bin_data_id`는 1-indexed 규칙을 유지한다.
 

--- a/mydocs/working/task_m020_408_stage1.md
+++ b/mydocs/working/task_m020_408_stage1.md
@@ -1,0 +1,145 @@
+# Task M020 #408 Stage 1 보고서
+
+## 단계 목적
+
+Stage 1의 목적은 opaque C handle과 기존 공개 ABI를 유지하면서 `RhwpHandle` 내부 document 타입을 `DocumentCore`에서 pinned `rhwp v0.7.17`의 `HwpDocument`로 전환하고, 기존 page/render/image 호출이 계속 compile되는지 확인하는 것이다.
+
+이 단계에서는 filename, external refs, bytes injection symbol을 아직 추가하지 않는다. 신규 ABI 구현은 Stage 2 범위로 유지한다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|------|-----------|
+| `RustBridge/src/lib.rs` | `HwpDocument` import, `RhwpHandle.doc` 타입, `rhwp_open` 생성자를 전환했다. 기존 formatting drift도 rustfmt로 정규화했다. 현재 325줄이다. |
+| `RustBridge/examples/svg_pdf_benchmark.rs` | crate 전체 formatter gate를 통과하기 위해 기존 formatting drift만 rustfmt로 정규화했다. 동작 변경은 없으며 현재 302줄이다. |
+| `mydocs/working/task_m020_408_stage1.md` | Stage 1 변경, 검증, 잔여 위험과 Stage 2 handoff를 기록한다. |
+| `mydocs/orders/20260710.md` | #408을 Stage 1 완료 및 Stage 2 승인 대기 상태로 갱신한다. |
+
+## 구현 결과
+
+### Handle 내부 타입 전환
+
+Stage 1의 의미 변경은 다음 세 항목이다.
+
+1. `use rhwp::DocumentCore`를 `use rhwp::wasm_api::HwpDocument`로 변경했다.
+2. `RhwpHandle.doc`을 `DocumentCore`에서 `HwpDocument`로 변경했다.
+3. `rhwp_open`에서 `DocumentCore::from_bytes(bytes)` 대신 `HwpDocument::from_bytes(bytes)`를 호출한다.
+
+`RhwpHandle` 자체는 계속 opaque struct이며 `rhwp_open`/`rhwp_close` signature도 바뀌지 않는다. `HwpDocument`는 내부에 `DocumentCore`를 소유하고 `Deref<Target = DocumentCore>` 및 `DerefMut`를 제공하므로 다음 기존 호출은 코드 변경 없이 compile됐다.
+
+- `page_count`
+- `get_page_info_native`
+- `render_page_svg_native`
+- `build_page_render_tree`
+- `get_page_overlay_images_native`
+- `render_page_png_native_with_export_options`
+- `get_bin_data`
+
+### ABI 무변경 확인
+
+Stage 1에서는 다음 파일을 변경하지 않았다.
+
+- `rhwp-ffi-symbols.txt`
+- `RustBridge/cbindgen.toml`
+- `RustBridge/Cargo.toml`
+- `RustBridge/Cargo.lock`
+- `rhwp-core.lock`
+
+따라서 기존 공개 symbol 집합, generated header 계약, pinned release tag `v0.7.17`, resolved commit `03351190ec35436e58cbfee0aa9278a8fdc04a59`, `native-skia` feature 기준은 그대로다.
+
+### 수명과 mutation 계약
+
+- `rhwp_open`은 입력 bytes를 `HwpDocument::from_bytes`로 파싱하고, 완성된 `HwpDocument`를 `Box<RhwpHandle>` 안에 소유한다.
+- `Box`가 유지되는 동안 opaque handle 주소는 안정적이며 `rhwp_close`가 같은 box를 해제한다.
+- `HwpDocument` 내부의 `DocumentCore`가 BinData를 계속 소유하므로 기존 `rhwp_image_data` pointer ownership은 바뀌지 않는다.
+- Swift는 `rhwp_image_data` 반환 pointer를 즉시 `Data`로 복사한다. Stage 2에서 mutable setter/injection이 추가되면 mutable 호출 전후로 pointer를 보관하지 않는 제약을 ABI 문서에 명시해야 한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 동작 의미 변경은 `RustBridge/src/lib.rs`의 document wrapper 전환 세 항목뿐이다.
+- `RustBridge/src/lib.rs`의 나머지 diff와 `svg_pdf_benchmark.rs` 전체 diff는 `cargo fmt`가 적용한 줄바꿈·block formatting 정규화다.
+- benchmark 계산, 파일 입출력, SVG/PDF 생성, summary 계산 로직은 바뀌지 않았다.
+- 기존 C 함수 signature, status enum 값, page/render/image data 처리 본문은 무손실이다.
+- Swift source, Quick Look/Thumbnail 제품 경로, generated framework는 변경하지 않았다.
+
+## 검증 결과
+
+### Rust formatting
+
+```bash
+cargo fmt --manifest-path RustBridge/Cargo.toml --check
+```
+
+결과: 최종 통과.
+
+첫 실행에서는 이번 변경 전부터 남아 있던 `RustBridge/src/lib.rs`와 `RustBridge/examples/svg_pdf_benchmark.rs`의 formatting drift가 검출됐다. `cargo fmt`가 library target만 선택하는 옵션을 제공하지 않아 두 파일을 formatter로 정규화한 뒤 같은 명령을 다시 실행해 통과했다.
+
+### Rust compile
+
+```bash
+cargo check --manifest-path RustBridge/Cargo.toml --locked
+```
+
+결과: 통과.
+
+```text
+Checking rhwp_mac_bridge v0.1.0 (.../RustBridge)
+Finished `dev` profile [unoptimized + debuginfo]
+```
+
+첫 sandbox 실행은 `skia-bindings v0.99.0` binary cache를 내려받는 과정에서 DNS가 제한되어 실패했다. 네트워크 권한이 있는 동일 명령으로 Skia binary cache를 준비한 뒤 성공했고, 이후 cached 재검증도 통과했다. 이는 source compatibility 실패가 아니다.
+
+### Rust test profile
+
+```bash
+cargo test --manifest-path RustBridge/Cargo.toml --locked
+```
+
+결과: 통과.
+
+```text
+running 0 tests
+test result: ok. 0 passed; 0 failed; 0 ignored
+```
+
+현재 RustBridge에는 unit test가 없으므로 이 결과는 test profile compile/link gate다. Stage 2에서 external ABI invalid-input/JSON lifecycle unit test를 추가한다.
+
+### 변경 및 계약 점검
+
+```bash
+git diff --check -- RustBridge/src/lib.rs RustBridge/examples/svg_pdf_benchmark.rs \
+  mydocs/working/task_m020_408_stage1.md mydocs/orders/20260710.md
+rg -n "HwpDocument|RhwpHandle|rhwp_open|page_count|get_page_info_native|build_page_render_tree|get_bin_data" \
+  RustBridge/src/lib.rs mydocs/working/task_m020_408_stage1.md
+```
+
+결과: 통과. `HwpDocument` 전환과 기존 호출 경로가 source/report에 존재하고 whitespace 오류가 없음을 확인했다.
+
+추가 확인:
+
+- `git diff -- rhwp-ffi-symbols.txt RustBridge/Cargo.toml RustBridge/Cargo.lock RustBridge/cbindgen.toml rhwp-core.lock`은 빈 결과다.
+- 변경 파일은 Stage 1 source/formatter 두 파일과 보고서/오늘할일뿐이다.
+- generated framework와 Xcode project는 변경하지 않았다.
+
+## 잔여 위험
+
+- Stage 1은 compile/test profile까지 확인했으며 generated `Rhwp.xcframework`를 재생성하지 않았다. staticlib/header 갱신은 신규 symbol이 추가되는 Stage 3에서 수행한다.
+- 현재 RustBridge unit test가 없어 기존 page/render/image ABI의 runtime 호출은 Stage 4 render smoke에서 확인해야 한다.
+- `HwpDocument`가 `DerefMut`를 제공하므로 Stage 2 mutation은 compile 가능하지만, injection 이후 page tree cache와 document-owned image pointer 수명은 별도 테스트와 문서화가 필요하다.
+- exact external image fixture가 없어 성공 injection의 `loaded: false -> true` end-to-end 검증은 Stage 2에서 fixture 존재 여부를 다시 확인하고, 없으면 #412에 남긴다.
+- formatter 정규화가 포함되어 Stage 1 diff가 의미 변경 세 줄보다 크다. 보고서에서 semantic diff와 formatting-only diff를 분리했고 동작 변경이 없는지 검토했다.
+
+## 다음 단계 영향
+
+Stage 2는 전환된 `HwpDocument`에 다음 additive ABI를 구현한다.
+
+- `RhwpExternalImageStatus`
+- `rhwp_set_file_name_utf8`
+- `rhwp_external_image_refs_json`
+- `rhwp_inject_external_image_by_key`
+
+Stage 2에서는 `serde_json::Value`로 refs JSON의 `key`와 `loaded`만 preflight하고 신규 dependency를 추가하지 않는다. pinned public API에 전체 image state 조회가 없으므로 `rhwp_image_state_json`은 구현하지 않는다.
+
+## 승인 요청
+
+Stage 1 `HwpDocument handle 전환과 기존 ABI 호환성 확인`은 완료됐다. Stage 2 `External image context C ABI와 Rust 검증 구현`으로 진행하려면 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m020_408_stage2.md
+++ b/mydocs/working/task_m020_408_stage2.md
@@ -1,0 +1,219 @@
+# Task M020 #408 Stage 2 보고서
+
+## 단계 목적
+
+Stage 2의 목적은 Stage 1에서 전환한 `HwpDocument` handle 위에 filename context setter, external image references JSON query, key-based bytes injection C ABI를 additive 방식으로 구현하고, Swift가 후속 #409에서 사용할 status와 pointer/length 계약을 Rust test로 고정하는 것이다.
+
+이 단계에서는 generated header/staticlib/xcframework, expected symbol lock, artifact provenance를 갱신하지 않는다. 해당 작업은 Stage 3 범위다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|------|-----------|
+| `RustBridge/src/lib.rs` | `RhwpExternalImageStatus`, 세 C ABI, pointer/length helper, refs preflight helper, unit test 4개를 추가했다. 현재 649줄이다. |
+| `RustBridge/cbindgen.toml` | `RhwpExternalImageStatus`를 export include에 추가했다. 현재 14줄이다. |
+| `mydocs/working/task_m020_408_stage2.md` | Stage 2 구현 계약, 검증 결과, 보류 항목과 Stage 3 handoff를 기록한다. |
+| `mydocs/orders/20260711.md` | 날짜 변경에 맞춰 #408 진행 행을 만들고 Stage 2 완료 및 Stage 3 승인 대기로 갱신한다. |
+
+## 구현 결과
+
+### `RhwpExternalImageStatus`
+
+`#[repr(C)]` enum을 다음 값으로 고정했다.
+
+| 값 | 이름 | 의미 |
+|----|------|------|
+| 0 | `RHWP_EXTERNAL_IMAGE_OK` | filename 설정 또는 bytes injection 성공 |
+| 1 | `RHWP_EXTERNAL_IMAGE_INVALID_HANDLE` | null document handle |
+| 2 | `RHWP_EXTERNAL_IMAGE_INVALID_INPUT` | pointer/length 불일치, 빈 key 또는 빈 data |
+| 3 | `RHWP_EXTERNAL_IMAGE_INVALID_UTF8` | filename, key 또는 display path UTF-8 오류 |
+| 4 | `RHWP_EXTERNAL_IMAGE_REFERENCE_NOT_FOUND` | refs JSON에 key가 없음 |
+| 5 | `RHWP_EXTERNAL_IMAGE_ALREADY_LOADED` | refs JSON의 `loaded`가 이미 `true` |
+| 6 | `RHWP_EXTERNAL_IMAGE_FAILURE` | JSON shape 오류, upstream injection 실패 또는 panic |
+
+status enum은 기존 `RhwpRenderStatus`와 독립적이며 기존 enum 값이나 ABI를 변경하지 않는다.
+
+### `rhwp_set_file_name_utf8`
+
+```c
+RhwpExternalImageStatus rhwp_set_file_name_utf8(
+    RhwpHandle *handle,
+    const uint8_t *name,
+    uintptr_t name_len
+);
+```
+
+- null handle을 status 1로 반환한다.
+- `name_len == 0`이면 null pointer를 허용하고 filename을 빈 문자열로 설정한다.
+- `name_len > 0`이면 non-null UTF-8 buffer가 필요하다.
+- `HwpDocument::set_file_name`을 호출해 upstream page tree cache invalidation 동작을 유지한다.
+- panic은 status 6으로 격리한다.
+
+### `rhwp_external_image_refs_json`
+
+```c
+char *rhwp_external_image_refs_json(const RhwpHandle *handle);
+```
+
+- upstream `HwpDocument::get_external_image_references()` 결과를 재가공하지 않고 Rust-owned C string으로 반환한다.
+- external ref가 없으면 upstream 계약대로 `[]`를 반환한다.
+- null handle 또는 panic이면 null pointer다.
+- caller는 반환값을 기존 `rhwp_free_string`으로 해제한다.
+- JSON 기준 필드는 `key`, `binDataId`, `originalPath`, `basename`, `extension`, `loaded`다.
+
+### `rhwp_inject_external_image_by_key`
+
+```c
+RhwpExternalImageStatus rhwp_inject_external_image_by_key(
+    RhwpHandle *handle,
+    const uint8_t *key,
+    uintptr_t key_len,
+    const uint8_t *data,
+    uintptr_t data_len,
+    const uint8_t *display_path,
+    uintptr_t display_path_len
+);
+```
+
+- key와 data는 non-null/non-empty여야 한다.
+- display path는 빈 값일 수 있고 길이가 0이면 null pointer를 허용한다.
+- production path는 전달받은 bytes만 upstream에 주입하며 파일이나 directory를 열지 않는다.
+- refs JSON의 `key`와 `loaded`만 `serde_json::Value`로 preflight한다.
+- key 미존재와 이미 loaded 상태를 upstream의 단일 `0` 반환에서 분리해 status 4/5로 표현한다.
+- unloaded reference에 upstream API가 `1`을 반환하면 status 0, `0`이면 status 6이다.
+- input buffer는 호출 동안 caller-owned이며 upstream injection이 필요한 bytes를 document 내부로 복사한다.
+
+### Private helper와 pointer 수명
+
+`borrowed_input_bytes`와 `borrowed_input_utf8`은 pointer/length 조합을 공통 검증한다. 빈 값 허용 여부를 caller가 지정하며 non-empty buffer는 호출 동안 readable해야 한다는 safety contract를 source comment로 남겼다.
+
+`external_image_reference_loaded`는 upstream refs JSON에서 key와 loaded boolean만 읽는다. 별도 DTO나 `serde` dependency를 추가하지 않아 pinned dependency graph를 유지한다.
+
+### `rhwp_image_state_json` 보류
+
+pinned `v0.7.17` public API에는 embedded/external/missing/injected 전체 image 상태를 반환하는 함수가 없다. refs JSON의 `loaded`를 전체 image 상태로 확장 해석하면 embedded missing 또는 renderer decode failure를 잘못 표현할 수 있으므로 `rhwp_image_state_json`은 구현하지 않았다.
+
+- external reference 상태: 이번 `rhwp_external_image_refs_json`
+- renderer missing/decode diagnostic: #410
+- exact external/large fixture와 visual regression: #412
+
+## Unit test
+
+`RustBridge/src/lib.rs`의 `#[cfg(test)]` module에 다음 4개 test를 추가했다.
+
+| test | 검증 내용 |
+|------|-----------|
+| `filename_context_validates_handle_and_utf8` | null handle, 빈 filename, 정상 UTF-8, invalid UTF-8, pointer/length 불일치 |
+| `external_refs_json_has_owned_string_lifecycle` | repository KTX fixture open, page count, refs JSON UTF-8/array, `rhwp_free_string`, close lifecycle |
+| `injection_validates_inputs_and_missing_reference` | null handle, 빈 key/data, invalid key/display UTF-8, 미존재 key status |
+| `external_reference_lookup_reads_loaded_state` | synthetic refs JSON의 `loaded=false`, `loaded=true`, key 미존재, 필드/array shape 오류 |
+
+repository 기본 sample에서는 exact external reference fixture를 확인하지 못했다. 따라서 실제 bytes injection 후 `loaded: false -> true` end-to-end test는 추가하지 않았으며 #412 fixture 의존성을 유지한다. 대신 status 5 판정의 입력인 refs preflight는 synthetic JSON test로 고정했다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 기존 공개 함수와 enum은 수정하지 않았다.
+- 신규 enum, 세 함수, private helper, test module만 additive로 추가했다.
+- `RustBridge/Cargo.toml`, `Cargo.lock`, `rhwp-ffi-symbols.txt`, `rhwp-core.lock`은 변경하지 않았다.
+- production RustBridge 코드에는 filesystem lookup, path normalization, logging을 추가하지 않았다.
+- Quick Look/Thumbnail/Swift source와 generated framework는 변경하지 않았다.
+- `cargo fmt` 결과 Stage 1에서 정규화한 기존 코드에는 추가 formatting diff가 생기지 않았다.
+
+## 검증 결과
+
+### 계획서 필수 gate
+
+```bash
+cargo fmt --manifest-path RustBridge/Cargo.toml --check
+```
+
+결과: 통과.
+
+```bash
+cargo check --manifest-path RustBridge/Cargo.toml --locked
+```
+
+결과: 통과.
+
+```text
+Checking rhwp_mac_bridge v0.1.0 (.../RustBridge)
+Finished `dev` profile [unoptimized + debuginfo]
+```
+
+```bash
+cargo test --manifest-path RustBridge/Cargo.toml --locked
+```
+
+결과: 4개 test 모두 통과.
+
+```text
+running 4 tests
+test tests::external_reference_lookup_reads_loaded_state ... ok
+test tests::external_refs_json_has_owned_string_lifecycle ... ok
+test tests::filename_context_validates_handle_and_utf8 ... ok
+test tests::injection_validates_inputs_and_missing_reference ... ok
+test result: ok. 4 passed; 0 failed
+```
+
+```bash
+rg -n "RhwpExternalImageStatus|rhwp_set_file_name_utf8|rhwp_external_image_refs_json|rhwp_inject_external_image_by_key|REFERENCE_NOT_FOUND|ALREADY_LOADED" \
+  RustBridge/src/lib.rs RustBridge/cbindgen.toml mydocs/working/task_m020_408_stage2.md
+git diff --check -- RustBridge/src/lib.rs RustBridge/cbindgen.toml \
+  mydocs/working/task_m020_408_stage2.md mydocs/orders/20260710.md
+git diff --check
+```
+
+결과: 통과. 구현계획서가 참조한 7월 10일 orders 파일은 Stage 1 기록으로 유지하고, 날짜가 바뀐 현재 진행 상태는 `mydocs/orders/20260711.md`에 기록했다. 전체 diff check로 신규 오늘할일도 함께 검증했다.
+
+### cbindgen 임시 header
+
+```bash
+cbindgen --quiet --config RustBridge/cbindgen.toml --crate rhwp_mac_bridge \
+  --output /private/tmp/task408_rhwp.h RustBridge
+rg -n -A24 -B4 "RhwpExternalImageStatus|rhwp_set_file_name_utf8|rhwp_external_image_refs_json|rhwp_inject_external_image_by_key" \
+  /private/tmp/task408_rhwp.h
+```
+
+결과: 통과. 임시 header에서 enum 값 0-6, mutable setter/injection handle, const refs query handle, `uintptr_t` length와 세 함수 선언을 확인했다. 이 임시 파일은 repository 산출물이 아니며 정식 generated artifact 갱신은 Stage 3에서 수행한다.
+
+### Clippy 보강 검증
+
+```bash
+cargo clippy --manifest-path RustBridge/Cargo.toml --locked -- \
+  -D warnings -A clippy::not_unsafe_ptr_arg_deref
+```
+
+결과: 통과.
+
+allow 없이 실행하면 기존 모든 public safe C ABI 함수가 raw pointer를 역참조한다는 `clippy::not_unsafe_ptr_arg_deref` 38건으로 실패한다. 이는 이번 신규 함수만의 문제가 아니라 current crate의 C ABI 정책 전반에 해당한다. C ABI를 `unsafe extern`으로 바꾸는 breaking source-contract 검토는 #408 범위에 포함하지 않고, 해당 lint만 명시적으로 허용한 상태에서 나머지 warning을 `-D warnings`로 확인했다.
+
+### 무변경 계약 확인
+
+```bash
+git diff -- RustBridge/Cargo.toml RustBridge/Cargo.lock rhwp-ffi-symbols.txt rhwp-core.lock
+```
+
+결과: 빈 diff. dependency, expected symbol set, core provenance와 artifact lock은 Stage 2에서 변경하지 않았다.
+
+## 잔여 위험
+
+- exact external image fixture가 없어 실제 injection 성공과 document image data/render 반영은 아직 end-to-end로 검증하지 못했다. #409 Preview 적용과 #412 fixture suite에서 검증해야 한다.
+- `ALREADY_LOADED` status는 upstream refs JSON의 `loaded` 필드에 의존한다. 이번 단계에서는 synthetic JSON으로 판정 로직을 검증했으며 실제 fixture 확인은 남아 있다.
+- upstream refs JSON이 array가 아니거나 `loaded` boolean을 잃으면 status 6으로 보수적으로 실패한다. #409 Swift는 이를 resolver 실패와 구분해 bridge failure로 처리해야 한다.
+- current Rust FFI는 C caller 편의를 위해 safe `extern "C"` 함수가 raw pointer를 처리한다. Clippy의 해당 lint는 crate-wide 기존 정책과 충돌하며, Rust caller safety surface를 별도 정리하려면 독립 이슈가 필요하다.
+- `rhwp_image_data` document-owned pointer는 injection 같은 mutable 호출을 넘겨 보관하면 안 된다. #409 Swift wrapper는 각 조회 결과를 즉시 `Data`로 복사해야 한다.
+- expected symbol lock은 아직 세 신규 symbol을 포함하지 않으므로 정식 build script는 Stage 3 갱신 전까지 symbol diff로 실패하는 것이 정상이다.
+
+## 다음 단계 영향
+
+Stage 3에서는 다음을 수행한다.
+
+1. `rhwp-ffi-symbols.txt`에 세 신규 symbol을 추가한다.
+2. `build-rust-macos.sh --update-lock`으로 universal staticlib, generated header, generated symbol set, xcframework를 재생성한다.
+3. `rhwp-core.lock`의 source tag/commit/features는 유지하고 artifact hash/size와 timestamp를 갱신한다.
+4. generated header의 enum/function signature와 expected symbol set을 검증한다.
+5. `RustBridge/README.md`와 `mydocs/tech/project_architecture.md`에 ABI와 ownership 계약을 문서화한다.
+
+## 승인 요청
+
+Stage 2 `External image context C ABI와 Rust 검증 구현`은 완료됐다. Stage 3 `Header, symbol, provenance와 ABI 문서 갱신`으로 진행하려면 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m020_408_stage3.md
+++ b/mydocs/working/task_m020_408_stage3.md
@@ -1,0 +1,209 @@
+# Task M020 #408 Stage 3 보고서
+
+## 단계 목적
+
+Stage 3의 목적은 Stage 2에서 구현한 external image context C ABI를 expected symbol set과 generated header/staticlib/xcframework에 반영하고, `rhwp-core.lock` artifact metadata와 RustBridge architecture/ownership 문서를 일치시키는 것이다.
+
+이 단계에서는 Swift wrapper나 Quick Look/Thumbnail 제품 경로를 변경하지 않는다. Swift compile/link와 embedded render regression은 Stage 4 범위다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|------|-----------|
+| `rhwp-ffi-symbols.txt` | 신규 symbol 세 개를 정렬된 expected set에 추가했다. 현재 15줄이다. |
+| `rhwp-core.lock` | source provenance는 유지하고 staticlib/header artifact hash, size, build timestamp를 갱신했다. |
+| `scripts/build-rust-macos.sh` | 숫자가 포함된 FFI symbol을 온전히 추출하도록 regex를 `[a-z0-9_]+`로 보강했다. 현재 677줄이다. |
+| `RustBridge/README.md` | current core pin, external image ABI, status, 메모리·filesystem 책임 경계를 문서화했다. 현재 80줄이다. |
+| `mydocs/tech/project_architecture.md` | current FFI 표면과 external context/ownership 규칙을 추가했다. 현재 265줄이다. |
+| `mydocs/working/task_m020_408_stage3.md` | Stage 3 build, artifact, provenance, 문서 검증과 Stage 4 handoff를 기록한다. |
+| `mydocs/orders/20260711.md` | #408을 Stage 3 완료 및 Stage 4 승인 대기 상태로 갱신한다. |
+
+생성·검증했지만 저장소 정책에 따라 commit하지 않는 ignored 산출물:
+
+- `Frameworks/generated_rhwp.h`
+- `Frameworks/generated_rhwp_symbols.txt`
+- `Frameworks/universal/librhwp.a`
+- `Frameworks/Rhwp.xcframework/**`
+
+## Expected/generated symbol 결과
+
+`rhwp-ffi-symbols.txt`에 다음 symbol을 추가했다.
+
+- `rhwp_external_image_refs_json`
+- `rhwp_inject_external_image_by_key`
+- `rhwp_set_file_name_utf8`
+
+최종 expected/generated symbol set은 15개이며 `diff -u rhwp-ffi-symbols.txt Frameworks/generated_rhwp_symbols.txt`가 빈 결과로 통과했다.
+
+generated header는 다음 계약을 포함한다.
+
+- `RhwpExternalImageStatus` enum 값 0-6
+- mutable `RhwpHandle *`를 받는 filename setter
+- const `RhwpHandle *`를 받는 refs JSON query
+- mutable `RhwpHandle *`, caller-owned key/data/display path buffer와 `uintptr_t` length를 받는 injection
+
+universal staticlib의 global text symbol에서도 세 함수가 확인됐다.
+
+```text
+_rhwp_external_image_refs_json
+_rhwp_inject_external_image_by_key
+_rhwp_set_file_name_utf8
+```
+
+## Build gate 보강
+
+첫 `./scripts/build-rust-macos.sh --update-lock` 실행은 arm64/x86_64 release build와 universal binary 생성까지 성공했지만 generated symbol 추출 단계에서 실패했다.
+
+원인은 기존 regex가 `\brhwp_[a-z_]+`여서 숫자 `8`을 허용하지 않고 `rhwp_set_file_name_utf8`을 `rhwp_set_file_name_utf`으로 잘랐기 때문이다. 함수명이나 cbindgen 출력 오류가 아니라 build gate의 symbol parser 문제였다.
+
+다음 최소 수정 후 같은 명령을 다시 실행했다.
+
+```diff
+-grep -oE '\brhwp_[a-z_]+'
++grep -oE '\brhwp_[a-z0-9_]+'
+```
+
+수정 후 expected/generated symbol diff, xcframework 생성, lock update와 verify가 모두 통과했다. `bash -n scripts/build-rust-macos.sh`도 통과했다.
+
+## Artifact와 provenance
+
+source provenance는 변경되지 않았다.
+
+| 필드 | 값 |
+|------|----|
+| `rhwp_ref_kind` | `release-tag` |
+| `rhwp_release_tag` | `v0.7.17` |
+| `rhwp_commit` | `03351190ec35436e58cbfee0aa9278a8fdc04a59` |
+| `rhwp_enabled_features` | `native-skia` |
+
+artifact 변화:
+
+| artifact | 이전 | 현재 | 변화 |
+|----------|------|------|------|
+| `Frameworks/universal/librhwp.a` | 202,902,712 bytes | 202,931,144 bytes | +28,432 bytes |
+| `Frameworks/generated_rhwp.h` | 2,059 bytes | 3,310 bytes | +1,251 bytes |
+
+현재 reference metadata:
+
+- staticlib sha256: `e454ac6b32667c84509d320ce6da7972277a5d97655f3187f19f2f5a9a8a5acd`
+- header sha256: `c4cba0728b7e443ba78541dc1184d6aa286b91b72006e423e9283d998c31d8e5`
+- `built_at`: `2026-07-11T13:10:18Z`
+- universal staticlib과 xcframework 표시 크기: 각각 194M
+- universal architectures: `x86_64 arm64`
+
+## ABI와 ownership 문서화
+
+`RustBridge/README.md`와 `project_architecture.md`에 다음을 반영했다.
+
+- 세 external image context 함수와 `RhwpExternalImageStatus`
+- refs JSON의 `key`, `binDataId`, `originalPath`, `basename`, `extension`, `loaded` 계약
+- filename/key/data/display path는 caller-owned이며 호출 동안 유효해야 한다는 규칙
+- refs JSON은 Rust-owned string이며 `rhwp_free_string`으로 해제한다는 규칙
+- injection 성공 시 upstream document가 image bytes를 복사해 소유한다는 규칙
+- `rhwp_image_data` pointer는 즉시 복사하고 mutable 호출을 넘겨 보관하지 않는다는 규칙
+- RustBridge가 original/display path를 filesystem lookup에 사용하지 않는다는 책임 경계
+- `rhwp_image_state_json`은 pinned public API 부재로 제공하지 않는다는 판단
+
+architecture의 기존 FFI 목록에서 빠져 있던 `rhwp_page_overlay_images`와 `rhwp_render_page_png`도 current expected symbol set에 맞춰 함께 보정했다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- RustBridge ABI 구현 source와 cbindgen 설정은 Stage 2 이후 변경하지 않았다.
+- expected symbol set은 신규 세 symbol만 additive로 증가했다.
+- build script는 symbol 추출 regex 한 줄만 수정했으며 build 순서, target, lock 정책은 변경하지 않았다.
+- `rhwp-core.lock`은 artifact metadata와 timestamp만 변경됐고 core repo/tag/commit/features는 무손실이다.
+- 두 문서는 기존 구조를 유지하며 current ABI와 ownership 규칙을 필요한 위치에 추가했다.
+- generated `Frameworks/**`와 Rust target 산출물은 ignored 상태이며 commit 대상에 포함하지 않는다.
+- Swift, Quick Look, Thumbnail, HostApp 제품 source는 변경하지 않았다.
+
+## 검증 결과
+
+### Artifact update
+
+```bash
+./scripts/build-rust-macos.sh --update-lock
+```
+
+최종 결과: 통과.
+
+```text
+[1/4] Rust staticlib (arm64 + x86_64)...
+[2/4] Universal binary... x86_64 arm64
+[3/4] cbindgen header check... 15 FFI symbols
+[4/4] XCFramework...
+xcframework successfully written out
+Updated: rhwp-core.lock
+```
+
+첫 실행의 숫자 symbol 절단 실패는 build gate regex를 보정한 뒤 같은 명령으로 회복했다.
+
+### Lock verification
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+```
+
+결과: 통과.
+
+```text
+Verified: rhwp-core.lock
+```
+
+두 build 실행의 `xcodebuild -create-xcframework` 과정에서 sandbox가 CoreSimulatorService와 사용자 log/cache 경로에 접근하지 못한다는 경고가 출력됐다. 이 작업은 simulator runtime을 사용하지 않으며 명령 exit code는 0, xcframework 생성과 lock verification은 성공했다.
+
+### Header와 symbol
+
+```bash
+rg -n "RhwpExternalImageStatus|rhwp_set_file_name_utf8|rhwp_external_image_refs_json|rhwp_inject_external_image_by_key" \
+  Frameworks/generated_rhwp.h Frameworks/generated_rhwp_symbols.txt rhwp-ffi-symbols.txt
+nm -gU Frameworks/universal/librhwp.a | \
+  rg "rhwp_(set_file_name_utf8|external_image_refs_json|inject_external_image_by_key)"
+diff -u rhwp-ffi-symbols.txt Frameworks/generated_rhwp_symbols.txt
+```
+
+결과: 모두 통과. Header declaration, expected/generated set 일치, staticlib global symbol 존재를 확인했다.
+
+### Source provenance
+
+```bash
+rg -n "v0.7.17|03351190ec35436e58cbfee0aa9278a8fdc04a59|native-skia" rhwp-core.lock
+```
+
+결과: 통과. release tag, commit, feature가 유지됐다.
+
+### Script와 문서 diff
+
+```bash
+bash -n scripts/build-rust-macos.sh
+LC_ALL=C sort -c rhwp-ffi-symbols.txt
+git diff --check -- rhwp-ffi-symbols.txt rhwp-core.lock RustBridge/README.md \
+  mydocs/tech/project_architecture.md scripts/build-rust-macos.sh \
+  mydocs/working/task_m020_408_stage3.md mydocs/orders/20260710.md
+git diff --check
+```
+
+결과: 통과. 구현계획서가 참조한 7월 10일 orders는 Stage 1 기록으로 유지하고, 현재 진행 상태는 7월 11일 orders에서 전체 diff check로 함께 검증했다.
+
+## 잔여 위험
+
+- Stage 3은 artifact 생성과 symbol/provenance 검증까지 완료했지만 Swift import/compile은 아직 실행하지 않았다. Stage 4에서 실제 generated xcframework를 HostApp과 link한다.
+- exact external fixture가 없어 신규 ABI의 성공 injection visual 경로는 아직 검증하지 못했다. #409와 #412에서 확인해야 한다.
+- `rhwp_image_state_json`이 없어 embedded/external/missing/decode failure 전체 상태를 단일 query로 얻을 수 없다. External loaded는 refs JSON, renderer failure는 #410이 소유한다.
+- staticlib hash는 build environment 영향을 받을 수 있다. 현재 lock은 이 작업 환경의 reference metadata이며 CI는 기존 정책에 따라 staticlib hash skip을 사용할 수 있다.
+- CoreSimulatorService 경고는 비치명적이었지만 Stage 4 xcodebuild에서도 sandbox 환경 경고가 반복될 수 있다. build exit code와 compile/link 결과를 기준으로 판정한다.
+- build symbol parser는 이제 소문자·숫자·underscore를 지원한다. 향후 대문자 symbol을 도입하면 regex 정책을 다시 검토해야 한다.
+
+## 다음 단계 영향
+
+Stage 4에서는 이번 단계에서 생성한 `Rhwp.xcframework`를 사용해 다음을 검증한다.
+
+1. `check-no-appkit.sh` 공통 계층 경계
+2. `xcodegen generate`와 HostApp Debug compile/link
+3. 기본 fixture의 page count/size/render tree/native bitmap smoke
+4. `samples/hwp-img-001.hwp`의 기존 embedded image lookup 회귀
+5. Rust unit test와 staticlib symbol 재확인
+6. Swift가 import한 신규 enum/function signature 기록
+
+## 승인 요청
+
+Stage 3 `Header, symbol, provenance와 ABI 문서 갱신`은 완료됐다. Stage 4 `Swift compile/link와 embedded render 회귀 검증`으로 진행하려면 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m020_408_stage4.md
+++ b/mydocs/working/task_m020_408_stage4.md
@@ -1,0 +1,217 @@
+# Task M020 #408 Stage 4 보고서
+
+## 단계 목적
+
+Stage 4의 목적은 Stage 3에서 생성한 `Rhwp.xcframework`가 기존 Swift HostApp, Quick Look Preview, Finder Thumbnail target과 compile/link되고, `HwpDocument` handle 전환과 additive external image ABI가 기존 page/render/embedded image 경로를 회귀시키지 않는지 검증하는 것이다.
+
+이 단계는 검증 전용이며 제품 Swift/Rust source를 변경하지 않는다. Finder extension 등록 smoke와 external image resolver 적용은 범위 밖이다.
+
+## 산출물
+
+| 산출물 | 요약 |
+|--------|------|
+| `mydocs/working/task_m020_408_stage4.md` | Swift/Xcode, render fixture, Rust test, symbol, import signature 검증 결과를 기록한다. |
+| `mydocs/orders/20260711.md` | #408을 Stage 4 완료 및 Stage 5 승인 대기 상태로 갱신한다. |
+| `build.noindex/DerivedData/Build/Products/Debug/Alhangeul.app` | HostApp Debug compile/link 검증 산출물. ignored이며 commit하지 않는다. |
+| `output/stage3-render/*.png` | 기본 fixture native render 결과. ignored이며 commit하지 않는다. |
+| `build.noindex/task408-render/hwp-img-001-page1.png` | embedded image fixture native render 결과. ignored이며 commit하지 않는다. |
+
+## Swift/Xcode compile·link 결과
+
+`xcodegen generate`가 `project.yml`에서 `Alhangeul.xcodeproj`를 생성한 뒤 HostApp Debug build가 성공했다.
+
+```text
+Target dependency graph (4 targets)
+- HostApp
+- QLExtension
+- ThumbnailExtension
+- Sparkle
+...
+-lrhwp
+...
+** BUILD SUCCEEDED **
+```
+
+build log에서 `ProcessXCFramework`가 `Frameworks/Rhwp.xcframework`를 macOS static library로 처리했고 HostApp linker가 `-lrhwp`를 사용했음을 확인했다. `RhwpDocument.swift`, `RenderTree.swift`, `CGTreeRenderer.swift`를 포함한 HostApp과 두 extension target이 같은 generated module로 compile됐다.
+
+첫 sandbox build는 Swift package `Sparkle 2.9.1` fetch 중 GitHub DNS 제한으로 실패했다. 네트워크 권한이 있는 동일 명령으로 package를 내려받은 뒤 build가 성공했으므로 source 또는 ABI compile failure가 아니다.
+
+Xcode는 CoreSimulatorService, provisioning profile, plist type detector 관련 경고를 출력했지만 macOS Debug build exit code는 0이고 최종 app/appex validation까지 완료됐다.
+
+## Render regression 결과
+
+### 기본 fixture
+
+```bash
+./scripts/validate-stage3-render.sh
+```
+
+| fixture | page | bitmap | textRuns | hangulRuns | hangulScalars | nonWhitePixels |
+|---------|------|--------|----------|------------|---------------|----------------|
+| `KTX.hwp` | 1 | 1123x794 | 410 | 76 | 209 | 455,061 |
+| `request.hwp` | 1 | 567x794 | 102 | 36 | 309 | 70,188 |
+| `exam_kor.hwp` | 1 | 1123x1588 | 133 | 86 | 1,368 | 173,981 |
+
+세 fixture 모두 document open, page size, render tree, 한글 glyph, native PNG, non-blank gate를 통과했다.
+
+### Embedded image fixture
+
+```bash
+./scripts/validate-stage3-render.sh build.noindex/task408-render samples/hwp-img-001.hwp
+```
+
+결과:
+
+```text
+OK hwp-img-001.hwp: page=1 size=794x1123 textRuns=66
+hangulRuns=35 hangulScalars=190 nonWhitePixels=57037
+```
+
+생성 PNG는 794x1123 RGBA이며 sha256은 `c8744c304ccb847cbdaa72b079f44762794efcee2a7b48205f74496f7463e49d`다. 직접 확인 결과 페이지 상단 정부 로고와 하단 기관/OPEN 로고를 포함한 embedded image가 표시되어 기존 `bin_data_id -> rhwp_image_data -> CoreGraphics` 경로가 유지됨을 확인했다.
+
+이 검증은 embedded image 회귀 gate이며 external image 성공 injection visual 검증을 대신하지 않는다.
+
+## Swift import signature
+
+저장소 밖 임시 Swift 파일에서 `import Rhwp` 후 신규 enum과 세 함수를 참조하고 generated header module을 직접 typecheck했다.
+
+```bash
+xcrun swiftc -typecheck -dump-ast \
+  -module-cache-path /private/tmp/task408-swift-module-cache \
+  -Xcc -fmodules-cache-path=/private/tmp/task408-clang-module-cache \
+  -I Frameworks/Rhwp.xcframework/macos-arm64_x86_64/Headers \
+  /private/tmp/task408_swift_import.swift
+```
+
+확인된 Swift interface type:
+
+```swift
+RhwpExternalImageStatus(rawValue: UInt32) -> RhwpExternalImageStatus
+
+rhwp_set_file_name_utf8:
+  (OpaquePointer?, UnsafePointer<UInt8>?, UInt)
+    -> RhwpExternalImageStatus
+
+rhwp_external_image_refs_json:
+  (OpaquePointer?) -> UnsafeMutablePointer<CChar>?
+
+rhwp_inject_external_image_by_key:
+  (OpaquePointer?,
+   UnsafePointer<UInt8>?, UInt,
+   UnsafePointer<UInt8>?, UInt,
+   UnsafePointer<UInt8>?, UInt)
+    -> RhwpExternalImageStatus
+```
+
+#409 Swift wrapper는 기존 `RhwpRenderStatus`와 같은 방식으로 `RhwpExternalImageStatus.rawValue`를 downstream enum에 매핑할 수 있다. refs JSON pointer는 `String(cString:)` 또는 `Data`로 복사한 뒤 반드시 `rhwp_free_string`으로 해제해야 한다.
+
+첫 typecheck는 default Clang module cache가 sandbox 밖 `~/.cache`에 있어 실패했다. Swift/Clang module cache를 `/private/tmp`로 지정한 동일 typecheck는 통과했다. 임시 Swift source는 검증 후 삭제했다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- Stage 4에서는 제품 Swift/Rust source, cbindgen, symbol lock, core lock을 변경하지 않았다.
+- `xcodegen generate`는 `project.yml`을 읽어 ignored/generated `Alhangeul.xcodeproj`를 만들었으며 project 원본은 무변경이다.
+- Xcode build, Rust target, render PNG와 module cache는 모두 `build.noindex/`, `output/`, `Frameworks/`, `RustBridge/target/` 아래 ignored 산출물이다.
+- tracked 변경은 Stage 4 보고서와 오늘할일 진행 메모뿐이다.
+- Quick Look/Thumbnail 제품 동작과 extension 등록 정책은 변경하지 않았다.
+
+## 검증 결과
+
+### Core artifact lock
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+```
+
+결과: 통과. arm64/x86_64 staticlib, 15개 symbol, generated header, xcframework와 `rhwp-core.lock` 일치를 확인했다.
+
+### Shared bridge dependency boundary
+
+```bash
+./scripts/check-no-appkit.sh
+```
+
+결과:
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+### Xcode project와 HostApp build
+
+```bash
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+
+결과: 통과, `** BUILD SUCCEEDED **`.
+
+### Native render smoke
+
+```bash
+./scripts/validate-stage3-render.sh
+./scripts/validate-stage3-render.sh build.noindex/task408-render samples/hwp-img-001.hwp
+```
+
+결과: 기본 3개와 image fixture 모두 통과. 세부 metric과 시각 확인은 앞 절에 기록했다.
+
+### Rust unit test
+
+```bash
+cargo test --manifest-path RustBridge/Cargo.toml --locked
+```
+
+결과: 4개 test 모두 통과.
+
+```text
+test result: ok. 4 passed; 0 failed
+```
+
+### Staticlib symbol
+
+```bash
+nm -gU Frameworks/universal/librhwp.a | \
+  rg "rhwp_(open|image_data|set_file_name_utf8|external_image_refs_json|inject_external_image_by_key|close)"
+```
+
+결과: 기존 open/image/close와 신규 세 symbol 모두 존재한다.
+
+### Tracked diff와 개발 등록 정리
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+결과: 검증 산출물 생성 직후 tracked working tree는 clean이었다.
+
+Xcode build가 Debug app에 `RegisterWithLaunchServices`를 실행했으므로 종료 시 해당 path 등록 해제를 시도했다. `lsregister -u`는 `-10814`를 반환했지만 이어서 registration dump를 조회했을 때 `build.noindex/DerivedData/Build/Products/Debug/Alhangeul.app` path가 존재하지 않아 개발 산출물 등록이 남아 있지 않음을 확인했다.
+
+## 잔여 위험
+
+- external image exact fixture가 없어 실제 resolver bytes injection 후 refs `loaded` 전환과 Quick Look output은 검증하지 못했다. #409와 #412 범위다.
+- Stage 4 image fixture는 embedded image 회귀를 확인하지만 external missing, oversized image, decode failure를 포함하지 않는다.
+- 신규 ABI는 generated module에 import되지만 Swift wrapper에서 아직 호출하지 않는다. #409에서 pointer/length와 status mapping test가 필요하다.
+- Debug build는 compile/link gate이며 signed/sealed Finder extension smoke의 진실 원천이 아니다. 이 단계에서는 extension 등록 smoke를 의도적으로 실행하지 않았다.
+- CoreSimulator와 provisioning 관련 Xcode 경고는 비치명적이었지만 CI/다른 Xcode 버전에서도 warning noise가 발생할 수 있다.
+- render smoke는 non-blank와 glyph sanity 중심이며 pixel equivalence를 보장하지 않는다. Full external/large visual regression은 #412가 소유한다.
+
+## 다음 단계 영향
+
+Stage 5에서는 다음을 최종 보고서와 #409 handoff로 정리한다.
+
+1. 최종 public symbol과 `RhwpExternalImageStatus` 값
+2. refs JSON shape와 pointer/length/free/lifetime 계약
+3. `rhwp_image_state_json` 보류와 external fixture 미측정 위험
+4. Swift import signature와 #409 wrapper/status mapping 입력
+5. Stage 1-4 검증 결과, artifact provenance와 build gate 보정
+6. 오늘할일 완료 처리와 task-final-report 전 최종 승인 요청
+
+## 승인 요청
+
+Stage 4 `Swift compile/link와 embedded render 회귀 검증`은 완료됐다. Stage 5 `최종 보고서와 #409 handoff`로 진행하려면 작업지시자 승인이 필요하다.

--- a/rhwp-core.lock
+++ b/rhwp-core.lock
@@ -4,15 +4,15 @@ rhwp_ref_kind = "release-tag"
 rhwp_release_tag = "v0.7.17"
 rhwp_commit = "03351190ec35436e58cbfee0aa9278a8fdc04a59"
 rhwp_enabled_features = "native-skia"
-built_at = "2026-06-23T04:58:54Z"
+built_at = "2026-07-11T13:10:18Z"
 ffi_symbols_file = "rhwp-ffi-symbols.txt"
 
 [[artifacts]]
 path = "Frameworks/universal/librhwp.a"
-sha256 = "96f550e03ead0af52f8952bf013c9c997fb2c193e073f5f5fdbe647f0a9ef8a6"
-size = 202902712
+sha256 = "e454ac6b32667c84509d320ce6da7972277a5d97655f3187f19f2f5a9a8a5acd"
+size = 202931144
 
 [[artifacts]]
 path = "Frameworks/generated_rhwp.h"
-sha256 = "31ed496ccbe86082885a82c584166669e1913a552dba26556ef5182842959601"
-size = 2059
+sha256 = "c4cba0728b7e443ba78541dc1184d6aa286b91b72006e423e9283d998c31d8e5"
+size = 3310

--- a/rhwp-ffi-symbols.txt
+++ b/rhwp-ffi-symbols.txt
@@ -1,8 +1,10 @@
 rhwp_close
+rhwp_external_image_refs_json
 rhwp_extract_thumbnail
 rhwp_free_bytes
 rhwp_free_string
 rhwp_image_data
+rhwp_inject_external_image_by_key
 rhwp_open
 rhwp_page_count
 rhwp_page_overlay_images
@@ -10,3 +12,4 @@ rhwp_page_size
 rhwp_render_page_png
 rhwp_render_page_svg
 rhwp_render_page_tree
+rhwp_set_file_name_utf8

--- a/scripts/build-rust-macos.sh
+++ b/scripts/build-rust-macos.sh
@@ -634,7 +634,7 @@ xcrun lipo -info "$UNIVERSAL_LIB"
 echo "[3/4] cbindgen header check..."
 cbindgen --quiet --config "$BRIDGE_ROOT/cbindgen.toml" --crate rhwp_mac_bridge \
   --output "$GENERATED_H" "$BRIDGE_ROOT"
-grep -oE '\brhwp_[a-z_]+' "$GENERATED_H" | sort -u > "$GENERATED_SYMBOLS"
+grep -oE '\brhwp_[a-z0-9_]+' "$GENERATED_H" | sort -u > "$GENERATED_SYMBOLS"
 if ! diff -u "$EXPECTED_SYMBOLS" "$GENERATED_SYMBOLS"; then
   echo "ERROR: generated FFI symbol set differs from $EXPECTED_SYMBOLS" >&2
   echo "Generated header: $GENERATED_H" >&2


### PR DESCRIPTION
## 요약

- `HwpDocument` 기반 handle로 전환해 upstream external image context API를 RustBridge에서 사용할 수 있게 했습니다.
- 외부 이미지 참조 조회, 파일명 context 설정, key 기반 byte 주입을 위한 C ABI와 상태 코드를 추가했습니다.
- cbindgen header, symbol artifact, lockfile 및 bridge/architecture 문서를 새 ABI 계약에 맞게 갱신했습니다.
- Rust 단위 테스트, Swift import, macOS 3개 target 링크, 기존 embedded image 렌더 회귀를 검증했습니다.

## PR base

- `devel`

## 변경 내역

- [Stage 1: HwpDocument handle 전환과 기존 ABI 호환성 확인](https://github.com/postmelee/alhangeul-macos/blob/7e4c488cab86457a99ecd88e4ca5d2b22ce29ffe/mydocs/working/task_m020_408_stage1.md) ([6cbe649](https://github.com/postmelee/alhangeul-macos/commit/6cbe649))
- [Stage 2: external image context C ABI 구현](https://github.com/postmelee/alhangeul-macos/blob/7e4c488cab86457a99ecd88e4ca5d2b22ce29ffe/mydocs/working/task_m020_408_stage2.md) ([3ddeb62](https://github.com/postmelee/alhangeul-macos/commit/3ddeb62))
- [Stage 3: external image ABI artifact와 계약 문서 갱신](https://github.com/postmelee/alhangeul-macos/blob/7e4c488cab86457a99ecd88e4ca5d2b22ce29ffe/mydocs/working/task_m020_408_stage3.md) ([5a29f81](https://github.com/postmelee/alhangeul-macos/commit/5a29f81))
- [Stage 4: Swift 호환성과 embedded image 회귀 검증](https://github.com/postmelee/alhangeul-macos/blob/7e4c488cab86457a99ecd88e4ca5d2b22ce29ffe/mydocs/working/task_m020_408_stage4.md) ([5af44e2](https://github.com/postmelee/alhangeul-macos/commit/5af44e2))
- [Stage 5: external image C ABI 완료 정리](https://github.com/postmelee/alhangeul-macos/blob/7e4c488cab86457a99ecd88e4ca5d2b22ce29ffe/mydocs/report/task_m020_408_report.md) ([7e4c488](https://github.com/postmelee/alhangeul-macos/commit/7e4c488))

계획 및 보고 문서:

- [수행 계획서](https://github.com/postmelee/alhangeul-macos/blob/7e4c488cab86457a99ecd88e4ca5d2b22ce29ffe/mydocs/plans/task_m020_408.md)
- [구현 계획서](https://github.com/postmelee/alhangeul-macos/blob/7e4c488cab86457a99ecd88e4ca5d2b22ce29ffe/mydocs/plans/task_m020_408_impl.md)
- [최종 보고서](https://github.com/postmelee/alhangeul-macos/blob/7e4c488cab86457a99ecd88e4ca5d2b22ce29ffe/mydocs/report/task_m020_408_report.md)

## Core review points

- 외부 이미지 byte 탐색은 Swift/macOS shell이 담당하고 RustBridge는 참조 조회와 주입만 제공해 파일 접근 권한 경계를 유지합니다.
- UTF-8, null pointer, 길이, 중복 주입을 명시적 `RhwpExternalImageStatus`로 구분하며 기존 ABI의 반환·메모리 해제 계약은 유지합니다.
- `rhwp_image_state_json`은 현재 고정된 upstream public API로 전체 상태를 정확히 표현할 수 없어 이번 범위에서 제외했습니다.

## 검증

- `./scripts/build-rust-macos.sh --verify-lock`
- `cargo test --manifest-path RustBridge/Cargo.toml --locked` (4 tests passed)
- `cargo fmt --manifest-path RustBridge/Cargo.toml --all -- --check`
- `cargo clippy --manifest-path RustBridge/Cargo.toml --locked --all-targets -- -A clippy::not_unsafe_ptr_arg_deref`
- cbindgen header 및 `nm` symbol 목록 일치 확인
- Swift에서 신규 enum/function import typecheck
- HostApp, QLExtension, ThumbnailExtension compile/link 성공
- 4개 대표 문서 렌더 smoke 및 embedded image 출력 확인

## 관련 이슈

- Parent: #407
- 선행 조사: #391, #404
- 후속 구현: #409, #410, #411, #412, #413

## 후속 이슈 제안

- 신규 제안 없음. 기존 #409 - #413 이슈에서 Swift resolver, renderer fallback, 통합 검증을 추적합니다.

## 남은 위험

- 저장소에 실제 external BinData fixture가 없어 이번 단계는 합성 단위 테스트와 ABI 경계 검증을 중심으로 수행했습니다.
- Swift resolver와 Quick Look/Thumbnail 주입 흐름은 후속 이슈 범위이므로 이 PR만으로 외부 링크 이미지가 표시되지는 않습니다.
- 전체 image 상태 진단 ABI는 upstream public API 확장 또는 안정적인 상태 모델 확정 후 별도 반영이 필요합니다.
