### PR TITLE
Task #409: Swift external image wrapper/resolver와 Quick Look Preview 적용

### DIFF
--- a/Sources/QLExtension/HwpPreviewProvider.swift
+++ b/Sources/QLExtension/HwpPreviewProvider.swift
@@ -17,6 +17,7 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
         logger.debug("Preview requested file=\(request.fileURL.lastPathComponent, privacy: .public)")
         do {
             let documentContext = try HwpPreviewPDFRenderer.load(fileURL: request.fileURL)
+            logExternalResourceReport(documentContext.externalResourceReport)
             if documentContext.pageCount == 1 {
                 let mode = HwpQuickLookPNGReplyModeResolver.resolve()
                 logger.debug("Preview selected PNG reply file=\(documentContext.filename, privacy: .public) mode=\(mode.identifier, privacy: .public) pages=\(documentContext.pageCount, privacy: .public) size=\(Int(documentContext.contentSize.width), privacy: .public)x\(Int(documentContext.contentSize.height), privacy: .public)")
@@ -36,6 +37,13 @@ final class HwpPreviewProvider: QLPreviewProvider, QLPreviewingController {
             logger.error("Preview failed file=\(request.fileURL.lastPathComponent, privacy: .public) error=\(Self.errorDescription(error), privacy: .public)")
             throw error
         }
+    }
+
+    private static func logExternalResourceReport(
+        _ report: RhwpExternalResourceReport
+    ) {
+        let summary = report.summary
+        logger.debug("Preview externalResource state=\(report.state.identifier, privacy: .public) total=\(summary.total, privacy: .public) injected=\(summary.injected, privacy: .public) alreadyLoaded=\(summary.alreadyLoaded, privacy: .public) missing=\(summary.missing, privacy: .public) rejected=\(summary.rejected, privacy: .public) tooLarge=\(summary.tooLarge, privacy: .public) permissionDenied=\(summary.permissionDenied, privacy: .public) readFailed=\(summary.readFailed, privacy: .public) bridgeFailed=\(summary.bridgeFailed, privacy: .public)")
     }
 
     private static func pngReply(

--- a/Sources/RhwpCoreBridge/RhwpDocument.swift
+++ b/Sources/RhwpCoreBridge/RhwpDocument.swift
@@ -1,5 +1,65 @@
+import Darwin
 import Foundation
 import Rhwp
+
+enum RhwpExternalImageOperationStatus: Equatable {
+    case ok
+    case invalidHandle
+    case invalidInput
+    case invalidUTF8
+    case referenceNotFound
+    case alreadyLoaded
+    case failure
+    case unknown(UInt32)
+
+    init(_ status: Rhwp.RhwpExternalImageStatus) {
+        self.init(rawValue: status.rawValue)
+    }
+
+    init(rawValue: UInt32) {
+        switch rawValue {
+        case 0:
+            self = .ok
+        case 1:
+            self = .invalidHandle
+        case 2:
+            self = .invalidInput
+        case 3:
+            self = .invalidUTF8
+        case 4:
+            self = .referenceNotFound
+        case 5:
+            self = .alreadyLoaded
+        case 6:
+            self = .failure
+        default:
+            self = .unknown(rawValue)
+        }
+    }
+}
+
+struct RhwpExternalImageReference: Decodable, Equatable {
+    let key: String
+    let binDataId: UInt16
+    let originalPath: String
+    let basename: String
+    let fileExtension: String
+    let loaded: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case key
+        case binDataId
+        case originalPath
+        case basename
+        case fileExtension = "extension"
+        case loaded
+    }
+}
+
+enum RhwpExternalImageBridgeError: Error, Equatable {
+    case referencesUnavailable
+    case invalidReferencesJSON
+}
 
 struct RhwpEmbeddedThumbnail {
     let data: Data
@@ -92,6 +152,75 @@ class RhwpDocument {
             throw RhwpError.parseFailure(filename: filename)
         }
         self.handle = validHandle
+    }
+
+    @discardableResult
+    func setFileName(_ filename: String) -> RhwpExternalImageOperationStatus {
+        Self.withUTF8Bytes(filename) { namePointer, nameLength in
+            RhwpExternalImageOperationStatus(
+                rhwp_set_file_name_utf8(
+                    handle,
+                    namePointer,
+                    nameLength
+                )
+            )
+        }
+    }
+
+    func externalImageReferences() throws -> [RhwpExternalImageReference] {
+        guard let jsonPointer = rhwp_external_image_refs_json(handle) else {
+            throw RhwpExternalImageBridgeError.referencesUnavailable
+        }
+        defer {
+            rhwp_free_string(jsonPointer)
+        }
+
+        let jsonData = Data(
+            bytes: jsonPointer,
+            count: Int(strlen(jsonPointer))
+        )
+        return try Self.decodeExternalImageReferences(from: jsonData)
+    }
+
+    @discardableResult
+    func injectExternalImage(
+        key: String,
+        data: Data,
+        displayPath: String? = nil
+    ) -> RhwpExternalImageOperationStatus {
+        Self.withUTF8Bytes(key) { keyPointer, keyLength in
+            data.withUnsafeBytes { dataBuffer in
+                let dataPointer = dataBuffer.bindMemory(to: UInt8.self).baseAddress
+                return Self.withOptionalUTF8Bytes(displayPath) {
+                    displayPathPointer,
+                    displayPathLength in
+                    RhwpExternalImageOperationStatus(
+                        rhwp_inject_external_image_by_key(
+                            handle,
+                            keyPointer,
+                            keyLength,
+                            dataPointer,
+                            UInt(dataBuffer.count),
+                            displayPathPointer,
+                            displayPathLength
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    static func decodeExternalImageReferences(
+        from data: Data
+    ) throws -> [RhwpExternalImageReference] {
+        do {
+            return try JSONDecoder().decode(
+                [RhwpExternalImageReference].self,
+                from: data
+            )
+        } catch {
+            throw RhwpExternalImageBridgeError.invalidReferencesJSON
+        }
     }
 
     deinit {
@@ -256,5 +385,25 @@ class RhwpDocument {
             height: Int(outHeight),
             format: outFormat.map { String(cString: $0) }
         )
+    }
+
+    private static func withUTF8Bytes<Result>(
+        _ string: String,
+        _ body: (UnsafePointer<UInt8>?, UInt) -> Result
+    ) -> Result {
+        let bytes = Array(string.utf8)
+        return bytes.withUnsafeBufferPointer { buffer in
+            body(buffer.baseAddress, UInt(buffer.count))
+        }
+    }
+
+    private static func withOptionalUTF8Bytes<Result>(
+        _ string: String?,
+        _ body: (UnsafePointer<UInt8>?, UInt) -> Result
+    ) -> Result {
+        guard let string, !string.isEmpty else {
+            return body(nil, 0)
+        }
+        return withUTF8Bytes(string, body)
     }
 }

--- a/Sources/Shared/HwpExternalImageResolver.swift
+++ b/Sources/Shared/HwpExternalImageResolver.swift
@@ -1,0 +1,441 @@
+import Foundation
+
+struct RhwpDocumentOpenContext: Equatable {
+    let sourceURL: URL?
+    let displayFilename: String?
+    let maximumExternalResourceBytes: Int
+}
+
+enum RhwpExternalResourceReportState: Equatable {
+    case disabledNoSourceURL
+    case disabledNonFileURL
+    case attempted
+    case referenceQueryFailed
+
+    var identifier: String {
+        switch self {
+        case .disabledNoSourceURL:
+            return "disabledNoSourceURL"
+        case .disabledNonFileURL:
+            return "disabledNonFileURL"
+        case .attempted:
+            return "attempted"
+        case .referenceQueryFailed:
+            return "referenceQueryFailed"
+        }
+    }
+}
+
+enum RhwpExternalResourceDecision: Equatable {
+    case alreadyLoaded
+    case injected(byteCount: Int)
+    case missing
+    case rejectedInvalidBasename
+    case rejectedOutsideSourceDirectory
+    case rejectedSourceDocument
+    case rejectedNonRegularFile
+    case tooLarge(actualBytes: Int?, limit: Int)
+    case permissionDenied
+    case readFailed
+    case bridgeRejected(RhwpExternalImageOperationStatus)
+    case verificationFailed
+}
+
+struct RhwpExternalResourceResolution: Equatable {
+    let key: String
+    let decision: RhwpExternalResourceDecision
+}
+
+struct RhwpExternalResourceSummary: Equatable, CustomStringConvertible {
+    let total: Int
+    let injected: Int
+    let alreadyLoaded: Int
+    let missing: Int
+    let rejected: Int
+    let tooLarge: Int
+    let permissionDenied: Int
+    let readFailed: Int
+    let bridgeFailed: Int
+
+    var description: String {
+        [
+            "total=\(total)",
+            "injected=\(injected)",
+            "alreadyLoaded=\(alreadyLoaded)",
+            "missing=\(missing)",
+            "rejected=\(rejected)",
+            "tooLarge=\(tooLarge)",
+            "permissionDenied=\(permissionDenied)",
+            "readFailed=\(readFailed)",
+            "bridgeFailed=\(bridgeFailed)"
+        ].joined(separator: " ")
+    }
+}
+
+struct RhwpExternalResourceReport: Equatable {
+    let state: RhwpExternalResourceReportState
+    let filenameStatus: RhwpExternalImageOperationStatus?
+    let resolutions: [RhwpExternalResourceResolution]
+
+    var summary: RhwpExternalResourceSummary {
+        var injected = 0
+        var alreadyLoaded = 0
+        var missing = 0
+        var rejected = 0
+        var tooLarge = 0
+        var permissionDenied = 0
+        var readFailed = 0
+        var bridgeFailed = 0
+
+        for resolution in resolutions {
+            switch resolution.decision {
+            case .injected:
+                injected += 1
+            case .alreadyLoaded:
+                alreadyLoaded += 1
+            case .missing:
+                missing += 1
+            case .rejectedInvalidBasename,
+                 .rejectedOutsideSourceDirectory,
+                 .rejectedSourceDocument,
+                 .rejectedNonRegularFile:
+                rejected += 1
+            case .tooLarge:
+                tooLarge += 1
+            case .permissionDenied:
+                permissionDenied += 1
+            case .readFailed:
+                readFailed += 1
+            case .bridgeRejected, .verificationFailed:
+                bridgeFailed += 1
+            }
+        }
+
+        return RhwpExternalResourceSummary(
+            total: resolutions.count,
+            injected: injected,
+            alreadyLoaded: alreadyLoaded,
+            missing: missing,
+            rejected: rejected,
+            tooLarge: tooLarge,
+            permissionDenied: permissionDenied,
+            readFailed: readFailed,
+            bridgeFailed: bridgeFailed
+        )
+    }
+
+    var privacySafeDescription: String {
+        "state=\(state.identifier) \(summary)"
+    }
+}
+
+struct RhwpDocumentOpenResult {
+    let document: RhwpDocument
+    let externalResourceReport: RhwpExternalResourceReport
+}
+
+protocol RhwpExternalImageDocumentAccess: AnyObject {
+    @discardableResult
+    func setFileName(_ filename: String) -> RhwpExternalImageOperationStatus
+
+    func externalImageReferences() throws -> [RhwpExternalImageReference]
+
+    @discardableResult
+    func injectExternalImage(
+        key: String,
+        data: Data,
+        displayPath: String?
+    ) -> RhwpExternalImageOperationStatus
+}
+
+extension RhwpDocument: RhwpExternalImageDocumentAccess {}
+
+enum HwpExternalImageResolver {
+    typealias DataLoader = (URL) throws -> Data
+
+    static func open(
+        data: Data,
+        context: RhwpDocumentOpenContext,
+        dataLoader: DataLoader = loadMappedData
+    ) throws -> RhwpDocumentOpenResult {
+        let document = try RhwpDocument(
+            data: data,
+            filename: context.displayFilename
+        )
+        let report = resolve(
+            document: document,
+            context: context,
+            dataLoader: dataLoader
+        )
+        return RhwpDocumentOpenResult(
+            document: document,
+            externalResourceReport: report
+        )
+    }
+
+    static func resolve(
+        document: RhwpExternalImageDocumentAccess,
+        context: RhwpDocumentOpenContext,
+        dataLoader: DataLoader = loadMappedData
+    ) -> RhwpExternalResourceReport {
+        let filenameStatus = context.displayFilename.map(document.setFileName)
+
+        guard let sourceURL = context.sourceURL else {
+            return RhwpExternalResourceReport(
+                state: .disabledNoSourceURL,
+                filenameStatus: filenameStatus,
+                resolutions: []
+            )
+        }
+        guard sourceURL.isFileURL else {
+            return RhwpExternalResourceReport(
+                state: .disabledNonFileURL,
+                filenameStatus: filenameStatus,
+                resolutions: []
+            )
+        }
+
+        let references: [RhwpExternalImageReference]
+        do {
+            references = try document.externalImageReferences()
+        } catch {
+            return RhwpExternalResourceReport(
+                state: .referenceQueryFailed,
+                filenameStatus: filenameStatus,
+                resolutions: []
+            )
+        }
+
+        let limit = max(0, context.maximumExternalResourceBytes)
+        var resolutions: [RhwpExternalResourceResolution] = []
+        resolutions.reserveCapacity(references.count)
+        var pendingVerification: [(index: Int, key: String)] = []
+
+        for reference in references {
+            if reference.loaded {
+                resolutions.append(
+                    RhwpExternalResourceResolution(
+                        key: reference.key,
+                        decision: .alreadyLoaded
+                    )
+                )
+                continue
+            }
+
+            let resolution = resolveReference(
+                reference,
+                sourceURL: sourceURL,
+                maximumBytes: limit,
+                document: document,
+                dataLoader: dataLoader
+            )
+            let resolutionIndex = resolutions.count
+            resolutions.append(resolution)
+            if case .injected = resolution.decision {
+                pendingVerification.append(
+                    (resolutionIndex, reference.key)
+                )
+            }
+        }
+
+        verifyPendingInjections(
+            pendingVerification,
+            document: document,
+            resolutions: &resolutions
+        )
+
+        return RhwpExternalResourceReport(
+            state: .attempted,
+            filenameStatus: filenameStatus,
+            resolutions: resolutions
+        )
+    }
+
+    private static func resolveReference(
+        _ reference: RhwpExternalImageReference,
+        sourceURL: URL,
+        maximumBytes: Int,
+        document: RhwpExternalImageDocumentAccess,
+        dataLoader: DataLoader
+    ) -> RhwpExternalResourceResolution {
+        guard isValidBasename(reference.basename) else {
+            return resolution(reference, .rejectedInvalidBasename)
+        }
+
+        let standardizedSource = sourceURL.standardizedFileURL
+        let sourceParent = standardizedSource
+            .deletingLastPathComponent()
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let candidate = standardizedSource
+            .deletingLastPathComponent()
+            .appendingPathComponent(reference.basename, isDirectory: false)
+            .standardizedFileURL
+        let resolvedCandidate = candidate
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+        let resolvedSource = standardizedSource
+            .resolvingSymlinksInPath()
+            .standardizedFileURL
+
+        if sameFilePath(candidate, standardizedSource)
+            || sameFilePath(resolvedCandidate, resolvedSource) {
+            return resolution(reference, .rejectedSourceDocument)
+        }
+        guard sameFilePath(
+            resolvedCandidate.deletingLastPathComponent(),
+            sourceParent
+        ) else {
+            return resolution(reference, .rejectedOutsideSourceDirectory)
+        }
+
+        let resourceValues: URLResourceValues
+        do {
+            resourceValues = try candidate.resourceValues(
+                forKeys: [.isRegularFileKey, .fileSizeKey]
+            )
+        } catch {
+            return resolution(reference, decision(forFileError: error))
+        }
+
+        guard resourceValues.isRegularFile == true else {
+            return resolution(reference, .rejectedNonRegularFile)
+        }
+        if let fileSize = resourceValues.fileSize, fileSize > maximumBytes {
+            return resolution(
+                reference,
+                .tooLarge(actualBytes: fileSize, limit: maximumBytes)
+            )
+        }
+
+        let data: Data
+        do {
+            data = try dataLoader(candidate)
+        } catch {
+            return resolution(reference, decision(forFileError: error))
+        }
+        guard data.count <= maximumBytes else {
+            return resolution(
+                reference,
+                .tooLarge(actualBytes: data.count, limit: maximumBytes)
+            )
+        }
+
+        let status = document.injectExternalImage(
+            key: reference.key,
+            data: data,
+            displayPath: reference.basename
+        )
+        switch status {
+        case .ok:
+            return resolution(
+                reference,
+                .injected(byteCount: data.count)
+            )
+        case .alreadyLoaded:
+            return resolution(reference, .alreadyLoaded)
+        default:
+            return resolution(reference, .bridgeRejected(status))
+        }
+    }
+
+    private static func verifyPendingInjections(
+        _ pending: [(index: Int, key: String)],
+        document: RhwpExternalImageDocumentAccess,
+        resolutions: inout [RhwpExternalResourceResolution]
+    ) {
+        guard !pending.isEmpty else {
+            return
+        }
+
+        let loadedKeys: Set<String>
+        do {
+            loadedKeys = Set(
+                try document.externalImageReferences()
+                    .filter(\.loaded)
+                    .map(\.key)
+            )
+        } catch {
+            for item in pending {
+                resolutions[item.index] = RhwpExternalResourceResolution(
+                    key: item.key,
+                    decision: .verificationFailed
+                )
+            }
+            return
+        }
+
+        for item in pending where !loadedKeys.contains(item.key) {
+            resolutions[item.index] = RhwpExternalResourceResolution(
+                key: item.key,
+                decision: .verificationFailed
+            )
+        }
+    }
+
+    private static func isValidBasename(_ basename: String) -> Bool {
+        !basename.isEmpty
+            && basename != "."
+            && basename != ".."
+            && !basename.contains("/")
+            && !basename.contains("\\")
+            && !basename.contains("\0")
+    }
+
+    private static func sameFilePath(_ lhs: URL, _ rhs: URL) -> Bool {
+        lhs.standardizedFileURL.path == rhs.standardizedFileURL.path
+    }
+
+    private static func decision(
+        forFileError error: Error
+    ) -> RhwpExternalResourceDecision {
+        let nsError = error as NSError
+
+        if nsError.domain == NSCocoaErrorDomain {
+            switch nsError.code {
+            case NSFileNoSuchFileError, NSFileReadNoSuchFileError:
+                return .missing
+            case NSFileReadNoPermissionError:
+                return .permissionDenied
+            default:
+                break
+            }
+        }
+
+        if nsError.domain == NSPOSIXErrorDomain {
+            switch nsError.code {
+            case Int(POSIXErrorCode.ENOENT.rawValue):
+                return .missing
+            case Int(POSIXErrorCode.EACCES.rawValue),
+                 Int(POSIXErrorCode.EPERM.rawValue):
+                return .permissionDenied
+            default:
+                break
+            }
+        }
+
+        if let underlyingError = nsError.userInfo[NSUnderlyingErrorKey] as? NSError,
+           underlyingError !== nsError {
+            let underlyingDecision = decision(forFileError: underlyingError)
+            if underlyingDecision != .readFailed {
+                return underlyingDecision
+            }
+        }
+
+        return .readFailed
+    }
+
+    private static func resolution(
+        _ reference: RhwpExternalImageReference,
+        _ decision: RhwpExternalResourceDecision
+    ) -> RhwpExternalResourceResolution {
+        RhwpExternalResourceResolution(
+            key: reference.key,
+            decision: decision
+        )
+    }
+
+    private static func loadMappedData(from url: URL) throws -> Data {
+        try Data(contentsOf: url, options: [.mappedIfSafe])
+    }
+}

--- a/Sources/Shared/HwpPreviewPDFRenderer.swift
+++ b/Sources/Shared/HwpPreviewPDFRenderer.swift
@@ -25,27 +25,45 @@ struct HwpPreviewDocumentContext {
     let contentSize: CGSize
     let pageCount: Int
     let document: RhwpDocument
+    let externalResourceReport: RhwpExternalResourceReport
 }
 
 enum HwpPreviewPDFRenderer {
     static func load(fileURL: URL) throws -> HwpPreviewDocumentContext {
-        let loadedDocument = try loadDocument(fileURL: fileURL)
+        let input = try loadInput(fileURL: fileURL)
+        let openResult = try HwpExternalImageResolver.open(
+            data: input.data,
+            context: RhwpDocumentOpenContext(
+                sourceURL: fileURL,
+                displayFilename: input.filename,
+                maximumExternalResourceBytes: hwpQuickLookMaxFileSize
+            )
+        )
+        let metadata = try previewMetadata(
+            document: openResult.document
+        )
 
         return HwpPreviewDocumentContext(
-            filename: loadedDocument.filename,
-            contentSize: loadedDocument.contentSize,
-            pageCount: loadedDocument.pageCount,
-            document: loadedDocument.document
+            filename: input.filename,
+            contentSize: metadata.contentSize,
+            pageCount: metadata.pageCount,
+            document: openResult.document,
+            externalResourceReport: openResult.externalResourceReport
         )
     }
 
     static func inspect(fileURL: URL) throws -> HwpPreviewDocumentInfo {
-        let loadedDocument = try loadDocument(fileURL: fileURL)
+        let input = try loadInput(fileURL: fileURL)
+        let document = try RhwpDocument(
+            data: input.data,
+            filename: input.filename
+        )
+        let metadata = try previewMetadata(document: document)
         return HwpPreviewDocumentInfo(
-            data: loadedDocument.data,
-            filename: loadedDocument.filename,
-            contentSize: loadedDocument.contentSize,
-            pageCount: loadedDocument.pageCount
+            data: input.data,
+            filename: input.filename,
+            contentSize: metadata.contentSize,
+            pageCount: metadata.pageCount
         )
     }
 
@@ -162,23 +180,32 @@ enum HwpPreviewPDFRenderer {
         context.endPDFPage()
     }
 
-    private struct LoadedDocument {
+    private struct LoadedInput {
         let data: Data
         let filename: String
-        let contentSize: CGSize
-        let pageCount: Int
-        let document: RhwpDocument
     }
 
-    private static func loadDocument(fileURL: URL) throws -> LoadedDocument {
+    private struct PreviewMetadata {
+        let contentSize: CGSize
+        let pageCount: Int
+    }
+
+    private static func loadInput(fileURL: URL) throws -> LoadedInput {
         let values = try fileURL.resourceValues(forKeys: [.fileSizeKey])
         if let fileSize = values.fileSize, fileSize > hwpQuickLookMaxFileSize {
             throw HwpRenderError.fileTooLarge
         }
 
         let data = try Data(contentsOf: fileURL, options: [.mappedIfSafe])
-        let filename = fileURL.lastPathComponent
-        let document = try RhwpDocument(data: data, filename: filename)
+        return LoadedInput(
+            data: data,
+            filename: fileURL.lastPathComponent
+        )
+    }
+
+    private static func previewMetadata(
+        document: RhwpDocument
+    ) throws -> PreviewMetadata {
         let pageCount = document.pageCount
         guard pageCount > 0 else {
             throw HwpRenderError.emptyDocument
@@ -189,12 +216,9 @@ enum HwpPreviewPDFRenderer {
             throw HwpRenderError.invalidPageSize
         }
 
-        return LoadedDocument(
-            data: data,
-            filename: filename,
+        return PreviewMetadata(
             contentSize: CGSize(width: firstPageSize.width, height: firstPageSize.height),
-            pageCount: pageCount,
-            document: document
+            pageCount: pageCount
         )
     }
 }

--- a/Tests/ExternalImageTests/ExternalImageTestSupport.swift
+++ b/Tests/ExternalImageTests/ExternalImageTestSupport.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum ExternalImageTestSupport {
+    static let repositoryRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+
+    static func sampleData(at relativePath: String) throws -> Data {
+        try Data(
+            contentsOf: repositoryRoot.appendingPathComponent(relativePath),
+            options: [.mappedIfSafe]
+        )
+    }
+}

--- a/Tests/ExternalImageTests/ExternalImageTestSupport.swift
+++ b/Tests/ExternalImageTests/ExternalImageTestSupport.swift
@@ -12,4 +12,33 @@ enum ExternalImageTestSupport {
             options: [.mappedIfSafe]
         )
     }
+
+    static func withTemporaryDirectory<Result>(
+        _ body: (URL) throws -> Result
+    ) throws -> Result {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "rhwp-external-image-tests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+        defer {
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+        return try body(directoryURL)
+    }
+
+    @discardableResult
+    static func write(
+        _ data: Data,
+        named filename: String,
+        in directoryURL: URL
+    ) throws -> URL {
+        let fileURL = directoryURL.appendingPathComponent(filename)
+        try data.write(to: fileURL)
+        return fileURL
+    }
 }

--- a/Tests/ExternalImageTests/HwpExternalImageResolverTests.swift
+++ b/Tests/ExternalImageTests/HwpExternalImageResolverTests.swift
@@ -1,0 +1,826 @@
+import Foundation
+import XCTest
+
+final class HwpExternalImageResolverTests: XCTestCase {
+    func testOpenCreatesDocumentWithoutEnablingResolverForBytesOnlyContext() throws {
+        let result = try HwpExternalImageResolver.open(
+            data: ExternalImageTestSupport.sampleData(at: "samples/basic/KTX.hwp"),
+            context: RhwpDocumentOpenContext(
+                sourceURL: nil,
+                displayFilename: "KTX.hwp",
+                maximumExternalResourceBytes: 1024
+            )
+        )
+
+        XCTAssertGreaterThan(result.document.pageCount, 0)
+        XCTAssertEqual(
+            result.externalResourceReport,
+            RhwpExternalResourceReport(
+                state: .disabledNoSourceURL,
+                filenameStatus: .ok,
+                resolutions: []
+            )
+        )
+    }
+
+    func testNilAndNonFileSourceDisableQueries() {
+        let contexts = [
+            RhwpDocumentOpenContext(
+                sourceURL: nil,
+                displayFilename: "sample.hwp",
+                maximumExternalResourceBytes: 1024
+            ),
+            RhwpDocumentOpenContext(
+                sourceURL: URL(string: "https://example.invalid/sample.hwp"),
+                displayFilename: "sample.hwp",
+                maximumExternalResourceBytes: 1024
+            )
+        ]
+
+        for (index, context) in contexts.enumerated() {
+            let document = FakeExternalImageDocument(
+                referenceResults: [.success([])]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context
+            )
+
+            XCTAssertEqual(
+                report.state,
+                index == 0 ? .disabledNoSourceURL : .disabledNonFileURL
+            )
+            XCTAssertEqual(report.filenameStatus, .ok)
+            XCTAssertEqual(document.referenceQueryCount, 0)
+            XCTAssertTrue(document.injections.isEmpty)
+        }
+    }
+
+    func testEmptyReferencesProduceAttemptedEmptyReport() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            let document = FakeExternalImageDocument(
+                referenceResults: [.success([])]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            )
+
+            XCTAssertEqual(report.state, .attempted)
+            XCTAssertEqual(report.resolutions, [])
+            XCTAssertEqual(report.summary.total, 0)
+            XCTAssertEqual(document.referenceQueryCount, 1)
+        }
+    }
+
+    func testReferenceQueryFailureIsNonFatal() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            let document = FakeExternalImageDocument(
+                referenceResults: [.failure(FakeDocumentError.referenceQuery)]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            )
+
+            XCTAssertEqual(report.state, .referenceQueryFailed)
+            XCTAssertEqual(report.filenameStatus, .ok)
+            XCTAssertEqual(report.resolutions, [])
+            XCTAssertTrue(document.injections.isEmpty)
+        }
+    }
+
+    func testAlreadyLoadedReferenceSkipsFileReadAndInjection() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            let reference = makeReference(
+                key: "binData:1",
+                basename: "already.png",
+                loaded: true
+            )
+            let document = FakeExternalImageDocument(
+                referenceResults: [.success([reference])]
+            )
+            var readCount = 0
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            ) { _ in
+                readCount += 1
+                return Data()
+            }
+
+            XCTAssertEqual(
+                report.resolutions,
+                [
+                    RhwpExternalResourceResolution(
+                        key: reference.key,
+                        decision: .alreadyLoaded
+                    )
+                ]
+            )
+            XCTAssertEqual(readCount, 0)
+            XCTAssertTrue(document.injections.isEmpty)
+            XCTAssertEqual(document.referenceQueryCount, 1)
+        }
+    }
+
+    func testValidSiblingInjectsBytesAndBasenameThenVerifiesLoaded() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            let imageData = Data([0x89, 0x50, 0x4E, 0x47])
+            let imageURL = try ExternalImageTestSupport.write(
+                imageData,
+                named: "sibling.png",
+                in: directoryURL
+            )
+            let unloaded = makeReference(
+                key: "binData:7",
+                basename: imageURL.lastPathComponent
+            )
+            let loaded = makeReference(
+                key: unloaded.key,
+                basename: unloaded.basename,
+                loaded: true
+            )
+            let document = FakeExternalImageDocument(
+                referenceResults: [
+                    .success([unloaded]),
+                    .success([loaded])
+                ]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            )
+
+            XCTAssertEqual(
+                report.resolutions,
+                [
+                    RhwpExternalResourceResolution(
+                        key: unloaded.key,
+                        decision: .injected(byteCount: imageData.count)
+                    )
+                ]
+            )
+            XCTAssertEqual(
+                document.injections,
+                [
+                    FakeInjection(
+                        key: unloaded.key,
+                        data: imageData,
+                        displayPath: "sibling.png"
+                    )
+                ]
+            )
+            XCTAssertEqual(document.referenceQueryCount, 2)
+        }
+    }
+
+    func testOriginalPathIsNotUsedForFileDiscovery() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { rootURL in
+            let sourceDirectoryURL = rootURL.appendingPathComponent(
+                "source",
+                isDirectory: true
+            )
+            let outsideDirectoryURL = rootURL.appendingPathComponent(
+                "outside",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: sourceDirectoryURL,
+                withIntermediateDirectories: false
+            )
+            try FileManager.default.createDirectory(
+                at: outsideDirectoryURL,
+                withIntermediateDirectories: false
+            )
+            let sourceURL = try makeSourceDocument(in: sourceDirectoryURL)
+            let outsideURL = try ExternalImageTestSupport.write(
+                Data([0x01]),
+                named: "outside.png",
+                in: outsideDirectoryURL
+            )
+            let reference = makeReference(
+                key: "binData:outside",
+                basename: "missing-sibling.png",
+                originalPath: outsideURL.path
+            )
+            let document = FakeExternalImageDocument(
+                referenceResults: [.success([reference])]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            )
+
+            XCTAssertEqual(report.resolutions.first?.decision, .missing)
+            XCTAssertTrue(document.injections.isEmpty)
+        }
+    }
+
+    func testInjectionAlreadyLoadedRaceIsAcceptedWithoutFinalQuery() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            try ExternalImageTestSupport.write(
+                Data([0x01]),
+                named: "race.png",
+                in: directoryURL
+            )
+            let reference = makeReference(
+                key: "binData:race",
+                basename: "race.png"
+            )
+            let document = FakeExternalImageDocument(
+                referenceResults: [.success([reference])],
+                injectionStatuses: [reference.key: .alreadyLoaded]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            )
+
+            XCTAssertEqual(
+                report.resolutions.first?.decision,
+                .alreadyLoaded
+            )
+            XCTAssertEqual(document.injections.count, 1)
+            XCTAssertEqual(document.referenceQueryCount, 1)
+        }
+    }
+
+    func testInvalidBasenamesAreRejectedWithoutReads() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            let invalidBasenames = [
+                "",
+                ".",
+                "..",
+                "nested/image.png",
+                #"nested\image.png"#,
+                "nul\0image.png"
+            ]
+            let references = invalidBasenames.enumerated().map { index, basename in
+                makeReference(
+                    key: "binData:\(index + 1)",
+                    basename: basename
+                )
+            }
+            let document = FakeExternalImageDocument(
+                referenceResults: [.success(references)]
+            )
+            var readCount = 0
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            ) { _ in
+                readCount += 1
+                return Data()
+            }
+
+            XCTAssertEqual(
+                report.resolutions.map(\.decision),
+                Array(
+                    repeating: .rejectedInvalidBasename,
+                    count: invalidBasenames.count
+                )
+            )
+            XCTAssertEqual(readCount, 0)
+            XCTAssertTrue(document.injections.isEmpty)
+        }
+    }
+
+    func testSourceDocumentAndDirectoryAreRejected() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            let childDirectoryURL = directoryURL.appendingPathComponent(
+                "images",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: childDirectoryURL,
+                withIntermediateDirectories: false
+            )
+            let references = [
+                makeReference(
+                    key: "binData:self",
+                    basename: sourceURL.lastPathComponent
+                ),
+                makeReference(
+                    key: "binData:directory",
+                    basename: childDirectoryURL.lastPathComponent
+                )
+            ]
+            let document = FakeExternalImageDocument(
+                referenceResults: [.success(references)]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            )
+
+            XCTAssertEqual(
+                report.resolutions.map(\.decision),
+                [.rejectedSourceDocument, .rejectedNonRegularFile]
+            )
+            XCTAssertTrue(document.injections.isEmpty)
+        }
+    }
+
+    func testSiblingSymlinkEscapingParentIsRejected() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { rootURL in
+            let sourceDirectoryURL = rootURL.appendingPathComponent(
+                "source",
+                isDirectory: true
+            )
+            let outsideDirectoryURL = rootURL.appendingPathComponent(
+                "outside",
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: sourceDirectoryURL,
+                withIntermediateDirectories: false
+            )
+            try FileManager.default.createDirectory(
+                at: outsideDirectoryURL,
+                withIntermediateDirectories: false
+            )
+            let sourceURL = try makeSourceDocument(in: sourceDirectoryURL)
+            let outsideImageURL = try ExternalImageTestSupport.write(
+                Data([0x01]),
+                named: "outside.png",
+                in: outsideDirectoryURL
+            )
+            let linkURL = sourceDirectoryURL.appendingPathComponent("linked.png")
+            try FileManager.default.createSymbolicLink(
+                at: linkURL,
+                withDestinationURL: outsideImageURL
+            )
+            let reference = makeReference(
+                key: "binData:escape",
+                basename: linkURL.lastPathComponent
+            )
+            let document = FakeExternalImageDocument(
+                referenceResults: [.success([reference])]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            )
+
+            XCTAssertEqual(
+                report.resolutions.first?.decision,
+                .rejectedOutsideSourceDirectory
+            )
+            XCTAssertTrue(document.injections.isEmpty)
+        }
+    }
+
+    func testMetadataAndReadByteLimitsAreAppliedIndependently() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            try ExternalImageTestSupport.write(
+                Data(repeating: 0x01, count: 5),
+                named: "metadata-large.png",
+                in: directoryURL
+            )
+            try ExternalImageTestSupport.write(
+                Data([0x01]),
+                named: "read-large.png",
+                in: directoryURL
+            )
+            let references = [
+                makeReference(
+                    key: "binData:metadata",
+                    basename: "metadata-large.png"
+                ),
+                makeReference(
+                    key: "binData:read",
+                    basename: "read-large.png"
+                )
+            ]
+            let document = FakeExternalImageDocument(
+                referenceResults: [.success(references)]
+            )
+            var loadedNames: [String] = []
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL, limit: 4)
+            ) { url in
+                loadedNames.append(url.lastPathComponent)
+                return Data(repeating: 0x02, count: 5)
+            }
+
+            XCTAssertEqual(
+                report.resolutions.map(\.decision),
+                [
+                    .tooLarge(actualBytes: 5, limit: 4),
+                    .tooLarge(actualBytes: 5, limit: 4)
+                ]
+            )
+            XCTAssertEqual(loadedNames, ["read-large.png"])
+            XCTAssertTrue(document.injections.isEmpty)
+        }
+    }
+
+    func testMissingPermissionAndGenericReadFailuresAreClassified() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            try ExternalImageTestSupport.write(
+                Data([0x01]),
+                named: "permission.png",
+                in: directoryURL
+            )
+            try ExternalImageTestSupport.write(
+                Data([0x02]),
+                named: "read-failure.png",
+                in: directoryURL
+            )
+            let references = [
+                makeReference(
+                    key: "binData:missing",
+                    basename: "missing.png"
+                ),
+                makeReference(
+                    key: "binData:permission",
+                    basename: "permission.png"
+                ),
+                makeReference(
+                    key: "binData:read",
+                    basename: "read-failure.png"
+                )
+            ]
+            let document = FakeExternalImageDocument(
+                referenceResults: [.success(references)]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            ) { url in
+                if url.lastPathComponent == "permission.png" {
+                    throw NSError(
+                        domain: NSCocoaErrorDomain,
+                        code: NSFileReadNoPermissionError
+                    )
+                }
+                throw NSError(
+                    domain: "HwpExternalImageResolverTests",
+                    code: 1
+                )
+            }
+
+            XCTAssertEqual(
+                report.resolutions.map(\.decision),
+                [.missing, .permissionDenied, .readFailed]
+            )
+            XCTAssertTrue(document.injections.isEmpty)
+        }
+    }
+
+    func testBridgeRejectionsPreserveStatuses() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            let statuses: [RhwpExternalImageOperationStatus] = [
+                .referenceNotFound,
+                .failure,
+                .unknown(77)
+            ]
+            let references = try statuses.enumerated().map { index, _ in
+                let basename = "bridge-\(index).png"
+                try ExternalImageTestSupport.write(
+                    Data([UInt8(index)]),
+                    named: basename,
+                    in: directoryURL
+                )
+                return makeReference(
+                    key: "binData:\(index)",
+                    basename: basename
+                )
+            }
+            let document = FakeExternalImageDocument(
+                referenceResults: [.success(references)],
+                injectionStatuses: Dictionary(
+                    uniqueKeysWithValues: zip(
+                        references.map(\.key),
+                        statuses
+                    )
+                )
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            )
+
+            XCTAssertEqual(
+                report.resolutions.map(\.decision),
+                statuses.map(RhwpExternalResourceDecision.bridgeRejected)
+            )
+            XCTAssertEqual(document.injections.count, statuses.count)
+            XCTAssertEqual(document.referenceQueryCount, 1)
+        }
+    }
+
+    func testReferenceFailureDoesNotStopLaterValidInjection() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            let validData = Data([0xCA, 0xFE])
+            try ExternalImageTestSupport.write(
+                validData,
+                named: "valid.png",
+                in: directoryURL
+            )
+            let missing = makeReference(
+                key: "binData:missing",
+                basename: "missing.png"
+            )
+            let valid = makeReference(
+                key: "binData:valid",
+                basename: "valid.png"
+            )
+            let loadedValid = makeReference(
+                key: valid.key,
+                basename: valid.basename,
+                loaded: true
+            )
+            let document = FakeExternalImageDocument(
+                referenceResults: [
+                    .success([missing, valid]),
+                    .success([missing, loadedValid])
+                ]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            )
+
+            XCTAssertEqual(
+                report.resolutions.map(\.decision),
+                [.missing, .injected(byteCount: validData.count)]
+            )
+            XCTAssertEqual(document.injections.map(\.key), [valid.key])
+        }
+    }
+
+    func testSuccessfulInjectionWithoutLoadedTransitionFailsVerification() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            try ExternalImageTestSupport.write(
+                Data([0x01]),
+                named: "pending.png",
+                in: directoryURL
+            )
+            let reference = makeReference(
+                key: "binData:pending",
+                basename: "pending.png"
+            )
+            let document = FakeExternalImageDocument(
+                referenceResults: [
+                    .success([reference]),
+                    .success([reference])
+                ]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            )
+
+            XCTAssertEqual(
+                report.resolutions.first?.decision,
+                .verificationFailed
+            )
+            XCTAssertEqual(document.referenceQueryCount, 2)
+        }
+    }
+
+    func testFinalReferenceQueryFailureFailsAllPendingVerification() throws {
+        try ExternalImageTestSupport.withTemporaryDirectory { directoryURL in
+            let sourceURL = try makeSourceDocument(in: directoryURL)
+            let references = try ["first.png", "second.png"].enumerated().map {
+                index,
+                basename in
+                try ExternalImageTestSupport.write(
+                    Data([UInt8(index)]),
+                    named: basename,
+                    in: directoryURL
+                )
+                return makeReference(
+                    key: "binData:\(index)",
+                    basename: basename
+                )
+            }
+            let document = FakeExternalImageDocument(
+                referenceResults: [
+                    .success(references),
+                    .failure(FakeDocumentError.referenceQuery)
+                ]
+            )
+
+            let report = HwpExternalImageResolver.resolve(
+                document: document,
+                context: context(sourceURL: sourceURL)
+            )
+
+            XCTAssertEqual(
+                report.resolutions.map(\.decision),
+                [.verificationFailed, .verificationFailed]
+            )
+            XCTAssertEqual(document.referenceQueryCount, 2)
+        }
+    }
+
+    func testReportSummaryContainsOnlyPrivacySafeCounts() {
+        let report = RhwpExternalResourceReport(
+            state: .attempted,
+            filenameStatus: .ok,
+            resolutions: [
+                RhwpExternalResourceResolution(
+                    key: "binData:1",
+                    decision: .injected(byteCount: 10)
+                ),
+                RhwpExternalResourceResolution(
+                    key: "binData:2",
+                    decision: .alreadyLoaded
+                ),
+                RhwpExternalResourceResolution(
+                    key: "binData:3",
+                    decision: .missing
+                ),
+                RhwpExternalResourceResolution(
+                    key: "binData:4",
+                    decision: .rejectedOutsideSourceDirectory
+                ),
+                RhwpExternalResourceResolution(
+                    key: "binData:5",
+                    decision: .tooLarge(actualBytes: 20, limit: 10)
+                ),
+                RhwpExternalResourceResolution(
+                    key: "binData:6",
+                    decision: .permissionDenied
+                ),
+                RhwpExternalResourceResolution(
+                    key: "binData:7",
+                    decision: .readFailed
+                ),
+                RhwpExternalResourceResolution(
+                    key: "binData:8",
+                    decision: .bridgeRejected(.failure)
+                ),
+                RhwpExternalResourceResolution(
+                    key: "binData:9",
+                    decision: .verificationFailed
+                )
+            ]
+        )
+
+        XCTAssertEqual(
+            report.summary,
+            RhwpExternalResourceSummary(
+                total: 9,
+                injected: 1,
+                alreadyLoaded: 1,
+                missing: 1,
+                rejected: 1,
+                tooLarge: 1,
+                permissionDenied: 1,
+                readFailed: 1,
+                bridgeFailed: 2
+            )
+        )
+        XCTAssertEqual(
+            report.privacySafeDescription,
+            "state=attempted total=9 injected=1 alreadyLoaded=1 "
+                + "missing=1 rejected=1 tooLarge=1 permissionDenied=1 "
+                + "readFailed=1 bridgeFailed=2"
+        )
+        XCTAssertFalse(report.privacySafeDescription.contains("secret.png"))
+        XCTAssertFalse(report.privacySafeDescription.contains("/private/"))
+        XCTAssertEqual(
+            Set(
+                Mirror(reflecting: report.summary)
+                    .children
+                    .compactMap(\.label)
+            ),
+            [
+                "total",
+                "injected",
+                "alreadyLoaded",
+                "missing",
+                "rejected",
+                "tooLarge",
+                "permissionDenied",
+                "readFailed",
+                "bridgeFailed"
+            ]
+        )
+    }
+
+    private func context(
+        sourceURL: URL,
+        limit: Int = 1024
+    ) -> RhwpDocumentOpenContext {
+        RhwpDocumentOpenContext(
+            sourceURL: sourceURL,
+            displayFilename: sourceURL.lastPathComponent,
+            maximumExternalResourceBytes: limit
+        )
+    }
+
+    private func makeSourceDocument(in directoryURL: URL) throws -> URL {
+        try ExternalImageTestSupport.write(
+            Data([0xD0, 0xCF]),
+            named: "document.hwp",
+            in: directoryURL
+        )
+    }
+
+    private func makeReference(
+        key: String,
+        basename: String,
+        originalPath: String = "/private/original/secret.png",
+        loaded: Bool = false
+    ) -> RhwpExternalImageReference {
+        RhwpExternalImageReference(
+            key: key,
+            binDataId: 1,
+            originalPath: originalPath,
+            basename: basename,
+            fileExtension: "png",
+            loaded: loaded
+        )
+    }
+}
+
+private enum FakeDocumentError: Error {
+    case referenceQuery
+}
+
+private struct FakeInjection: Equatable {
+    let key: String
+    let data: Data
+    let displayPath: String?
+}
+
+private final class FakeExternalImageDocument: RhwpExternalImageDocumentAccess {
+    private let referenceResults: [Result<[RhwpExternalImageReference], Error>]
+    private let injectionStatuses: [String: RhwpExternalImageOperationStatus]
+
+    private(set) var filenames: [String] = []
+    private(set) var referenceQueryCount = 0
+    private(set) var injections: [FakeInjection] = []
+
+    init(
+        referenceResults: [Result<[RhwpExternalImageReference], Error>],
+        injectionStatuses: [String: RhwpExternalImageOperationStatus] = [:]
+    ) {
+        self.referenceResults = referenceResults
+        self.injectionStatuses = injectionStatuses
+    }
+
+    func setFileName(_ filename: String) -> RhwpExternalImageOperationStatus {
+        filenames.append(filename)
+        return .ok
+    }
+
+    func externalImageReferences() throws -> [RhwpExternalImageReference] {
+        defer {
+            referenceQueryCount += 1
+        }
+        guard !referenceResults.isEmpty else {
+            return []
+        }
+        let index = min(referenceQueryCount, referenceResults.count - 1)
+        return try referenceResults[index].get()
+    }
+
+    func injectExternalImage(
+        key: String,
+        data: Data,
+        displayPath: String?
+    ) -> RhwpExternalImageOperationStatus {
+        injections.append(
+            FakeInjection(
+                key: key,
+                data: data,
+                displayPath: displayPath
+            )
+        )
+        return injectionStatuses[key] ?? .ok
+    }
+}

