### PR TITLE
Task #430 Stage 5: GitHub Pages docs-only 배포

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -9,7 +9,7 @@
     content="알한글은 Mac에서 HWP/HWPX 문서를 Quick Look, Finder 썸네일, WKWebView 기반 뷰어로 다루는 오픈소스 macOS 앱입니다." />
   <meta property="og:title" content="알한글 - Mac에서 한글 파일은 더 이상 이방인이 아닙니다." />
   <meta property="og:description"
-    content="한글을 구매하기 어려운 사람도 문서 접근에서 소외되지 않도록, Mac에서 HWP/HWPX를 미리보고 편집하고 공유하는 오픈소스 앱입니다." />
+    content="Mac에서 HWP/HWPX를 미리보고 편집하고 공유하는 오픈소스 앱입니다." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://postmelee.github.io/alhangeul-macos/" />
   <meta property="og:image" content="https://postmelee.github.io/alhangeul-macos/assets/og-main.png" />
@@ -26,7 +26,7 @@
   <script>
     document.documentElement.classList.add("reveal-ready");
   </script>
-  <link rel="stylesheet" href="./styles.css?v=20260626-feedback-page" />
+  <link rel="stylesheet" href="./styles.css?v=20260721-philosophy-balanced" />
 </head>
 
 <body>
@@ -240,6 +240,17 @@
           rel="noreferrer"><code>edwardkim/rhwp</code></a>를 코어로 사용합니다.
         HWP/HWPX 문서를 웹과 네이티브 환경에서 다룰 수 있게 만든 이 프로젝트 덕분에 알한글도 탄생할 수 있었습니다.
       </p>
+    </section>
+
+    <section class="philosophy-section" aria-labelledby="philosophy-title" data-reveal-group data-reveal-gap="180">
+      <div class="philosophy-inner">
+        <h2 id="philosophy-title" data-reveal-item>
+          <strong class="philosophy-highlight">문서 접근</strong>은 <strong class="philosophy-emphasis">특정 프로그램 구매 여부</strong>에 묶이면 안 됩니다.
+        </h2>
+        <p class="philosophy-description" data-reveal-item>
+          알한글은 한글을 구매하기 어렵거나 설치할 수 없는 사람도 필요한 문서를 확인하고 제출할 수 있도록 만드는 오픈소스 도구입니다.
+        </p>
+      </div>
     </section>
   </main>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -402,6 +402,46 @@ video {
   word-break: keep-all;
 }
 
