### PR TITLE
Task #424 Stage 4-6: v0.1.8 official publish 완료 기록

### DIFF
--- a/mydocs/orders/20260719.md
+++ b/mydocs/orders/20260719.md
@@ -10,4 +10,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #424 | v0.1.8 public release 준비와 배포 실행 | 진행중 | M900, Stage 5 official publish와 public surface 검증 완료, Stage 6 최종 보고 승인 대기 |
+| #424 | v0.1.8 public release 준비와 배포 실행 | 완료 | M900, 완료: 13:10, official publish와 public surface 검증 완료, 최종 PR 승인 대기 |

--- a/mydocs/orders/20260719.md
+++ b/mydocs/orders/20260719.md
@@ -10,4 +10,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #424 | v0.1.8 public release 준비와 배포 실행 | 진행중 | M900, 구현계획서 작성 및 Stage 1 진행 |
+| #424 | v0.1.8 public release 준비와 배포 실행 | 진행중 | M900, Stage 4 signed draft 차단 gate 완료, Stage 5 official publish 승인 대기 |

--- a/mydocs/orders/20260719.md
+++ b/mydocs/orders/20260719.md
@@ -10,4 +10,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #424 | v0.1.8 public release 준비와 배포 실행 | 진행중 | M900, Stage 4 signed draft 차단 gate 완료, Stage 5 official publish 승인 대기 |
+| #424 | v0.1.8 public release 준비와 배포 실행 | 진행중 | M900, Stage 5 official publish와 public surface 검증 완료, Stage 6 최종 보고 승인 대기 |

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.8` | 후보 준비중 | [Alhangeul v0.1.8](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) | [v0.1.8](https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html) | [`v0.1.8.md`](v0.1.8.md) |
+| `v0.1.8` | 공개 완료 | [Alhangeul v0.1.8](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) | [v0.1.8](https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html) | [`v0.1.8.md`](v0.1.8.md) |
 | `v0.1.7` | 공개 완료 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |
 | `v0.1.6` | 공개 완료 | [Alhangeul v0.1.6](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.6) | [v0.1.6](https://postmelee.github.io/alhangeul-macos/updates/v0.1.6.html) | [`v0.1.6.md`](v0.1.6.md) |
 | `v0.1.5` | 공개 완료 | [Alhangeul v0.1.5](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.5) | [v0.1.5](https://postmelee.github.io/alhangeul-macos/updates/v0.1.5.html) | [`v0.1.5.md`](v0.1.5.md) |

--- a/mydocs/release/v0.1.8.md
+++ b/mydocs/release/v0.1.8.md
@@ -4,10 +4,10 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.8` build `14` official stable publish와 public surface 검증 완료, Stage 6 최종 보고 승인 대기 |
-| 목표 Git tag | `v0.1.8` |
-| 목표 app version | `0.1.8` |
-| 목표 build | `14` |
+| 상태 | `v0.1.8` build `14` official stable publish, public surface 검증과 Stage 6 최종 보고 완료, 최종 PR 승인 대기 |
+| Git tag | `v0.1.8` |
+| app version | `0.1.8` |
+| build | `14` |
 | 직전 public release | `v0.1.7` build `13` |
 | 직전 release commit | `876d2667c2bff60e8599af8bccb45c4cab19099f` |
 | 직전 public DMG SHA256 | `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` |