--- a/Tests/ExternalImageTests/RhwpDocumentExternalImageBridgeTests.swift
+++ b/Tests/ExternalImageTests/RhwpDocumentExternalImageBridgeTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import XCTest
+
+final class RhwpDocumentExternalImageBridgeTests: XCTestCase {
+    func testExternalImageStatusRawValueMapping() {
+        let expected: [(UInt32, RhwpExternalImageOperationStatus)] = [
+            (0, .ok),
+            (1, .invalidHandle),
+            (2, .invalidInput),
+            (3, .invalidUTF8),
+            (4, .referenceNotFound),
+            (5, .alreadyLoaded),
+            (6, .failure),
+            (UInt32.max, .unknown(UInt32.max))
+        ]
+
+        for (rawValue, status) in expected {
+            XCTAssertEqual(
+                RhwpExternalImageOperationStatus(rawValue: rawValue),
+                status
+            )
+        }
+    }
+
+    func testReferenceDecoderMapsExtensionAndIgnoresAdditiveFields() throws {
+        let json = """
+        [
+          {
+            "key": "binData:7",
+            "binDataId": 7,
+            "originalPath": "C:\\\\images\\\\sample.png",
+            "basename": "sample.png",
+            "extension": "png",
+            "loaded": false,
+            "futureField": {"enabled": true}
+          }
+        ]
+        """
+
+        let references = try RhwpDocument.decodeExternalImageReferences(
+            from: Data(json.utf8)
+        )
+
+        XCTAssertEqual(
+            references,
+            [
+                RhwpExternalImageReference(
+                    key: "binData:7",
+                    binDataId: 7,
+                    originalPath: "C:\\images\\sample.png",
+                    basename: "sample.png",
+                    fileExtension: "png",
+                    loaded: false
+                )
+            ]
+        )
+    }
+
+    func testReferenceDecoderRejectsInvalidShapes() {
+        let invalidPayloads = [
+            """
+            [{"key":"binData:1","binDataId":1,"originalPath":"a.png","basename":"a.png","extension":"png"}]
+            """,
+            """
+            [{"key":"binData:1","binDataId":65536,"originalPath":"a.png","basename":"a.png","extension":"png","loaded":false}]
+            """,
+            """
+            {"key":"binData:1","binDataId":1,"originalPath":"a.png","basename":"a.png","extension":"png","loaded":false}
+            """
+        ]
+
+        for payload in invalidPayloads {
+            XCTAssertThrowsError(
+                try RhwpDocument.decodeExternalImageReferences(
+                    from: Data(payload.utf8)
+                )
+            ) { error in
+                XCTAssertEqual(
+                    error as? RhwpExternalImageBridgeError,
+                    .invalidReferencesJSON
+                )
+            }
+        }
+    }
+
+    func testBridgeCallsUseFilenameReferencesAndMissingKeyContracts() throws {
+        let document = try RhwpDocument(
+            data: ExternalImageTestSupport.sampleData(at: "samples/basic/KTX.hwp"),
+            filename: "KTX.hwp"
+        )
+
+        XCTAssertEqual(document.setFileName("한글 KTX.hwp"), .ok)
+        XCTAssertEqual(try document.externalImageReferences(), [])
+        XCTAssertEqual(
+            document.injectExternalImage(
+                key: "not-a-reference",
+                data: Data([0x01]),
+                displayPath: nil
+            ),
+            .referenceNotFound
+        )
+    }
+
+    func testBridgeRejectsEmptyInjectionInputs() throws {
+        let document = try RhwpDocument(
+            data: ExternalImageTestSupport.sampleData(at: "samples/basic/KTX.hwp"),
+            filename: "KTX.hwp"
+        )
+
+        XCTAssertEqual(
+            document.injectExternalImage(
+                key: "",
+                data: Data([0x01]),
+                displayPath: ""
+            ),
+            .invalidInput
+        )
+        XCTAssertEqual(
+            document.injectExternalImage(
+                key: "not-a-reference",
+                data: Data(),
+                displayPath: ""
+            ),
+            .invalidInput
+        )
+    }
+
+    func testRepeatedReferenceQueriesRemainStable() throws {
+        let document = try RhwpDocument(
+            data: ExternalImageTestSupport.sampleData(at: "samples/basic/KTX.hwp"),
+            filename: "KTX.hwp"
+        )
+
+        for _ in 0..<128 {
+            XCTAssertEqual(try document.externalImageReferences(), [])
+        }
+    }
+}