+.philosophy-section {
+  width: 100%;
+  border-top: 1px solid rgba(29, 29, 31, 0.08);
+  padding: clamp(88px, 10vh, 120px) 20px;
+  background: #ffffff;
+}
+
+.philosophy-inner {
+  width: min(860px, 100%);
+  margin: 0 auto;
+  text-align: center;
+}
+
+.philosophy-inner h2 {
+  margin: 0;
+  font-size: 40px;
+  line-height: 1.14;
+  letter-spacing: -0.035em;
+  font-weight: 400;
+  word-break: keep-all;
+}
+
+.philosophy-highlight {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.philosophy-emphasis {
+  font-weight: 600;
+}
+
+.philosophy-description {
+  max-width: 760px;
+  margin: 26px auto 0;
+  color: var(--muted);
+  font-size: clamp(18px, 1.8vw, 21px);
+  line-height: 1.55;
+  word-break: keep-all;
+}
+
 .features-section {
   width: 100%;
   padding: clamp(80px, 10vh, 112px) 20px clamp(96px, 13vh, 144px);
@@ -1411,6 +1451,10 @@ video {
     font-size: 38px;
   }
 
+  .philosophy-inner h2 {
+    font-size: 38px;
+  }
+
   .app-intro-lead {
     font-size: 20px;
   }
@@ -1548,6 +1592,7 @@ video {
 
   .demo-section,
   .app-intro-section,
+  .philosophy-section,
   .features-section,
   .feedback-section,
   .faq-section {
@@ -1564,6 +1609,22 @@ video {
   .app-intro-section {
     padding-top: 44px;
     padding-bottom: 56px;
+  }
+
+  .philosophy-section {
+    padding-top: 68px;
+    padding-bottom: 68px;
+  }
+
+  .philosophy-inner h2 {
+    font-size: 32px;
+    line-height: 1.2;
+  }
+
+  .philosophy-description {
+    margin-top: 20px;
+    font-size: 17px;
+    line-height: 1.55;
   }
 
   .app-intro-inner {


### PR DESCRIPTION
## 요약

- 대상 타스크: #430 Stage 5 GitHub Pages docs-only 승격
- 왜: `devel` 전체의 10개 고유 커밋을 함께 승격하지 않고 승인된 Pages 변경만 `main`에 반영하기 위해서입니다.
- 무엇: `origin/main` 기준 `docs/index.html`, `docs/styles.css` 두 파일에 PR #431 변경에서 검증한 철학 섹션과 짧은 Open Graph 설명을 반영했습니다.
- 리뷰 포인트: 두 파일 외 변경이 없는지, footer 원문이 유지되는지, merge 후 기존 `Docs-only Pages Deploy`가 public appcast를 보존하는지 확인해 주세요.

## PR base

- base: `main`

## 변경 내역

- **[Stage 5](https://github.com/postmelee/alhangeul-macos/commit/24efce97b795557f1865b7889612fa409a81e173)** ([24efce9](https://github.com/postmelee/alhangeul-macos/commit/24efce97b795557f1865b7889612fa409a81e173)): `origin/main`에서 승인된 Pages HTML/CSS 두 파일만 승격했습니다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `docs/index.html` | Open Graph 설명 단축, FAQ 뒤·footer 앞 철학 섹션 추가 | 문구·위치·footer 원문 유지 |
| `docs/styles.css` | 제목 강조, 40/38/32px 반응형 크기, 대칭 여백 추가 | 기존 heading 위계와 모바일 줄바꿈 |

- 통합 PR: [#431](https://github.com/postmelee/alhangeul-macos/pull/431)
- 최종 보고서: [task_m010_430_report.md](https://github.com/postmelee/alhangeul-macos/blob/68f866a01b3a7e4c2e38dd06430802b44efe0224/mydocs/report/task_m010_430_report.md)

## 핵심 리뷰 포인트

- PR diff가 `docs/index.html`, `docs/styles.css` 두 파일로 제한되어 있으며 Task #424 기록 등 다른 `devel` 변경은 포함하지 않습니다.
- 철학 제목 기본 굵기는 400, `문서 접근`과 `특정 프로그램 구매 여부`는 600이며 `문서 접근`에만 기존 accent를 적용합니다.
- 이 PR을 merge하면 `main`의 `docs/**` push를 감지한 production `Docs-only Pages Deploy`가 실행됩니다. workflow나 appcast source는 변경하지 않습니다.

## 검증

- merge된 `origin/devel`의 `docs/index.html`, `docs/styles.css`와 파일 내용 일치 확인
- `node --check docs/script.js`
- `scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check`
- `git diff --check -- docs`
- public `appcast.xml`에 `xmllint --noout` 실행
- `scripts/ci/prepare-pages-artifact.sh --docs-dir docs --appcast /tmp/task430-stage5-public-appcast.xml --output-dir build.noindex/task430-main-pages-artifact`
- artifact의 `index.html`, `updates/index.html`, 유효한 `appcast.xml` 존재 확인
- 공개 appcast와 artifact appcast SHA-256 `fd1c25bb6befcbaa0c4bceb7670c2b7b42cf6db7848cc3824ce6272ce0114af4` 일치 확인
- 최신 appcast item `Alhangeul v0.1.8`과 tag 고정 DMG URL 유지 확인

## 관련 이슈

- 없음

## 후속 이슈 제안

- 없음

## 남은 리스크

- merge 직후 production Pages 배포가 실행되므로 merge 승인 전 PR diff와 CI 결과를 최종 확인해야 합니다.
- docs-only workflow는 현재 public appcast 다운로드와 XML 검증에 의존하며, 실패하면 stale repository appcast로 대체하지 않고 배포를 중단합니다.
- workflow 성공 뒤 CDN 캐시로 공개 HTML/CSS 반영이 잠시 지연될 수 있습니다.