@@ -21,10 +21,10 @@
 | Release 실행 이슈 | [#424](https://github.com/postmelee/alhangeul-macos/issues/424) |
 | expected rhwp | `v0.7.18` / `93862a4e16df59834ebce46d91e948cd739208e9` |
 | upstream latest | `v0.7.19`, 이번 release에서 제외 |
-| latest guard 예외 | Task #422 결과와 upstream `edwardkim/rhwp#2396` 근거로 Publish 실행별 별도 승인 필요 |
+| latest guard 예외 | Task #422와 upstream #2396 근거로 Stage 4/5 실행별 `false` 승인, workflow 기본값 `true` 유지 |
 | Rehearsal DMG SHA256 | `2dbdf0bfbd20e2a1924450b53b6815a2434b8c515c373f1d126d1fc8cbdeaba9` (public 사용 금지) |
 
-2026-07-19 live 조회에서 `v0.1.7`은 non-draft/non-prerelease public release이며, `alhangeul-macos-0.1.7.dmg` asset digest는 위 SHA256과 일치했다. upstream `rhwp v0.7.18`과 `v0.7.19`도 모두 public stable release이고, `edwardkim/rhwp#2396`은 OPEN 상태다.
+2026-07-19 Stage 3 조회에서 `v0.1.7`은 non-draft/non-prerelease public release이며, `alhangeul-macos-0.1.7.dmg` asset digest는 위 SHA256과 일치했다. upstream `rhwp v0.7.18`과 `v0.7.19`도 모두 public stable release이고, 당시 `edwardkim/rhwp#2396`은 OPEN 상태였다. official publish 뒤 upstream PR #2398이 merge되어 #2396은 CLOSED됐지만 최신 stable release는 계속 `v0.7.19`이므로 수정된 후속 tag는 이번 릴리즈에 포함되지 않는다.
 
 2026-07-19 Stage 3에서 candidate `2872cd1492cb2a72101f9e9a9bedfd620748d4eb` 기준 source preflight와 별도 승인된 local rehearsal을 완료했다. rehearsal DMG는 159,624,609 bytes이고 checksum과 `hdiutil verify`, mounted layout 자동 검증 및 작업지시자의 Finder 육안 확인을 통과했지만 unsigned 검증 산출물이므로 public GitHub Release, Sparkle 또는 Homebrew에 사용하지 않는다.
 
@@ -71,12 +71,12 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 | `#405` | `Task #404: upstream 렌더 PR 대표 샘플 diff 측정` | verification-only | 아니오 | 아니오 | `#404` | `#390`, `#391` | PR body, `mydocs/report/task_m020_404_report.md` | 제품 source 변화 없음 |
 | `#414` | `Task #391: filename/external image context ABI 조사와 bridge 설계` | documentation/design | 아니오 | 아니오 | `#391` | `#407`, `#408`, `#409` | PR body, `mydocs/report/task_m020_391_report.md` | 제품 기능 아님 |
 | `#416` | `Task #408: RustBridge external image context C ABI 구현` | developer-facing bridge | 아니오 | 아니오 | `#408` | `#407`, `#409` | PR body, `mydocs/report/task_m020_408_report.md` | #409 전 external image 제품 지원 아님 |
-| `#417` | `Task #406: HOP 등록 HWP/HWPX UTI 호환 지원 추가` | 사용자-facing | 예 | 예 | `#406` | `#408` | PR body, `mydocs/report/task_m020_406_report.md` | Finder 후보 호환 보강, signed gate 필요 |
+| `#417` | `Task #406: HOP 등록 HWP/HWPX UTI 호환 지원 추가` | 사용자-facing | 예 | 예 | `#406` | `#408` | PR body, `mydocs/report/task_m020_406_report.md` | Finder 후보 호환 보강, Stage 4/5 signed gate 통과 |
 | `#420` | `Task #418: rhwp v0.7.18 full sync 재생성과 current devel 통합 검증` | upstream sync | 예 | 예 | `#418` | `#396`, `#406`, `#408`, `#409` | PR body, `mydocs/report/task_m020_418_report.md` | core/studio 개선과 provenance 갱신 |
 | `#423` | `Task #422: rhwp v0.7.19 회귀 판정과 v0.7.18 릴리스 후보 확정` | release safety | 아니오 | 아니오 | `#422` | `#406`, `#409`, `#418`, upstream `#2396` | PR body, `mydocs/report/task_m020_422_report.md` | v0.7.19 미반영 근거 |
 | `#425` | `Task #424 Stage 1-3: v0.1.8 release candidate 준비` | 운영/배포 | 아니오 | 아니오 | 진행중 `#424` | `#406`, `#418`, `#422` | Issue body, `mydocs/plans/task_m900_424_impl.md` | version/build, release communication과 source/rehearsal gate |
 
-## GitHub Release 본문 구조 후보
+## GitHub Release 본문 구조
 
 ### 변경 요약
 
@@ -132,7 +132,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 | [#408](https://github.com/postmelee/alhangeul-macos/issues/408) | [#416](https://github.com/postmelee/alhangeul-macos/pull/416) | merge 완료 | external image context C ABI 기반 |
 | [#418](https://github.com/postmelee/alhangeul-macos/issues/418) | [#420](https://github.com/postmelee/alhangeul-macos/pull/420) | merge 완료 | `rhwp v0.7.18` core/studio sync |
 | [#422](https://github.com/postmelee/alhangeul-macos/issues/422) | [#423](https://github.com/postmelee/alhangeul-macos/pull/423) | merge 완료 | v0.7.19 blocker와 v0.7.18 후보 확정 |
-| [#424](https://github.com/postmelee/alhangeul-macos/issues/424) | [#425](https://github.com/postmelee/alhangeul-macos/pull/425), [#426](https://github.com/postmelee/alhangeul-macos/pull/426), [#427](https://github.com/postmelee/alhangeul-macos/pull/427) | 진행중 | official stable publish와 public surface 검증 완료. Stage 6 최종 보고 승인 대기 |
+| [#424](https://github.com/postmelee/alhangeul-macos/issues/424) | [#425](https://github.com/postmelee/alhangeul-macos/pull/425), [#426](https://github.com/postmelee/alhangeul-macos/pull/426), [#427](https://github.com/postmelee/alhangeul-macos/pull/427) | 진행중 | official stable publish, public surface 검증과 Stage 6 최종 보고 완료. 최종 PR 승인 대기 |
 
 ## 검증 기준
 
@@ -142,7 +142,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 | Core lock | `rhwp_release_tag=v0.7.18`, commit `93862a4e...` | Stage 1 통과 |
 | Studio asset | bundled manifest가 `v0.7.18` / `93862a4e...` | Stage 1 통과 |
 | Workflow default | `0.1.8`, `v0.1.7`, `v0.7.18` | Stage 1 통과 |
-| Release PR analysis | `v0.1.7..HEAD` 14개 first-parent merge PR + Task #424 | Stage 3 candidate `2872cd1...` 재생성 완료, final candidate에서 다시 생성 필요 |
+| Release PR analysis | `v0.1.7..HEAD` 14개 first-parent merge PR + Task #424 | official run에서 release commit `542a35f...` 기준 재생성·업로드 통과 |
 | Release communication | README, Pages home/update, release index/record | Stage 2 작성 완료 |
 | Shared Swift boundary | `Sources/RhwpCoreBridge` AppKit/UIKit 의존 없음 | Stage 3 통과 |
 | Debug build와 native render | HostApp build, representative HWP/HWPX | Stage 3 통과: HWP 3종, HWPX 1종 |
@@ -165,7 +165,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 | rhwp core commit | `93862a4e16df59834ebce46d91e948cd739208e9` |
 | bundled rhwp-studio release tag | `v0.7.18` |
 | bundled rhwp-studio commit | `93862a4e16df59834ebce46d91e948cd739208e9` |
-| release title 후보 | `Alhangeul v0.1.8 (rhwp v0.7.18)` |
+| release title | `Alhangeul v0.1.8 (rhwp v0.7.18)` |
 | `require_latest_rhwp` | workflow default `true`, Stage 4/5 실행별 승인 시 `false` |
 | `include_rhwp_in_title` | `true` |
 | core lock | `rhwp-core.lock` |
@@ -175,7 +175,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 
 - [x] app/extension source version을 `0.1.8 (14)`로 정렬
 - [x] release workflow default를 `0.1.8`, `v0.1.7`, `v0.7.18`로 정렬
-- [x] README, Pages update/home, release index와 record 후보 작성
+- [x] README, Pages update/home, release index와 record 작성
 - [x] 포함 PR 자동 분석과 release owner 판정 작성
 - [x] source preflight, release helper와 universal package 검증
 - [x] 별도 승인 후 rehearsal DMG 생성과 checksum 검증
@@ -197,7 +197,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 - external image context C ABI는 포함되지만 Swift resolver #409 작업이 미완료이므로 외부 연결 이미지를 자동 탐색하거나 표시하지 않는다.
 - Skia Thumbnail/Quick Look 경로는 DEBUG/internal opt-in이며 production default는 CoreGraphics다.
 - HOP 호환 선언은 Finder 후보 자격을 보강하지만 LaunchServices cache와 함께 설치된 앱에 따라 후보 표시가 달라질 수 있다. 기본 앱을 강제 변경하지 않는다.
-- upstream `rhwp v0.7.19`는 `edwardkim/rhwp#2396` Host RPC 회귀 때문에 포함하지 않는다. downstream vendor patch 대신 수정된 새 stable tag를 다음 core sync에서 검토한다.
+- upstream `rhwp v0.7.19`는 release 시점의 `edwardkim/rhwp#2396` Host RPC 회귀 때문에 포함하지 않았다. upstream PR #2398의 수정은 merge됐지만 아직 새 stable tag가 없으므로 수정된 후속 release를 다음 core sync에서 검토한다.
 - public DMG SHA256, appcast EdDSA signature, notarization과 signed exact UTI는 Stage 5 official artifact에서 확정했다. Homebrew digest는 별도 승인 전이라 미확정이다.
 - Stage 3 rehearsal DMG는 unsigned local artifact이다. Developer ID signing, notarization, staple, Gatekeeper 또는 signed Finder integration 통과 근거로 사용하지 않는다.
 
@@ -207,7 +207,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 - [x] `CFBundleVersion`을 직전 public build `13`보다 큰 `14`로 증가
 - [x] release workflow의 `version`, `previous_release_ref`, `expected_rhwp_tag` 정렬
 - [x] latest guard 기본값 `true` 유지와 실행별 예외 조건 기록
-- [x] README 최신 릴리즈 후보 요약 갱신
+- [x] README 최신 공개 릴리즈 요약 갱신
 - [x] `docs/updates/v0.1.8.html` 추가
 - [x] `docs/updates/index.html`과 `docs/index.html` 최신 다운로드 경로 갱신
 - [x] `mydocs/release/index.md`에 v0.1.8 공개 완료 상태 반영

--- a/mydocs/release/v0.1.8.md
+++ b/mydocs/release/v0.1.8.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.8` build `14` Stage 3 source preflight와 local rehearsal 완료, Stage 4 승인 대기 |
+| 상태 | `v0.1.8` build `14` Stage 4 signed candidate 차단 gate 완료, Stage 5 official publish 승인 대기 |
 | 목표 Git tag | `v0.1.8` |
 | 목표 app version | `0.1.8` |
 | 목표 build | `14` |
@@ -12,9 +12,11 @@
 | 직전 release commit | `876d2667c2bff60e8599af8bccb45c4cab19099f` |
 | 직전 public DMG SHA256 | `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` |
 | GitHub Release 후보 | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8 |
+| Draft release | https://github.com/postmelee/alhangeul-macos/releases/tag/untagged-4de9d30f7bb39ba0bb44 |
 | Pages 릴리즈 노트 후보 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html |
 | Public DMG 후보 | `alhangeul-macos-0.1.8.dmg` |
 | Public DMG SHA256 | official stable publish 후 기록 |
+| Draft DMG SHA256 | `5d16eced64f1aef95cc5dd9704a93c4acd30f80ee40ce49352854d1b99995250` (161,077,475 bytes) |
 | Homebrew Cask | public DMG SHA256 확정 후 별도 승인으로 반영 |
 | Release 실행 이슈 | [#424](https://github.com/postmelee/alhangeul-macos/issues/424) |
 | expected rhwp | `v0.7.18` / `93862a4e16df59834ebce46d91e948cd739208e9` |
@@ -25,6 +27,8 @@
 2026-07-19 live 조회에서 `v0.1.7`은 non-draft/non-prerelease public release이며, `alhangeul-macos-0.1.7.dmg` asset digest는 위 SHA256과 일치했다. upstream `rhwp v0.7.18`과 `v0.7.19`도 모두 public stable release이고, `edwardkim/rhwp#2396`은 OPEN 상태다.
 
 2026-07-19 Stage 3에서 candidate `2872cd1492cb2a72101f9e9a9bedfd620748d4eb` 기준 source preflight와 별도 승인된 local rehearsal을 완료했다. rehearsal DMG는 159,624,609 bytes이고 checksum과 `hdiutil verify`, mounted layout 자동 검증 및 작업지시자의 Finder 육안 확인을 통과했지만 unsigned 검증 산출물이므로 public GitHub Release, Sparkle 또는 Homebrew에 사용하지 않는다.
+
+2026-07-19 Stage 4에서 Task #424 source PR #425, main back-merge PR #427과 release PR #426을 merge하고 release commit `542a35f2179e5499996b2ab7d2b1a94774b544a2`에 annotated tag `v0.1.8`을 생성했다. 별도 승인된 draft Publish run `29670015725`는 `require_latest_rhwp=false`, `draft=true`, `prerelease=false`로 성공했다. signed/notarized draft DMG는 checksum, Gatekeeper, staple, universal slice, mounted layout, HOP exact UTI의 Finder 후보와 실제 HWPX open, Host RPC, PDF export, 저장·공유·인쇄 시작 경로를 통과했다. 최초 Quick Look에서는 기존 v0.1.7 provider 선택을 발견해 결과에서 제외했고, v0.1.7과 HOP provider를 잠시 해제한 격리 smoke에서 signed v0.1.8 Preview의 9페이지 render와 Thumbnail PNG 생성을 실제 프로세스 경로로 확인했다. 검증 뒤 모든 provider 등록을 복원했다. stable appcast와 Pages deploy는 정상적으로 skip되어 public surface는 `v0.1.7`을 유지한다.
 
 ## 사용자용 요약
 
@@ -68,7 +72,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 | `#417` | `Task #406: HOP 등록 HWP/HWPX UTI 호환 지원 추가` | 사용자-facing | 예 | 예 | `#406` | `#408` | PR body, `mydocs/report/task_m020_406_report.md` | Finder 후보 호환 보강, signed gate 필요 |
 | `#420` | `Task #418: rhwp v0.7.18 full sync 재생성과 current devel 통합 검증` | upstream sync | 예 | 예 | `#418` | `#396`, `#406`, `#408`, `#409` | PR body, `mydocs/report/task_m020_418_report.md` | core/studio 개선과 provenance 갱신 |
 | `#423` | `Task #422: rhwp v0.7.19 회귀 판정과 v0.7.18 릴리스 후보 확정` | release safety | 아니오 | 아니오 | `#422` | `#406`, `#409`, `#418`, upstream `#2396` | PR body, `mydocs/report/task_m020_422_report.md` | v0.7.19 미반영 근거 |
-| Task #424 PR 예정 | `v0.1.8 public release 준비와 배포 실행` | 운영/배포 | 아니오 | 아니오 | `#424` | `#406`, `#418`, `#422` | Issue body, `mydocs/plans/task_m900_424_impl.md` | version/build, release communication과 배포 gate |
+| `#425` | `Task #424 Stage 1-3: v0.1.8 release candidate 준비` | 운영/배포 | 아니오 | 아니오 | 진행중 `#424` | `#406`, `#418`, `#422` | Issue body, `mydocs/plans/task_m900_424_impl.md` | version/build, release communication과 source/rehearsal gate |
 
 ## GitHub Release 본문 구조 후보
 
@@ -126,7 +130,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 | [#408](https://github.com/postmelee/alhangeul-macos/issues/408) | [#416](https://github.com/postmelee/alhangeul-macos/pull/416) | merge 완료 | external image context C ABI 기반 |
 | [#418](https://github.com/postmelee/alhangeul-macos/issues/418) | [#420](https://github.com/postmelee/alhangeul-macos/pull/420) | merge 완료 | `rhwp v0.7.18` core/studio sync |
 | [#422](https://github.com/postmelee/alhangeul-macos/issues/422) | [#423](https://github.com/postmelee/alhangeul-macos/pull/423) | merge 완료 | v0.7.19 blocker와 v0.7.18 후보 확정 |
-| [#424](https://github.com/postmelee/alhangeul-macos/issues/424) | 예정 | 진행중 | `v0.1.8` release candidate 준비와 public release 실행 |
+| [#424](https://github.com/postmelee/alhangeul-macos/issues/424) | [#425](https://github.com/postmelee/alhangeul-macos/pull/425), [#426](https://github.com/postmelee/alhangeul-macos/pull/426), [#427](https://github.com/postmelee/alhangeul-macos/pull/427) | 진행중 | source/main release merge와 signed draft 차단 gate 완료. Stage 5 official publish 승인 대기 |
 
 ## 검증 기준
 
@@ -142,8 +146,8 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 | Debug build와 native render | HostApp build, representative HWP/HWPX | Stage 3 통과: HWP 3종, HWPX 1종 |
 | Release package | app/extension universal `arm64 + x86_64` | Stage 3 통과: 세 target `0.1.8 (14)` |
 | Local rehearsal DMG | unsigned rehearsal layout/checksum | Stage 3 통과: SHA256 `2dbdf0bf...`, `hdiutil VALID` |
-| Signed HOP exact UTI | Finder 후보, open, Quick Look, Thumbnail, handler diagnostics | Stage 4 차단 gate |
-| Signed Host RPC | readiness, page count, SVG/PDF, 저장·공유·인쇄 시작 | Stage 4 차단 gate |
+| Signed HOP exact UTI | Finder 후보, open, Quick Look, Thumbnail, handler diagnostics | Stage 4 통과 |
+| Signed Host RPC | readiness, page count, SVG/PDF, 저장·공유·인쇄 시작 | Stage 4 통과 |
 | Public update | v0.1.7 -> v0.1.8 Sparkle와 extension refresh | Stage 5 예정 |
 
 ## Release metadata
@@ -173,11 +177,11 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 - [x] 포함 PR 자동 분석과 release owner 판정 작성
 - [x] source preflight, release helper와 universal package 검증
 - [x] 별도 승인 후 rehearsal DMG 생성과 checksum 검증
-- [ ] Task #424 PR을 `devel`에 merge
-- [ ] 별도 승인 후 `devel -> main` release PR merge
-- [ ] 별도 승인 후 정확한 final candidate에 `v0.1.8` tag 생성
-- [ ] `require_latest_rhwp=false` 예외를 별도 승인하고 draft Publish workflow 실행
-- [ ] signed/notarized draft DMG의 HOP exact UTI와 Host RPC 차단 gate 통과
+- [x] Task #424 PR #425를 `devel`에 merge
+- [x] 별도 승인 후 `devel -> main` release PR #426 merge
+- [x] 별도 승인 후 정확한 final candidate `542a35f...`에 `v0.1.8` tag 생성
+- [x] `require_latest_rhwp=false` 예외를 별도 승인하고 draft Publish workflow 실행
+- [x] signed/notarized draft DMG의 HOP exact UTI와 Host RPC 차단 gate 통과
 - [ ] 별도 승인 후 official stable Publish workflow 실행
 - [ ] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
 - [ ] v0.1.7에서 v0.1.8 Sparkle update와 extension refresh 확인
@@ -208,7 +212,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 - [x] HOP 호환과 기본 앱 자동 변경의 경계 명시
 - [x] external linked image, Skia default와 v0.7.19 기능 주장 제외
 - [x] source preflight와 rehearsal 검증
-- [ ] installed signed candidate의 HOP exact UTI와 Host RPC 검증
+- [x] installed signed candidate의 HOP exact UTI와 Host RPC 검증
 - [ ] public DMG와 SHA256 기록
 - [ ] public GitHub Release와 Pages/Sparkle 확인
 - [ ] Homebrew Cask 반영과 검증

--- a/mydocs/release/v0.1.8.md
+++ b/mydocs/release/v0.1.8.md
@@ -4,20 +4,20 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.8` build `14` Stage 4 signed candidate 차단 gate 완료, Stage 5 official publish 승인 대기 |
+| 상태 | `v0.1.8` build `14` official stable publish와 public surface 검증 완료, Stage 6 최종 보고 승인 대기 |
 | 목표 Git tag | `v0.1.8` |
 | 목표 app version | `0.1.8` |
 | 목표 build | `14` |
 | 직전 public release | `v0.1.7` build `13` |
 | 직전 release commit | `876d2667c2bff60e8599af8bccb45c4cab19099f` |
 | 직전 public DMG SHA256 | `332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d` |
-| GitHub Release 후보 | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8 |
+| Public GitHub Release | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8 |
 | Draft release | https://github.com/postmelee/alhangeul-macos/releases/tag/untagged-4de9d30f7bb39ba0bb44 |
-| Pages 릴리즈 노트 후보 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html |
-| Public DMG 후보 | `alhangeul-macos-0.1.8.dmg` |
-| Public DMG SHA256 | official stable publish 후 기록 |
+| Pages 릴리즈 노트 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html |
+| Public DMG | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.8/alhangeul-macos-0.1.8.dmg |
+| Public DMG SHA256 | `ecf34e240c72c3d9123004f06e4d3a07806c8fa9f5323f471fd5c0cd19cfeb18` (161,077,481 bytes) |
 | Draft DMG SHA256 | `5d16eced64f1aef95cc5dd9704a93c4acd30f80ee40ce49352854d1b99995250` (161,077,475 bytes) |
-| Homebrew Cask | public DMG SHA256 확정 후 별도 승인으로 반영 |
+| Homebrew Cask | public DMG SHA256 확정, 별도 승인 전이라 미반영 |
 | Release 실행 이슈 | [#424](https://github.com/postmelee/alhangeul-macos/issues/424) |
 | expected rhwp | `v0.7.18` / `93862a4e16df59834ebce46d91e948cd739208e9` |
 | upstream latest | `v0.7.19`, 이번 release에서 제외 |
@@ -29,6 +29,8 @@
 2026-07-19 Stage 3에서 candidate `2872cd1492cb2a72101f9e9a9bedfd620748d4eb` 기준 source preflight와 별도 승인된 local rehearsal을 완료했다. rehearsal DMG는 159,624,609 bytes이고 checksum과 `hdiutil verify`, mounted layout 자동 검증 및 작업지시자의 Finder 육안 확인을 통과했지만 unsigned 검증 산출물이므로 public GitHub Release, Sparkle 또는 Homebrew에 사용하지 않는다.
 
 2026-07-19 Stage 4에서 Task #424 source PR #425, main back-merge PR #427과 release PR #426을 merge하고 release commit `542a35f2179e5499996b2ab7d2b1a94774b544a2`에 annotated tag `v0.1.8`을 생성했다. 별도 승인된 draft Publish run `29670015725`는 `require_latest_rhwp=false`, `draft=true`, `prerelease=false`로 성공했다. signed/notarized draft DMG는 checksum, Gatekeeper, staple, universal slice, mounted layout, HOP exact UTI의 Finder 후보와 실제 HWPX open, Host RPC, PDF export, 저장·공유·인쇄 시작 경로를 통과했다. 최초 Quick Look에서는 기존 v0.1.7 provider 선택을 발견해 결과에서 제외했고, v0.1.7과 HOP provider를 잠시 해제한 격리 smoke에서 signed v0.1.8 Preview의 9페이지 render와 Thumbnail PNG 생성을 실제 프로세스 경로로 확인했다. 검증 뒤 모든 provider 등록을 복원했다. stable appcast와 Pages deploy는 정상적으로 skip되어 public surface는 `v0.1.7`을 유지한다.
+
+2026-07-19 Stage 5에서 별도 승인된 official Publish run [`29671844342`](https://github.com/postmelee/alhangeul-macos/actions/runs/29671844342)을 `require_latest_rhwp=false`, `draft=false`, `prerelease=false`로 실행했다. release와 Pages job이 모두 성공했고 GitHub Release, public DMG, Pages home/릴리즈 노트와 stable appcast가 `v0.1.8 (14)`로 갱신됐다. public DMG는 checksum, `hdiutil verify`, Developer ID signing, notarization, staple, Gatekeeper와 universal slice를 통과했다. 공개 설치본에서 HWP/HWPX 문서 열기, Finder Quick Look과 Thumbnail을 확인했으며, 기존 `/Applications/Alhangeul.app` v0.1.7에서 실제 Sparkle update를 수행한 뒤 수동 provider 등록 보정 없이 Preview와 Thumbnail이 v0.1.8 경로로 갱신되는 smoke를 통과했다. Homebrew Cask는 별도 승인 전이라 실행하지 않았다.
 
 ## 사용자용 요약
 
@@ -130,7 +132,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 | [#408](https://github.com/postmelee/alhangeul-macos/issues/408) | [#416](https://github.com/postmelee/alhangeul-macos/pull/416) | merge 완료 | external image context C ABI 기반 |
 | [#418](https://github.com/postmelee/alhangeul-macos/issues/418) | [#420](https://github.com/postmelee/alhangeul-macos/pull/420) | merge 완료 | `rhwp v0.7.18` core/studio sync |
 | [#422](https://github.com/postmelee/alhangeul-macos/issues/422) | [#423](https://github.com/postmelee/alhangeul-macos/pull/423) | merge 완료 | v0.7.19 blocker와 v0.7.18 후보 확정 |
-| [#424](https://github.com/postmelee/alhangeul-macos/issues/424) | [#425](https://github.com/postmelee/alhangeul-macos/pull/425), [#426](https://github.com/postmelee/alhangeul-macos/pull/426), [#427](https://github.com/postmelee/alhangeul-macos/pull/427) | 진행중 | source/main release merge와 signed draft 차단 gate 완료. Stage 5 official publish 승인 대기 |
+| [#424](https://github.com/postmelee/alhangeul-macos/issues/424) | [#425](https://github.com/postmelee/alhangeul-macos/pull/425), [#426](https://github.com/postmelee/alhangeul-macos/pull/426), [#427](https://github.com/postmelee/alhangeul-macos/pull/427) | 진행중 | official stable publish와 public surface 검증 완료. Stage 6 최종 보고 승인 대기 |
 
 ## 검증 기준
 
@@ -148,7 +150,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 | Local rehearsal DMG | unsigned rehearsal layout/checksum | Stage 3 통과: SHA256 `2dbdf0bf...`, `hdiutil VALID` |
 | Signed HOP exact UTI | Finder 후보, open, Quick Look, Thumbnail, handler diagnostics | Stage 4 통과 |
 | Signed Host RPC | readiness, page count, SVG/PDF, 저장·공유·인쇄 시작 | Stage 4 통과 |
-| Public update | v0.1.7 -> v0.1.8 Sparkle와 extension refresh | Stage 5 예정 |
+| Public update | v0.1.7 -> v0.1.8 Sparkle와 extension refresh | Stage 5 통과: 수동 등록 보정 없이 Preview/Thumbnail v0.1.8 경로 확인 |
 
 ## Release metadata
 
@@ -182,9 +184,9 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 - [x] 별도 승인 후 정확한 final candidate `542a35f...`에 `v0.1.8` tag 생성
 - [x] `require_latest_rhwp=false` 예외를 별도 승인하고 draft Publish workflow 실행
 - [x] signed/notarized draft DMG의 HOP exact UTI와 Host RPC 차단 gate 통과
-- [ ] 별도 승인 후 official stable Publish workflow 실행
-- [ ] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
-- [ ] v0.1.7에서 v0.1.8 Sparkle update와 extension refresh 확인
+- [x] 별도 승인 후 official stable Publish workflow 실행
+- [x] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
+- [x] v0.1.7에서 v0.1.8 Sparkle update와 extension refresh 확인
 - [ ] 별도 승인 후 Homebrew Cask 반영과 install/uninstall smoke
 
 ## 알려진 제한 사항과 후속 이슈
@@ -196,7 +198,7 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 - Skia Thumbnail/Quick Look 경로는 DEBUG/internal opt-in이며 production default는 CoreGraphics다.
 - HOP 호환 선언은 Finder 후보 자격을 보강하지만 LaunchServices cache와 함께 설치된 앱에 따라 후보 표시가 달라질 수 있다. 기본 앱을 강제 변경하지 않는다.
 - upstream `rhwp v0.7.19`는 `edwardkim/rhwp#2396` Host RPC 회귀 때문에 포함하지 않는다. downstream vendor patch 대신 수정된 새 stable tag를 다음 core sync에서 검토한다.
-- public DMG SHA256, appcast EdDSA signature, notarization, signed exact UTI와 Homebrew digest는 Stage 3에서도 단정하지 않는다.
+- public DMG SHA256, appcast EdDSA signature, notarization과 signed exact UTI는 Stage 5 official artifact에서 확정했다. Homebrew digest는 별도 승인 전이라 미확정이다.
 - Stage 3 rehearsal DMG는 unsigned local artifact이다. Developer ID signing, notarization, staple, Gatekeeper 또는 signed Finder integration 통과 근거로 사용하지 않는다.
 
 ## Release communication checklist
@@ -208,11 +210,11 @@ HOP이 등록한 HWP/HWPX 문서 형식도 알한글의 호환 형식으로 인�
 - [x] README 최신 릴리즈 후보 요약 갱신
 - [x] `docs/updates/v0.1.8.html` 추가
 - [x] `docs/updates/index.html`과 `docs/index.html` 최신 다운로드 경로 갱신
-- [x] `mydocs/release/index.md`에 v0.1.8 후보와 v0.1.7 공개 완료 상태 반영
+- [x] `mydocs/release/index.md`에 v0.1.8 공개 완료 상태 반영
 - [x] HOP 호환과 기본 앱 자동 변경의 경계 명시
 - [x] external linked image, Skia default와 v0.7.19 기능 주장 제외
 - [x] source preflight와 rehearsal 검증
 - [x] installed signed candidate의 HOP exact UTI와 Host RPC 검증
-- [ ] public DMG와 SHA256 기록
-- [ ] public GitHub Release와 Pages/Sparkle 확인
+- [x] public DMG와 SHA256 기록
+- [x] public GitHub Release와 Pages/Sparkle 확인
 - [ ] Homebrew Cask 반영과 검증

--- a/mydocs/report/task_m900_424_report.md
+++ b/mydocs/report/task_m900_424_report.md
@@ -1,0 +1,161 @@
+# Task M900 #424 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#424 `v0.1.8 public release 준비와 배포 실행`](https://github.com/postmelee/alhangeul-macos/issues/424) |
+| 마일스톤 | Release Operations |
+| 기준 브랜치 | `devel` |
+| 작업 브랜치 | `local/task424` |
+| 공개 릴리즈 | [Alhangeul v0.1.8 (rhwp v0.7.18)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) |
+| release commit | `542a35f2179e5499996b2ab7d2b1a94774b544a2` |
+| release tag | annotated `v0.1.8` |
+| app / extension | `0.1.8 (14)` |
+| rhwp core / studio | `v0.7.18` / `93862a4e16df59834ebce46d91e948cd739208e9` |
+| official workflow | [run 29671844342](https://github.com/postmelee/alhangeul-macos/actions/runs/29671844342) |
+| 단계 | 수행계획, 구현계획, Stage 1~6 |
+
+`v0.1.8` release source와 communication을 `rhwp v0.7.18` 기준으로 정렬하고, source preflight, unsigned rehearsal, signed/notarized draft 차단 gate를 거쳐 official stable release를 게시했다. public DMG, Pages, stable Sparkle appcast와 실제 v0.1.7 업데이트 경로까지 확인했다.
+
+이번 릴리즈에는 HOP이 등록한 `net.golbin.hop.hwp`, `net.golbin.hop.hwpx` 호환 선언과 `rhwp v0.7.18` core/studio 개선이 포함된다. upstream latest `v0.7.19`는 custom scheme legacy Host RPC 회귀 `edwardkim/rhwp#2396` 때문에 제외했다.
+
+## 단계별 결과
+
+| 단계 | 커밋 | 결과 |
+|------|------|------|
+| 수행계획 | `0c81dce` | 별도 worktree, Task 문서와 오늘할일 생성 |
+| 구현계획 | `a24f4ad` | 6단계 release source, signed gate, publish와 cleanup 계약 확정 |
+| Stage 1 | `be406ef` | app/extension `0.1.8 (14)`, workflow `v0.7.18` metadata 정렬 |
+| Stage 2 | `2872cd1` | README, Pages, release note와 내부 release record 작성 |
+| Stage 3 | `086ff46`, `8966128` | source preflight, universal package와 local rehearsal DMG 검증 |
+| Stage 4 | `db4173f` | main/tag 확정, signed/notarized draft의 HOP exact UTI와 Host RPC 차단 gate 통과 |
+| Stage 5 | `d117200` | official publish, public artifact/Pages/appcast와 실제 Sparkle 갱신 검증 |
+| Stage 6 | 이번 커밋 | 최종 release record, 최종 보고와 오늘할일 완료 처리 |
+
+Stage 1~3 source와 communication은 PR #425로 `devel`에 반영됐다. release PR #426은 `devel -> main`을 merge했고, main closeout은 PR #427로 `devel`에 역병합했다. 현재 최종 PR은 Stage 4~6 운영 기록을 `devel`에 반영하는 범위다.
+
+## Release Identity와 Publish
+
+| 항목 | 값 |
+|------|----|
+| version / build | `0.1.8 (14)` |
+| previous release | `v0.1.7 (13)` |
+| tag peeled commit | `542a35f2179e5499996b2ab7d2b1a94774b544a2` |
+| expected rhwp tag | `v0.7.18` |
+| expected rhwp commit | `93862a4e16df59834ebce46d91e948cd739208e9` |
+| `include_rhwp_in_title` | `true` |
+| `draft` / `prerelease` | `false` / `false` |
+| GitHub Release 상태 | non-draft, non-prerelease, latest stable |
+| published at | `2026-07-19T03:42:35Z` |
+
+official run의 build/publish job과 Pages deploy job은 모두 성공했다. release tag ref와 head SHA가 확정 release commit에 일치하며, release input validation, core/header/ABI lock, Developer ID signing, notarization, public artifact, release notes, Sparkle appcast와 Pages deploy가 통과했다.
+
+## Latest Guard 예외
+
+workflow 기본값 `require_latest_rhwp=true`는 유지했다. Stage 4 draft와 Stage 5 official 실행에서만 별도 승인으로 `require_latest_rhwp=false`를 사용했다.
+
+실행 시점 upstream latest는 `rhwp v0.7.19`였지만 Task #422에서 다음 release blocker를 확인했다.
+
+- original v0.7.19 bundled studio가 `alhangeul-studio:` custom scheme에서 legacy `rhwp-request` Host RPC를 차단한다.
+- 문서 표시는 가능해도 readiness, page count, 저장, 공유, 인쇄와 PDF 내보내기 command가 timeout된다.
+- 원인은 upstream MessageChannel origin 검증으로 축소했고 [edwardkim/rhwp#2396](https://github.com/edwardkim/rhwp/issues/2396)에 등록했다. official publish 실행 시점에는 OPEN이었다.
+- downstream vendor patch 없이 검증된 `v0.7.18`을 사용하고 수정된 후속 stable tag를 다음 core sync에서 검토한다.
+
+따라서 latest guard skip은 임의 우회가 아니라 승인된 release decision이며, workflow의 안전 기본값은 약화하지 않았다.
+
+official publish 뒤 upstream [PR #2398](https://github.com/edwardkim/rhwp/pull/2398)이 merge commit `7a64a7cef977f157893dd89cfd66d82c0d40e99a`로 반영되어 #2396은 CLOSED됐다. 그러나 Stage 6 조회에서도 최신 stable release는 계속 `v0.7.19`이므로 이 수정은 아직 release tag로 배포되지 않았고 v0.1.8의 `v0.7.18` provenance는 변경하지 않는다.
+
+## Public Artifact
+
+| 항목 | 결과 |
+|------|------|
+| DMG | `alhangeul-macos-0.1.8.dmg` |
+| URL | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.8/alhangeul-macos-0.1.8.dmg |
+| size | 161,077,481 bytes |
+| SHA256 | `ecf34e240c72c3d9123004f06e4d3a07806c8fa9f5323f471fd5c0cd19cfeb18` |
+| checksum asset | `alhangeul-macos-0.1.8.dmg.sha256`, 92 bytes |
+| DMG integrity | checksum과 `hdiutil verify` 통과 |
+| code signature | deep/strict 검증, Designated Requirement 충족 |
+| notarization | app과 DMG staple validate, Gatekeeper Notarized Developer ID accepted |
+| architecture | app, Preview, Thumbnail 모두 `arm64 + x86_64` |
+| legal resources | LICENSE, THIRD_PARTY_LICENSES, FONTS canonical hash 일치 |
+| mounted layout | app과 Applications symlink 확인 |
+
+draft run `29670015725`의 DMG SHA256은 `5d16eced...`이고 official DMG와 다르다. public 설치와 Homebrew 입력에는 official SHA256만 사용해야 한다. Stage 3 rehearsal DMG는 unsigned 검증 산출물이므로 배포에 사용할 수 없다.
+
+## Signed Candidate Gate
+
+### HOP Exact UTI와 Finder
+
+signed app의 HostApp, Preview와 Thumbnail built plist에서 다음 호환 타입을 확인했다.
+
+- `net.golbin.hop.hwp`
+- `net.golbin.hop.hwpx`
+
+exact handler 조회에 알한글이 포함됐고 Finder `다음으로 열기`에서 실제 알한글 후보를 선택해 9페이지 HWPX를 열었다. 기존 v0.1.7 provider와 HOP provider를 잠시 배제한 격리 smoke에서는 v0.1.8 Preview와 Thumbnail 실제 프로세스 경로, 9페이지 Quick Look과 non-blank PNG를 확인한 뒤 등록을 복원했다.
+
+이 Mac의 `mdls`는 한컴 Viewer UTI cache를 우선했으므로 파일의 실제 content type을 `net.golbin.hop.*`로 직접 분류하지는 못했다. 이는 signed plist, exact handler, Finder 후보와 실제 open 결과와 분리해 기록했으며 release 차단 사유는 아니다.
+
+### Host RPC와 앱 경로
+
+signed candidate의 bundled `rhwp-studio v0.7.18`에서 HWP와 HWPX의 custom scheme readiness, load, page count와 non-white render가 통과했다. 실제 앱 UI에서 HWP/HWPX open, 저장 panel 시작, share 후보 표시, 1페이지 PDF export와 print preview까지 확인했다. 저장 원본 변경, 외부 공유 전송과 실제 print job은 수행하지 않았다.
+
+## Pages와 Sparkle
+
+| surface | 결과 |
+|---------|------|
+| Pages home | 최신 다운로드가 v0.1.8 public DMG를 가리킴 |
+| release note | `updates/v0.1.8.html`, HTTP 200 |
+| stable appcast version | `14` / `0.1.8` |
+| enclosure | public DMG URL과 length `161077481` 일치 |
+| release notes link | v0.1.8 Pages 문서 일치 |
+| EdDSA | non-empty signature 확인 |
+| minimum macOS | `12.0` |
+
+기존 `/Applications/Alhangeul.app` v0.1.7에서 실제 `업데이트 확인...`을 실행했다. Sparkle이 v0.1.8 release note와 161.1MB public DMG를 표시했고 설치와 재실행 뒤 앱을 `0.1.8 (14)`로 교체했다.
+
+post-update smoke는 `Registration repair used: 0`으로 통과했다. Preview와 Thumbnail provider는 각각 `/Applications/Alhangeul.app`의 v0.1.8 extension 경로 하나로 조회됐고, HWP/HWPX Thumbnail과 Finder Space Quick Look이 모두 실제 문서 내용으로 렌더링됐다.
+
+## 변경 파일과 기록
+
+| 경로 | 내용 |
+|------|------|
+| app/extension Info.plist | `0.1.8 (14)` identity 정렬 |
+| release workflow | v0.1.8, previous v0.1.7, expected rhwp v0.7.18 기본 입력 정렬 |
+| README, `docs/` | 최신 공개 릴리즈, Pages home/update와 이전 버전 고지 |
+| `mydocs/release/v0.1.8.md` | release decision, delta, public artifact와 검증 기록 |
+| `mydocs/working/task_m900_424_stage1.md` ~ `stage5.md` | 단계별 source, rehearsal, signed gate와 official publish 기록 |
+| `mydocs/report/task_m900_424_report.md` | 전체 release 실행과 최종 판정 |
+| `mydocs/orders/20260719.md` | Task #424 완료 상태 |
+
+제품 source와 release communication은 이미 PR #425, #426과 #427을 통해 반영됐다. 이번 최종 PR은 Stage 4~6 이후 확정된 공개 artifact와 post-publish 검증 기록을 추가한다.
+
+## Homebrew와 미실행 항목
+
+Homebrew Cask는 public DMG URL과 SHA256을 확정했지만 별도 승인 없이 실행하지 않았다. 따라서 Cask 변경, `brew style`, `brew audit`, install/uninstall smoke와 Homebrew digest는 이번 Task 완료 근거에 포함하지 않는다. GitHub Release DMG와 Sparkle update는 정상적인 공개 설치 경로로 제공된다.
+
+Intel Mac 실기기 설치와 실행도 수행하지 않았다. app과 두 extension의 universal `arm64 + x86_64` slice는 자동 검증했지만 Intel 실기기 runtime은 잔여 위험이다.
+
+로컬 검증 결과 `/Applications/Alhangeul.app`은 public v0.1.8로 업데이트됐다. 공개 DMG 첫 설치 smoke에 사용한 `/Users/melee/Applications/Alhangeul.app` v0.1.8 복사본도 남아 있으므로 merge 후 cleanup에서 작업지시자 확인을 받아 정리한다.
+
+## 잔여 위험과 후속
+
+| 항목 | 상태 | 후속 |
+|------|------|------|
+| upstream #2396 | CLOSED, PR #2398 merge | 수정이 포함된 새 stable tag 확인 후 다음 core sync |
+| Homebrew Cask | 미반영 | 별도 승인된 배포 작업에서 official SHA256 사용 |
+| Intel Mac 실기기 | 미실행 | 가능한 환경에서 설치와 Quick Look smoke |
+| external linked image | #408 C ABI 기반만 포함 | open #409 이후 제품 지원 판단 |
+| Skia renderer | DEBUG/internal opt-in | production CoreGraphics default 유지 |
+| Finder 후보 | 설치 앱과 LaunchServices 상태 영향 | 기본 앱 자동 변경을 주장하지 않음 |
+
+## 최종 결론
+
+`v0.1.8 (14)`는 release commit `542a35f...`, `rhwp v0.7.18`과 동일한 signed/notarized universal app으로 public 배포됐다. source preflight, rehearsal, signed HOP exact UTI, custom scheme Host RPC, public artifact, Pages/appcast, Finder와 실제 Sparkle update에 신규 blocker가 없다.
+
+Homebrew와 Intel 실기기 검증은 명시된 미실행 항목으로 남지만 GitHub Release DMG와 Sparkle 경로의 official stable publish는 완료됐다. Task #424의 release 준비와 배포 실행 목표를 달성한 것으로 판정한다.
+
+## 작업지시자 승인 요청
+
+최종 보고서와 Stage 6 커밋을 승인해 주시면 `publish/task424` 원격 브랜치로 push하고 `devel` 대상 최종 운영 기록 PR을 게시한다. PR merge 뒤에는 Issue #424, local/publish branch와 분리 worktree를 `pr-merge-cleanup` 절차로 정리한다.

--- a/mydocs/working/task_m900_424_stage4.md
+++ b/mydocs/working/task_m900_424_stage4.md
@@ -1,0 +1,143 @@
+# Task M900 #424 Stage 4 완료보고서
+
+## 단계 목적
+
+`v0.1.8 (14)` release candidate를 `main`과 annotated tag로 확정하고, 별도 승인된 pre-public draft Publish workflow가 만든 signed/notarized DMG에서 배포 전 차단 smoke를 수행한다.
+
+## 확정 기준점
+
+| 항목 | 값 |
+|------|----|
+| Task #424 source PR | [#425](https://github.com/postmelee/alhangeul-macos/pull/425), `devel` merge 완료 |
+| main back-merge PR | [#427](https://github.com/postmelee/alhangeul-macos/pull/427), `devel` merge 완료 |
+| release PR | [#426](https://github.com/postmelee/alhangeul-macos/pull/426), `devel -> main` merge 완료 |
+| release commit | `542a35f2179e5499996b2ab7d2b1a94774b544a2` |
+| tag | annotated `v0.1.8`, peeled commit `542a35f2179e5499996b2ab7d2b1a94774b544a2` |
+| app / extension | `0.1.8 (14)` |
+| rhwp core / studio | `v0.7.18` / `93862a4e16df59834ebce46d91e948cd739208e9` |
+| draft workflow | [run 29670015725](https://github.com/postmelee/alhangeul-macos/actions/runs/29670015725) |
+
+Task #424 source PR merge 뒤 `main`에만 있던 v0.1.7 종료 기록을 `devel`로 되돌리는 merge를 먼저 수행했다. 이력 보존을 위해 squash나 cherry-pick으로 재작성하지 않고 PR #427의 merge commit으로 반영한 뒤 release PR #426을 merge했다.
+
+## Draft Publish 실행
+
+별도 승인을 받아 tag `v0.1.8`에서 다음 입력으로 `Release Publish DMG` workflow를 실행했다.
+
+| 입력 | 값 |
+|------|----|
+| `version` | `0.1.8` |
+| `previous_release_ref` | `v0.1.7` |
+| `expected_rhwp_tag` | `v0.7.18` |
+| `require_latest_rhwp` | `false` |
+| `include_rhwp_in_title` | `true` |
+| `draft` / `prerelease` | `true` / `false` |
+
+workflow는 release commit과 동일한 `542a35f...`에서 성공했다. `require_latest_rhwp=false`는 upstream `v0.7.19`의 custom scheme legacy RPC 회귀 `edwardkim/rhwp#2396`을 피하기 위한 승인된 실행별 예외이며 workflow 기본값은 변경하지 않았다.
+
+draft 실행에서는 stable Sparkle appcast 갱신과 Pages deploy가 모두 skip됐다. 검증 중 public stable appcast와 Pages 최신 릴리즈 표시는 계속 `v0.1.7`이었다.
+
+## Draft DMG와 서명 검증
+
+| 항목 | 결과 |
+|------|------|
+| draft release title | `Alhangeul v0.1.8 (rhwp v0.7.18)` |
+| DMG | `alhangeul-macos-0.1.8.dmg`, 161,077,475 bytes |
+| DMG SHA256 | `5d16eced64f1aef95cc5dd9704a93c4acd30f80ee40ce49352854d1b99995250` |
+| checksum | `shasum -a 256 -c` 통과 |
+| `hdiutil verify` | 통과 |
+| Gatekeeper | app과 DMG 모두 Notarized Developer ID accepted |
+| staple | app과 DMG 모두 `xcrun stapler validate` 통과 |
+| code signature | Developer ID Application: Taegyu Lee (XH6JHKYXV8), hardened runtime, timestamp |
+| architecture | app, Preview, Thumbnail 모두 `arm64 + x86_64` |
+| version | app과 extension 모두 `0.1.8 (14)` |
+| Legal | `LICENSE`, `THIRD_PARTY_LICENSES.md`, `FONTS.md` canonical 일치 |
+| mounted layout | 앱과 Applications symlink만 visible, `720x460` background와 기존 icon layout 일치 |
+
+검증용 signed candidate는 기존 `/Applications/Alhangeul.app` v0.1.7을 덮어쓰지 않고 `/Users/melee/Applications/Alhangeul.app`에 설치했다.
+
+## Finder와 HOP exact UTI 차단 smoke
+
+signed candidate의 built Info.plist가 `net.golbin.hop.hwp`, `net.golbin.hop.hwpx`를 document type과 imported UTI에 포함하는지 확인했다.
+
+exact handler 조회 결과:
+
+| UTI | 알한글 포함 여부 | 함께 조회된 주요 앱 |
+|-----|------------------|---------------------|
+| `net.golbin.hop.hwp` | `com.postmelee.alhangeul` 포함 | HOP, 한컴 Viewer |
+| `net.golbin.hop.hwpx` | `com.postmelee.alhangeul` 포함 | HOP, 한컴 Viewer, Archive Utility, The Unarchiver |
+
+`scripts/smoke-finder-integration.sh`를 signed candidate로 실행해 HWP와 HWPX Thumbnail 생성을 모두 통과했다. 검증 산출물은 `/private/tmp/alhangeul-v018-draft-finder/task151-20260719-113920`에 보관했다. 다만 같은 bundle identifier를 사용하는 v0.1.7 provider가 함께 등록된 상태였으므로 이 실행만으로 signed v0.1.8 Thumbnail provenance를 단정하지 않았다.
+
+첫 Finder Space HWPX Quick Look은 9페이지를 표시했지만 실행 프로세스가 `/Applications/Alhangeul.app` v0.1.7의 `AlhangeulPreview.appex`임을 확인했다. 이 결과는 signed v0.1.8 통과 근거에서 제외했다.
+
+provider provenance를 분리하기 위해 기존 v0.1.7과 HOP의 Preview/Thumbnail 등록을 잠시 해제하고 `/Users/melee/Applications/Alhangeul.app` v0.1.8 provider만 활성화했다. 기존 파일과 byte hash가 다른 유효한 ZIP HWPX `/private/tmp/Alhangeul-v018-alhangeul-preview.hwpx`를 사용한 결과는 다음과 같다.
+
+| 경로 | 결과 |
+|------|------|
+| Finder Quick Look | `/Users/melee/Applications/Alhangeul.app/.../AlhangeulPreview` 프로세스 실행 확인, 9페이지 non-blank render |
+| Thumbnail | `/Users/melee/Applications/Alhangeul.app/.../AlhangeulThumbnail` 프로세스 실행 확인, 566x800 PNG 생성 |
+| Thumbnail SHA256 | `0bd1bdae4b85f1f2e87b5174e022a05c8a657808219f5f249f34d47697d260e9` |
+| Thumbnail 산출물 | `/private/tmp/alhangeul-v018-isolated-thumbnail-1219/Alhangeul-v018-alhangeul-preview.hwpx.png` |
+
+이 환경의 `mdls`는 테스트 HWPX를 `com.haansoft.hancomofficeviewer.mac.hwpx`로 분류했다. 설치 앱에 따라 한 개의 실제 content type이 우선되는 macOS 특성 때문에 `net.golbin.hop.*` 직접 분류는 재현하지 못했지만, signed built plist의 선언과 exact handler 조회로 두 HOP UTI의 후보 자격을 확인했고 실제 Finder open, Preview와 Thumbnail은 동일 호환 선언에 포함된 문서 형식으로 통과했다. 전역 LaunchServices 또는 Quick Look cache reset은 수행하지 않았다.
+
+격리 smoke 뒤 HOP과 `/Applications/Alhangeul.app` v0.1.7 등록을 모두 복원했다. 최종 `pluginkit` 조회에서 Alhangeul Preview와 Thumbnail은 각각 v0.1.7 및 v0.1.8 두 항목, HOP Preview와 Thumbnail은 각각 한 항목이 다시 등록된 상태를 확인했다.
+
+Finder에서 임시 `Alhangeul-v018-routing.hwpx`를 우클릭한 결과 `다음으로 열기` 하위 메뉴에 `알한글.app`이 표시됐다. 해당 항목을 실제 선택했고 `/Users/melee/Applications/Alhangeul.app` 프로세스가 문서를 받아 9페이지 HWPX로 비어 있지 않게 렌더링했다. 전역 LaunchServices reset이나 기본 앱 변경은 수행하지 않았다.
+
+## Host RPC와 앱 UI 차단 smoke
+
+signed candidate의 bundled `rhwp-studio` resource를 사용해 다음 자동 smoke를 실행했다.
+
+```text
+scripts/preview-visual-diff-harness.sh \
+  /private/tmp/alhangeul-v018-draft-host-rpc \
+  --resource-dir /Users/melee/Applications/Alhangeul.app/Contents/Resources/rhwp-studio \
+  samples/basic/KTX.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+| 샘플 | 전략 | 페이지 | 결과 |
+|------|------|--------|------|
+| `KTX.hwp` | `rhwp-request` | 1 | readiness, `loadFile`, page count, non-white canvas/snapshot 통과 |
+| `hwpx-01.hwpx` | `rhwp-request` | 9 | readiness, `loadFile`, page count, non-white canvas/snapshot 통과 |
+
+실제 signed app UI에서는 다음을 확인했다.
+
+| 경로 | 결과 |
+|------|------|
+| HWP 열기 | `KTX.hwp`, 1페이지, non-blank render |
+| HWP 다른 이름으로 저장 | `HWP 문서 저장` panel 진입 후 취소, 원본 미변경 |
+| 공유 | macOS share popover와 AirDrop/Mail/메시지 등 후보 표시 후 취소, 전송 없음 |
+| PDF 내보내기 | `/private/tmp/Alhangeul-v018-KTX.pdf`, 490,220 bytes, PDF 1.3, 1페이지 |
+| 인쇄 | `Command-P`로 1/1페이지 print preview 표시 후 취소, print job 없음 |
+| HWPX Finder open | `Alhangeul-v018-routing.hwpx`, 9페이지 render |
+
+인쇄 대화상자가 표시되기 전에 studio의 `print-document` payload에 포함된 SVG page를 native `RhwpStudioPrintController`가 WKWebView PDF로 변환한다. 따라서 1/1페이지 print preview 확인은 SVG payload와 PDF 변환 경로가 함께 통과했다는 근거다.
+
+첫 `파일 > 인쇄...` AX 메뉴 클릭은 대화상자를 표시하지 않았지만 같은 command의 `Command-P` 실행에서는 정상적으로 print preview가 열렸다. 제품 기능 실패로 판정할 근거는 없으며 실제 인쇄 작업은 실행하지 않았다.
+
+## 미실행 항목
+
+Stage 4에서는 다음 public side effect를 실행하지 않았다.
+
+- draft release의 official publish 전환
+- stable Sparkle appcast와 Pages v0.1.8 배포
+- v0.1.7에서 v0.1.8로 Sparkle update와 extension refresh
+- public DMG URL/SHA256을 사용하는 Homebrew Cask 반영
+- Intel Mac 실기기 실행
+
+## 판단
+
+- `main` release commit과 annotated tag가 동일한 candidate를 가리킨다.
+- draft DMG의 Developer ID signing, notarization, staple, Gatekeeper, universal slice와 layout이 모두 통과했다.
+- signed candidate에서 HOP exact UTI Finder 후보와 handler diagnostics, 실제 HWPX open이 통과했다.
+- 기존 provider를 배제한 격리 smoke에서 signed v0.1.8 Preview와 Thumbnail의 실제 프로세스 경로와 non-blank 산출물을 확인했다.
+- bundled `rhwp-studio v0.7.18` custom scheme legacy RPC readiness/load와 HWP/HWPX page count가 통과했다.
+- 저장, 공유, SVG/PDF, 인쇄 시작 경로가 실제 UI에서 통과했다.
+- 검증 중 변경한 provider 등록을 원상 복구했으며 public stable surface는 계속 v0.1.7을 유지한다.
+- Stage 4 pre-public signed candidate 차단 gate를 통과로 판정한다.
+
+## 승인 요청
+
+Stage 4 완료보고서와 단계 커밋 승인 후 Stage 5 official stable Publish workflow 실행 승인을 별도로 요청한다. 이 승인 전에는 draft release 공개 전환, stable appcast/Pages 배포와 Homebrew 반영을 실행하지 않는다.

--- a/mydocs/working/task_m900_424_stage5.md
+++ b/mydocs/working/task_m900_424_stage5.md
@@ -1,0 +1,116 @@
+# Task M900 #424 Stage 5 완료보고서
+
+## 단계 목적
+
+Stage 4 signed candidate 차단 gate를 통과한 `v0.1.8 (14)`를 official stable release로 게시하고, public artifact, Pages, Sparkle와 설치 후 Finder surface를 검증한다.
+
+## Official Publish 실행
+
+별도 승인을 받아 annotated tag `v0.1.8`에서 다음 입력으로 `Release Publish DMG` workflow를 실행했다.
+
+| 항목 | 값 |
+|------|----|
+| workflow run | [29671844342](https://github.com/postmelee/alhangeul-macos/actions/runs/29671844342) |
+| release commit | `542a35f2179e5499996b2ab7d2b1a94774b544a2` |
+| `version` | `0.1.8` |
+| `previous_release_ref` | `v0.1.7` |
+| `expected_rhwp_tag` | `v0.7.18` |
+| `require_latest_rhwp` | `false` |
+| `include_rhwp_in_title` | `true` |
+| `draft` / `prerelease` | `false` / `false` |
+| 결과 | build/publish job과 Pages deploy job 모두 성공 |
+
+`require_latest_rhwp=false`는 upstream `v0.7.19`의 custom scheme legacy RPC 회귀 `edwardkim/rhwp#2396`을 피하기 위한 승인된 실행별 예외다. workflow 기본값 `true`는 변경하지 않았고 upstream Issue는 실행 시점에도 OPEN이었다.
+
+## Public GitHub Release와 DMG
+
+| 항목 | 결과 |
+|------|------|
+| GitHub Release | [Alhangeul v0.1.8 (rhwp v0.7.18)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) |
+| 공개 상태 | non-draft, non-prerelease, latest release |
+| DMG | `alhangeul-macos-0.1.8.dmg`, 161,077,481 bytes |
+| DMG URL | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.8/alhangeul-macos-0.1.8.dmg |
+| SHA256 | `ecf34e240c72c3d9123004f06e4d3a07806c8fa9f5323f471fd5c0cd19cfeb18` |
+| checksum asset | `alhangeul-macos-0.1.8.dmg.sha256`, local checksum 일치 |
+| DMG integrity | `hdiutil verify` 통과 |
+| DMG signing | Gatekeeper Notarized Developer ID accepted, staple validate 통과 |
+| app signing | deep/strict codesign, Gatekeeper와 staple validate 통과 |
+| architecture | app, Preview, Thumbnail 모두 `arm64 + x86_64` |
+| Legal | `LICENSE`, `THIRD_PARTY_LICENSES.md`, `FONTS.md` canonical hash 일치 |
+| mounted layout | `Alhangeul.app`과 `Applications` symlink 구성 확인 |
+
+sandbox 내부 `codesign --verify --deep --strict`는 resource 접근 제한 때문에 잘못된 invalid signature를 보고했다. 동일 app을 sandbox 밖에서 다시 검증해 `valid on disk`와 Designated Requirement 충족을 확인했으므로 제품 결함으로 판정하지 않았다.
+
+## Pages와 Stable Appcast
+
+official publish 전 public home과 stable appcast는 `v0.1.7 (13)`을 유지했고 `updates/v0.1.8.html`은 404였다. publish 뒤 다음 surface가 모두 v0.1.8로 전환됐다.
+
+| surface | 결과 |
+|---------|------|
+| Pages home | 최신 다운로드가 public v0.1.8 DMG를 가리킴 |
+| v0.1.8 release note | https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html 접근 및 내용 확인 |
+| 이전 release note | v0.1.8 최신 릴리즈 고지와 링크 확인 |
+| stable appcast | `sparkle:version=14`, `sparkle:shortVersionString=0.1.8` |
+| enclosure | public DMG URL, length `161077481` 일치 |
+| EdDSA | non-empty signature 확인 |
+| XML | `xmllint --noout` 통과 |
+
+appcast EdDSA signature는 다음과 같다.
+
+```text
+O55dgpadPSpSQfbH+XdZ4BMWalADNLYsq1FLt2SOwI8NqQbEixf6eBWLNFSGOIE31Zp42gTuZ030cLtvmMp6BQ==
+```
+
+## Public 설치본과 Finder 검증
+
+공개 DMG의 app을 `/Users/melee/Applications/Alhangeul.app`에 설치해 기존 `/Applications/Alhangeul.app` v0.1.7을 덮어쓰지 않은 상태에서 먼저 검증했다.
+
+| 경로 | 결과 |
+|------|------|
+| app identity | `0.1.8 (14)`, mounted public app과 실행 파일 SHA256 일치 |
+| 첫 실행 HWP | `KTX.hwp`, 1페이지 정상 render |
+| 첫 실행 HWPX | `hwpx-01.hwpx`, 9페이지 정상 render |
+| Finder integration smoke | HWP와 HWPX Thumbnail 생성 통과 |
+| smoke 산출물 | `/private/tmp/alhangeul-v018-official-finder/task151-20260719-124936` |
+| UTI binding | 알한글 document type에 `net.golbin.hop.hwp`, `net.golbin.hop.hwpx` 포함 확인 |
+
+생성된 HWP 512x363 PNG와 HWPX 363x512 PNG를 열어 실제 문서 내용이 비어 있지 않게 렌더링된 것을 확인했다. HOP과 한컴 Viewer가 함께 설치된 실제 LaunchServices 환경에서도 알한글의 HOP UTI binding이 유지됐다.
+
+## 실제 Sparkle Update와 Extension Refresh
+
+기존 `/Applications/Alhangeul.app` v0.1.7의 `알한글 > 업데이트 확인...`을 실행했다. Sparkle은 stable appcast에서 v0.1.8, public release note와 161.1MB DMG를 표시했고, `업데이트 설치`와 `설치 & 재실행`을 거쳐 앱을 `0.1.8 (14)`로 교체했다.
+
+업데이트 뒤 결과는 다음과 같다.
+
+| 항목 | 결과 |
+|------|------|
+| 설치본 | `/Applications/Alhangeul.app`, `0.1.8 (14)` |
+| public app 동일성 | `/Users/melee/Applications` 공개 설치본과 실행 파일 SHA256 일치 |
+| code signature | deep/strict 검증 통과 |
+| notarization | Gatekeeper accepted, staple validate 통과 |
+| refresh smoke | `OK: post-Sparkle extension refresh smoke passed` |
+| 등록 보정 | `Registration repair used: 0` |
+| Preview provider | `/Applications/Alhangeul.app/Contents/PlugIns/AlhangeulPreview.appex`, v0.1.8 단일 조회 |
+| Thumbnail provider | `/Applications/Alhangeul.app/Contents/PlugIns/AlhangeulThumbnail.appex`, v0.1.8 단일 조회 |
+| smoke 산출물 | `/private/tmp/alhangeul-v018-official-sparkle-refresh/20260719-125736` |
+
+refresh smoke의 HWP 768x544와 HWPX 544x768 Thumbnail은 첫 시도에 생성됐고 실제 문서 내용이 정상 표시됐다. Finder에서 같은 fresh sample을 Space로 열어 HWP 1페이지와 HWPX 9페이지 Quick Look render 및 페이지 navigation을 확인했다. 전역 LaunchServices 수동 재등록이나 `--repair-registration`은 사용하지 않았다.
+
+## 미실행 항목
+
+- Homebrew Cask 반영과 install/uninstall smoke: public DMG URL과 SHA256은 확정했지만 별도 승인 전이라 실행하지 않음
+- Intel Mac 실기기 설치와 실행: universal slice 자동 검증으로 대체했으며 실기기 미실행
+
+## 판단
+
+- official workflow의 release와 Pages job이 모두 성공했고 GitHub Release는 public stable 상태다.
+- public DMG의 checksum, signing, notarization, staple, Gatekeeper, universal slice와 layout이 통과했다.
+- Pages home, v0.1.8 release note와 stable appcast가 동일 version, build, DMG URL, size를 사용한다.
+- 공개 설치본의 HWP/HWPX 앱 열기, Finder Thumbnail과 Quick Look이 통과했다.
+- 실제 v0.1.7 -> v0.1.8 Sparkle update 뒤 수동 등록 보정 없이 Preview와 Thumbnail provider가 새 `/Applications` 경로로 갱신됐다.
+- Homebrew Cask는 core release publish와 분리된 별도 승인 gate로 남긴다.
+- Stage 5 official publish와 post-publish surface gate를 통과로 판정한다.
+
+## 승인 요청
+
+Stage 5 완료보고서와 단계 커밋 승인 후 Stage 6 최종 보고와 Task #424 cleanup handoff 진행 승인을 요청한다. Homebrew Cask를 이번 타스크에서 반영하려면 Stage 6 전에 별도 승인이 필요하다.


### PR DESCRIPTION
## 요약

- `v0.1.8 (14)` release commit과 annotated tag를 확정하고 signed/notarized draft 차단 gate 결과를 기록합니다.
- official stable publish, public DMG, Pages와 stable Sparkle appcast 검증 결과를 반영합니다.
- 실제 v0.1.7 -> v0.1.8 Sparkle update 뒤 수동 등록 보정 없이 Quick Look/Thumbnail provider가 갱신되는 것을 확인했습니다.
- Stage 6 최종 보고서와 release record를 확정하고 Task #424 오늘할일을 완료 처리합니다.

## 공개 릴리즈

- GitHub Release: https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8
- Release commit: `542a35f2179e5499996b2ab7d2b1a94774b544a2`
- Official workflow: https://github.com/postmelee/alhangeul-macos/actions/runs/29671844342
- DMG SHA256: `ecf34e240c72c3d9123004f06e4d3a07806c8fa9f5323f471fd5c0cd19cfeb18`
- Core/studio: `rhwp v0.7.18` / `93862a4e16df59834ebce46d91e948cd739208e9`

## 단계별 결과

- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/578702734eb1a1a44cd381b98ce697e3e4554311/mydocs/working/task_m900_424_stage4.md)** ([db4173f](https://github.com/postmelee/alhangeul-macos/commit/db4173fa467863fa74ae2347994e6adf1b45c6e2)): `main`/tag와 signed candidate를 확정하고 HOP exact UTI, Finder와 Host RPC 차단 gate를 통과했습니다.
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/578702734eb1a1a44cd381b98ce697e3e4554311/mydocs/working/task_m900_424_stage5.md)** ([d117200](https://github.com/postmelee/alhangeul-macos/commit/d117200)): official release와 Pages를 게시하고 public DMG, appcast, Finder와 실제 Sparkle update를 검증했습니다.
- **Stage 6** ([5787027](https://github.com/postmelee/alhangeul-macos/commit/578702734eb1a1a44cd381b98ce697e3e4554311)): 최종 release record와 보고서, 오늘할일 완료 상태를 정리했습니다.

## 검증

- official workflow build/publish job과 Pages deploy job 성공
- GitHub Release non-draft/non-prerelease 상태와 public asset digest 확인
- public DMG checksum, `hdiutil verify`, deep/strict codesign, staple와 Gatekeeper 통과
- app, Preview와 Thumbnail의 `arm64 + x86_64` universal slice 확인
- HOP exact UTI handler, Finder `다음으로 열기`, 실제 HWPX open 확인
- HWP/HWPX 앱 render, Finder Quick Look과 Thumbnail 확인
- custom scheme Host RPC readiness, page count, PDF export와 저장·공유·인쇄 시작 경로 확인
- stable appcast `0.1.8 (14)`, public DMG URL/size와 EdDSA signature 확인
- 실제 Sparkle update 후 `Registration repair used: 0` extension refresh smoke 통과
- `git diff --check` 통과

## 미실행과 후속

- Homebrew Cask 반영과 install/uninstall smoke는 별도 승인 전이라 실행하지 않았습니다.
- Intel Mac 실기기 smoke는 미실행이며 universal slice 자동 검증으로 한정했습니다.
- upstream Issue #2396 이슈는 PR #2398 merge로 종료됐지만 수정이 포함된 새 stable tag는 아직 없습니다.
- `/Users/melee/Applications/Alhangeul.app` 공개 DMG smoke 복사본은 merge 후 cleanup 시 작업지시자 확인을 받아 정리합니다.

## 작업 문서

- 릴리즈 기록: [v0.1.8.md](https://github.com/postmelee/alhangeul-macos/blob/578702734eb1a1a44cd381b98ce697e3e4554311/mydocs/release/v0.1.8.md)
- 최종 보고서: [task_m900_424_report.md](https://github.com/postmelee/alhangeul-macos/blob/578702734eb1a1a44cd381b98ce697e3e4554311/mydocs/report/task_m900_424_report.md)

Closes #424