--- a/mydocs/orders/20260724.md
+++ b/mydocs/orders/20260724.md
@@ -4,7 +4,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, Stage 3 Quick Look Preview 연결·privacy-safe log 완료 · Stage 4 승인 대기 |
+| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, Stage 4 external fixture·registered Preview 통합 검증 완료, Quick Look sibling sandbox 제한 확정 · Stage 5 승인 대기 |
 
 ## M040 — 믿고 설치한다
 

--- a/mydocs/orders/20260724.md
+++ b/mydocs/orders/20260724.md
@@ -4,7 +4,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, Stage 1 Swift wrapper·FFI 계약 완료 · Stage 2 승인 대기 |
+| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, Stage 2 basename-only resolver·report 완료 · Stage 3 승인 대기 |
 
 ## M040 — 믿고 설치한다
 

--- a/mydocs/orders/20260724.md
+++ b/mydocs/orders/20260724.md
@@ -4,7 +4,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, 수행계획 승인 · 구현계획서 작성 후 승인 대기 |
 
 ## M040 — 믿고 설치한다
 

--- a/mydocs/orders/20260724.md
+++ b/mydocs/orders/20260724.md
@@ -4,7 +4,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, Stage 2 basename-only resolver·report 완료 · Stage 3 승인 대기 |
+| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, Stage 3 Quick Look Preview 연결·privacy-safe log 완료 · Stage 4 승인 대기 |
 
 ## M040 — 믿고 설치한다
 

--- a/mydocs/orders/20260724.md
+++ b/mydocs/orders/20260724.md
@@ -4,7 +4,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, 수행계획 승인 · 구현계획서 작성 후 승인 대기 |
+| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, Stage 1 Swift wrapper·FFI 계약 완료 · Stage 2 승인 대기 |
 
 ## M040 — 믿고 설치한다
 

--- a/mydocs/orders/20260724.md
+++ b/mydocs/orders/20260724.md
@@ -1,5 +1,11 @@
 # 오늘 할일 - 2026년 7월 24일
 
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+
 ## M040 — 믿고 설치한다
 
 | Issue | 타스크 | 상태 | 비고 |

--- a/mydocs/orders/20260724.md
+++ b/mydocs/orders/20260724.md
@@ -4,7 +4,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 진행중 | M020, Stage 4 external fixture·registered Preview 통합 검증 완료, Quick Look sibling sandbox 제한 확정 · Stage 5 승인 대기 |
+| #409 | Swift external image wrapper/resolver와 Quick Look Preview 적용 | 완료 | M020, Stage 5 최종 보고서·검증 완료, Quick Look sibling sandbox 제한·후속 handoff 확정, PR 게시 승인 대기 · 완료: 15:32 |
 
 ## M040 — 믿고 설치한다
 

--- a/mydocs/plans/task_m020_409.md
+++ b/mydocs/plans/task_m020_409.md
@@ -1,0 +1,250 @@
+# Task M020 #409 수행계획서
+
+## 목적
+
+`Swift external image wrapper/resolver와 Quick Look Preview 적용`을 수행한다.
+
+현재 pinned `rhwp v0.7.18`과 #408에서 제공한 external image context C ABI를 Swift에서 안전하게 감싸고, Quick Look Preview가 source document와 같은 디렉터리의 external image를 basename 기준으로만 찾아 명시적으로 주입하도록 한다. resolver의 missing, rejected, permission denied, too large 같은 결과는 문서 렌더 전체 실패로 올리지 않고 진단 보고서에 남기며, filename 설정과 external image 주입이 page count, page size, render tree/PNG 조회보다 먼저 끝나는 호출 순서를 고정한다.
+
+## 배경
+
+#391 조사와 #408 구현 결과 다음 책임 경계와 입력이 확정됐다.
+
+- `rhwp-core.lock`은 release tag `v0.7.18`, commit `93862a4e16df59834ebce46d91e948cd739208e9`, feature `native-skia`를 고정한다.
+- RustBridge에는 `rhwp_set_file_name_utf8`, `rhwp_external_image_refs_json`, `rhwp_inject_external_image_by_key`와 raw value 0~6의 `RhwpExternalImageStatus`가 이미 포함돼 있다.
+- RustBridge는 external path를 열지 않으며 filename, key, image bytes, display path 입력은 Swift caller가 FFI 호출 동안 소유한다.
+- refs JSON 반환 문자열은 Swift가 복사한 뒤 `rhwp_free_string`으로 해제해야 하고, injection 같은 mutable 호출 전에 `rhwp_image_data` 반환 bytes를 즉시 복사해야 한다.
+- 현재 `RhwpDocument(data:filename:)`의 `filename`은 Swift 오류 문맥에만 사용되고 Rust document filename context로 전달되지 않는다.
+- 현재 `HwpPreviewPDFRenderer.load(fileURL:)`는 main document를 연 직후 page count와 첫 page size를 조회하므로 external refs 조회·주입 지점이 없다.
+- Quick Look Preview는 `QLFilePreviewRequest.fileURL`을 제공하므로 source URL과 sibling read 권한을 적용할 첫 제품 surface로 적합하다.
+- `HwpPageImageRenderer.renderFirstPage(fileURL:)`는 Finder Thumbnail도 사용하므로 #411 cache signature 전에는 이 경로에서 resolver를 활성화하면 안 된다.
+- HostApp WKWebView는 main document bytes만 bundled studio에 전달하므로 native Swift resolver를 연결하는 작업과 별개이며 #413이 소유한다.
+
+따라서 #409는 Rust ABI나 core pin을 바꾸지 않고 Swift wrapper, Foundation 기반 resolver, Quick Look Preview open flow와 진단만 연결한다.
+
+## 범위
+
+포함:
+
+- upstream refs JSON의 additive field를 허용하는 `RhwpExternalImageReference: Decodable`
+  - `key`
+  - `binDataId`
+  - `originalPath`
+  - `basename`
+  - JSON `extension`을 Swift의 안전한 property 이름으로 매핑
+  - `loaded`
+- C enum raw value 0~6을 downstream case로 보존하는 Swift external image status 모델
+- `RhwpDocument`의 filename setter, external refs 조회, key 기반 bytes injection wrapper
+- refs JSON pointer 복사와 `rhwp_free_string` 해제, UTF-8 string pointer/length, image bytes caller lifetime 검증
+- optional source URL, display filename, external resource 최대 bytes를 가진 `RhwpDocumentOpenContext` 또는 동등한 open context
+- reference별 결정과 전체 집계를 표현하는 `RhwpExternalResourceResolution` 및 report summary
+- source document parent의 단일 sibling file만 허용하는 v1 basename-only resolver
+- 빈 이름, `.`, `..`, `/` 또는 `\` 포함 이름, parent escape, directory, symlink escape, size cap 초과, missing, permission denied/read failure 진단
+- valid sibling bytes를 reference key로 주입하고 성공 후 refs의 `loaded` 상태를 재확인하는 흐름
+- `HwpPreviewPDFRenderer.load(fileURL:)`에서 filename 설정, refs 조회, resolve/inject를 page count/size/render 전에 수행
+- single-page PNG와 multi-page PDF가 같은 resolved `RhwpDocument`를 재사용하는 현재 구조 유지
+- `HwpPreviewDocumentContext` 또는 동등한 결과에 external resolution report를 포함하고 `HwpPreviewProvider`가 경로·basename 없이 집계만 privacy-safe하게 기록
+- source URL이 없거나 file URL이 아니거나 bytes-only open으로 source가 유실된 경우 resolver disabled와 기존 render 유지
+- wrapper/resolver 단위 검증과 최소 external image fixture 기반 Preview 경로 smoke
+- 기존 HWP/HWPX, embedded image, single-page PNG, multi-page PDF 회귀 검증
+
+제외:
+
+- Finder Thumbnail resolver 활성화, cache key, prepared request, cache signature 변경
+- CoreGraphics `ImageNode.externalPath`, missing placeholder, decode failure diagnostic 변경
+- HostApp WKWebView JS/native external resource bridge
+- HostApp bytes-only PDF export에서 sibling resolver 활성화
+- directory recursive lookup, search path 확대, arbitrary absolute path 접근
+- `originalPath`를 filesystem path나 URL로 해석하는 동작
+- Windows drive path, UNC/network path, URL string 접근
+- network download와 remote resource 지원
+- external resource contents hash, directory mtime, Thumbnail cache invalidation
+- RustBridge C ABI, `rhwp` core dependency, generated framework artifact 변경
+- public release, 배포, 서명, 공증, Homebrew Cask 작업
+- #412가 소유하는 정식 external/large image fixture suite와 전체 visual regression
+
+## 설계 방향
+
+1. 계층 경계를 유지한다.
+   - `Sources/RhwpCoreBridge`는 external model과 FFI wrapper만 소유하고 AppKit/UIKit 및 filesystem 탐색을 추가하지 않는다.
+   - `Sources/Shared`는 Foundation 기반 open context, sibling resolver, resolution/report와 Preview open orchestration을 소유한다.
+   - `Sources/QLExtension`은 report의 count/reason 집계만 `OSLog`에 기록한다.
+2. 기존 `RhwpDocument(data:filename:)` 호출 호환성을 유지한다. 새 context initializer 또는 동등한 helper가 필요하면 기존 initializer가 source URL 없는 context로 위임하도록 하고, source URL이 없을 때는 filename context만 설정한 뒤 resolver를 비활성화한다.
+3. FFI 호출 순서를 `rhwp_open -> filename setter -> refs JSON copy/decode/free -> sibling resolve/read -> key injection -> refs 재조회 -> page count/page size/render`로 고정한다. resolver가 완료된 `RhwpDocument`만 Preview context 밖으로 반환해 이후 caller가 injection 이전 상태를 관찰하지 않게 한다.
+4. refs JSON의 알 수 없는 additive field는 무시한다. 필수 field 누락, 타입 불일치, `binDataId` 범위 오류, null refs pointer는 bridge/query 진단으로 기록하되 기존 문서를 렌더할 수 있으면 전체 Preview failure로 승격하지 않는다.
+5. resolver는 `reference.basename`만 후보 이름으로 사용한다. `originalPath`에서 basename을 추출하거나 original path를 그대로 열지 않는다.
+6. source URL이 file URL인지 확인한 뒤 standardized source parent와 candidate를 계산한다. candidate의 symlink-resolved parent가 source parent 밖이면 reject하고, regular sibling file만 허용한다.
+7. external resource size는 metadata에서 먼저 확인하고 bytes read 후 실제 `Data.count`를 다시 확인한다. 기본 per-resource 상한은 기존 Quick Look 50 MB 정책을 재사용하는 방향으로 구현계획서에서 확정하며, 상한 초과는 read/injection 없이 report에 남긴다.
+8. missing, rejected, permission denied, read failure, bridge failure는 reference별 resolution으로 누적하고 다음 reference를 계속 처리한다. main document open, page count/size, render 자체의 기존 오류만 Preview fallback/throw 계약을 유지한다.
+9. log에는 main document의 기존 표시 filename과 resolution count/reason만 사용한다. external `originalPath`, resolved absolute path, full candidate URL은 public log에 포함하지 않는다.
+10. Thumbnail이 사용하는 `HwpPageImageRenderer.renderFirstPage(fileURL:)`는 source URL을 resolver에 넘기지 않는다. #411 전까지 filename context 설정 외의 external injection을 하지 않는 회귀 test를 둔다.
+11. 최소 external image fixture는 라이선스와 개인정보를 확인한 재현 가능한 자료만 사용한다. 저장소 편입이 부적절하면 test-local 또는 `build.noindex/` 생성 fixture로 검증하고, 정식 suite 편입은 #412에 남긴다.
+
+## 예상 변경 파일
+
+수행계획서 단계:
+
+- `mydocs/orders/20260724.md`
+- `mydocs/plans/task_m020_409.md`
+
+수행계획 승인 후 예상 Swift 변경:
+
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- 필요 시 `Sources/RhwpCoreBridge/RhwpExternalImage.swift`
+- 신규 `Sources/Shared/HwpExternalImageResolver.swift` 또는 동등한 Foundation helper
+- `Sources/Shared/HwpPreviewPDFRenderer.swift`
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- 필요 시 resolver/report test target을 선언하는 `project.yml`
+
+예상 검증 코드·fixture:
+
+- 필요 시 신규 `Tests/RhwpCoreBridgeTests/` 또는 `Tests/SharedTests/` 하위 wrapper/resolver test
+- 필요 시 기존 test target을 재사용하는 `Tests/HostAppTests/` 하위 neutral Foundation test
+- 필요 시 최소 external image test fixture 또는 `build.noindex/` fixture 생성 helper
+- 필요 시 Quick Look Preview source-level smoke script
+
+후속 문서 산출물:
+
+- `mydocs/plans/task_m020_409_impl.md`
+- `mydocs/working/task_m020_409_stage{N}.md`
+- `mydocs/report/task_m020_409_report.md`
+
+생성·검증 대상이지만 직접 수정하거나 commit하지 않는 산출물:
+
+- `Alhangeul.xcodeproj/**`
+- `build.noindex/**`
+- `/private/tmp/**` 검증 산출물
+
+다음 파일은 #409 기본 범위에서 변경하지 않는다.
+
+- `RustBridge/**`
+- `rhwp-ffi-symbols.txt`
+- `rhwp-core.lock`
+- `Frameworks/**`
+- `Sources/ThumbnailExtension/**`
+- `Sources/HostApp/Resources/rhwp-studio/**`
+
+구현 중 C ABI, core pin, entitlement, Thumbnail cache, renderer placeholder 변경이 필요하다고 확인되면 현재 범위를 확장하지 않고 먼저 작업지시자 승인을 요청한다.
+
+## 잠정 단계
+
+1. Stage 1: Swift external image model과 RustBridge wrapper 구현
+   - status raw value mapping, refs JSON decode, filename setter, refs query/free, key injection을 구현한다.
+   - UTF-8 pointer/length, empty display path, image bytes lifetime, invalid JSON/status를 검증한다.
+2. Stage 2: open context, basename-only sibling resolver와 report 구현
+   - source URL disabled 조건, basename 검증, parent/symlink 경계, regular file와 size cap, missing/permission/read 결과를 구현한다.
+   - 임시 디렉터리 기반 단위 test로 valid sibling과 모든 reject/diagnostic 경로를 검증한다.
+3. Stage 3: Quick Look Preview open flow와 privacy-safe diagnostic 연결
+   - `HwpPreviewPDFRenderer.load(fileURL:)`에서 resolve/inject 완료 후 page count/size를 조회하도록 순서를 바꾼다.
+   - single-page PNG와 multi-page PDF context 재사용, report 전달, QLExtension 집계 log를 연결한다.
+   - Thumbnail과 bytes-only HostApp 경로의 resolver disabled 회귀를 확인한다.
+4. Stage 4: external fixture Preview smoke와 전체 회귀 검증
+   - valid sibling injection 후 refs `loaded == true`, missing/rejected/too large 시 기존 render 지속, 호출 순서를 확인한다.
+   - no-AppKit, unit test, Xcode project 생성, HostApp/QLExtension compile, 기본 renderer smoke를 통과시킨다.
+   - 실제 등록 Quick Look smoke가 필요하면 개발 산출물 등록·해제를 포함한 표준 절차와 별도 승인을 적용한다.
+5. Stage 5: 최종 결과 보고서와 후속 이슈 handoff 정리
+   - wrapper/resolver 계약, report taxonomy, 검증 결과, privacy/sandbox 잔여 위험을 정리한다.
+   - Thumbnail #411, fixture suite #412, WKWebView #413과 CoreGraphics diagnostic #410의 경계를 명시한다.
+
+## 검증 계획
+
+계획 단계:
+
+```bash
+git diff --check -- mydocs/orders/20260724.md mydocs/plans/task_m020_409.md
+rg -n "#409|RhwpExternal|basename|sibling|Quick Look|resolver|injection|privacy|Thumbnail|#410|#411|#412|#413" \
+  mydocs/orders/20260724.md mydocs/plans/task_m020_409.md
+```
+
+Swift wrapper/resolver 구현 단계 후보:
+
+```bash
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostAppTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Tests \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+```
+
+구현계획서에서 별도 common test scheme을 확정하면 위 `HostAppTests` 명령을 해당 scheme으로 바꾼다. 최소 test matrix는 다음을 포함한다.
+
+- status raw value 0~6과 unknown fallback
+- refs JSON 정상/additive field/invalid shape
+- refs JSON 반환 string 해제와 input UTF-8/data lifetime
+- source URL nil/non-file resolver disabled
+- external refs empty
+- valid sibling injection과 `loaded` 재확인
+- missing
+- empty, `.`, `..`, slash/backslash basename reject
+- standardized parent escape와 symlink escape reject
+- directory reject
+- per-resource size cap 초과
+- permission denied 또는 read failure
+- 한 reference 실패 후 다음 reference 계속 처리
+- resolver 실패 후 page count/page size/render 지속
+- bytes-only HostApp와 Thumbnail resolver disabled
+
+compile/link와 기존 render 회귀 후보:
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409 \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme QLExtension \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409QL \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+./scripts/validate-stage3-render.sh build.noindex/task409-stage3-render \
+  samples/basic/KTX.hwp \
+  samples/basic/request.hwp \
+  samples/hwp-img-001.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+Preview source-level smoke는 구현계획서에서 확정한 최소 fixture로 다음을 증명한다.
+
+- valid sibling은 injection 성공과 `loaded == true`
+- single-page PNG 또는 multi-page PDF output이 비어 있지 않음
+- missing, invalid basename, too large, permission/read failure는 report에 남고 main preview render는 계속됨
+- report/log에는 external original path와 absolute candidate path가 없음
+- page count/page size/render가 resolution 완료 후 호출됨
+
+Finder/Quick Look 실제 등록 smoke는 Debug `CODE_SIGNING_ALLOWED=NO` 산출물로 판정하지 않는다. 필요할 경우 `build.noindex/` Release package, `scripts/check-extension-registration-hygiene.sh`, 표준 등록/해제 helper를 사용하되, local package·등록·정리 실행 전 작업지시자에게 별도 명시 승인을 요청한다.
+
+## 리스크
+
+- Quick Look sandbox가 main document URL read 권한은 주더라도 sibling file read를 허용하지 않을 수 있다. 이 경우 entitlement를 임의 확장하지 않고 permission denied report와 기존 render 유지가 우선이며, 실제 제품 권한 정책 보강은 별도 승인 대상으로 분리한다.
+- basename 검증과 symlink resolution 뒤 read 사이에 filesystem 상태가 바뀌는 TOCTOU 위험이 남는다. v1은 standardized/resolved parent 검증과 read 직전 metadata 확인으로 범위를 줄이고, fd 기반 hardening이 필요하면 후속 이슈로 분리한다.
+- upstream refs JSON은 additive field에는 안전하지만 필수 field 이름이나 타입이 바뀌면 decode가 실패할 수 있다. bridge/query diagnostic으로 구분하고 Preview 전체 실패로 과장하지 않는다.
+- Swift `UInt16` 범위를 넘는 `binDataId` 또는 알 수 없는 status raw value가 들어올 수 있다. 임의 truncate하지 않고 decode/unknown failure로 보존한다.
+- filename setter나 injection은 document의 내부 image cache를 바꿀 수 있다. `rhwp_image_data` pointer를 mutation 너머 보관하지 않고, injection 이후 render tree/image data를 새로 조회한다.
+- size metadata와 실제 read bytes가 다를 수 있다. read 전후 상한을 모두 검사하고 초과 bytes는 injection하지 않는다.
+- valid external image exact fixture가 현재 앱 저장소에 없다. fixture 확보가 늦어져도 resolver security/unit test와 기존 render 회귀를 먼저 통과시키되, injection 성공과 Preview output 검증 없이 #409를 완료 처리하지 않는다.
+- `HwpPreviewPDFRenderer.inspect(fileURL:)` 후 bytes-only `render(previewInfo:)`처럼 source URL이 유실되는 경로가 있다. 이 경로에서 resolver가 뜻하지 않게 활성화되거나 Preview가 external 지원을 보장한다고 표현하지 않도록 source context 전달 여부를 명시적으로 구분한다.
+- `RhwpDocument(data:filename:)`가 filename setter를 호출하도록 바뀌면 기존 documents의 core context와 cache 동작이 달라질 수 있다. embedded image와 기본 HWP/HWPX render regression을 필수 gate로 둔다.
+- test target 추가가 필요하면 `project.yml`만 수정하고 `Alhangeul.xcodeproj`를 직접 수정하지 않는다.
+- resolver를 Thumbnail 경로까지 공통 적용하면 #411 전 stale cache가 생긴다. Preview open helper에서만 source URL을 전달하고 Thumbnail regression test로 범위를 잠근다.
+
+## 승인 요청 사항
+
+1. #409를 parent #407의 Swift wrapper/Quick Look 적용 이슈로 진행하고, 기준 브랜치 `devel`, 작업 브랜치 `local/task409`을 사용하는 범위 승인
+2. `RhwpCoreBridge = FFI wrapper`, `Shared = Foundation resolver/report`, `QLExtension = privacy-safe 집계 log` 책임 분리 승인
+3. `reference.basename`만 사용하고 source parent의 단일 regular sibling만 허용하며 absolute/original/network path를 해석하지 않는 v1 resolver 정책 승인
+4. external resolver 실패는 report에 누적하고 기존 document render는 계속하되, main document open/render 오류는 기존 fallback 계약을 유지하는 방향 승인
+5. 기존 Quick Look 50 MB 상한을 external resource별 기본 상한 후보로 두고 구현계획서에서 확정하는 방향 승인
+6. wrapper/resolver test와 최소 injection fixture를 #409에 포함하되 정식 fixture suite와 전체 visual regression은 #412에 남기는 범위 승인
+7. 위 5개 잠정 단계 승인
+
+수행계획서 승인 전에는 구현계획서 작성, Swift source 변경, fixture 편입, Quick Look 등록 smoke를 진행하지 않는다.

--- a/mydocs/plans/task_m020_409_impl.md
+++ b/mydocs/plans/task_m020_409_impl.md
@@ -1,0 +1,683 @@
+# Task M020 #409 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_409.md`
+
+각 단계 완료 후 `task-stage-report` 절차로 단계 보고서와 해당 단계 변경을 함께 커밋하고, 작업지시자 승인을 받은 뒤 다음 단계로 넘어간다.
+
+## 작업 개요
+
+- 이슈: #409 `Swift external image wrapper/resolver와 Quick Look Preview 적용`
+- Parent: #407 `external image context ABI 후속 구현 추적`
+- 선행 조사: #391 `filename/external image context ABI 조사 및 bridge 설계`
+- 선행 구현: #408 `RustBridge external image context C ABI 구현`
+- 관련 측정: #404 `upstream 렌더 PR 대표 샘플 diff 측정`
+- 후속 경계:
+  - #410 CoreGraphics external missing/decode diagnostic
+  - #411 Thumbnail external resource cache signature
+  - #412 external/large image 정식 fixture suite
+  - #413 HostApp WKWebView external image bridge
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task409`
+- 목표: pinned `rhwp v0.7.18`의 external image context C ABI를 Swift wrapper로 노출하고, Quick Look Preview에서 안전한 basename-only sibling resolver를 page count/size/render 전에 실행한다.
+
+## 구현 전 확인 결론
+
+현재 코드와 pinned upstream checkout을 대조한 결론이다.
+
+| 항목 | 현재 상태 | 구현 판단 |
+|------|-----------|-----------|
+| core provenance | `rhwp v0.7.18`, commit `93862a4e16df59834ebce46d91e948cd739208e9`, `native-skia` | core pin과 generated artifact를 변경하지 않는다. |
+| C status | raw value 0~6의 `RhwpExternalImageStatus` | Swift 별도 enum으로 모두 보존하고 unknown raw value도 버리지 않는다. |
+| filename setter | `rhwp_set_file_name_utf8(handle,name,len)` | Quick Look open helper가 explicit 호출한다. |
+| refs query | `rhwp_external_image_refs_json(handle)` | Swift가 반환 C string을 즉시 복사하고 `rhwp_free_string`으로 해제한다. |
+| key injection | `rhwp_inject_external_image_by_key(handle,key,data,display_path)` | resolver가 허용한 bytes와 basename display path만 전달한다. |
+| refs JSON | `key`, `binDataId`, `originalPath`, `basename`, `extension`, `loaded` | `extension`은 Swift `fileExtension`에 매핑하고 unknown additive field는 무시한다. |
+| current Swift open | `RhwpDocument(data:filename:)`가 `rhwp_open`만 호출 | 기존 initializer 동작은 유지하고 Quick Look 전용 Shared loader가 setter/query/injection을 조정한다. |
+| current Preview load | document open 직후 page count와 첫 page size 조회 | external resolution이 끝난 document를 받은 뒤에만 page metadata를 조회하도록 순서를 바꾼다. |
+| single/multi reply | 같은 `HwpPreviewDocumentContext.document`로 PNG 또는 PDF 생성 | resolved document 재사용 구조를 유지한다. |
+| Thumbnail path | `HwpPageImageRenderer.renderFirstPage(fileURL:)`가 별도 open | #411 전 resolver를 연결하지 않는다. |
+| bytes-only path | `render(previewInfo:)`, HostApp PDF export가 source URL 없이 open | filename/error context만 유지하고 sibling resolver는 비활성화한다. |
+| Quick Look entitlement | app sandbox + user-selected read-only | entitlement를 변경하지 않고 실제 registered Preview smoke로 sibling 접근 가능 여부를 검증한다. |
+| exact external fixture | pinned checkout에 `hwp3-sample10-{hwp5,hwpx}`와 `oracle.gif`, `rdb02.gif`, `s1.jpg` 존재 | MIT checkout fixture를 `build.noindex/`에 복사해 smoke에만 쓰고 저장소에는 편입하지 않는다. |
+
+pinned checkout의 확인 경로는 `/Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/93862a4`다. 이 경로의 HEAD는 lock과 같은 `93862a4e16df59834ebce46d91e948cd739208e9`이며 repository license는 MIT다. fixture의 정식 저장소 편입과 장기 provenance는 #412가 소유한다.
+
+## 구현 원칙
+
+- `Sources/RhwpCoreBridge`에는 model과 FFI wrapper만 추가한다. AppKit/UIKit, URL resolution, `FileManager`, file read 정책을 넣지 않는다.
+- 기존 `RhwpDocument(data:filename:)`의 제품 동작을 암묵적으로 확장하지 않는다. Quick Look만 `Sources/Shared`의 명시적 external-resource open helper를 호출한다.
+- `RhwpDocument.handle`은 계속 `private`로 유지한다. FFI wrapper method는 같은 `RhwpDocument.swift` 안에 구현하고 handle을 다른 파일에 노출하지 않는다.
+- Swift string은 UTF-8 bytes와 명시 길이로 전달하고, empty display path는 nil pointer/0 length로 전달한다.
+- refs JSON C string은 `defer { rhwp_free_string(...) }`로 모든 decode 결과에서 해제한다.
+- `rhwp_image_data` 결과는 기존처럼 즉시 `Data`로 복사한다. setter/injection 같은 mutable 호출을 넘겨 pointer를 보관하지 않는다.
+- resolver는 `reference.basename`만 사용한다. `originalPath`는 decode 보존만 하고 filesystem 접근, report, log에 사용하지 않는다.
+- source parent의 한 단계 sibling regular file만 허용한다. recursion, absolute/original path, URL/network, Windows drive/UNC 해석을 금지한다.
+- source URL 없음/non-file URL은 disabled 상태다. 이 경우 refs query와 injection을 실행하지 않는다.
+- 이미 loaded인 reference는 file lookup 없이 `alreadyLoaded`로 기록한다.
+- reference 한 건의 missing/rejected/read/bridge failure는 다음 reference 처리를 막지 않고 main Preview render 실패로 승격하지 않는다.
+- main document read/open, page count/size, PNG/PDF render의 기존 오류 계약은 유지한다.
+- provider log는 report state와 count만 기록한다. external basename, original path, resolved candidate, absolute path는 기록하지 않는다.
+- `project.yml`만 Xcode project 원본으로 수정하고 `Alhangeul.xcodeproj`는 생성·검증 후 commit하지 않는다.
+- RustBridge, core lock, generated framework, entitlement, Thumbnail cache, HostApp WKWebView를 변경해야 하는 상황이 확인되면 현재 단계에서 멈추고 범위 확장 승인을 요청한다.
+
+## Swift FFI wrapper 확정안
+
+### Status model
+
+Swift model 이름은 imported C enum과의 혼동을 피하기 위해 `RhwpExternalImageOperationStatus`로 고정한다.
+
+```swift
+enum RhwpExternalImageOperationStatus: Equatable {
+    case ok
+    case invalidHandle
+    case invalidInput
+    case invalidUTF8
+    case referenceNotFound
+    case alreadyLoaded
+    case failure
+    case unknown(UInt32)
+}
+```
+
+| raw value | Swift case |
+|-----------|------------|
+| 0 | `.ok` |
+| 1 | `.invalidHandle` |
+| 2 | `.invalidInput` |
+| 3 | `.invalidUTF8` |
+| 4 | `.referenceNotFound` |
+| 5 | `.alreadyLoaded` |
+| 6 | `.failure` |
+| 그 외 | `.unknown(rawValue)` |
+
+initializer 입력 타입은 module qualification을 사용해 `Rhwp.RhwpExternalImageStatus`로 명시한다.
+
+### Reference model
+
+```swift
+struct RhwpExternalImageReference: Decodable, Equatable {
+    let key: String
+    let binDataId: UInt16
+    let originalPath: String
+    let basename: String
+    let fileExtension: String
+    let loaded: Bool
+}
+```
+
+- `CodingKeys.fileExtension = "extension"`으로 매핑한다.
+- `JSONDecoder` 기본 동작으로 unknown additive field를 무시한다.
+- 필수 field 누락, 타입 불일치, `UInt16` 범위 초과는 decode failure다.
+- `originalPath`는 upstream 계약 보존과 test 검증에만 사용하며 resolver/report/log에 전달하지 않는다.
+
+### Bridge error와 method
+
+```swift
+enum RhwpExternalImageBridgeError: Error, Equatable {
+    case referencesUnavailable
+    case invalidReferencesJSON
+}
+
+extension RhwpDocument {
+    @discardableResult
+    func setFileName(_ filename: String) -> RhwpExternalImageOperationStatus
+
+    func externalImageReferences() throws -> [RhwpExternalImageReference]
+
+    @discardableResult
+    func injectExternalImage(
+        key: String,
+        data: Data,
+        displayPath: String? = nil
+    ) -> RhwpExternalImageOperationStatus
+}
+```
+
+- `setFileName`은 empty String도 valid setter 요청으로 전달한다.
+- refs pointer가 nil이면 `.referencesUnavailable`, JSON decode 실패면 `.invalidReferencesJSON`을 던진다.
+- `injectExternalImage`는 key/data/display path의 nested buffer lifetime을 FFI 호출 범위 안에 고정한다.
+- resolver는 `displayPath`에 absolute candidate path가 아니라 허용된 `basename`만 전달한다.
+
+## Open context, resolver와 report 확정안
+
+### Open context
+
+```swift
+struct RhwpDocumentOpenContext: Equatable {
+    let sourceURL: URL?
+    let displayFilename: String?
+    let maximumExternalResourceBytes: Int
+}
+```
+
+- Quick Look은 `sourceURL = request.fileURL`, `displayFilename = request.fileURL.lastPathComponent`, `maximumExternalResourceBytes = hwpQuickLookMaxFileSize`를 사용한다.
+- 상한은 external resource 한 건당 적용한다. 기본값은 기존 Quick Look main document 상한과 같은 50 MB다.
+- bytes-only caller는 이 context를 만들지 않고 기존 initializer를 사용하므로 resolver가 자동 활성화되지 않는다.
+
+### Report state와 decision
+
+```swift
+enum RhwpExternalResourceReportState: Equatable {
+    case disabledNoSourceURL
+    case disabledNonFileURL
+    case attempted
+    case referenceQueryFailed
+}
+
+enum RhwpExternalResourceDecision: Equatable {
+    case alreadyLoaded
+    case injected(byteCount: Int)
+    case missing
+    case rejectedInvalidBasename
+    case rejectedOutsideSourceDirectory
+    case rejectedSourceDocument
+    case rejectedNonRegularFile
+    case tooLarge(actualBytes: Int?, limit: Int)
+    case permissionDenied
+    case readFailed
+    case bridgeRejected(RhwpExternalImageOperationStatus)
+    case verificationFailed
+}
+
+struct RhwpExternalResourceResolution: Equatable {
+    let key: String
+    let decision: RhwpExternalResourceDecision
+}
+
+struct RhwpExternalResourceReport: Equatable {
+    let state: RhwpExternalResourceReportState
+    let filenameStatus: RhwpExternalImageOperationStatus?
+    let resolutions: [RhwpExternalResourceResolution]
+}
+```
+
+- resolution에는 safe discovery key와 decision만 둔다.
+- basename, original path, candidate URL/path는 report에 저장하지 않는다.
+- report는 injected, alreadyLoaded, missing, rejected, tooLarge, permissionDenied, readFailed, bridgeFailed count를 computed summary로 제공한다.
+- initial refs query 실패는 `referenceQueryFailed`이며 main render는 계속한다.
+- injection `.ok`은 refs 재조회에서 같은 key의 `loaded == true`가 확인된 경우에만 최종 `.injected`다.
+- injection과 refs 재조회 사이의 race 또는 query failure는 `.verificationFailed`다.
+- injection 시점에 `.alreadyLoaded`가 반환되면 경쟁 상태를 허용해 `.alreadyLoaded`로 확정한다.
+
+### Resolver algorithm
+
+`Sources/Shared/HwpExternalImageResolver.swift`에 다음 역할을 둔다.
+
+1. main bytes로 `RhwpDocument`를 연다.
+2. display filename이 있으면 `setFileName`을 호출하고 status를 report에 보존한다.
+3. source URL이 nil이면 `disabledNoSourceURL`, file URL이 아니면 `disabledNonFileURL`로 즉시 반환한다.
+4. refs를 query한다. 실패하면 `referenceQueryFailed` report와 document를 반환한다.
+5. loaded ref는 `alreadyLoaded`로 기록한다.
+6. unloaded ref의 `basename`을 검증한다.
+   - empty, `.`, `..`
+   - `/`, `\`, NUL 포함
+7. source parent와 candidate를 standardized file URL로 계산한다.
+8. candidate가 source document 자신이면 reject한다.
+9. source parent와 candidate의 symlink-resolved parent가 정확히 같지 않으면 outside/symlink escape로 reject한다.
+10. resource metadata를 읽어 missing, permission denied, non-regular file, size cap을 구분한다.
+11. 허용된 candidate를 `.mappedIfSafe`로 읽고 실제 `Data.count`를 다시 size cap과 비교한다.
+12. key/data/basename display path로 injection한다.
+13. 모든 ref 처리 후 refs를 한 번 재조회해 `.ok` injection의 loaded 상태를 검증한다.
+14. 완료된 document와 report를 `RhwpDocumentOpenResult`로 반환한다.
+15. caller는 open result를 받은 뒤에만 page count/page size/render를 호출한다.
+
+resolver test에서 permission/read failure를 결정적으로 재현할 수 있도록 production `Data(contentsOf:)`를 감싼 internal data-loader dependency를 주입 가능하게 한다. path metadata와 containment 정책은 실제 임시 디렉터리로 검증하고, 오류 분류만 test closure로 주입한다.
+
+## Preview 소비 경로 확정
+
+| caller | source URL | external resolver | 이유 |
+|--------|------------|-------------------|------|
+| `HwpPreviewPDFRenderer.load(fileURL:)` | 있음 | 활성 | Quick Look Preview 제품 경로 |
+| `HwpPreviewPDFRenderer.render(fileURL:)` | 있음 | `load`를 통해 활성 | 같은 Preview convenience 경로 |
+| single-page `HwpPreviewPNGRenderer.render(context:)` | resolved context 재사용 | 추가 실행 없음 | 한 handle에서 injection 후 PNG |
+| multi-page `HwpPreviewPDFRenderer.render(context:)` | resolved context 재사용 | 추가 실행 없음 | 한 handle에서 injection 후 모든 page |
+| `HwpPreviewPDFRenderer.inspect(fileURL:)` | 입력 URL은 있으나 반환 시 document 폐기 | 비활성 | 뒤의 bytes-only render가 source context를 보존하지 않음 |
+| `HwpPreviewPDFRenderer.render(previewInfo:)` | 없음 | 비활성 | bytes-only diagnostic path |
+| `HwpPageImageRenderer.renderFirstPage(fileURL:)` | 있음 | 비활성 | Thumbnail cache signature가 #411 전 미완료 |
+| `RhwpStudioPDFExportController` | 없음 | 비활성 | HostApp WKWebView/export는 #413 경계 |
+| 기타 script의 `RhwpDocument(data:filename:)` | 없음 | 비활성 | 기존 diagnostic/render 계약 유지 |
+
+`HwpPreviewDocumentContext`에는 `externalResourceReport`를 추가한다. QLExtension은 load 직후 다음 항목만 log한다.
+
+- report state identifier
+- total reference resolution count
+- injected/alreadyLoaded/missing/rejected/tooLarge
+- permissionDenied/readFailed/bridgeFailed
+
+external path나 basename은 log field에 넣지 않는다.
+
+## Stage 1. Swift external image model과 FFI wrapper
+
+### 목표
+
+#408 C ABI를 Swift에서 수명 규칙을 지키며 호출하고, status/JSON 계약을 unit test로 고정한다.
+
+### 대상
+
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `Tests/ExternalImageTests/RhwpDocumentExternalImageBridgeTests.swift`
+- `Tests/ExternalImageTests/ExternalImageTestSupport.swift`
+- `project.yml`
+- `mydocs/working/task_m020_409_stage1.md`
+- `mydocs/orders/20260724.md`
+
+### 작업
+
+1. `RhwpExternalImageOperationStatus`, `RhwpExternalImageReference`, `RhwpExternalImageBridgeError`를 `RhwpDocument.swift`에 추가한다.
+2. imported C enum의 raw value 0~6과 unknown mapping을 구현한다.
+3. UTF-8 bytes/pointer/length를 FFI call 범위에 고정하는 private helper를 구현한다.
+4. `setFileName`, `externalImageReferences`, `injectExternalImage`를 구현한다.
+5. refs C string을 Swift `Data`로 복사한 뒤 `defer`로 해제하고 `JSONDecoder`로 decode한다.
+6. `project.yml`에 standalone `ExternalImageTests` unit test target을 추가한다.
+   - `RhwpDocument.swift`
+   - `RenderTree.swift`
+   - `Tests/ExternalImageTests`
+   - `Rhwp.xcframework`와 기존 Rust staticlib link dependency
+7. test에서 status raw mapping, unknown, 정상/additive/invalid JSON decode를 확인한다.
+8. repository `KTX.hwp`로 filename `.ok`, refs `[]`, unknown key injection `.referenceNotFound`를 확인한다.
+9. refs query를 반복 호출해 copy/free 경로가 안정적으로 동작하는지 확인한다.
+10. 기존 initializer와 render/image method signature는 변경하지 않는다.
+
+### 검증
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage1 \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+rg -n "RhwpExternalImageOperationStatus|RhwpExternalImageReference|setFileName|externalImageReferences|injectExternalImage|rhwp_free_string" \
+  Sources/RhwpCoreBridge/RhwpDocument.swift Tests/ExternalImageTests
+git diff --check
+```
+
+### 완료 조건
+
+- status 0~6과 unknown mapping이 test로 고정되어 있다.
+- refs JSON additive field와 invalid shape가 구분된다.
+- C string이 모든 반환 경로에서 해제된다.
+- key/data/display path buffer lifetime이 FFI call 안에 제한된다.
+- `ExternalImageTests`가 통과하고 `RhwpCoreBridge` no-AppKit 경계를 유지한다.
+- 기존 initializer가 resolver를 자동 실행하지 않는다.
+
+### 커밋
+
+```text
+Task #409 Stage 1: Swift external image wrapper와 FFI 계약 구현
+```
+
+## Stage 2. Open context, basename-only resolver와 report
+
+### 목표
+
+filesystem policy와 FFI injection을 분리한 Shared loader를 구현하고, 실패를 non-fatal report로 고정한다.
+
+### 대상
+
+- 신규 `Sources/Shared/HwpExternalImageResolver.swift`
+- `Tests/ExternalImageTests/HwpExternalImageResolverTests.swift`
+- `Tests/ExternalImageTests/ExternalImageTestSupport.swift`
+- `project.yml`
+- `mydocs/working/task_m020_409_stage2.md`
+- `mydocs/orders/20260724.md`
+
+### 작업
+
+1. open context, open result, report state, decision, resolution, summary model을 구현한다.
+2. resolver가 사용할 최소 document-access protocol을 정의하고 `RhwpDocument`를 conform시킨다.
+3. source nil/non-file disabled 경로에서는 refs query/injection이 호출되지 않게 한다.
+4. basename invalid 조건과 source document self-reference reject를 구현한다.
+5. standardized/resolved parent equality로 parent/symlink escape를 차단한다.
+6. regular file, metadata size, read-after-size 검사를 구현한다.
+7. missing, permission denied, read failure를 Foundation/POSIX error code로 구분한다.
+8. ref 단위 실패 후 다음 ref를 계속 처리한다.
+9. injection에는 safe key, bytes, basename display path만 전달한다.
+10. final refs re-query로 loaded 상태를 확인한다.
+11. report가 path/basename을 소유하지 않고 count summary만 제공하는지 test한다.
+12. `ExternalImageTests` target에 Shared resolver source를 추가한다.
+
+### 필수 test matrix
+
+- source URL nil → disabled, refs query 0회
+- non-file URL → disabled, refs query 0회
+- refs empty → attempted, resolution 0건
+- 이미 loaded → file read/injection 없이 alreadyLoaded
+- valid sibling → injection, byte count, basename display path, loaded 재확인
+- empty, `.`, `..`, slash, backslash, NUL basename reject
+- candidate가 source document 자신인 경우 reject
+- directory reject
+- sibling symlink가 parent 밖으로 나가는 경우 reject
+- parent 내부 regular sibling 허용
+- metadata size cap 초과
+- read 뒤 actual byte count cap 초과
+- missing
+- injected data-loader permission denied
+- injected data-loader generic read failure
+- bridge referenceNotFound/failure/unknown status
+- 한 ref 실패 후 다음 valid ref injection 지속
+- injection `.ok` 후 loaded 미전환 → verificationFailed
+- final refs query 실패 → pending injection verificationFailed
+- report summary 문자열/필드에 original/candidate path와 basename 없음
+
+### 검증
+
+```bash
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage2 \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+rg -n "originalPath|basename|resolvingSymlinksInPath|isRegularFile|fileSize|permissionDenied|verificationFailed" \
+  Sources/Shared/HwpExternalImageResolver.swift Tests/ExternalImageTests
+git diff --check
+```
+
+### 완료 조건
+
+- resolver가 basename 외 external path 정보를 filesystem 접근에 사용하지 않는다.
+- parent/symlink escape, directory, source self-reference, size cap이 차단된다.
+- permission/missing/read/bridge failure가 render-fatal exception 대신 report로 남는다.
+- valid sibling이 key injection되고 final loaded 상태가 확인된다.
+- report와 summary가 privacy-safe하다.
+
+### 커밋
+
+```text
+Task #409 Stage 2: basename-only resolver와 진단 report 구현
+```
+
+## Stage 3. Quick Look Preview open flow와 privacy-safe log 연결
+
+### 목표
+
+Quick Look Preview의 실제 load 경로에 external resolution을 연결하고, single/multi reply가 resolved document를 재사용하게 한다.
+
+### 대상
+
+- `Sources/Shared/HwpPreviewPDFRenderer.swift`
+- `Sources/QLExtension/HwpPreviewProvider.swift`
+- `scripts/smoke-quicklook-skia-policy.sh`
+- `scripts/quicklook_skia_policy_smoke.swift`
+- `scripts/compare-quicklook-pdf-renderers.sh`
+- 필요 시 `Tests/ExternalImageTests/`의 Preview contract test
+- `mydocs/working/task_m020_409_stage3.md`
+- `mydocs/orders/20260724.md`
+
+### 작업
+
+1. `HwpPreviewDocumentContext`에 `externalResourceReport`를 추가한다.
+2. `HwpPreviewPDFRenderer.load(fileURL:)`가 50 MB main file preflight와 data read 후 `RhwpDocumentOpenContext`를 생성하게 한다.
+3. Shared loader가 resolve/inject를 마친 뒤 반환한 document에서만 page count와 first page size를 조회한다.
+4. `render(fileURL:)`는 기존처럼 `load`를 사용해 resolver가 활성화된다.
+5. `inspect(fileURL:)`와 `render(previewInfo:)`는 source context를 보존하지 않으므로 resolver disabled를 유지한다.
+6. single-page PNG와 multi-page PDF는 context의 같은 document handle을 사용한다.
+7. `HwpPreviewProvider`가 external report summary를 load 직후 한 번 기록한다.
+8. log field를 state/count로 제한하고 external basename/path를 전달하지 않는다.
+9. source-level Quick Look smoke helper에 external report count를 detail/summary로 추가한다.
+10. `HwpExternalImageResolver.swift`를 compile list에 추가해야 하는 두 shell helper를 갱신한다.
+11. standard no-external HWP/HWPX에서 attempted + resolution 0건과 기존 output을 확인한다.
+12. HostApp/Thumbnail target은 새 Shared source를 compile하되 resolver 호출 경로가 추가되지 않았는지 확인한다.
+
+### 검증
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage3Tests \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage3 \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme QLExtension \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage3QL \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ThumbnailExtension \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage3Thumb \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+./scripts/smoke-quicklook-skia-policy.sh \
+  build.noindex/task409-stage3-quicklook \
+  samples/basic/request.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+rg -n "externalResource|injected|missing|rejected|permissionDenied|readFailed|bridgeFailed" \
+  Sources/QLExtension/HwpPreviewProvider.swift scripts/quicklook_skia_policy_smoke.swift
+git diff --check
+```
+
+### 완료 조건
+
+- Preview open 순서가 setter/query/injection 완료 후 page count/size다.
+- single-page PNG와 multi-page PDF가 같은 resolved handle을 사용한다.
+- no-external fixture output과 reply shape에 회귀가 없다.
+- inspect/bytes-only/Thumbnail/HostApp 경로에서 resolver가 활성화되지 않는다.
+- provider log에 external path와 basename이 없다.
+- 세 제품 target과 unit test가 통과한다.
+
+### 커밋
+
+```text
+Task #409 Stage 3: Quick Look Preview external image 연결
+```
+
+## Stage 4. Pinned external fixture와 registered Preview 통합 검증
+
+### 목표
+
+실제 external refs와 sibling image bytes로 injection/loaded/render를 증명하고, Quick Look sandbox 제품 경로에서 sibling 접근을 확인한다.
+
+### 대상
+
+- pinned upstream checkout의 다음 비커밋 fixture
+  - `samples/hwp3-sample10-hwpx.hwpx`
+  - `samples/oracle.gif`
+  - `samples/rdb02.gif`
+  - `samples/s1.jpg`
+- `build.noindex/task409-*` 검증 산출물
+- 필요 시 Stage 4 안에서 발견된 #409 범위 source/test 보정
+- `mydocs/working/task_m020_409_stage4.md`
+- `mydocs/orders/20260724.md`
+
+### fixture 준비
+
+```bash
+TASK409_RHWP_ROOT=/Users/melee/.cargo/git/checkouts/rhwp-6f8f299952213fc0/93862a4
+test "$(git -C "$TASK409_RHWP_ROOT" rev-parse HEAD)" = "93862a4e16df59834ebce46d91e948cd739208e9"
+
+mkdir -p build.noindex/task409-external-valid
+ditto "$TASK409_RHWP_ROOT/samples/hwp3-sample10-hwpx.hwpx" \
+  build.noindex/task409-external-valid/hwp3-sample10-hwpx.hwpx
+ditto "$TASK409_RHWP_ROOT/samples/oracle.gif" \
+  build.noindex/task409-external-valid/oracle.gif
+ditto "$TASK409_RHWP_ROOT/samples/rdb02.gif" \
+  build.noindex/task409-external-valid/rdb02.gif
+ditto "$TASK409_RHWP_ROOT/samples/s1.jpg" \
+  build.noindex/task409-external-valid/s1.jpg
+
+TASK409_MISSING_DIR="$(mktemp -d build.noindex/task409-external-missing.XXXXXX)"
+ditto "$TASK409_RHWP_ROOT/samples/hwp3-sample10-hwpx.hwpx" \
+  "$TASK409_MISSING_DIR/hwp3-sample10-hwpx.hwpx"
+ditto "$TASK409_RHWP_ROOT/samples/rdb02.gif" \
+  "$TASK409_MISSING_DIR/rdb02.gif"
+ditto "$TASK409_RHWP_ROOT/samples/s1.jpg" \
+  "$TASK409_MISSING_DIR/s1.jpg"
+```
+
+missing case에는 `oracle.gif`을 복사하지 않는다. upstream checkout과 repository sample 원본은 수정하지 않는다.
+
+### 작업
+
+1. valid fixture에서 initial refs 3건이 unloaded인지 확인한다.
+2. Preview source-level smoke로 sibling 3건 injection, final loaded 3건, non-empty PNG/PDF output을 확인한다.
+3. missing fixture에서 available ref는 injection되고 missing ref는 report에 남으며 main render가 계속되는지 확인한다.
+4. unit test 전체 matrix로 invalid basename, escape, directory, too large, permission/read failure를 다시 확인한다.
+5. 기본 HWP/HWPX/embedded/multi-page renderer 회귀를 실행한다.
+6. strict log/code inspection으로 external original/candidate path 미노출을 확인한다.
+7. Quick Look registration hygiene를 check-only로 확인한다.
+8. 실제 registered Preview smoke는 작업지시자에게 local package·registration·cleanup 승인을 별도로 받은 뒤 표준 helper로 수행한다.
+   - signed/sealed local app만 사용한다.
+   - active provider path를 확인한다.
+   - valid sibling fixture를 `qlmanage -p`로 연다.
+   - QLExtension subsystem log에서 injected count를 확인한다.
+   - external path/basename이 log에 없는지 확인한다.
+   - 검증 종료 시 개발 산출물 registration을 표준 cleanup helper로 해제한다.
+9. registered smoke에서 sandbox permission denied가 나오면 entitlement를 임의 변경하지 않는다. exact error/report와 active provider path를 기록하고 범위 확장 승인을 요청한다.
+
+### 검증
+
+#### Source-level external fixture
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh \
+  build.noindex/task409-external-valid-output \
+  build.noindex/task409-external-valid/hwp3-sample10-hwpx.hwpx
+rg -n "external.*3|injected.*3|missing.*0|loadStatus=OK|status=OK" \
+  build.noindex/task409-external-valid-output
+
+./scripts/smoke-quicklook-skia-policy.sh \
+  build.noindex/task409-external-missing-output \
+  "$TASK409_MISSING_DIR/hwp3-sample10-hwpx.hwpx"
+rg -n "injected|missing|loadStatus=OK|status=OK" \
+  build.noindex/task409-external-missing-output
+```
+
+#### 전체 회귀
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage4Tests \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage4 \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+./scripts/validate-stage3-render.sh \
+  build.noindex/task409-stage4-render \
+  samples/basic/KTX.hwp \
+  samples/basic/request.hwp \
+  samples/hwp-img-001.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+./scripts/check-extension-registration-hygiene.sh --check-only
+git diff --check
+git diff --exit-code -- RustBridge rhwp-ffi-symbols.txt rhwp-core.lock Frameworks
+```
+
+### 완료 조건
+
+- pinned fixture 세 external ref가 Swift wrapper에서 decode된다.
+- valid sibling 3건이 injection되고 final `loaded == true`로 확인된다.
+- source-level Preview output이 non-empty이며 main render가 성공한다.
+- missing/rejected/tooLarge/permission/read/bridge failure가 report로 남고 render-fatal로 승격되지 않는다.
+- actual registered QLExtension에서 valid sibling 접근과 injected count가 확인된다.
+- provider log에 original path, candidate absolute path, basename이 없다.
+- 기존 HWP/HWPX, embedded image, single/multi reply에 회귀가 없다.
+- 개발 산출물 registration cleanup과 active provider hygiene가 확인된다.
+
+### 커밋
+
+```text
+Task #409 Stage 4: external fixture와 Preview 통합 검증
+```
+
+## Stage 5. 최종 보고서와 후속 handoff
+
+### 목표
+
+wrapper/resolver/Preview 계약과 검증 근거를 최종 정리하고, 후속 external image 작업의 책임 경계를 확정한다.
+
+### 대상
+
+- `mydocs/report/task_m020_409_report.md`
+- `mydocs/orders/20260724.md`
+
+### 작업
+
+1. Stage 1-4 source, test, smoke 결과와 commit을 요약한다.
+2. status mapping, refs JSON, C string free, UTF-8/data lifetime을 기록한다.
+3. basename-only containment, symlink, size, permission, privacy 정책을 기록한다.
+4. source-level fixture와 registered QLExtension smoke 결과를 분리해 기록한다.
+5. Thumbnail #411, fixture suite #412, WKWebView #413, renderer diagnostic #410에 남긴 범위를 명시한다.
+6. actual sandbox sibling access와 잔여 TOCTOU/total-memory risk를 기록한다.
+7. 오늘할일을 완료로 갱신한다.
+8. 최종 검증 후 `task-final-report` 실행 전 승인을 요청한다.
+
+### 검증
+
+```bash
+rg -n "#409|RhwpExternalImageOperationStatus|basename|sibling|injected|loaded|permission|privacy|Quick Look|#410|#411|#412|#413" \
+  mydocs/report/task_m020_409_report.md mydocs/orders/20260724.md
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409FinalTests \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Final \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+./scripts/validate-stage3-render.sh build.noindex/task409-final-render
+git diff --check
+git status --short
+git log --oneline origin/devel..HEAD
+```
+
+### 완료 조건
+
+- 최종 보고서가 구현, security policy, FFI lifetime, source/registered smoke, 잔여 리스크를 포함한다.
+- 모든 단계 보고서와 검증 결과가 commit과 대응한다.
+- 오늘할일이 완료 처리되어 있다.
+- working tree가 clean하고 최종 PR 게시 승인 요청이 가능하다.
+
+### 커밋
+
+```text
+Task #409 Stage 5 + 최종 보고서: Quick Look external image 지원 정리
+```
+
+## 단계별 승인 지점
+
+1. 이 구현계획서 승인 후 Stage 1을 시작한다.
+2. Stage 1 완료보고서 승인 후 Stage 2를 시작한다.
+3. Stage 2 완료보고서 승인 후 Stage 3을 시작한다.
+4. Stage 3 완료보고서 승인 후 Stage 4를 시작한다.
+5. Stage 4의 actual Quick Look registration smoke 전 local package·registration·cleanup 승인을 별도로 확인한다.
+6. Stage 4 완료보고서 승인 후 Stage 5를 시작한다.
+7. 최종 결과보고서 승인 후 `task-final-report` 절차로 PR을 게시한다.
+
+구현계획서 승인 전에는 Swift source, `project.yml`, test, script, fixture, Quick Look registration을 변경하지 않는다.

--- a/mydocs/report/task_m020_409_report.md
+++ b/mydocs/report/task_m020_409_report.md
@@ -1,0 +1,407 @@
+# Task #409 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#409 Swift external image wrapper/resolver와 Quick Look Preview 적용](https://github.com/postmelee/alhangeul-macos/issues/409) |
+| Parent | #407 external image context ABI 후속 구현 추적 |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 작업 브랜치 | `local/task409` |
+| 단계 | Stage 1~5 |
+| core 기준 | `rhwp` v0.7.18, commit `93862a4e16df59834ebce46d91e948cd739208e9`, feature `native-skia` |
+
+#408에서 추가된 external image C ABI를 Swift에서 안전하게 감싸고, source document와 같은 directory의 regular sibling image만 `basename` 기준으로 주입하는 resolver를 구현했다. 이 resolver를 Quick Look Preview의 file URL open 경로에 연결하고 single-page PNG와 multi-page PDF가 injection이 끝난 동일한 `RhwpDocument` handle을 재사용하도록 했다.
+
+핵심 결과:
+
+- C ABI status raw value, refs JSON, UTF-8/data pointer와 반환 문자열 ownership을 Swift 계약으로 고정했다.
+- `originalPath`를 filesystem discovery에 사용하지 않는 basename-only sibling 정책을 구현했다.
+- invalid basename, source self-reference, symlink escape, directory, size, missing, permission, read와 bridge failure를 reference별 non-fatal report로 분류했다.
+- pinned fixture의 external reference 3건을 source-level Preview 경로에서 모두 injection하고 final `loaded == true`와 764-page render를 확인했다.
+- missing 1건과 oversize 1건은 각각 report에 남기면서 main render를 계속했다.
+- 실제 registered Quick Look에서는 macOS 26.5.2 sandbox가 sibling capability를 부여하지 않아 `permissionDenied=3`이 됐지만, privacy-safe fallback으로 main document Preview를 유지했다.
+- Thumbnail, HostApp WKWebView, renderer placeholder/diagnostic과 정식 fixture suite는 기존 후속 이슈의 책임으로 남겼다.
+
+## 변경 파일과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `Sources/RhwpCoreBridge/RhwpDocument.swift` | external image status/model/error, filename setter, refs query, key 기반 injection Swift wrapper |
+| `Sources/Shared/HwpExternalImageResolver.swift` | open context/result, basename-only resolver, resolution/report/summary |
+| `Sources/Shared/HwpPreviewPDFRenderer.swift` | file input → resolve/inject → metadata 순서와 resolved document context 재사용 |
+| `Sources/QLExtension/HwpPreviewProvider.swift` | external resource state와 9개 summary count의 privacy-safe log |
+| `Tests/ExternalImageTests/` | bridge 6개, resolver/security policy 18개 unit test |
+| `project.yml` | 독립 `ExternalImageTests` target과 resolver source 선언 |
+| `scripts/quicklook_skia_policy_smoke.swift` | source-level Preview smoke의 external state/count 출력 |
+| `scripts/smoke-quicklook-skia-policy.sh` | resolver source compile 목록 추가 |
+| `scripts/compare-quicklook-pdf-renderers.sh` | resolver source compile 목록 추가 |
+| `mydocs/plans/task_m020_409.md` | 수행 범위와 책임 경계 |
+| `mydocs/plans/task_m020_409_impl.md` | 5단계 구현·검증 계획 |
+| `mydocs/working/task_m020_409_stage1.md` | Swift FFI wrapper 계약과 검증 |
+| `mydocs/working/task_m020_409_stage2.md` | resolver와 security policy 검증 |
+| `mydocs/working/task_m020_409_stage3.md` | Quick Look Preview 연결과 privacy-safe log |
+| `mydocs/working/task_m020_409_stage4.md` | pinned fixture, registered Preview와 sandbox 제한 |
+| `mydocs/report/task_m020_409_report.md` | 최종 계약, 검증, 잔여 위험과 handoff |
+| `mydocs/orders/20260724.md` | #409 단계 진행 및 완료 상태 |
+
+제품 Swift source의 최종 변경량은 `+642 / -20`이다. 이 중 `RhwpDocument.swift`가 `+149`, 신규 resolver가 `+441`, Preview renderer가 `+44 / -20`, provider가 `+8`이다. `ExternalImageTests`에는 test/support `+1,008`을 추가했다.
+
+다음 영역은 변경하지 않았다.
+
+- `RustBridge/**`
+- `rhwp-ffi-symbols.txt`
+- `rhwp-core.lock`
+- `Frameworks/**`
+- `Sources/ThumbnailExtension/**`
+- `Sources/HostApp/Resources/rhwp-studio/**`
+- entitlement와 source plist
+
+`project.yml`을 Xcode project의 진실 원천으로 사용했다. 각 단계와 최종 검증에서 `xcodegen generate`를 실행했지만 생성된 `Alhangeul.xcodeproj/project.pbxproj`는 복원해 커밋하지 않았다.
+
+## Swift와 FFI 계약
+
+### Status mapping
+
+`RhwpExternalImageOperationStatus`는 C enum의 raw value를 다음처럼 보존한다.
+
+| C raw value | Swift |
+|-------------|-------|
+| `0` | `.ok` |
+| `1` | `.invalidHandle` |
+| `2` | `.invalidInput` |
+| `3` | `.invalidUTF8` |
+| `4` | `.referenceNotFound` |
+| `5` | `.alreadyLoaded` |
+| `6` | `.failure` |
+| 그 외 | `.unknown(rawValue)` |
+
+알 수 없는 값을 `.failure`로 합치지 않아 ABI가 additive하게 확장될 때 raw 의미를 잃지 않는다.
+
+### External reference JSON
+
+`rhwp_external_image_refs_json`의 array element를 `RhwpExternalImageReference`로 decode한다.
+
+| JSON field | Swift property | 용도 |
+|------------|----------------|------|
+| `key` | `key` | injection과 final loaded verification |
+| `binDataId` | `binDataId: UInt16` | reference metadata |
+| `originalPath` | `originalPath` | metadata로만 decode하며 filesystem discovery에는 사용하지 않음 |
+| `basename` | `basename` | 유일한 filesystem candidate 입력 |
+| `extension` | `fileExtension` | 안전한 Swift property 이름으로 매핑 |
+| `loaded` | `loaded` | initial skip와 final injection verification |
+
+알 수 없는 additive field는 `JSONDecoder` 기본 동작으로 무시한다. 필수 field 누락, 타입 불일치, `UInt16` 범위 초과 또는 array가 아닌 root는 `.invalidReferencesJSON`으로 정규화한다. C 함수가 null을 반환하면 `.referencesUnavailable`로 구분한다.
+
+### Pointer, 문자열과 handle 수명
+
+- Swift `String`은 UTF-8 byte array로 변환하고 `withUnsafeBufferPointer` closure 안에서만 C pointer와 length를 사용한다.
+- key, image `Data`, optional display path는 중첩 closure 안에서 한 번의 `rhwp_inject_external_image_by_key` 호출 동안만 빌린다.
+- nil 또는 빈 display path는 `(nil, 0)`으로 전달한다.
+- refs JSON의 non-null C string은 Swift `Data`로 즉시 복사한다.
+- JSON pointer를 얻은 직후 `defer { rhwp_free_string(jsonPointer) }`를 등록해 decode 성공과 throw 양쪽에서 한 번 해제한다.
+- `RhwpDocument`는 opaque handle을 소유하고 `deinit`에서 `rhwp_close`를 호출한다.
+- main document와 external image caller-owned buffer는 FFI call 밖으로 노출하지 않는다. mutation 뒤 render는 document handle의 새 상태를 조회한다.
+
+호출 순서는 다음으로 고정했다.
+
+```text
+rhwp_open
+→ rhwp_set_file_name_utf8
+→ refs JSON query/copy/free
+→ sibling validate/read
+→ key-based injection
+→ refs JSON 재조회와 loaded 검증
+→ page count/page size/render
+```
+
+## Basename-only resolver와 security policy
+
+### 책임 경계
+
+| 계층 | 책임 |
+|------|------|
+| `Sources/RhwpCoreBridge` | FFI model/wrapper와 handle 수명 |
+| `Sources/Shared` | Foundation source context, filesystem policy, injection orchestration와 report |
+| `Sources/QLExtension` | Quick Look request와 privacy-safe summary log |
+| RustBridge/core | filename context, refs enumeration, explicit bytes injection과 render |
+
+`Sources/RhwpCoreBridge`에는 filesystem 탐색과 AppKit/UIKit dependency를 추가하지 않았다. RustBridge/core도 product path에서 external file을 직접 열지 않는다.
+
+### Candidate 제한
+
+resolver가 filesystem candidate를 만드는 입력은 `reference.basename` 하나뿐이다. `originalPath`는 절대 경로, URL, Windows drive/UNC path 또는 basename 추출 원본으로도 사용하지 않는다.
+
+다음 basename은 read 전에 `.rejectedInvalidBasename`으로 거부한다.
+
+- empty
+- `.`
+- `..`
+- `/` 포함
+- `\` 포함
+- NUL 포함
+
+허용된 이름은 source document의 standardized parent에 단일 path component로 붙인다. source, parent와 candidate를 standardize하고 symlink를 resolve한 뒤 다음을 적용한다.
+
+- source document 자신을 가리킴 → `.rejectedSourceDocument`
+- resolved parent가 source parent 밖임 → `.rejectedOutsideSourceDirectory`
+- regular file이 아님 → `.rejectedNonRegularFile`
+
+따라서 directory, source self-reference와 sibling symlink를 통한 parent escape는 image read 전에 차단한다.
+
+### Size, read와 failure taxonomy
+
+external resource별 상한은 Quick Look main file 정책과 같은 50 MB다.
+
+1. metadata `fileSize`가 상한을 넘으면 read 없이 `.tooLarge`
+2. `.mappedIfSafe` read 후 실제 `Data.count`가 상한을 넘으면 injection 없이 `.tooLarge`
+
+file error는 다음처럼 분류한다.
+
+| Foundation/POSIX 결과 | Decision |
+|-----------------------|----------|
+| no-such-file, `ENOENT` | `.missing` |
+| no-permission, `EACCES`, `EPERM` | `.permissionDenied` |
+| 그 밖의 metadata/read 오류 | `.readFailed` |
+
+underlying error가 더 구체적인 missing/permission 정보를 제공하면 그 분류를 보존한다. 한 reference가 실패해도 다음 reference를 계속 처리한다.
+
+### Injection과 final loaded verification
+
+검증을 통과한 sibling에 대해서만 upstream `key`, image bytes와 검증된 `basename` display path를 bridge에 전달한다.
+
+- `.ok` → pending verification
+- injection 시점 `.alreadyLoaded` → 경쟁 상태를 허용하고 `.alreadyLoaded`
+- 나머지 status → `.bridgeRejected(status)`
+
+모든 reference 처리 후 refs를 한 번 재조회한다. 같은 key가 `loaded == true`일 때만 `.injected(byteCount:)`를 유지하며, key 누락/false/final query failure는 `.verificationFailed`로 바꾼다.
+
+### Privacy-safe report
+
+reference report에는 key와 decision만 남기고 basename, `originalPath`, candidate URL, resolved absolute path를 저장하지 않는다. 제품 log는 다음 state/count만 기록한다.
+
+- state
+- total
+- injected
+- alreadyLoaded
+- missing
+- rejected
+- tooLarge
+- permissionDenied
+- readFailed
+- bridgeFailed
+
+`.bridgeRejected`와 `.verificationFailed`는 `bridgeFailed`에 집계한다. external basename/path/key는 Quick Look provider log formatter에 전달하지 않는다.
+
+## Quick Look Preview 적용 경계
+
+`HwpPreviewPDFRenderer.load(fileURL:)`는 main file size/read 뒤 `RhwpDocumentOpenContext`를 만들고 resolver가 완료된 document에서만 page count와 first page size를 조회한다.
+
+`HwpPreviewDocumentContext`가 같은 `RhwpDocument`를 소유하므로:
+
+- single-page reply는 같은 context를 `HwpPreviewPNGRenderer`에 전달한다.
+- multi-page reply는 같은 context를 `HwpPreviewPDFRenderer.render(context:)`에 전달한다.
+- PDF의 모든 page는 같은 injected document handle로 render된다.
+
+resolver 활성 범위는 source file URL을 보존한 Quick Look Preview open뿐이다.
+
+| 경로 | Resolver |
+|------|----------|
+| QLExtension `HwpPreviewProvider` → `load(fileURL:)` | 활성 |
+| `render(fileURL:)` | 활성 |
+| `inspect(fileURL:)` | 비활성 |
+| bytes-only `render(previewInfo:)` | 비활성 |
+| HostApp PDF export | 비활성 |
+| ThumbnailExtension | 비활성 |
+
+source URL이 nil이면 `.disabledNoSourceURL`, file URL이 아니면 `.disabledNonFileURL`이고 refs query/read/injection을 실행하지 않는다.
+
+## External fixture 통합 검증
+
+fixture는 core pin과 같은 upstream commit `93862a4e16df59834ebce46d91e948cd739208e9`의 Cargo checkout에서 `build.noindex`로 복사했다.
+
+| Fixture | SHA-256 |
+|---------|---------|
+| `hwp3-sample10-hwpx.hwpx` | `3395e19bebea8b6689f383df1f4ea1ddb253dee91c4320392cc40e90e2e4f191` |
+| `oracle.gif` | `464e863dd2c1650fc6997b03a5d96c9413e61bbabaf7337c783db27203cc2761` |
+| `rdb02.gif` | `bfadf4cdbbeeb5f3d8632cb54c8c3696977f405204b651f99a7a24c8f39532cf` |
+| `s1.jpg` | `77dea18ce7f8f93b0931e133dec222aec642eef0ed87b8f2031b94dcbea5c514` |
+
+### Source-level Preview
+
+| Case | Total | Injected | Missing | Too large | Render |
+|------|------:|---------:|--------:|----------:|--------|
+| valid | 3 | 3 | 0 | 0 | CoreGraphics/SkiaDecode 각 764 pages, OK |
+| missing | 3 | 2 | 1 | 0 | CoreGraphics/SkiaDecode 각 764 pages, OK |
+| oversize | 3 | 2 | 0 | 1 | CoreGraphics/SkiaDecode 각 764 pages, OK |
+
+valid case의 `alreadyLoaded=0`, `injected=3`과 final query 결과로 initial unloaded 3건이 이번 open에서 모두 loaded로 전환됐음을 확인했다. missing/oversize case도 reference 실패를 document-fatal error로 올리지 않고 764-page main render를 유지했다.
+
+### Registered Quick Look
+
+macOS 26.5.2(25F84)의 signed temporary app과 실제 active provider를 사용해 `qlmanage -p`와 Finder Space Preview를 실행했다.
+
+다음 조합을 검사했다.
+
+- 기존 read-only entitlement와 direct sibling read
+- `NSFilePresenter`/`NSFileCoordinator` sibling별 접근
+- same-stem main document/related image
+- parent directory presenter/coordinator
+- 작업지시자가 승인한 read-write entitlement 실험
+
+모든 경우의 제품 log는 다음 결과로 수렴했다.
+
+```text
+Preview externalResource state=attempted total=3 injected=0 alreadyLoaded=0 missing=0 rejected=0 tooLarge=0 permissionDenied=3 readFailed=0 bridgeFailed=0
+```
+
+Foundation은 related-item sandbox extension과 file presenter sandbox extension을 발급하지 못했다. 현재 Quick Look host가 extension에 전달한 main document capability만으로는 sibling file capability를 파생할 수 없고, extension entitlement를 read-write로 넓히는 것만으로 이 capability가 추가되지 않았다.
+
+작업지시자 승인으로 Stage 4 완료 조건을 다음처럼 조정했다.
+
+- source-level 경로의 3건 injection과 render 성공을 구현 성립 근거로 사용한다.
+- actual registered Preview에서는 `permissionDenied=3`의 privacy-safe graceful fallback과 main render 유지를 수용한다.
+- sandbox 해제, broad folder entitlement, temporary absolute-path exception, unsandboxed broker와 사용자 folder authorization은 #409에 추가하지 않는다.
+
+실험용 plist/entitlement/Foundation presenter 변경은 모두 복원했으며 제품 변경으로 남기지 않았다.
+
+## 최종 검증 결과
+
+### Core, shared boundary와 generated project
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/check-no-appkit.sh
+xcodegen generate
+```
+
+결과: 모두 통과.
+
+- arm64/x86_64 universal static library와 XCFramework를 생성·검증했다.
+- external image 3개를 포함한 총 15개 FFI symbol과 `rhwp-core.lock` 일치를 확인했다.
+- shared Swift code의 AppKit/UIKit dependency가 없다.
+- generated Xcode project는 검증 후 복원했다.
+- CoreSimulator service 관련 출력은 macOS artifact 결과에 영향을 주지 않는 비차단 warning이다.
+
+### ExternalImageTests
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409FinalTests \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+```
+
+결과:
+
+```text
+HwpExternalImageResolverTests: 18 passed
+RhwpDocumentExternalImageBridgeTests: 6 passed
+Total: 24 tests, 0 failures
+** TEST SUCCEEDED **
+```
+
+result bundle:
+
+```text
+build.noindex/DerivedDataTask409FinalTests/Logs/Test/
+Test-ExternalImageTests-2026.07.28_15-31-54-+0900.xcresult
+```
+
+첫 sandbox 실행은 Sparkle package 조회 중 GitHub DNS 제한으로 exit 74가 발생했다. 네트워크 접근이 가능한 환경에서 같은 명령을 재실행해 compile/link와 24개 test가 통과했다. source 또는 assertion 실패는 없었다.
+
+### HostApp build
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Final \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+
+결과: `** BUILD SUCCEEDED **` (`12.252 sec`).
+
+HostApp과 embedded QLExtension/ThumbnailExtension dependency graph가 모두 compile/link됐다. 첫 sandbox 실행의 Sparkle DNS 제한은 test와 같은 환경 요인이며 동일 명령 재실행에서 통과했다.
+
+### Renderer 회귀
+
+```bash
+./scripts/validate-stage3-render.sh build.noindex/task409-final-render
+```
+
+결과:
+
+| Fixture | First page | Text runs | Hangul runs | Scalars | Non-white pixels |
+|---------|------------|----------:|------------:|--------:|-----------------:|
+| `KTX.hwp` | 1123×794 | 410 | 76 | 209 | 455,341 |
+| `request.hwp` | 567×794 | 102 | 36 | 309 | 70,188 |
+| `exam_kor.hwp` | 1123×1588 | 133 | 86 | 1,368 | 173,981 |
+
+세 fixture 모두 page 1 render와 text/Hangul/non-white sanity를 통과했다. Stage 4에서는 embedded image와 HWPX를 포함한 5개 fixture 회귀도 별도로 통과했다.
+
+### Registration hygiene와 diff
+
+```bash
+./scripts/check-extension-registration-hygiene.sh --check-only
+git diff --check
+git diff --exit-code -- RustBridge rhwp-ffi-symbols.txt rhwp-core.lock Frameworks
+```
+
+결과: 모두 통과.
+
+- development registration, provider app root, legacy candidate와 issue가 없다.
+- `build.noindex` 아래 Debug app은 존재하지만 등록되지 않은 검증 산출물이다.
+- PlugInKit이 provider path를 보고하지 않은 warning만 있고 development registration 오염은 없다.
+- core/FFI/framework tracked diff와 whitespace 오류가 없다.
+
+## 단계 요약
+
+| Stage | 커밋 | 요약 |
+|-------|------|------|
+| 수행계획 | `15f70da` | 범위, 책임 경계와 오늘할일 등록 |
+| 구현계획 | `54da246` | 5단계 구현·검증 계획 |
+| Stage 1 | `7b527e8` | Swift external image model과 FFI wrapper |
+| Stage 2 | `f9fb735` | basename-only resolver와 privacy-safe report |
+| Stage 3 | `3b8058c` | Quick Look Preview open flow와 summary log |
+| Stage 4 | `0760013` | pinned fixture와 registered Preview 통합 검증 |
+| Stage 5 | 이번 커밋 | 최종 보고서, 후속 handoff와 최종 검증 |
+
+## 후속 이슈 handoff
+
+| 이슈 | 남긴 책임 |
+|------|-----------|
+| #410 | `ImageNode.externalPath` decode, missing external/decode failure placeholder와 renderer diagnostic |
+| #411 | Thumbnail prepared request, external resource cache signature와 resolver 활성화 |
+| #412 | 라이선스·개인정보가 확인된 external/large fixture suite, visual/performance regression |
+| #413 | HostApp WKWebView와 bundled `rhwp-studio` 사이 external bytes JS/native bridge |
+
+#409는 Quick Look native Preview의 Swift wrapper/resolver와 open orchestration까지만 소유한다. 후속 이슈의 cache, renderer 표현, fixture vendoring과 WKWebView bridge를 미리 구현하지 않았다.
+
+## 잔여 위험
+
+| 항목 | 상태와 처리 |
+|------|-------------|
+| actual Quick Look sibling access | macOS 26.5.2에서 `permissionDenied=3`. main render fallback을 수용하며 broader authorization/broker 설계는 별도 이슈가 필요하다. |
+| TOCTOU | standardize/symlink/metadata/read가 순차적이라 검사 사이 file 교체 가능성이 남는다. file-descriptor 기반 hardening은 후속 security 작업이다. |
+| total memory | resource별 50 MB 상한은 있으나 document 전체 external resource 합계 상한은 없다. 다수 reference의 aggregate memory 정책은 후속 성능/보안 검토 대상이다. |
+| refs JSON schema | additive field에는 안전하지만 필수 field 제거/타입 변경은 `.invalidReferencesJSON`이 된다. bridge failure report로 남고 main render는 계속된다. |
+| Thumbnail | #411 전 resolver 비활성이다. current cache key가 sibling 변경을 반영하지 않으므로 조기 활성화하지 않는다. |
+| HostApp/WKWebView | #413 전 external image 지원을 보장하지 않는다. bytes-only PDF export도 source context가 없어 resolver 비활성이다. |
+| renderer 표현 | injection 실패 시 main render는 계속되지만 missing/decode placeholder와 세분화 diagnostic은 #410 범위다. |
+| fixture 관리 | upstream fixture는 `build.noindex`에서만 사용했다. 정식 repository fixture 편입과 visual gate는 #412가 소유한다. |
+
+## 결론
+
+#409는 #408의 external image C ABI를 Swift에서 안전하게 소비하는 wrapper와 basename-only sibling resolver를 구현하고, Quick Look Preview open 순서에 연결했다. source-level pinned fixture에서는 3건 injection, final loaded 확인과 764-page render가 성공했고, missing/oversize는 non-fatal report로 분리됐다.
+
+실제 registered Quick Look에서는 macOS sandbox가 sibling read capability를 제공하지 않는 플랫폼 제한이 확인됐다. 임의 entitlement 확대나 sandbox 우회는 제품 변경으로 남기지 않고, `permissionDenied` count와 main document graceful fallback을 현재 지원 계약으로 확정했다.
+
+따라서 Swift/FFI/resolver/Preview orchestration 구현은 완료됐으며, 실제 sibling access를 가능하게 하는 별도 authorization 또는 broker 설계가 필요할 경우 #409와 분리해 보안 검토와 함께 진행해야 한다.
+
+## 승인 요청
+
+Stage 5 최종 보고서와 검증 결과의 승인을 요청한다. 승인 후 명시적으로 `task-final-report` 절차를 실행해 `publish/task409` push와 `devel` 대상 Open PR 게시를 진행한다.

--- a/mydocs/working/task_m020_409_stage1.md
+++ b/mydocs/working/task_m020_409_stage1.md
@@ -1,0 +1,202 @@
+# Task M020 #409 Stage 1 보고서
+
+## 단계 목적
+
+Stage 1의 목적은 #408에서 추가한 external image C ABI를 Swift에서 포인터 수명 규칙에 맞게 호출하고, status와 refs JSON 계약을 독립 unit test로 고정하는 것이다.
+
+이 단계에서는 filesystem resolver나 Quick Look Preview 연결을 구현하지 않는다. 기존 `RhwpDocument` initializer도 resolver를 자동 실행하지 않으며, filename context와 external image injection은 명시 호출 API로만 추가한다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|------|-----------|
+| `Sources/RhwpCoreBridge/RhwpDocument.swift` | Swift status/model/error와 filename setter, refs query, key 기반 image injection wrapper를 추가했다. 현재 409줄이다. |
+| `Tests/ExternalImageTests/RhwpDocumentExternalImageBridgeTests.swift` | status, JSON decode, 실제 C ABI 호출, invalid input, 반복 query를 검증하는 test 6개를 추가했다. 현재 138줄이다. |
+| `Tests/ExternalImageTests/ExternalImageTestSupport.swift` | repository sample을 test data로 읽는 helper를 추가했다. 현재 15줄이다. |
+| `project.yml` | `ExternalImageTests` standalone unit test target과 `Rhwp.xcframework` link dependency를 추가했다. 현재 175줄이다. |
+| `mydocs/working/task_m020_409_stage1.md` | Stage 1 변경, 검증, 잔여 위험과 Stage 2 handoff를 기록한다. |
+| `mydocs/orders/20260724.md` | #409를 Stage 1 완료 및 Stage 2 승인 대기 상태로 갱신한다. |
+
+## 구현 결과
+
+### Swift status와 refs model
+
+imported C enum과 이름 충돌을 피하도록 `RhwpExternalImageOperationStatus`를 추가하고 raw value를 다음처럼 보존했다.
+
+| C raw value | Swift status |
+|-------------|--------------|
+| `0` | `.ok` |
+| `1` | `.invalidHandle` |
+| `2` | `.invalidInput` |
+| `3` | `.invalidUTF8` |
+| `4` | `.referenceNotFound` |
+| `5` | `.alreadyLoaded` |
+| `6` | `.failure` |
+| 그 외 | `.unknown(rawValue)` |
+
+`RhwpExternalImageReference`는 upstream JSON의 다음 필드를 decode한다.
+
+- `key`
+- `binDataId`
+- `originalPath`
+- `basename`
+- `extension` → Swift `fileExtension`
+- `loaded`
+
+`JSONDecoder`의 기본 additive-field 허용 동작은 유지하면서 필수 필드 누락, `UInt16` 범위 초과, 배열이 아닌 root 같은 invalid shape는 `RhwpExternalImageBridgeError.invalidReferencesJSON`으로 정규화한다. `rhwp_external_image_refs_json`이 null을 반환하면 `.referencesUnavailable`로 구분한다.
+
+### FFI wrapper와 수명 규칙
+
+`RhwpDocument`에 다음 명시 호출 API를 추가했다.
+
+```swift
+func setFileName(_ filename: String) -> RhwpExternalImageOperationStatus
+func externalImageReferences() throws -> [RhwpExternalImageReference]
+func injectExternalImage(
+    key: String,
+    data: Data,
+    displayPath: String? = nil
+) -> RhwpExternalImageOperationStatus
+```
+
+수명과 ownership 규칙은 다음과 같이 적용했다.
+
+- Swift `String`은 UTF-8 byte array로 변환하고 해당 `withUnsafeBufferPointer` closure 안에서만 C pointer를 사용한다.
+- injection의 key, image data, optional display path buffer는 중첩 closure로 묶어 `rhwp_inject_external_image_by_key` 호출이 끝나기 전에 어느 pointer도 escape하지 않는다.
+- nil 또는 빈 display path는 C ABI에 `(nil, 0)`으로 전달한다.
+- refs JSON C string은 Swift `Data`로 즉시 복사한다.
+- non-null refs pointer를 얻은 직후 `defer { rhwp_free_string(jsonPointer) }`를 등록하므로 JSON decode 성공과 throw 경로 모두에서 한 번 해제한다.
+
+기존 `RhwpDocument` initializer, render, page tree, overlay, image data method signature는 변경하지 않았다. initializer는 기존 filename 인자를 계속 받지만 external image resolver나 injection을 자동 실행하지 않는다.
+
+### 독립 test target
+
+`project.yml`에 `ExternalImageTests`를 additive하게 추가했다. test target은 다음 source만 compile한다.
+
+- `Tests/ExternalImageTests`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+
+제품 target과 같은 `Rhwp.xcframework` 및 macOS system link dependency를 사용하되 HostApp, PreviewExtension, ThumbnailExtension을 test host로 두지 않는다. `xcodegen generate`로 생성한 `Alhangeul.xcodeproj/project.pbxproj`는 검증에만 사용한 뒤 복원했으며 커밋하지 않는다.
+
+test 6개가 고정한 계약은 다음과 같다.
+
+1. status raw value `0...6`과 unknown value 보존
+2. refs JSON의 `extension` 매핑과 additive field 허용
+3. 필수 필드 누락, `UInt16` overflow, non-array JSON 거부
+4. repository `samples/basic/KTX.hwp`의 filename `.ok`, refs `[]`, 미등록 key `.referenceNotFound`
+5. 빈 key와 빈 data의 `.invalidInput`
+6. refs query 128회 반복 시 copy/free 경로 안정성
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- `RhwpDocument.swift`의 기존 본문은 그대로 두고 external image model과 명시 호출 method를 additive하게 추가했다.
+- 기존 initializer의 parse/handle 소유 흐름과 `deinit`의 `rhwp_close` 호출은 변경하지 않았다.
+- 기존 SVG/tree/overlay/PNG/image data API의 signature와 구현은 변경하지 않았다.
+- `Sources/RhwpCoreBridge`에 AppKit/UIKit 의존성을 추가하지 않았다.
+- `project.yml`의 기존 target 정의는 수정하지 않고 신규 unit test target만 추가했다.
+- RustBridge source, `rhwp-core.lock`, FFI symbol 목록, entitlement, Quick Look/Thumbnail 제품 경로는 변경하지 않았다.
+- `build-rust-macos.sh --verify-lock`이 재생성한 framework/staticlib는 lock 기준과 동일해 Git 변경으로 남지 않았다.
+
+## 검증 결과
+
+### Core lock과 XCFramework 검증
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+```
+
+결과: 최종 통과.
+
+```text
+Architectures in the fat file: .../Frameworks/universal/librhwp.a are: x86_64 arm64
+FFI symbols:
+rhwp_external_image_refs_json
+rhwp_inject_external_image_by_key
+rhwp_set_file_name_utf8
+...
+Verified: .../rhwp-core.lock
+```
+
+첫 sandbox 실행은 `skia-bindings v0.99.0` binary와 source를 내려받는 과정에서 GitHub DNS가 제한되어 실패했다. 네트워크 권한으로 같은 명령을 다시 실행해 두 architecture build, cbindgen header check, XCFramework 생성, lock 검증을 모두 통과했다. 이는 source 또는 lock 불일치가 아니다.
+
+### Shared boundary
+
+```bash
+./scripts/check-no-appkit.sh
+```
+
+결과: 통과.
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+### Xcode project 생성과 unit test
+
+```bash
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage1 \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+```
+
+결과: 통과.
+
+```text
+Test Suite 'RhwpDocumentExternalImageBridgeTests' passed
+Executed 6 tests, with 0 failures
+** TEST SUCCEEDED **
+```
+
+test result bundle:
+
+```text
+build.noindex/DerivedDataTask409Stage1/Logs/Test/
+Test-ExternalImageTests-2026.07.24_21-57-21-+0900.xcresult
+```
+
+첫 sandbox test 실행은 Swift compile 문제가 아니라 Sparkle package fetch의 DNS 제한으로 실패했다. 네트워크 권한이 있는 같은 명령에서 Sparkle 2.9.1을 resolve한 뒤 compile/link와 test가 모두 성공했다.
+
+비차단 warning으로 test target deployment target 12.0과 XCTest link minimum 14.0 차이, AppIntents metadata가 없다는 안내가 출력됐다. test 실행과 제품 source compile에는 영향을 주지 않았다.
+
+### 계약 및 변경 점검
+
+```bash
+rg -n "RhwpExternalImageOperationStatus|RhwpExternalImageReference|setFileName|externalImageReferences|injectExternalImage|rhwp_free_string" \
+  Sources/RhwpCoreBridge/RhwpDocument.swift Tests/ExternalImageTests
+git diff --check
+git status --short
+```
+
+결과: 통과.
+
+- wrapper/model/test symbol이 계획된 source에 존재한다.
+- whitespace 오류가 없다.
+- 생성된 Xcode project와 framework는 변경 목록에 남지 않았다.
+- 변경 목록은 Stage 1 source, test, `project.yml`, 보고서, 오늘할일로 한정된다.
+
+## 잔여 위험
+
+- repository의 `KTX.hwp`는 external refs가 없는 sample이므로 refs query와 실패 status는 실제 ABI로 검증했지만 성공 injection의 `loaded: false → true` 전이는 아직 검증하지 못했다.
+- 현재 refs decode는 #408/upstream의 여섯 필드를 필수 계약으로 둔다. upstream이 필드를 제거하거나 타입을 바꾸면 의도대로 `.invalidReferencesJSON`이 된다.
+- `strlen`은 #408이 반환하는 null-terminated JSON 계약에 의존한다. pointer가 null이면 decode를 시도하지 않고 `.referencesUnavailable`로 종료한다.
+- standalone test target은 계획된 bridge source만 compile한다. Stage 2 resolver source를 추가할 때 target source 목록과 compile helper 목록을 함께 갱신해야 한다.
+- Quick Look runtime과 sandbox filesystem 접근은 Stage 3 및 Stage 4 검증 전까지 확인되지 않는다.
+
+## 다음 단계 영향
+
+Stage 2는 이번 단계의 model과 wrapper 위에 open context, basename-only sibling resolver, non-fatal report를 구현한다.
+
+- filesystem 접근에는 `originalPath`를 사용하지 않고 `reference.basename`만 사용한다.
+- 절대 경로, 경로 구분자, `.`/`..`, symlink escape, non-regular file을 거부한다.
+- read/permission/verification/bridge rejection을 report로 분리하고 문서 open 자체는 실패시키지 않는다.
+- 허용된 sibling file bytes와 basename display path만 이번 단계의 `injectExternalImage`에 전달한다.
+- `ExternalImageTests` target에 resolver source와 policy test를 추가한다.
+
+## 승인 요청
+
+Stage 1 `Swift external image model과 FFI wrapper`는 완료됐다. Stage 2 `Open context, basename-only resolver와 report`로 진행하려면 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m020_409_stage2.md
+++ b/mydocs/working/task_m020_409_stage2.md
@@ -1,0 +1,233 @@
+# Task M020 #409 Stage 2 보고서
+
+## 단계 목적
+
+Stage 2의 목적은 filesystem 정책을 Rust FFI wrapper와 분리한 Shared open helper를 구현하고, source document와 같은 디렉터리의 regular sibling만 `basename`으로 읽어 external image key에 주입하는 것이다.
+
+reference 단위의 missing, reject, size, permission, read, bridge, verification 실패는 main document open이나 이후 render의 fatal error로 올리지 않고 privacy-safe report에 남긴다. 이 단계에서는 Quick Look Preview 제품 경로에 resolver를 아직 연결하지 않는다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|------|-----------|
+| `Sources/Shared/HwpExternalImageResolver.swift` | open context/result, document-access protocol, basename-only resolver, resolution/report/summary를 추가했다. 현재 441줄이다. |
+| `Tests/ExternalImageTests/HwpExternalImageResolverTests.swift` | filesystem 정책, 실패 분류, injection, 최종 loaded 검증, privacy-safe summary를 검증하는 test 18개를 추가했다. 현재 826줄이다. |
+| `Tests/ExternalImageTests/ExternalImageTestSupport.swift` | test별 임시 디렉터리와 file 생성 helper를 추가했다. 현재 44줄이다. |
+| `project.yml` | `ExternalImageTests` target에 Shared resolver source를 추가했다. 현재 176줄이다. |
+| `mydocs/working/task_m020_409_stage2.md` | Stage 2 변경, 검증, 잔여 위험과 Stage 3 handoff를 기록한다. |
+| `mydocs/orders/20260724.md` | #409를 Stage 2 완료 및 Stage 3 승인 대기 상태로 갱신한다. |
+
+## 구현 결과
+
+### Open context와 document 경계
+
+`RhwpDocumentOpenContext`는 다음 세 입력만 소유한다.
+
+- optional `sourceURL`
+- optional `displayFilename`
+- external resource 한 건당 `maximumExternalResourceBytes`
+
+`HwpExternalImageResolver.open(data:context:)`는 main bytes로 `RhwpDocument`를 생성하고 resolver가 끝난 document와 report를 `RhwpDocumentOpenResult`로 반환한다. resolver가 사용할 bridge 표면은 `RhwpExternalImageDocumentAccess` protocol의 다음 세 method로 제한했다.
+
+- `setFileName`
+- `externalImageReferences`
+- `injectExternalImage`
+
+`RhwpDocument`는 이 protocol을 별도 handle 노출 없이 채택한다. test는 fake document를 사용해 filesystem policy와 FFI status 처리를 독립적으로 검증한다.
+
+display filename이 있으면 source 활성 여부보다 먼저 setter를 호출하고 결과를 `filenameStatus`에 보존한다. setter 실패는 report 값이며 main document open을 실패시키지 않는다.
+
+source가 nil이면 `.disabledNoSourceURL`, file URL이 아니면 `.disabledNonFileURL`을 반환한다. 두 disabled 경로에서는 refs query와 injection을 호출하지 않는다. bytes-only 기존 caller는 계속 기존 initializer를 직접 사용할 수 있고 resolver가 자동 활성화되지 않는다.
+
+### Basename-only sibling 정책
+
+filesystem 후보를 만들 때 사용하는 external reference field는 `basename` 하나뿐이다. `originalPath`는 resolver source에서 참조하지 않으며, test에서 실제 outside file path를 `originalPath`로 주더라도 sibling basename이 없으면 `.missing`이 되는 계약을 고정했다.
+
+다음 basename은 candidate 계산 전에 `.rejectedInvalidBasename`으로 거부한다.
+
+- empty
+- `.`
+- `..`
+- `/` 포함
+- `\` 포함
+- NUL 포함
+
+허용된 basename은 source document의 standardized parent에 단일 path component로만 붙인다. source, source parent, candidate에 표준화와 symlink resolution을 적용하고 다음을 구분한다.
+
+- candidate 또는 resolved candidate가 source document와 같음 → `.rejectedSourceDocument`
+- symlink-resolved candidate parent가 symlink-resolved source parent와 다름 → `.rejectedOutsideSourceDirectory`
+- metadata상 regular file이 아님 → `.rejectedNonRegularFile`
+
+따라서 directory, source self-reference, parent 밖을 가리키는 sibling symlink는 file read 전에 차단된다. parent 내부 direct regular sibling은 허용된다.
+
+### Metadata, read와 실패 분류
+
+candidate metadata에서 `.isRegularFileKey`와 `.fileSizeKey`를 조회한다. metadata size가 상한을 넘으면 read하지 않고 `.tooLarge(actualBytes:limit:)`를 기록한다.
+
+허용된 candidate는 production에서 `Data(contentsOf:options: [.mappedIfSafe])`로 읽는다. test에서는 data-loader closure를 주입할 수 있어 실제 metadata 정책을 유지한 채 permission/read 오류와 read-after-size를 결정적으로 검증한다. read 후 `Data.count`를 다시 상한과 비교하므로 metadata 이후 크기가 커진 입력도 injection 전에 `.tooLarge`가 된다.
+
+Foundation/POSIX 오류는 다음처럼 분류한다.
+
+- Cocoa no-such-file 또는 POSIX `ENOENT` → `.missing`
+- Cocoa no-permission 또는 POSIX `EACCES`/`EPERM` → `.permissionDenied`
+- 그 외 metadata/read 오류 → `.readFailed`
+
+underlying error가 permission/missing을 제공하면 같은 분류를 보존한다. 한 reference의 실패 후에도 다음 reference 처리는 계속된다.
+
+### Injection과 최종 verification
+
+허용된 candidate는 다음 값만 bridge에 전달한다.
+
+- upstream reference `key`
+- 읽은 image bytes
+- 검증된 `basename` display path
+
+bridge status 처리는 다음과 같다.
+
+- `.ok` → pending verification
+- injection 시점 `.alreadyLoaded` → 경쟁 상태를 허용하고 최종 `.alreadyLoaded`
+- 나머지 status → raw 의미를 보존한 `.bridgeRejected(status)`
+
+모든 reference 처리가 끝난 뒤 pending `.ok` injection이 하나라도 있으면 refs를 한 번만 재조회한다. 같은 key의 `loaded == true`가 확인된 경우에만 `.injected(byteCount:)`를 유지한다. key가 없거나 loaded가 false이거나 final query가 실패하면 `.verificationFailed`로 바꾼다.
+
+### Privacy-safe report
+
+reference별 `RhwpExternalResourceResolution`은 safe discovery `key`와 decision만 소유한다. basename, original path, candidate URL, resolved absolute path를 report에 저장하지 않는다.
+
+`RhwpExternalResourceSummary`는 다음 count만 제공한다.
+
+- total
+- injected
+- alreadyLoaded
+- missing
+- rejected
+- tooLarge
+- permissionDenied
+- readFailed
+- bridgeFailed
+
+`privacySafeDescription`은 report state identifier와 이 count만 문자열화한다. `.bridgeRejected`와 `.verificationFailed`는 `bridgeFailed` 집계에 포함한다.
+
+## Test matrix 결과
+
+신규 resolver test 18개가 다음 계약을 검증한다.
+
+1. 실제 `KTX.hwp` bytes-only open은 document를 열되 resolver를 disabled로 유지
+2. source URL nil/non-file에서 refs query와 injection 0회
+3. refs empty에서 attempted/0건
+4. initial refs query 실패가 non-fatal `referenceQueryFailed`
+5. 이미 loaded인 ref는 read/injection 없이 `alreadyLoaded`
+6. valid sibling bytes/key/basename injection과 final loaded 확인
+7. 실제 outside `originalPath`를 filesystem discovery에 사용하지 않음
+8. injection 시점 `.alreadyLoaded` 경쟁 상태 허용
+9. empty, `.`, `..`, slash, backslash, NUL basename 거부
+10. source document self-reference와 directory 거부
+11. parent 밖 sibling symlink 거부
+12. metadata size와 read 후 실제 byte size 상한을 각각 적용
+13. missing, permission denied, generic read failure 구분
+14. bridge `.referenceNotFound`, `.failure`, `.unknown` 보존
+15. 한 ref 실패 후 다음 valid ref injection 지속
+16. `.ok` injection 후 loaded 미전환 시 verification failure
+17. final refs query 실패 시 pending injection 전체 verification failure
+18. summary field와 문자열이 count만 포함하는지 확인
+
+Stage 1 bridge test 6개도 함께 실행해 총 24개가 통과했다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 신규 구현은 `Sources/Shared/HwpExternalImageResolver.swift` 한 파일에 격리했다.
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`와 Rust FFI 본문은 변경하지 않았다.
+- `Sources/RhwpCoreBridge`에 Foundation filesystem 정책이나 AppKit/UIKit 의존성을 추가하지 않았다.
+- `project.yml`은 기존 `ExternalImageTests` source 목록에 resolver 파일 한 건만 추가했다.
+- HostApp, QLExtension, ThumbnailExtension의 기존 open/render 호출 순서와 제품 동작은 변경하지 않았다.
+- entitlement, RustBridge, `rhwp-core.lock`, FFI symbol, generated framework를 변경하지 않았다.
+- `xcodegen generate`로 검증한 `Alhangeul.xcodeproj/project.pbxproj`는 복원했으며 커밋하지 않는다.
+
+## 검증 결과
+
+### Shared boundary
+
+```bash
+./scripts/check-no-appkit.sh
+```
+
+결과: 통과.
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+### Xcode project 생성과 unit test
+
+```bash
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage2 \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+```
+
+결과: 최종 통과.
+
+```text
+Test Suite 'HwpExternalImageResolverTests' passed
+Executed 18 tests, with 0 failures
+Test Suite 'RhwpDocumentExternalImageBridgeTests' passed
+Executed 6 tests, with 0 failures
+Test Suite 'All tests' passed
+Executed 24 tests, with 0 failures
+** TEST SUCCEEDED **
+```
+
+최종 test result bundle:
+
+```text
+build.noindex/DerivedDataTask409Stage2/Logs/Test/
+Test-ExternalImageTests-2026.07.24_23-20-55-+0900.xcresult
+```
+
+첫 sandbox 실행은 Sparkle package fetch의 GitHub DNS 제한으로 중단됐다. 네트워크 권한으로 같은 명령을 실행해 compile/link와 22개 당시 test가 통과했다. 정책 보완 test 2개를 추가한 뒤 sandbox 재검증은 SwiftPM/Clang 사용자 cache 쓰기 제한으로 중단됐고, 정상 Xcode cache 접근이 가능한 같은 명령에서 최종 24개가 통과했다. 두 실패 모두 source/test assertion 실패가 아니다.
+
+비차단 warning으로 test target deployment target 12.0과 XCTest link minimum 14.0 차이, AppIntents metadata가 없다는 안내가 출력됐다. Stage 1과 같은 기존 test 환경 warning이며 실행 결과에는 영향을 주지 않았다.
+
+### 정책 symbol과 변경 점검
+
+```bash
+rg -n "originalPath|basename|resolvingSymlinksInPath|isRegularFile|fileSize|permissionDenied|verificationFailed" \
+  Sources/Shared/HwpExternalImageResolver.swift Tests/ExternalImageTests
+git diff --check
+git status --short
+```
+
+결과: 통과.
+
+- resolver source에는 `originalPath` 참조가 없고 filesystem candidate는 `reference.basename`으로만 만든다.
+- standardized/resolved parent, regular-file, metadata/read size, permission, verification 정책 symbol이 source와 test에 존재한다.
+- whitespace 오류가 없다.
+- 생성된 Xcode project와 build 산출물은 변경 목록에 남지 않았다.
+- 변경 목록은 Stage 2 resolver, test/support, `project.yml`, 보고서, 오늘할일로 한정된다.
+
+## 잔여 위험
+
+- 성공 injection의 실제 FFI `loaded: false → true` 전이는 아직 protocol fake로 고정한 상태다. pinned upstream external fixture와 실제 bridge를 사용하는 end-to-end 검증은 Stage 4가 수행한다.
+- 실제 Quick Look extension sandbox에서 sibling read 권한이 유지되는지는 Stage 3 연결 뒤 Stage 4 registered smoke로 확인해야 한다.
+- permission/read 분류는 deterministic data-loader 오류로 검증했다. extension sandbox가 반환하는 실제 NSError/POSIX 조합은 Stage 4 report와 log에서 다시 확인한다.
+- v1 resolver는 계획대로 standardized path, symlink resolution, metadata, read를 순차 수행한다. 파일시스템 항목이 각 단계 사이에서 공격적으로 교체되는 TOCTOU까지 원자적으로 막는 file-descriptor 기반 resolver는 이번 범위가 아니며, 실제 smoke나 보안 검토에서 필요성이 확인되면 별도 작업으로 분리해야 한다.
+- report resolution은 upstream key를 보존한다. 현재 key는 `binData:{id}` 계약이며 Stage 3 log에는 resolution key 자체를 기록하지 않고 summary count만 사용해야 한다.
+
+## 다음 단계 영향
+
+Stage 3는 이번 단계의 open result를 Quick Look Preview 제품 경로에 연결한다.
+
+- `HwpPreviewPDFRenderer.load(fileURL:)`의 main file preflight/read 뒤 `RhwpDocumentOpenContext`를 만든다.
+- `HwpExternalImageResolver.open`이 끝난 document에서만 page count와 first page size를 조회한다.
+- `HwpPreviewDocumentContext`에 external resource report를 포함한다.
+- single-page PNG와 multi-page PDF는 같은 resolved document handle을 재사용한다.
+- `HwpPreviewProvider`는 state identifier와 summary count만 log하고 external basename/path/key는 기록하지 않는다.
+- Thumbnail, bytes-only render, HostApp WKWebView 경로는 resolver 비활성 상태를 유지한다.
+
+## 승인 요청
+
+Stage 2 `Open context, basename-only resolver와 report`는 완료됐다. Stage 3 `Quick Look Preview open flow와 privacy-safe log 연결`로 진행하려면 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m020_409_stage3.md
+++ b/mydocs/working/task_m020_409_stage3.md
@@ -1,0 +1,299 @@
+# Task M020 #409 Stage 3 보고서
+
+## 단계 목적
+
+Stage 3의 목적은 Stage 2에서 구현한 basename-only external image resolver를 Quick Look Preview의 실제 open 경로에 연결하고, resolver가 완료된 동일한 document handle을 single-page PNG와 multi-page PDF render가 재사용하게 하는 것이다.
+
+제품 경로에서 남기는 진단은 external resource의 상태와 집계 count로 제한한다. external basename, 원본 path, candidate path, bridge key는 log와 smoke report에 기록하지 않는다. `inspect(fileURL:)`, bytes-only `render(previewInfo:)`, HostApp PDF export와 Thumbnail 경로는 source context가 없으므로 resolver 비활성 상태를 유지한다.
+
+## 산출물
+
+| 파일 | 변경 요약 |
+|------|-----------|
+| `Sources/Shared/HwpPreviewPDFRenderer.swift` | Preview load를 input read, external resolve, preview metadata 조회 순서로 분리하고 context에 external report를 포함했다. 현재 224줄이다. |
+| `Sources/QLExtension/HwpPreviewProvider.swift` | load 직후 external report의 state와 summary count만 한 번 기록한다. 현재 188줄이다. |
+| `scripts/smoke-quicklook-skia-policy.sh` | source-level smoke compile 목록에 resolver source를 추가했다. 현재 81줄이다. |
+| `scripts/quicklook_skia_policy_smoke.swift` | external state와 9개 summary count를 detail/summary 결과에 추가했다. 현재 662줄이다. |
+| `scripts/compare-quicklook-pdf-renderers.sh` | PDF renderer compare compile 목록에 resolver source를 추가했다. 현재 77줄이다. |
+| `mydocs/working/task_m020_409_stage3.md` | Stage 3 변경, 검증, 잔여 위험과 Stage 4 handoff를 기록한다. |
+| `mydocs/orders/20260724.md` | #409를 Stage 3 완료 및 Stage 4 승인 대기 상태로 갱신한다. |
+
+## 구현 결과
+
+### Quick Look Preview open 순서
+
+`HwpPreviewPDFRenderer.load(fileURL:)`의 순서를 다음처럼 명시적으로 분리했다.
+
+1. main document의 file size를 확인해 기존 50 MB 상한을 적용한다.
+2. main bytes를 `.mappedIfSafe`로 읽고 display filename을 보존한다.
+3. source URL, display filename, external resource별 50 MB 상한으로 `RhwpDocumentOpenContext`를 만든다.
+4. `HwpExternalImageResolver.open(data:context:)`로 main document를 열고 external reference query/read/injection/final verification을 마친다.
+5. resolver가 반환한 document에서 page count와 first page size를 조회한다.
+6. 같은 document와 external report를 `HwpPreviewDocumentContext`에 담는다.
+
+따라서 filename setter와 external reference resolution이 page count/size 조회보다 먼저 완료된다. `render(fileURL:)`는 기존처럼 `load(fileURL:)`를 통하므로 resolver가 활성화된다.
+
+### 동일 document handle 재사용
+
+`HwpPreviewDocumentContext`는 resolver가 반환한 `RhwpDocument`와 page metadata를 함께 소유한다.
+
+- single-page PNG reply는 context를 `HwpPreviewPNGRenderer`에 전달한다.
+- multi-page PDF reply는 같은 context를 `HwpPreviewPDFRenderer.render(context:)`에 전달한다.
+- PDF page loop는 context의 같은 document handle로 모든 page를 render한다.
+
+resolver 이후 document를 다시 열지 않으므로 injected external image 상태가 reply 유형과 무관하게 유지된다.
+
+### Resolver 활성·비활성 경계
+
+| 경로 | Resolver | 근거 |
+|------|----------|------|
+| Quick Look `HwpPreviewProvider` → `load(fileURL:)` | 활성 | 실제 source file URL을 open context에 전달한다. |
+| `render(fileURL:)` | 활성 | 내부에서 `load(fileURL:)`를 사용한다. |
+| `inspect(fileURL:)` | 비활성 | bytes와 filename으로 `RhwpDocument`를 직접 열고 source context를 보존하지 않는다. |
+| `render(previewInfo:)` | 비활성 | 보존된 bytes와 filename으로 document를 직접 다시 연다. |
+| HostApp PDF export | 비활성 | `inspect`와 `render(previewInfo:)` 경로를 사용한다. |
+| ThumbnailExtension | 비활성 | resolver open 호출을 추가하지 않았다. |
+
+제품 source에서 `HwpExternalImageResolver.open` 호출은 `HwpPreviewPDFRenderer.load(fileURL:)` 한 곳뿐이며, 실제 제품 caller는 QLExtension의 `HwpPreviewProvider` 한 곳이다.
+
+### Privacy-safe provider log
+
+`HwpPreviewProvider`는 `load` 성공 직후 report를 한 번 log한다. 추가한 field는 다음 값뿐이다.
+
+- state
+- total
+- injected
+- alreadyLoaded
+- missing
+- rejected
+- tooLarge
+- permissionDenied
+- readFailed
+- bridgeFailed
+
+external basename, original path, candidate/resolved URL, reference key는 log formatter에 전달하지 않는다. 기존 main document filename 진단은 변경하지 않았다.
+
+### Source-level smoke report
+
+`quicklook_skia_policy_smoke.swift`의 file measurement에 external state와 summary를 추가했다.
+
+- summary table에 state와 9개 count column을 추가했다.
+- fixture별 detail file에도 같은 state/count를 기록한다.
+- console summary는 `external={state}:{total}`만 추가한다.
+- external path, basename, key는 결과 형식에 추가하지 않았다.
+
+`HwpPreviewPDFRenderer`가 resolver source를 참조하게 됐으므로 다음 두 standalone `swiftc` helper의 compile 목록에 `HwpExternalImageResolver.swift`를 추가했다.
+
+- `smoke-quicklook-skia-policy.sh`
+- `compare-quicklook-pdf-renderers.sh`
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- `HwpPreviewPDFRenderer`의 기존 file-size 상한, mapped data read, empty-document 검사, first-page size 검사와 PDF page render 본문을 보존했다.
+- 기존 `loadDocument` 책임을 `loadInput`과 `previewMetadata`로 분리해 resolver 호출 순서를 사이에 배치했다.
+- single-page PNG와 multi-page PDF reply 선택 및 render 정책을 변경하지 않았다.
+- `inspect(fileURL:)`와 `render(previewInfo:)`는 의도적으로 resolver를 사용하지 않으며 기존 bytes-only 동작을 보존했다.
+- `Sources/RhwpCoreBridge`, Rust FFI, RustBridge header, `Rhwp.xcframework`, `rhwp-core.lock`, entitlement와 `project.yml`은 변경하지 않았다.
+- `Sources/RhwpCoreBridge`에 AppKit/UIKit 또는 filesystem resolver 정책을 추가하지 않았다.
+- `xcodegen generate`로 검증한 `Alhangeul.xcodeproj/project.pbxproj`는 복원했으며 커밋하지 않는다.
+- Stage 3는 실제 Quick Look 등록, Finder preview 요청, pinned external fixture 복사를 수행하지 않았다. 해당 범위는 승인 후 Stage 4에서 수행한다.
+
+## 검증 결과
+
+### Rust artifact와 lock
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+```
+
+결과: 통과.
+
+- x86_64와 arm64 macOS artifact를 다시 검증했다.
+- external image setter/query/injection symbol을 포함한 C ABI surface를 확인했다.
+- `Rhwp.xcframework` 생성과 `rhwp-core.lock` 일치를 확인했다.
+- Xcode의 simulator destination 관련 안내는 macOS artifact 결과에 영향을 주지 않는 비차단 warning이었다.
+
+### Shared boundary와 Xcode project 생성
+
+```bash
+./scripts/check-no-appkit.sh
+xcodegen generate
+```
+
+결과: 모두 통과.
+
+```text
+OK: shared Swift code has no AppKit/UIKit dependencies
+```
+
+생성된 Xcode project diff는 검증 후 복원했다.
+
+### ExternalImageTests
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage3Tests \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+```
+
+결과: 통과.
+
+```text
+Test Suite 'HwpExternalImageResolverTests' passed
+Executed 18 tests, with 0 failures
+Test Suite 'RhwpDocumentExternalImageBridgeTests' passed
+Executed 6 tests, with 0 failures
+Test Suite 'All tests' passed
+Executed 24 tests, with 0 failures
+** TEST SUCCEEDED **
+```
+
+test result bundle:
+
+```text
+build.noindex/DerivedDataTask409Stage3Tests/Logs/Test/
+Test-ExternalImageTests-2026.07.24_23-31-19-+0900.xcresult
+```
+
+첫 sandbox 실행은 Sparkle package 조회 중 GitHub DNS 제한으로 중단됐다. 네트워크 접근이 가능한 동일 명령으로 재실행해 compile/link와 24개 test가 통과했다. source 또는 assertion 실패는 없었다.
+
+test target deployment target과 XCTest minimum version 차이, AppIntents metadata 부재 안내는 기존 비차단 warning이며 test 결과에 영향을 주지 않았다.
+
+### 제품 target build
+
+다음 세 명령을 `CODE_SIGNING_ALLOWED=NO`로 실행했다.
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage3 \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme QLExtension \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage3QL \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ThumbnailExtension \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage3Thumb \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+
+결과: HostApp, QLExtension, ThumbnailExtension 모두 `** BUILD SUCCEEDED **`.
+
+### 계획된 Quick Look source-level smoke
+
+```bash
+./scripts/smoke-quicklook-skia-policy.sh \
+  build.noindex/task409-stage3-quicklook \
+  samples/basic/request.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+결과: 통과.
+
+| Fixture | Load | Reply | Pages | External state | 9개 summary count |
+|---------|------|-------|-------|----------------|-------------------|
+| `request.hwp` | OK | png | 1 | attempted | 모두 0 |
+| `hwp-multi-001.hwp` | OK | pdf | 9 | attempted | 모두 0 |
+| `hwpx-01.hwpx` | OK | pdf | 9 | attempted | 모두 0 |
+
+세 fixture 모두 external refs가 없어 `total=0`이며 injected, alreadyLoaded, missing, rejected, tooLarge, permissionDenied, readFailed, bridgeFailed도 0이다. 기존 PNG/PDF reply shape, page count, CoreGraphics/Skia backend와 fallback 결과를 보존했다.
+
+결과 파일:
+
+```text
+build.noindex/task409-stage3-quicklook/summary.txt
+build.noindex/task409-stage3-quicklook/*-quicklook-skia-policy.txt
+```
+
+### 변경된 PDF compare helper smoke
+
+compile 목록 변경을 별도로 확인하기 위해 다음 명령도 실행했다.
+
+```bash
+./scripts/compare-quicklook-pdf-renderers.sh \
+  build.noindex/task409-stage3-compare \
+  samples/basic/request.hwp
+```
+
+결과: 통과.
+
+```text
+request.hwp: OK, pages=1, currentReply=png, nativePDFPages=1
+```
+
+결과 파일:
+
+```text
+build.noindex/task409-stage3-compare/summary.txt
+```
+
+### 활성 경계, privacy와 등록 위생
+
+```bash
+rg -n "HwpExternalImageResolver\.open|externalResourceReport|externalResourceState|alreadyLoaded|permissionDenied|bridgeFailed" \
+  Sources/QLExtension Sources/Shared scripts/quicklook_skia_policy_smoke.swift
+rg -n "HwpPreviewPDFRenderer\.(load|inspect|render)" Sources Tests scripts
+./scripts/check-extension-registration-hygiene.sh --check-only
+```
+
+결과: 통과.
+
+- resolver open은 `HwpPreviewPDFRenderer.load(fileURL:)` 한 곳에만 있다.
+- QLExtension은 `load(fileURL:)`, HostApp export는 disabled인 `inspect`/`render(previewInfo:)`를 사용한다.
+- provider와 smoke에는 state/count field만 추가됐고 external basename/path/key는 없다.
+- 등록 위생 검사에서 development registration, provider app root, legacy candidate와 issue가 모두 없었다.
+- `build.noindex` 아래 세 Debug app bundle은 존재하지만 등록되지 않은 산출물이다. 따라서 등록 해제 작업은 수행할 대상이 없었다.
+
+### 최종 변경 점검
+
+```bash
+bash -n \
+  scripts/smoke-quicklook-skia-policy.sh \
+  scripts/compare-quicklook-pdf-renderers.sh
+git diff --check
+git status --short
+```
+
+결과: 통과.
+
+- shell helper 두 개의 syntax 오류가 없다.
+- whitespace 오류가 없다.
+- 생성된 Xcode project와 framework 변경은 목록에 남지 않았다.
+- 변경 범위는 Stage 3 Preview 연결, provider log, smoke helper, 단계 보고서와 오늘할일로 한정된다.
+
+## 잔여 위험
+
+- no-external fixture는 resolver 호출과 report shape를 검증하지만 실제 FFI injection의 `loaded: false → true` 전이를 증명하지 않는다. pinned upstream external fixture를 사용하는 검증은 Stage 4가 수행한다.
+- 실제 Quick Look extension sandbox에서 source document sibling image read가 허용되는지는 등록된 extension을 통해 확인해야 한다.
+- provider의 privacy-safe OSLog는 source와 build 수준에서 확인했다. 실제 등록 Preview 요청에서 state/count가 한 번 기록되는지는 Stage 4에서 확인한다.
+- external image가 single-page PNG와 multi-page PDF 출력에 실제 반영되는지는 Stage 4의 valid/missing/oversize fixture matrix와 output inspection으로 확인한다.
+- ThumbnailExtension과 HostApp는 의도적으로 resolver 비활성이다. 해당 제품에도 external image가 필요해지면 별도 issue에서 source-context 계약과 sandbox 정책을 설계해야 한다.
+
+## 다음 단계 영향
+
+Stage 4는 이번 단계에서 연결한 Preview open 경로를 실제 pinned external fixture와 등록된 QLExtension에서 검증한다.
+
+- pinned upstream commit과 fixture checksum/구성을 확인한다.
+- valid sibling image, missing sibling, oversize sibling matrix를 `build.noindex`에 준비한다.
+- source-level resolver report로 injection/loaded 상태와 non-fatal 실패 분류를 확인한다.
+- signed Debug app과 QLExtension을 표준 smoke 절차로 등록해 Finder/Quick Look Preview를 요청한다.
+- actual provider log가 state/count만 기록하는지 확인한다.
+- PNG/PDF 결과와 external image 반영 여부를 검사한다.
+- smoke 종료 후 개발용 Quick Look/Thumbnail 등록을 해제하고 등록 위생을 다시 확인한다.
+
+## 승인 요청
+
+Stage 3 `Quick Look Preview open flow와 privacy-safe log 연결`은 완료됐다. Stage 4 `Pinned external fixture와 registered Preview 통합 검증`으로 진행하려면 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m020_409_stage4.md
+++ b/mydocs/working/task_m020_409_stage4.md
@@ -1,0 +1,242 @@
+# Task M020 #409 Stage 4 보고서
+
+## 단계 목적
+
+Stage 4의 목적은 고정된 upstream external image fixture로 Swift resolver의 실제 reference decode, sibling image injection, final loaded 상태와 Preview render를 통합 검증하고, 등록된 Quick Look extension의 sandbox에서 같은 동작이 가능한지 확인하는 것이다.
+
+source-level 검증에서는 valid, missing, oversize fixture를 구분해 성공과 비치명 실패를 확인했다. registered Preview 검증에서는 macOS 26.5.2(25F84)의 Quick Look host가 main document에 부여한 sandbox capability만으로 sibling file capability를 발급하지 못하는 플랫폼 제한을 확인했다. read-only/read-write entitlement와 Foundation related-item API 조합을 추가로 실험했지만 결과가 같았다.
+
+작업지시자는 이 결과를 확인한 뒤 Stage 4 완료 조건을 다음처럼 조정하는 데 승인했다.
+
+- source-level 경로에서 external image 3건의 injection과 render 성공을 증명한다.
+- 실제 registered Preview에서는 `permissionDenied`가 privacy-safe count로 남고 main document render가 계속되는 graceful fallback을 증명한다.
+- #409에는 sandbox 해제, broad folder entitlement, 임시 absolute-path exception, unsandboxed broker 또는 사용자 folder authorization을 추가하지 않는다.
+
+## 산출물
+
+| 파일/산출물 | 결과 |
+|-------------|------|
+| `mydocs/working/task_m020_409_stage4.md` | pinned fixture, source-level smoke, registered Preview 실험, 플랫폼 제한과 검증 결과를 기록한다. |
+| `mydocs/orders/20260724.md` | #409를 Stage 4 완료 및 Stage 5 승인 대기 상태로 갱신한다. |
+| `build.noindex/task409-external-*-output/` | valid, missing, oversize source-level smoke 결과를 보존한다. Git 추적 대상은 아니다. |
+| `build.noindex/task409-stage4-render/` | 기존 HWP/HWPX renderer 회귀 결과를 보존한다. Git 추적 대상은 아니다. |
+| `build.noindex/DerivedDataTask409Stage4Tests/` | ExternalImageTests 결과 bundle을 보존한다. Git 추적 대상은 아니다. |
+| source, plist, entitlement | Stage 4에서 최종 변경하지 않았다. sandbox 실험용 임시 변경은 모두 복원했다. |
+
+## Pinned fixture
+
+fixture는 `rhwp-core.lock`이 고정한 다음 upstream commit의 Cargo checkout에서 복사했다.
+
+```text
+93862a4e16df59834ebce46d91e948cd739208e9
+```
+
+checkout의 실제 `HEAD`가 위 commit과 일치하는지 확인했으며 upstream checkout과 repository sample 원본은 수정하지 않았다.
+
+| Fixture | SHA-256 |
+|---------|---------|
+| `hwp3-sample10-hwpx.hwpx` | `3395e19bebea8b6689f383df1f4ea1ddb253dee91c4320392cc40e90e2e4f191` |
+| `oracle.gif` | `464e863dd2c1650fc6997b03a5d96c9413e61bbabaf7337c783db27203cc2761` |
+| `rdb02.gif` | `bfadf4cdbbeeb5f3d8632cb54c8c3696977f405204b651f99a7a24c8f39532cf` |
+| `s1.jpg` | `77dea18ce7f8f93b0931e133dec222aec642eef0ed87b8f2031b94dcbea5c514` |
+
+main document의 external reference는 3건이다. valid case에는 세 sibling image를 모두 배치했고, missing case에는 `oracle.gif`을 제외했으며, oversize case에는 한 sibling이 resolver의 resource별 50 MB 상한을 넘도록 구성했다.
+
+## Source-level Preview 통합 결과
+
+Stage 3에서 연결한 `HwpPreviewPDFRenderer.load(fileURL:)` 경로를 standalone Preview smoke로 실행했다.
+
+| Case | Total | Injected | Missing | Too large | Permission denied | Render |
+|------|------:|---------:|--------:|----------:|------------------:|--------|
+| valid | 3 | 3 | 0 | 0 | 0 | CoreGraphics/SkiaDecode 각 764 pages, `Status: OK` |
+| missing | 3 | 2 | 1 | 0 | 0 | CoreGraphics/SkiaDecode 각 764 pages, `Status: OK` |
+| oversize | 3 | 2 | 0 | 1 | 0 | CoreGraphics/SkiaDecode 각 764 pages, `Status: OK` |
+
+valid case는 initial unloaded reference 3건을 모두 injection한 뒤 final verification을 통과했다. `alreadyLoaded=0`이므로 세 건 모두 이번 open에서 injection된 결과다. output은 비어 있지 않았다.
+
+| Backend | valid output bytes | missing/oversize output bytes |
+|---------|-------------------:|------------------------------:|
+| CoreGraphics | 78,200,238 | 78,273,662 |
+| SkiaDecode | 59,036,272 | 59,137,709 |
+
+missing과 oversize case도 main document load와 764-page render를 유지했다. 따라서 개별 external resource 실패를 document-fatal error로 승격하지 않는 Stage 2 정책이 실제 fixture에서도 보존됐다.
+
+계획서의 `rg` 예시는 lowercase field 이름을 가정했지만 smoke detail은 `LoadStatus`, `ExternalResourceInjected`처럼 CamelCase를 사용한다. 같은 결과 파일을 `rg -ni`로 다시 검사해 valid의 `total=3`, `injected=3`, `missing=0`과 missing의 `injected=2`, `missing=1`, 양쪽 renderer의 `Status: OK`를 확인했다.
+
+## Registered Quick Look Preview 검증
+
+### 실행 범위
+
+signed temporary app의 실제 active Preview provider를 확인한 뒤 `qlmanage -p`와 Finder Space Preview에서 valid fixture를 열었다. 초기 read-only entitlement 결과가 `permissionDenied=3`이어서 작업지시자 승인 아래 Foundation related-item 접근과 read-write entitlement까지 범위를 확장했다.
+
+| 실험 | 요청 경로 | 결과 |
+|------|-----------|------|
+| 기존 read-only entitlement, direct sibling read | `qlmanage -p`, Finder | injected 0, permissionDenied 3 |
+| `NSFilePresenter`/`NSFileCoordinator`, sibling별 presenter | `qlmanage -p`, Finder | injected 0, permissionDenied 3 |
+| same-stem main document와 related image | `qlmanage -p` | injected 0, permissionDenied 3 |
+| parent directory presenter/coordinator | `qlmanage -p` | injected 0, permissionDenied 3 |
+| read-write entitlement, sibling별 presenter | `qlmanage -p` | injected 0, permissionDenied 3 |
+| read-write entitlement, directory presenter | `qlmanage -p` | injected 0, permissionDenied 3 |
+
+모든 실제 provider 요청에서 제품 log는 다음 privacy-safe summary로 수렴했다.
+
+```text
+Preview externalResource state=attempted total=3 injected=0 alreadyLoaded=0 missing=0 rejected=0 tooLarge=0 permissionDenied=3 readFailed=0 bridgeFailed=0
+```
+
+제품 log에는 original path, candidate absolute path, external basename과 bridge key가 포함되지 않았다. Finder Preview에서도 main document는 graceful fallback으로 계속 표시됐고 extension crash는 없었다.
+
+Foundation 진단에는 다음 sandbox extension 발급 실패가 반복됐다.
+
+```text
+NSFileSandboxingRequestRelatedItemExtension: Failed to issue extension
++[NSFileCoordinator addFilePresenter:] could not get a sandbox extension
+```
+
+same-stem case에서도 related image의 read capability를 얻지 못했고, main document에 write capability를 요구하는 경로도 거부됐다. directory presenter는 parent directory read capability를 얻지 못했다. 이 관찰을 종합하면 현재 Quick Look host가 extension에 전달한 main document capability는 Foundation related-item sandbox extension을 파생하기에 충분하지 않으며, extension entitlement를 read-write로 넓히는 것만으로 host가 부여하지 않은 capability가 추가되지 않는다.
+
+### 완료 조건 조정
+
+원래 계획의 “actual registered QLExtension에서 valid sibling 3건 injection” 조건은 현재 macOS Quick Look sandbox에서는 충족할 수 없었다. 이를 우회하려면 user-selected folder authorization/security-scoped bookmark, 별도 broker 또는 sandbox 정책 변경처럼 #409의 보안·제품 구조 범위를 넘는 설계가 필요하다.
+
+작업지시자 승인에 따라 Stage 4는 다음 근거로 완료 처리한다.
+
+- Swift/FFI/source-level Preview 경로는 pinned fixture 3건을 정상 injection하고 764-page render를 완료한다.
+- actual registered Preview는 sibling 접근 거부를 `permissionDenied=3`으로 분류하고 main render를 중단하지 않는다.
+- provider 진단은 path/basename/key를 노출하지 않는다.
+- 효과가 없었던 plist/entitlement/Foundation presenter 실험은 제품 변경으로 남기지 않는다.
+- 플랫폼 제한과 후속 설계 필요성을 Stage 5 최종 보고서에 인계한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- Stage 4에는 최종 source, test, script, plist, entitlement 변경이 없다.
+- Stage 1~3에서 구현한 Swift wrapper, basename-only resolver, Preview 연결과 privacy-safe log를 그대로 검증했다.
+- related-item type declaration, same-stem presenter, directory presenter와 read-write entitlement 실험은 모두 임시 산출물에서 수행했고 tracked source를 `HEAD` 상태로 복원했다.
+- `Sources/RhwpCoreBridge`에 AppKit/UIKit 또는 filesystem resolver 정책을 추가하지 않았다.
+- sandbox 해제, broad folder entitlement, temporary absolute-path entitlement, user-selected folder permission 또는 별도 broker를 추가하지 않았다.
+- `xcodegen generate`가 만든 `Alhangeul.xcodeproj/project.pbxproj` 변경은 검증 후 복원했으며 커밋하지 않는다.
+- `RustBridge`, `rhwp-ffi-symbols.txt`, `rhwp-core.lock`, `Frameworks/Rhwp.xcframework`는 변경되지 않았다.
+- 임시 registered provider와 `/Users/melee/Applications/Alhangeul.app`은 제거했고 개발용 launch environment도 해제했다.
+
+## 검증 결과
+
+### Rust artifact, shared boundary와 Xcode project
+
+```bash
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/check-no-appkit.sh
+xcodegen generate
+```
+
+결과: 모두 통과.
+
+- external image setter/query/injection symbol을 포함한 FFI surface와 lock을 확인했다.
+- `Rhwp.xcframework` 생성 결과가 lock과 일치했다.
+- shared Swift code에 AppKit/UIKit dependency가 없음을 확인했다.
+- `xcodegen` 생성 project는 검증에 사용한 뒤 tracked project를 복원했다.
+- CoreSimulator 관련 안내는 macOS artifact 결과에 영향을 주지 않는 비차단 warning이었다.
+
+### ExternalImageTests
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage4Tests \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+```
+
+결과: 통과.
+
+```text
+HwpExternalImageResolverTests: 18 tests passed
+RhwpDocumentExternalImageBridgeTests: 6 tests passed
+Total: 24 tests, 0 failures
+** TEST SUCCEEDED **
+```
+
+test result bundle:
+
+```text
+build.noindex/DerivedDataTask409Stage4Tests/Logs/Test/
+Test-ExternalImageTests-2026.07.27_21-14-39-+0900.xcresult
+```
+
+첫 sandbox 실행은 Sparkle package 조회 중 GitHub DNS 제한으로 exit 74가 발생했다. 네트워크 접근이 가능한 환경에서 같은 명령을 재실행해 compile/link와 24개 test가 통과했다. source 또는 assertion 실패는 없었다.
+
+### HostApp build
+
+```bash
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedDataTask409Stage4 \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+
+결과: `** BUILD SUCCEEDED **`.
+
+첫 sandbox 실행의 Sparkle DNS 제한은 ExternalImageTests와 같았고, 동일 명령 재실행에서 HostApp, QLExtension, ThumbnailExtension dependency graph가 모두 build됐다.
+
+### 기존 renderer 회귀
+
+```bash
+./scripts/validate-stage3-render.sh \
+  build.noindex/task409-stage4-render \
+  samples/basic/KTX.hwp \
+  samples/basic/request.hwp \
+  samples/hwp-img-001.hwp \
+  samples/hwp-multi-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+결과: 다섯 fixture 모두 통과.
+
+| Fixture | First page | Text runs | Hangul runs | Scalars | Non-white pixels |
+|---------|------------|----------:|------------:|--------:|-----------------:|
+| `KTX.hwp` | 1123×794 | 410 | 76 | 209 | 455,341 |
+| `request.hwp` | 567×794 | 102 | 36 | 309 | 70,188 |
+| `hwp-img-001.hwp` | 794×1123 | 66 | 35 | 190 | 57,024 |
+| `hwp-multi-001.hwp` | 794×1123 | 279 | 113 | 409 | 142,602 |
+| `hwpx-01.hwpx` | 794×1123 | 269 | 118 | 440 | 134,090 |
+
+### 등록 위생과 최종 무변경 점검
+
+```bash
+./scripts/check-extension-registration-hygiene.sh --check-only
+git diff --check
+git diff --exit-code -- RustBridge rhwp-ffi-symbols.txt rhwp-core.lock Frameworks
+```
+
+결과: 모두 통과.
+
+- development registration, provider app root, legacy candidate와 issue가 없다.
+- `build.noindex` 아래 Debug app bundle은 존재하지만 등록되지 않은 검증 산출물이다.
+- PlugInKit이 최종 check-only 시점에 Preview/Thumbnail provider path를 보고하지 않아 warning만 남았고, development registration 오염은 없었다.
+- whitespace 오류와 core/FFI/framework tracked diff가 없다.
+
+## 잔여 위험
+
+- macOS 26.5.2 Quick Look sandbox에서는 main document와 같은 directory의 external image도 extension이 읽지 못한다. 해당 image는 Preview에서 누락되지만 main document render는 계속된다.
+- Foundation related-item API와 read-write entitlement가 향후 macOS에서 다른 결과를 낼 가능성은 있으나, 현재 관찰만으로 지원을 보장할 수 없다.
+- sibling injection 자체의 Swift/FFI 계약은 source-level process가 directory read capability를 가진 경우에만 제품과 동일하게 동작한다.
+- user-selected folder authorization, security-scoped bookmark, broker 또는 entitlement 정책 변경은 별도 issue의 제품·보안 설계와 검토가 필요하다.
+- ThumbnailExtension과 HostApp external image resolution은 #409에서 의도적으로 활성화하지 않았다.
+- total external resource memory 상한과 open/read 사이 TOCTOU는 기존 resource별 상한과 containment 검사만 적용된다. 필요하면 후속 issue에서 별도 강화한다.
+
+## 다음 단계 영향
+
+Stage 5는 Stage 1~4 구현과 검증을 최종 보고서로 통합한다.
+
+- status mapping, reference JSON, C string free와 UTF-8/data lifetime을 정리한다.
+- basename-only containment, symlink, size, permission과 privacy 정책을 정리한다.
+- source-level 3건 injection 성공과 registered Preview의 sandbox `permissionDenied` fallback을 분리해 기록한다.
+- Thumbnail #411, fixture suite #412, WKWebView #413, renderer diagnostic #410으로 남긴 책임 경계를 명시한다.
+- current Quick Look sibling sandbox 제한, 잔여 TOCTOU와 total-memory risk를 기록한다.
+- 최종 검증과 오늘할일 완료 처리는 Stage 5 승인 후 수행한다.
+
+## 승인 요청
+
+Stage 4 `Pinned external fixture와 registered Preview 통합 검증`은 승인된 완료 조건 조정에 따라 완료됐다. Stage 5 `최종 보고서와 후속 handoff`로 진행하려면 작업지시자 승인이 필요하다.

--- a/project.yml
+++ b/project.yml
@@ -149,6 +149,7 @@ targets:
     platform: macOS
     sources:
       - path: Tests/ExternalImageTests
+      - path: Sources/Shared/HwpExternalImageResolver.swift
       - path: Sources/RhwpCoreBridge/RhwpDocument.swift
       - path: Sources/RhwpCoreBridge/RenderTree.swift
     dependencies:

--- a/project.yml
+++ b/project.yml
@@ -143,3 +143,33 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.postmelee.alhangeul.HostAppTests
         GENERATE_INFOPLIST_FILE: YES
+
+  ExternalImageTests:
+    type: bundle.unit-test
+    platform: macOS
+    sources:
+      - path: Tests/ExternalImageTests
+      - path: Sources/RhwpCoreBridge/RhwpDocument.swift
+      - path: Sources/RhwpCoreBridge/RenderTree.swift
+    dependencies:
+      - framework: Frameworks/Rhwp.xcframework
+        embed: false
+      - sdk: CoreFoundation.framework
+      - sdk: CoreText.framework
+      - sdk: CoreGraphics.framework
+      - sdk: Foundation.framework
+      - sdk: ImageIO.framework
+      - sdk: CoreServices.framework
+      - sdk: ApplicationServices.framework
+      - sdk: Security.framework
+      - sdk: Metal.framework
+      - sdk: QuartzCore.framework
+      - sdk: IOSurface.framework
+      - sdk: ColorSync.framework
+      - sdk: libc++.tbd
+      - sdk: libiconv.tbd
+      - sdk: libz.tbd
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: com.postmelee.alhangeul.ExternalImageTests
+        GENERATE_INFOPLIST_FILE: YES

--- a/scripts/compare-quicklook-pdf-renderers.sh
+++ b/scripts/compare-quicklook-pdf-renderers.sh
@@ -57,6 +57,7 @@ swiftc -parse-as-library \
   "$ROOT/Sources/RhwpCoreBridge/FontFallback.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontResourceRegistry.swift" \
   "$ROOT/Sources/RhwpCoreBridge/CGTreeRenderer.swift" \
+  "$ROOT/Sources/Shared/HwpExternalImageResolver.swift" \
   "$ROOT/Sources/Shared/HwpPageImageRenderer.swift" \
   "$ROOT/Sources/Shared/HwpNativePageCompositor.swift" \
   "$ROOT/Sources/Shared/HwpPreviewPDFRenderer.swift" \

--- a/scripts/quicklook_skia_policy_smoke.swift
+++ b/scripts/quicklook_skia_policy_smoke.swift
@@ -67,6 +67,8 @@ struct FileMeasurement {
     let pageCount: Int?
     let replyType: String?
     let firstPageSize: CGSize?
+    let externalResourceState: String?
+    let externalResourceSummary: RhwpExternalResourceSummary?
     let coreGraphics: ModeMeasurement?
     let skiaDecode: ModeMeasurement?
     let skiaDirect: ModeMeasurement?
@@ -145,6 +147,8 @@ struct QuickLookSkiaPolicySmoke {
                 pageCount: context.pageCount,
                 replyType: replyType,
                 firstPageSize: context.contentSize,
+                externalResourceState: context.externalResourceReport.state.identifier,
+                externalResourceSummary: context.externalResourceReport.summary,
                 coreGraphics: coreGraphics,
                 skiaDecode: skiaDecode,
                 skiaDirect: skiaDirect
@@ -159,6 +163,8 @@ struct QuickLookSkiaPolicySmoke {
                 pageCount: nil,
                 replyType: nil,
                 firstPageSize: nil,
+                externalResourceState: nil,
+                externalResourceSummary: nil,
                 coreGraphics: nil,
                 skiaDecode: nil,
                 skiaDirect: nil
@@ -369,8 +375,8 @@ struct QuickLookSkiaPolicySmoke {
         lines.append("ResolverEnvKey: \(resolverContract.environmentKey)")
         lines.append("ResolverContract: \(resolverContract.status)")
         lines.append("")
-        lines.append("| File | Load | Reply | Pages | Size | CGStatus | CGBackend | CGFallback | CGBytes | CGSeconds | SkiaDecodeStatus | SkiaDecodeBackend | SkiaDecodeFallback | SkiaDecodeBytes | SkiaDecodePNGBytes | SkiaDecodeSeconds | SkiaDirectStatus | SkiaDirectBackend | SkiaDirectFallback | SkiaDirectBytes | SkiaDirectPNGBytes | SkiaDirectSeconds | SkiaDirectPixel |")
-        lines.append("|------|------|-------|-------|------|----------|-----------|------------|---------|-----------|------------------|-------------------|--------------------|----------------|-------------------|-------------------|------------------|-------------------|--------------------|----------------|-------------------|-------------------|-----------------|")
+        lines.append("| File | Load | Reply | Pages | Size | ExternalState | ExternalTotal | ExternalInjected | ExternalAlreadyLoaded | ExternalMissing | ExternalRejected | ExternalTooLarge | ExternalPermissionDenied | ExternalReadFailed | ExternalBridgeFailed | CGStatus | CGBackend | CGFallback | CGBytes | CGSeconds | SkiaDecodeStatus | SkiaDecodeBackend | SkiaDecodeFallback | SkiaDecodeBytes | SkiaDecodePNGBytes | SkiaDecodeSeconds | SkiaDirectStatus | SkiaDirectBackend | SkiaDirectFallback | SkiaDirectBytes | SkiaDirectPNGBytes | SkiaDirectSeconds | SkiaDirectPixel |")
+        lines.append("|------|------|-------|-------|------|---------------|---------------|------------------|-----------------------|-----------------|------------------|------------------|--------------------------|--------------------|----------------------|----------|-----------|------------|---------|-----------|------------------|-------------------|--------------------|----------------|-------------------|-------------------|------------------|-------------------|--------------------|----------------|-------------------|-------------------|-----------------|")
 
         for measurement in measurements {
             lines.append([
@@ -379,6 +385,16 @@ struct QuickLookSkiaPolicySmoke {
                 measurement.replyType ?? "-",
                 optionalInt(measurement.pageCount),
                 sizeString(measurement.firstPageSize),
+                measurement.externalResourceState ?? "-",
+                optionalInt(measurement.externalResourceSummary?.total),
+                optionalInt(measurement.externalResourceSummary?.injected),
+                optionalInt(measurement.externalResourceSummary?.alreadyLoaded),
+                optionalInt(measurement.externalResourceSummary?.missing),
+                optionalInt(measurement.externalResourceSummary?.rejected),
+                optionalInt(measurement.externalResourceSummary?.tooLarge),
+                optionalInt(measurement.externalResourceSummary?.permissionDenied),
+                optionalInt(measurement.externalResourceSummary?.readFailed),
+                optionalInt(measurement.externalResourceSummary?.bridgeFailed),
                 measurement.coreGraphics?.status ?? "-",
                 backendSummary(measurement.coreGraphics),
                 fallbackSummary(measurement.coreGraphics),
@@ -440,6 +456,16 @@ struct QuickLookSkiaPolicySmoke {
         lines.append("ReplyType: \(measurement.replyType ?? "-")")
         lines.append("PageCount: \(optionalInt(measurement.pageCount))")
         lines.append("FirstPageSize: \(sizeString(measurement.firstPageSize))")
+        lines.append("ExternalResourceState: \(measurement.externalResourceState ?? "-")")
+        lines.append("ExternalResourceTotal: \(optionalInt(measurement.externalResourceSummary?.total))")
+        lines.append("ExternalResourceInjected: \(optionalInt(measurement.externalResourceSummary?.injected))")
+        lines.append("ExternalResourceAlreadyLoaded: \(optionalInt(measurement.externalResourceSummary?.alreadyLoaded))")
+        lines.append("ExternalResourceMissing: \(optionalInt(measurement.externalResourceSummary?.missing))")
+        lines.append("ExternalResourceRejected: \(optionalInt(measurement.externalResourceSummary?.rejected))")
+        lines.append("ExternalResourceTooLarge: \(optionalInt(measurement.externalResourceSummary?.tooLarge))")
+        lines.append("ExternalResourcePermissionDenied: \(optionalInt(measurement.externalResourceSummary?.permissionDenied))")
+        lines.append("ExternalResourceReadFailed: \(optionalInt(measurement.externalResourceSummary?.readFailed))")
+        lines.append("ExternalResourceBridgeFailed: \(optionalInt(measurement.externalResourceSummary?.bridgeFailed))")
         appendMode(measurement.coreGraphics, name: "CoreGraphics", lines: &lines)
         appendMode(measurement.skiaDecode, name: "SkiaDecode", lines: &lines)
         appendMode(measurement.skiaDirect, name: "SkiaDirect", lines: &lines)
@@ -570,7 +596,7 @@ struct QuickLookSkiaPolicySmoke {
         guard measurement.loadStatus == "OK" else {
             return measurement.loadError ?? "load failed"
         }
-        return "reply=\(measurement.replyType ?? "-") pages=\(optionalInt(measurement.pageCount)) cg=\(backendSummary(measurement.coreGraphics)) skiaDecode=\(backendSummary(measurement.skiaDecode)) skiaDirect=\(backendSummary(measurement.skiaDirect)) directFallback=\(fallbackSummary(measurement.skiaDirect))"
+        return "reply=\(measurement.replyType ?? "-") pages=\(optionalInt(measurement.pageCount)) external=\(measurement.externalResourceState ?? "-"):\(optionalInt(measurement.externalResourceSummary?.total)) cg=\(backendSummary(measurement.coreGraphics)) skiaDecode=\(backendSummary(measurement.skiaDecode)) skiaDirect=\(backendSummary(measurement.skiaDirect)) directFallback=\(fallbackSummary(measurement.skiaDirect))"
     }
 
     private static func isFailure(_ measurement: ModeMeasurement?) -> Bool {

--- a/scripts/smoke-quicklook-skia-policy.sh
+++ b/scripts/smoke-quicklook-skia-policy.sh
@@ -59,6 +59,7 @@ swiftc -parse-as-library \
   "$ROOT/Sources/RhwpCoreBridge/FontFallback.swift" \
   "$ROOT/Sources/RhwpCoreBridge/FontResourceRegistry.swift" \
   "$ROOT/Sources/RhwpCoreBridge/CGTreeRenderer.swift" \
+  "$ROOT/Sources/Shared/HwpExternalImageResolver.swift" \
   "$ROOT/Sources/Shared/HwpPageImageRenderer.swift" \
   "$ROOT/Sources/Shared/HwpNativePageCompositor.swift" \
   "$ROOT/Sources/Shared/HwpPreviewPDFRenderer.swift" \


### PR DESCRIPTION
## 요약

- 대상 타스크: Quick Look Preview의 Swift external image wrapper와 basename-only sibling resolver를 구현했습니다.
- 왜: #408 C ABI를 macOS source URL 권한·filesystem 정책과 연결하고, external image 실패를 main render 실패와 분리해야 했습니다.
- 무엇: FFI wrapper, resolver/report, Preview open orchestration, privacy-safe log와 24개 unit test를 추가했습니다.
- 리뷰 포인트: pointer lifetime, basename/symlink/size 경계, registered Quick Look의 `permissionDenied` graceful fallback을 우선 확인해 주세요.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/bfce9d19d96340d16b06779d4447960b84acf2df/mydocs/working/task_m020_409_stage1.md)** ([7b527e8](https://github.com/postmelee/alhangeul-macos/commit/7b527e8d39accf3e19de5e4140555a379f845155)): Swift external image model과 FFI wrapper 계약을 구현했습니다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/bfce9d19d96340d16b06779d4447960b84acf2df/mydocs/working/task_m020_409_stage2.md)** ([f9fb735](https://github.com/postmelee/alhangeul-macos/commit/f9fb73519f3cdef981b5c59ec1a9c9770fd5c230)): basename-only resolver와 privacy-safe resolution report를 구현했습니다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/bfce9d19d96340d16b06779d4447960b84acf2df/mydocs/working/task_m020_409_stage3.md)** ([3b8058c](https://github.com/postmelee/alhangeul-macos/commit/3b8058c8c99ae79dcfafb1e406d6667273b3d1c9)): Quick Look Preview open flow와 summary log를 연결했습니다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/bfce9d19d96340d16b06779d4447960b84acf2df/mydocs/working/task_m020_409_stage4.md)** ([0760013](https://github.com/postmelee/alhangeul-macos/commit/07600134663f8561e40065e8bf146f53d51d53a1)): pinned fixture와 registered Preview를 통합 검증하고 sandbox 제한을 확정했습니다.
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/bfce9d19d96340d16b06779d4447960b84acf2df/mydocs/report/task_m020_409_report.md)** ([bfce9d1](https://github.com/postmelee/alhangeul-macos/commit/bfce9d19d96340d16b06779d4447960b84acf2df)): 최종 계약, 검증과 후속 handoff를 정리했습니다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| `RhwpDocument` bridge | status/refs JSON/filename setter/key injection wrapper | UTF-8·Data pointer closure와 C string copy/free |
| Shared resolver | source context, basename-only sibling 정책, report | original path 미사용, symlink/regular file/50 MB 경계 |
| Quick Look Preview | resolve 후 metadata 조회, 동일 handle PNG/PDF 재사용 | resolver 활성 범위와 non-fatal fallback |
| Provider diagnostics | state와 9개 count만 OSLog 기록 | external basename/path/key 미노출 |
| Tests/smoke | bridge 6개, resolver 18개, external fixture smoke | loaded 재확인과 실패 taxonomy |

- 수행 계획서: [task_m020_409.md](https://github.com/postmelee/alhangeul-macos/blob/bfce9d19d96340d16b06779d4447960b84acf2df/mydocs/plans/task_m020_409.md)
- 구현 계획서: [task_m020_409_impl.md](https://github.com/postmelee/alhangeul-macos/blob/bfce9d19d96340d16b06779d4447960b84acf2df/mydocs/plans/task_m020_409_impl.md)
- 최종 보고서: [task_m020_409_report.md](https://github.com/postmelee/alhangeul-macos/blob/bfce9d19d96340d16b06779d4447960b84acf2df/mydocs/report/task_m020_409_report.md)

## 핵심 리뷰 포인트

- `RhwpExternalImageOperationStatus` raw value 보존, refs JSON 즉시 복사/해제와 UTF-8/image buffer의 FFI call 한정 수명을 확인해 주세요.
- resolver가 `originalPath`를 열지 않고 검증된 `basename` sibling만 읽으며, source self-reference·symlink escape·directory·size 초과를 injection 전에 거부하는지 확인해 주세요.
- macOS 26.5.2 registered Quick Look에서는 sibling read가 `permissionDenied=3`이므로 main document graceful fallback을 현재 계약으로 두고 entitlement 우회를 남기지 않았습니다.

## 검증

- `./scripts/build-rust-macos.sh --verify-lock`: arm64/x86_64 XCFramework, 15개 FFI symbol과 `rhwp-core.lock` 일치
- `./scripts/check-no-appkit.sh`: shared Swift의 AppKit/UIKit dependency 없음
- `xcodegen generate`: project 생성 성공, generated `project.pbxproj`는 검증 후 복원
- `ExternalImageTests`: resolver 18개 + bridge 6개, 총 24개/실패 0
- `HostApp` Debug build: embedded Preview/Thumbnail extension 포함 `BUILD SUCCEEDED`
- `validate-stage3-render.sh`: 기본 HWP fixture 3개 통과, Stage 4의 HWP/HWPX/embedded 5개 회귀도 통과
- pinned external fixture: valid `injected=3`, missing `injected=2/missing=1`, oversize `injected=2/tooLarge=1`; 모두 764-page render 성공
- signed registered Preview: `qlmanage -p`와 Finder에서 `permissionDenied=3`, main document fallback 유지, external path/basename 미노출
- `check-extension-registration-hygiene.sh --check-only`: development registration과 issue 없음
- `git diff --check` 및 core/FFI/framework 무변경 검사 통과

## 관련 이슈

- Parent/Epic: #407
- 선행 ABI: #408
- 설계 조사: #391
- 후속 renderer diagnostic: #410
- 후속 Thumbnail cache: #411
- 후속 fixture/visual suite: #412
- 후속 WKWebView bridge: #413

## 후속 이슈 제안

- 없음. 남은 제품 범위는 이미 #410, #411, #412, #413 이슈로 등록되어 있습니다.

## 남은 리스크

- 현재 macOS Quick Look sandbox는 main document의 sibling read capability를 extension에 제공하지 않아 실제 registered Preview에서는 external image가 누락됩니다.
- path 검증과 read 사이 TOCTOU 및 resource별 50 MB 외 document 전체 aggregate memory 상한은 후속 security/performance 검토 대상입니다.
- Thumbnail과 HostApp WKWebView는 각각 #411, #413 전까지 external image resolver가 비활성입니다.
