### PR TITLE
Task #441 Stage 4.1: PR #448 반영과 v0.1.9 후보 재검증 준비

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Maintained with support from **OpenAI’s [Codex for Open Source](https://develo
 
 ### v0.1.9
 
-`v0.1.9`은 upstream `rhwp v0.8.2` core와 bundled 편집기를 반영해 복잡한 표·페이지 배치, 저장 뒤 서식 보존, 오래된 HWP 그림 표시와 편집기의 입력·실행취소 안정성을 보강하고, 창 너비에 따라 viewer/editor 상단 도구 모음이 겹치거나 잘리던 문제를 수정하는 patch release입니다. HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 미리보기가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내합니다. Quick Look의 외부 연결 그림은 macOS가 sibling file 접근을 허용할 때만 불러오며, 접근이 거부돼도 문서 본문 미리보기는 계속 표시합니다.
+`v0.1.9`은 upstream `rhwp v0.8.2` core와 bundled 편집기를 반영해 복잡한 표·페이지 배치, 저장 뒤 서식 보존, 오래된 HWP 그림 표시와 편집기의 입력·실행취소 안정성을 보강하고, 창 너비에 따라 viewer/editor 상단 도구 모음이 겹치거나 잘리던 문제를 수정하는 patch release입니다. HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 미리보기가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내합니다. Quick Look의 외부 연결 그림은 macOS가 sibling file 접근을 허용할 때만 불러오며, 접근이 거부돼도 문서 본문 미리보기는 계속 표시합니다. 외부 그림 데이터를 처리할 때 Finder 썸네일 확장이 종료될 수 있던 문제도 수정했습니다.
 
 - GitHub Release: [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9)
 - 업데이트 페이지: [알한글 v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html)

--- a/docs/updates/v0.1.9.html
+++ b/docs/updates/v0.1.9.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#ffffff" />
   <meta name="description" content="알한글 v0.1.9 릴리즈 노트입니다." />
   <meta property="og:title" content="알한글 v0.1.9 릴리즈 노트" />
-  <meta property="og:description" content="rhwp v0.8.2 문서 처리·편집 개선, 반응형 툴바 수정과 Quick Look 충돌 안내를 포함한 알한글 패치 릴리즈입니다." />
+  <meta property="og:description" content="rhwp v0.8.2 문서 처리·편집 개선, 반응형 툴바와 Finder 썸네일 안정성 수정을 포함한 알한글 패치 릴리즈입니다." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html" />
   <meta property="og:image" content="https://postmelee.github.io/alhangeul-macos/assets/og-main.png" />
@@ -48,7 +48,7 @@
   <main id="main" class="updates-page">
     <section class="updates-hero" aria-labelledby="release-title">
       <h1 id="release-title">알한글 v0.1.9</h1>
-      <p><code>rhwp v0.8.2</code> 문서 처리·편집 개선, 반응형 툴바 수정과 Quick Look 충돌 안내를 포함한 패치 릴리즈입니다.</p>
+      <p><code>rhwp v0.8.2</code> 문서 처리·편집 개선, 반응형 툴바와 Finder 썸네일 안정성 수정을 포함한 패치 릴리즈입니다.</p>
       <div class="updates-actions" aria-label="릴리즈 주요 링크">
         <a class="page-action-button"
           href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.9/alhangeul-macos-0.1.9.dmg">
@@ -68,7 +68,7 @@
           <li>편집 뒤 저장할 때 문서 서식을 보존하는 범위와 편집기의 입력 반응성·실행취소 동작을 보강했습니다.</li>
           <li>창 너비가 바뀔 때 viewer/editor 상단 도구 모음과 서식 도구 모음이 겹치거나 잘리던 문제를 수정했습니다.</li>
           <li>HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 미리보기가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내합니다.</li>
-          <li>Quick Look에서 외부 연결 그림을 읽을 수 없는 경우에도 문서 본문 미리보기를 계속 표시하도록 처리 경계를 보강했습니다.</li>
+          <li>외부 연결 그림을 읽지 못해도 Quick Look 본문을 유지하고, 같은 그림을 처리하던 Finder 썸네일 확장이 종료될 수 있던 문제를 수정했습니다.</li>
         </ul>
       </section>
 
@@ -93,6 +93,7 @@
           <li>검증된 HOP Quick Look version이 알한글보다 오래된 <code>rhwp</code>를 포함하면 실행 안내와 About의 Quick Look 진단에서 버전 근거를 보여줍니다.</li>
           <li>알한글은 확장 프로그램 설정 화면만 열며 HOP이나 알한글 확장의 활성 상태를 자동으로 바꾸지 않습니다.</li>
           <li>Quick Look은 안전한 sibling filename만 외부 연결 그림 후보로 사용하고, 누락·권한 거부·크기 초과를 문서 전체 실패와 분리합니다.</li>
+          <li>Rust 이미지 데이터를 안전한 소유 버퍼로 전달해 외부 그림이 포함된 문서의 Finder 썸네일 안정성을 보강했습니다.</li>
           <li>설치본 version/build 기준은 <code>0.1.9 (15)</code>입니다.</li>
         </ul>
       </section>

--- a/mydocs/orders/20260729.md
+++ b/mydocs/orders/20260729.md
@@ -16,4 +16,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #441 | v0.1.9 public release 준비와 배포 실행 | 보류 | M900, Stage 4 signed candidate에서 #447 crash blocker 확인 · public publish 중단 |
+| #441 | v0.1.9 public release 준비와 배포 실행 | 진행중 | M900, Stage 4 재개 · PR #448 merge `f2a78b7` 반영 · 새 signed candidate 준비 |

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.9` | 후보 · Stage 3 완료 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
+| `v0.1.9` | 후보 · Stage 4 재검증중 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
 | `v0.1.8` | 공개 완료 | [Alhangeul v0.1.8](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) | [v0.1.8](https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html) | [`v0.1.8.md`](v0.1.8.md) |
 | `v0.1.7` | 공개 완료 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |
 | `v0.1.6` | 공개 완료 | [Alhangeul v0.1.6](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.6) | [v0.1.6](https://postmelee.github.io/alhangeul-macos/updates/v0.1.6.html) | [`v0.1.6.md`](v0.1.6.md) |

--- a/mydocs/release/v0.1.9.md
+++ b/mydocs/release/v0.1.9.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.9` build `15` Stage 3 완료, Stage 4 source PR 승인 대기 |
+| 상태 | `v0.1.9` build `15` Stage 4 재개, PR #448 반영 candidate 재생성중 |
 | 목표 Git tag | `v0.1.9` |
 | 목표 app version | `0.1.9` |
 | 목표 build | `15` |
@@ -18,6 +18,12 @@
 | Stage 3 exact candidate | `07b9f34cb14827223e085bc583406ba2654171c0` |
 | 유효 rehearsal | run `30424930226`, SHA256 `e5b03e67a03d1e4aecada0f78fc351dfeb904158a7259bdea5a3b6d8988f7db0` |
 | 폐기한 rehearsal 후보 | run `30365232108`, candidate `1d358103a877a9d0b6c924a280b84e60e94d6739` — PR #443 미포함 |
+| Stage 4 source / back-merge / release PR | PR #444 / PR #445 / PR #446 |
+| 기존 `main` release commit | `1e7f5df59684713745cb9d59c0a0e9dfdaaf0272` |
+| 기존 annotated tag | `v0.1.9` -> `1e7f5df59684713745cb9d59c0a0e9dfdaaf0272`, PR #448 미포함 |
+| 폐기한 signed draft | run `30432036513`, SHA256 `e854cedb59b8708d412151414ea877605209710ba850306d1f315c0a61d6e75a` |
+| Task #447 수정 PR / merge commit | PR #448 / `f2a78b799f62985d2767afc9ba4434581e9b10be` |
+| 새 candidate 기준 | `origin/devel` / `f2a78b799f62985d2767afc9ba4434581e9b10be`, `main` 반영·tag 재지정 전 |
 | GitHub Release 후보 | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9 |
 | Pages 릴리즈 노트 후보 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html |
 | Public DMG 후보 | `alhangeul-macos-0.1.9.dmg` |
@@ -28,29 +34,32 @@
 | upstream latest | `v0.8.2`, candidate lock과 일치 |
 | latest guard | `require_latest_rhwp=true`, 예외 계획 없음 |
 
-2026-07-28 live 조회에서 `v0.1.8`은 non-draft/non-prerelease public release이며, upstream latest는 `rhwp v0.8.2`였다. 2026-07-29에는 HostApp 툴바 회귀를 수정한 PR #443 변경이 merge돼 `origin/devel`이 `e2aef4c...`로 이동했고, Task #441 브랜치는 이를 `a9760bbe...`에서 통합했다. `v0.1.9` tag는 아직 없다.
+2026-07-28 live 조회에서 `v0.1.8`은 non-draft/non-prerelease public release이며, upstream latest는 `rhwp v0.8.2`였다. 2026-07-29에는 HostApp 툴바 회귀를 수정한 PR #443 변경을 통합한 뒤 PR #444 source 반영, PR #445 `main -> devel` back-merge와 PR #446 `devel -> main` release merge를 완료했다. annotated `v0.1.9` tag는 당시 `main` release commit `1e7f5df...`에 생성했다.
 
 기존 Release Rehearsal run `30365232108`은 PR #443 변경을 포함하지 않은 candidate `1d358103...`에서 실행됐다. workflow 자체는 성공했지만 릴리스 소유자 visual QA에서 차단 회귀가 확인됐으므로 해당 run과 artifact를 공개 릴리스 승인 근거로 재사용하지 않는다.
 
 새 exact candidate `07b9f34...`에서 source preflight를 다시 수행하고 Release Rehearsal run [`30424930226`](https://github.com/postmelee/alhangeul-macos/actions/runs/30424930226)을 실행했다. workflow, checksum, universal slice, DMG integrity/layout과 수동 앱 줌 smoke가 통과했다. rehearsal은 unsigned 검증 계층이며 signing/notarization 또는 public asset 근거가 아니다.
 
-최종 release candidate commit은 Task #441 Stage 1~3 source/communication PR, 필요한 `main -> devel` back-merge와 `devel -> main` release PR이 모두 반영된 뒤 확정한다. Stage 2의 candidate URL과 DMG 경로는 official publish 전까지 실제 public asset을 뜻하지 않는다.
+기존 tag에서 실행한 signed/notarized draft run [`30432036513`](https://github.com/postmelee/alhangeul-macos/actions/runs/30432036513)은 workflow 자체는 성공했지만 image data 수명 회귀로 Thumbnail crash가 확인돼 폐기했다. 해당 draft release는 비공개 상태이고 asset download count는 0이지만, DMG와 checksum은 새 후보의 서명·공증·smoke 근거로 재사용하지 않는다.
+
+Task #447 수정 PR #448 변경은 `devel` merge commit `f2a78b7...`에 반영됐다. 새 final candidate는 이 commit을 `main`에 반영하는 추가 release candidate PR, annotated tag 재지정, 새 Rehearsal과 새 signed draft를 모두 거쳐야 한다. tag 재지정과 workflow 실행은 release owner의 별도 승인 전에는 수행하지 않는다. candidate URL과 DMG 경로는 official publish 전까지 실제 public asset을 뜻하지 않는다.
 
 ## 사용자용 요약
 
 `v0.1.9`은 upstream `rhwp v0.8.2` core와 bundled 편집기를 반영해 복잡한 표·페이지 배치, 저장 뒤 서식 보존, 오래된 HWP 그림 표시와 편집기의 입력·실행취소 안정성을 보강하고, 창 너비에 따라 viewer/editor 상단 도구 모음이 겹치거나 잘리던 문제를 수정하는 patch release다.
 
-HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 provider가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내한다. Quick Look의 외부 연결 그림은 macOS가 sibling file 접근을 허용할 때만 불러오며, 접근이 거부돼도 문서 본문 미리보기는 계속 표시한다.
+HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 provider가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내한다. Quick Look의 외부 연결 그림은 macOS가 sibling file 접근을 허용할 때만 불러오며, 접근이 거부돼도 문서 본문 미리보기는 계속 표시한다. 외부 그림 데이터를 처리할 때 Finder Thumbnail extension이 종료될 수 있던 image buffer 수명 회귀도 수정했다.
 
 ## 직전 공개 릴리즈 대비 변경점
 
-기준 범위는 `v0.1.8^{}..origin/devel`이다. Stage 2 시작 시 `origin/devel`은 `76c86fc76a9e2b7291f80e57b8b85c7c1e1ff525`였고, PR #443 merge 뒤 현재 기준은 `e2aef4c232a48963f7e2abcaaca4bc4230b3b454`다. Task #441 타스크의 local metadata/communication commit과 final release transport는 final candidate 확정 시 다시 분석한다.
+기준 범위는 `v0.1.8^{}..origin/devel`이다. Stage 2 시작 시 `origin/devel`은 `76c86fc76a9e2b7291f80e57b8b85c7c1e1ff525`였고, PR #443 병합 뒤 `e2aef4c232a48963f7e2abcaaca4bc4230b3b454`, PR #444 및 PR #445 병합 뒤 `1b1213db5a0bd75638f54bf03d49fbf4cb63edcc`, PR #448 병합 뒤 현재 기준은 `f2a78b799f62985d2767afc9ba4434581e9b10be`다. 새 `main` release candidate가 확정되면 포함 PR 분석과 delta checklist를 다시 생성한다.
 
 | 영역 | 변경 |
 |------|------|
 | Upstream core/studio | PR #436: native core, RustBridge와 bundled `rhwp-studio`를 `v0.8.2` / `9b16aa9e...`로 full sync |
 | Sync 통합 검증 | PR #440: latest `devel` 결합에서 provenance, ABI, app target, renderer, Finder와 Release package를 검증하고 generated project drift를 정합화 |
 | HostApp 반응형 툴바 | PR #443: stale WKWebView layout override를 select 표시 보정으로 축소해 창 너비별 toolbar/style bar 겹침과 clipping을 수정하고 ownership guard 추가 |
+| Finder Thumbnail 안정성 | PR #448: RustBridge image data를 caller-owned buffer로 바꾸고 Swift exact free를 적용해 외부 그림 처리 중 use-after-free crash 수정 |
 | Quick Look external image | PR #437: Swift wrapper와 basename-only sibling resolver, privacy-safe report, permission failure의 main document fallback 추가 |
 | Quick Look 충돌 안내 | PR #434: HOP과 알한글의 검증된 `rhwp` provenance를 비교해 실행 안내, About 진단과 시스템 설정 진입 제공 |
 | Pages 문구 | PR #431: 프로젝트 철학 섹션과 Open Graph 설명 보강. 앱 릴리즈 주요 변화에서는 제외 |
@@ -65,6 +74,7 @@ HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는
 
 | PR | 제목 | 분류 | 사용자-facing | 공개 요약 반영 | 해결된 Issue | 참고/연관 Issue | 근거 문서 | 비고 |
 |----|------|------|---------------|----------------|---------------|-----------------|-----------|------|
+| `#448` | `Task #447: RustBridge image data 수명 회귀와 Thumbnail 크래시 수정` | 사용자-facing | 예 | 예 | `#447` | `#441` | PR body, `mydocs/report/task_m020_447_report.md` | caller-owned image buffer와 Swift exact free, signed candidate 재생성 필요 |
 | `#443` | `Task #442: rhwp-studio v0.8.2 HostApp 툴바 회귀 수정` | 사용자-facing | 예 | 예 | `#442` | `#441` | PR body, `mydocs/report/task_m010_442_report.md` | upstream responsive layout ownership 복원과 breakpoint별 visual 검증 |
 | `#440` | `Task #438: rhwp v0.8.2 sync 통합 검증과 Xcode project 정합화` | 개발자-facing | 아니오 | 예 | `#438` | `#409`, `#439` | PR body, `mydocs/report/task_m020_438_report.md` | 주요 변화 자체가 아니라 #436 결합과 release readiness 검증 근거 |
 | `#436` | `Sync rhwp upstream v0.8.2` | upstream sync | 예 | 예 | 없음 | `#438` | PR body, upstream `v0.7.19`~`v0.8.2` release note, `mydocs/report/task_m020_438_report.md` | core/studio 누적 개선과 provenance 갱신 |
@@ -72,7 +82,10 @@ HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는
 | `#434` | `Task #433: HOP Quick Look 충돌 가능성 감지와 최신 rhwp 안내 UI 추가` | 사용자-facing | 예 | 예 | `#433` | 없음 | PR body, `mydocs/report/task_m040_433_report.md` | provider를 강제 변경하지 않는 사용자 안내 |
 | `#431` | `Task #430: GitHub Pages 철학 문구와 Open Graph 설명 보강` | 문서-only | 예 | 아니오 | `#430` | 없음 | PR body, `mydocs/report/task_m010_430_report.md` | Pages 사용자 표면이지만 v0.1.9 앱 주요 변화와 분리 |
 | `#428` | `Task #424 Stage 4-6: v0.1.8 official publish 완료 기록` | 운영/배포 | 아니오 | 아니오 | `#424` | upstream `#2396`, PR `#2398` | PR body, `mydocs/report/task_m900_424_report.md` | 직전 public release closeout |
-| Task #441 PR 예정 | `v0.1.9 public release 준비와 배포 실행` | 운영/배포 | 아니오 | 아니오 | 진행중 `#441` | `#438`, `#439` | Issue body, `mydocs/plans/task_m900_441_impl.md` | version/build, communication과 release gate |
+| `#444` | `Task #441: v0.1.9 release candidate source 준비` | 운영/배포 | 아니오 | 아니오 | 없음 | `#441` | PR body, Stage 1~3 보고서 | version/build, communication과 preflight 기록을 `devel`에 반영 |
+| `#445` | `Task #441: main release 이력 역병합` | 운영/배포 | 아니오 | 아니오 | 없음 | `#441` | PR body | `main` 전용 이력을 `devel`에 보존 |
+| `#446` | `Release: Alhangeul v0.1.9` | 운영/배포 | 아니오 | 아니오 | 없음 | `#441` | PR body | 초기 release transport, PR #448 미포함으로 새 candidate PR 필요 |
+| Task #441 후보 갱신 PR 예정 | `v0.1.9 candidate에 PR #448 반영` | 운영/배포 | 아니오 | 아니오 | 진행중 `#441` | `#447` | Issue body, `mydocs/plans/task_m900_441_impl.md` | 새 `main` commit과 tag를 확정하는 transport |
 
 PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈는 PR body에서 후속 fixture/visual suite로만 참조되며 현재 OPEN이다. 따라서 해결된 Issue에서 제외하고 참고/연관 Issue로 보정했다.
 
@@ -84,7 +97,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - 편집 뒤 저장할 때 문서 서식을 보존하는 범위와 편집기의 입력 반응성·실행취소 동작을 보강했습니다.
 - 창 너비가 바뀔 때 viewer/editor 상단 도구 모음과 서식 도구 모음이 겹치거나 잘리던 문제를 수정했습니다.
 - HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 미리보기가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내합니다.
-- Quick Look에서 외부 연결 그림을 읽을 수 없는 경우에도 문서 본문 미리보기를 계속 표시하도록 처리 경계를 보강했습니다.
+- 외부 연결 그림을 읽지 못해도 Quick Look 본문을 유지하고, 같은 그림을 처리하던 Finder 썸네일 확장이 종료될 수 있던 문제를 수정했습니다.
 
 ### 포함된 rhwp 변화
 
@@ -103,11 +116,13 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - 알한글은 확장 프로그램 설정 화면만 열며 HOP이나 알한글 확장의 활성 상태를 자동으로 바꾸지 않습니다.
 - Quick Look은 안전한 sibling filename만 외부 연결 그림 후보로 사용하고, 누락·권한 거부·크기 초과를 문서 전체 실패와 분리합니다.
 - registered Quick Look sandbox가 sibling file 접근을 허용하지 않으면 외부 연결 그림은 빠지지만 문서 본문 미리보기는 유지됩니다.
+- RustBridge image data를 caller-owned buffer로 전달하고 Swift가 복사 직후 해제하도록 정렬해 외부 그림이 포함된 문서의 Finder 썸네일 안정성을 보강했습니다.
 
 ### 릴리즈 요약에 반영된 PR
 
 - [#436: Sync rhwp upstream v0.8.2](https://github.com/postmelee/alhangeul-macos/pull/436) - core와 bundled editor의 v0.8.2 반영 근거입니다.
 - [#443: Task #442: rhwp-studio v0.8.2 HostApp 툴바 회귀 수정](https://github.com/postmelee/alhangeul-macos/pull/443) - 창 너비별 툴바 배치와 WKWebView 보정 경계를 수정한 근거입니다.
+- [#448: Task #447: RustBridge image data 수명 회귀와 Thumbnail 크래시 수정](https://github.com/postmelee/alhangeul-macos/pull/448) - 외부 그림 처리 중 Finder 썸네일 확장이 종료될 수 있던 문제를 수정한 근거입니다.
 - [#434: Task #433: HOP Quick Look 충돌 가능성 감지와 최신 rhwp 안내 UI 추가](https://github.com/postmelee/alhangeul-macos/pull/434) - HOP과 알한글 Quick Look 충돌 안내 근거입니다.
 - [#437: Task #409: Swift external image wrapper/resolver와 Quick Look Preview 적용](https://github.com/postmelee/alhangeul-macos/pull/437) - 외부 연결 그림 resolver와 permission fallback 근거입니다.
 - [#440: Task #438: rhwp v0.8.2 sync 통합 검증과 Xcode project 정합화](https://github.com/postmelee/alhangeul-macos/pull/440) - v0.8.2와 최신 앱 경로의 통합 검증 근거입니다.
@@ -116,6 +131,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 
 - [#438: rhwp v0.8.2 full sync와 최신 devel 통합 검증](https://github.com/postmelee/alhangeul-macos/issues/438) - v0.8.2 core/studio 동기화와 앱 통합 검증을 완료했습니다.
 - [#442: rhwp-studio v0.8.2 반영 후 HostApp 상단 툴바 겹침 수정](https://github.com/postmelee/alhangeul-macos/issues/442) - 창 너비별 툴바 겹침·clipping 회귀를 수정했습니다.
+- [#447: rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정](https://github.com/postmelee/alhangeul-macos/issues/447) - image data 소유권 회귀와 signed candidate 차단 크래시를 수정했습니다.
 - [#433: HOP Quick Look 충돌 가능성 감지와 최신 rhwp 안내 UI 추가](https://github.com/postmelee/alhangeul-macos/issues/433) - 충돌 가능성 안내와 사용자 설정 경로를 추가했습니다.
 - [#409: Swift external image wrapper/resolver와 Quick Look Preview 적용](https://github.com/postmelee/alhangeul-macos/issues/409) - Swift resolver와 Quick Look fallback 계약을 완료했습니다.
 
@@ -128,6 +144,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 
 - PR #436 변경은 `v0.7.18`에서 `v0.8.2`까지 네 개 upstream release의 누적 변경을 반영한다.
 - PR #443 변경은 기존 rehearsal 뒤 발견된 HostApp 툴바 차단 회귀를 수정했다. run `30365232108`과 candidate `1d358103...`는 폐기했고, 새 exact candidate `07b9f34...`의 run `30424930226`에서 source preflight와 rehearsal을 다시 통과했다.
+- PR #448 변경은 기존 signed draft에서 확인한 RustBridge image data use-after-free를 caller-owned allocation과 Swift exact free로 수정했다. run `30432036513`, 당시 tag commit `1e7f5df...`와 DMG는 폐기하며, PR #448 변경을 포함한 candidate에서 Rehearsal과 signed draft를 모두 다시 실행한다.
 - strict local `librhwp.a` byte hash/size는 기존 lock reference와 다르지만 source tag/commit, Cargo resolution, generated header와 15개 FFI symbol은 일치했다. Stage 3에서 strict와 portable 결과를 분리해 portable release artifact 경계를 허용했다.
 - upstream `v0.8.2`에는 studio PDF 안내 modal 관련 Issue #3450 이슈와 page-local repaint 관련 Issue #3412 이슈가 알려진 문제로 남아 있다. 실제 알한글 장문서·인쇄/PDF 경로는 signed candidate gate 전까지 통과로 기록하지 않는다.
 
@@ -139,8 +156,9 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | [#433](https://github.com/postmelee/alhangeul-macos/issues/433) | [#434](https://github.com/postmelee/alhangeul-macos/pull/434) | merge·close 완료 | HOP Quick Look 충돌 안내 |
 | [#438](https://github.com/postmelee/alhangeul-macos/issues/438) | [#436](https://github.com/postmelee/alhangeul-macos/pull/436), [#440](https://github.com/postmelee/alhangeul-macos/pull/440) | merge·close 완료 | `rhwp v0.8.2` full sync와 통합 검증 |
 | [#442](https://github.com/postmelee/alhangeul-macos/issues/442) | [#443](https://github.com/postmelee/alhangeul-macos/pull/443) | merge·close 완료 | HostApp responsive toolbar와 WKWebView override 경계 수정 |
+| [#447](https://github.com/postmelee/alhangeul-macos/issues/447) | [#448](https://github.com/postmelee/alhangeul-macos/pull/448) | merge·close 완료 | RustBridge image data 수명 회귀와 Thumbnail crash 수정 |
 | [#439](https://github.com/postmelee/alhangeul-macos/issues/439) | 없음 | Open | sync workflow provenance 자동화 후속 |
-| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | 예정 | 진행중 | `v0.1.9` release candidate와 public release 실행 |
+| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | [#444](https://github.com/postmelee/alhangeul-macos/pull/444), [#445](https://github.com/postmelee/alhangeul-macos/pull/445), [#446](https://github.com/postmelee/alhangeul-macos/pull/446), 후보 갱신 PR 예정 | 진행중 | PR #448 포함 candidate와 public release 실행 |
 
 ## 검증 기준
 
@@ -150,14 +168,16 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | Core lock | `rhwp_release_tag=v0.8.2`, commit `9b16aa9e...` | Stage 1 통과 |
 | Studio asset | bundled manifest가 `v0.8.2` / `9b16aa9e...` | Stage 1 통과 |
 | Workflow default | `0.1.9`, `v0.1.8`, `v0.8.2` | Stage 1 통과 |
-| Release PR analysis | `v0.1.8..candidate` merge PR 7개 + Task #441 | `07b9f34...`에서 재생성 통과, final candidate에서 반복 필요 |
-| Release communication | README, Pages home/update, release index/record | PR #443 사용자 영향 보정 완료 |
+| Release PR analysis | `v0.1.8..candidate` merge PR과 Task #441 transport | PR #448 포함 초안 보정, final `main` candidate에서 반복 필요 |
+| Release communication | README, Pages home/update, release index/record | PR #443 및 PR #448 사용자 영향 보정 |
 | Static archive | strict byte reference와 portable source/header/FFI를 분리 | strict mismatch 기록, portable 검증 통과·허용 |
 | Shared Swift boundary | `Sources/RhwpCoreBridge` AppKit/UIKit 의존 없음 | Stage 3 통과 |
-| Rust/Swift tests | RustBridge와 ExternalImageTests | `4/4`, `24/24` 통과 |
-| Release build/render | 세 target Release build, representative renderer와 policy | Stage 3 통과 |
+| Rust/Swift tests | RustBridge와 ExternalImageTests | PR #448 기준 `7/7`, `27/27` 통과 |
+| Release build/render | 세 target build, representative renderer와 image visual harness | PR #448 기준 통과, final candidate에서 release gate 반복 필요 |
 | Rehearsal DMG | unsigned rehearsal layout/checksum | run `30424930226`, checksum/integrity/universal 통과 |
-| Signed Finder/Preview | 실제 provider path, HWP/HWPX, external sibling fallback | Stage 4 차단 gate |
+| Signed draft DMG | Developer ID signing/notarization/staple/Gatekeeper | run `30432036513`은 PR #448 미포함으로 폐기, 새 candidate 필요 |
+| Signed Finder/Preview | 실제 provider path, HWP/HWPX, external sibling fallback | PR #448 포함 새 Stage 4 차단 gate |
+| Image-heavy Thumbnail | HWP 3종 + HWPX 1종 반복, crash 0 | PR #448 local candidate 20/20, 새 signed provider에서 반복 필요 |
 | Signed editor | 장문서 repaint, 인쇄 preview와 PDF 시작 경로 | Stage 4 차단 gate |
 | Public update | v0.1.8 -> v0.1.9 Sparkle와 extension refresh | Stage 5 예정 |
 | Homebrew | official public DMG URL/SHA256과 install/uninstall | 별도 승인 필요 |
@@ -190,11 +210,15 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - [x] 포함 PR 자동 분석과 release owner 판정 작성
 - [x] source preflight, strict/portable artifact와 universal package 검증
 - [x] 별도 승인 후 Rehearsal workflow 실행과 artifact 검증
-- [ ] Task #441 source PR을 `devel`에 merge
-- [ ] `main` 전용 PR #432 변경의 reviewed back-merge 필요 여부 확정
-- [ ] 별도 승인 후 `devel -> main` release PR merge
-- [ ] 별도 승인 후 정확한 final candidate에 annotated `v0.1.9` tag 생성
-- [ ] 별도 승인 후 `draft=true`, `prerelease=false` Publish workflow 실행
+- [x] Task #441 source PR #444 변경을 `devel`에 merge
+- [x] `main` 전용 이력을 PR #445 변경으로 `devel`에 back-merge
+- [x] 초기 `devel -> main` release PR #446 merge와 annotated `v0.1.9` tag 생성
+- [x] 초기 `draft=true`, `prerelease=false` run `30432036513` 실행
+- [x] 초기 signed candidate crash를 Issue #447 이슈로 분리하고 PR #448 변경으로 `devel`에 수정
+- [ ] PR #448 포함 `devel -> main` candidate 갱신 PR merge
+- [ ] 별도 승인 후 정확한 새 final candidate로 annotated `v0.1.9` tag 재지정
+- [ ] 새 final candidate에서 Release Rehearsal 재실행
+- [ ] 새 final candidate에서 `draft=true`, `prerelease=false` Publish workflow 재실행
 - [ ] signed/notarized draft DMG의 앱, Finder, Preview, editor와 Sparkle 차단 gate 통과
 - [ ] 별도 승인 후 official stable Publish workflow 실행
 - [ ] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
@@ -211,6 +235,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - HOP 충돌 안내는 HOP Preview `0.2.0 -> rhwp v0.7.13`처럼 검증된 mapping만 사용하며 실제 활성 provider를 판정하거나 자동 변경하지 않는다.
 - upstream `v0.8.2` known issue인 page-local repaint Issue #3412 이슈와 PDF 안내 modal Issue #3450 이슈의 알한글 영향은 Stage 4 signed editor smoke 전까지 미확정이다.
 - strict local `librhwp.a` byte reference mismatch가 남아 있다. Stage 3에서 portable source/Cargo/header/FFI/XCFramework 검증과 분리해 기록하고, workflow의 문서화된 portable release artifact 경계를 허용했다.
+- 기존 `v0.1.9` tag와 draft release는 PR #448 미포함 commit을 가리킨다. 새 candidate PR merge, tag 재지정과 workflow 재실행 전까지 release 근거로 사용하지 않는다.
 - Skia Thumbnail/Quick Look 경로의 production default 전환은 이번 release 범위가 아니다.
 - public DMG SHA256, appcast EdDSA signature, notarization, signed provider provenance와 Homebrew digest는 Stage 2에서 단정하지 않는다.
 - Intel Mac 실기기 설치·실행은 아직 수행하지 않았다. universal slice 자동 검증과 별개 잔여 위험으로 유지한다.
@@ -229,8 +254,10 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - [x] HOP provider 자동 변경을 주장하지 않음
 - [x] external sibling source-level 성립과 registered sandbox 제한을 분리
 - [x] PR #443 변경의 반응형 툴바 회귀 수정과 기존 rehearsal 무효화를 반영
+- [x] PR #448 변경의 Thumbnail crash 수정과 기존 signed draft 무효화를 반영
 - [x] strict artifact, signed Finder/editor, Intel Mac과 public digest를 미확정 gate로 유지
 - [x] source preflight와 Rehearsal 검증
+- [ ] PR #448 포함 final candidate source preflight와 Rehearsal 재검증
 - [ ] installed signed candidate의 Finder/Preview/editor와 Sparkle 차단 gate
 - [ ] public DMG와 SHA256 기록
 - [ ] public GitHub Release와 Pages/Sparkle 확인


### PR DESCRIPTION
## 요약

- 대상 타스크: Issue #441 대상 v0.1.9 release candidate 갱신
- 왜: 기존 `v0.1.9` tag와 signed draft는 PR #448 변경의 Finder Thumbnail crash 수정을 포함하지 않아 재사용할 수 없습니다.
- 무엇: PR #448 merge commit `f2a78b7...`을 새 후보 기준으로 기록하고 README, Pages 릴리즈 노트와 내부 release record의 사용자 문구·상태를 보정했습니다.
- 리뷰 포인트: 기존 tag/draft를 폐기한 근거, PR #448 사용자 영향, 새 `main` 후보·tag·Rehearsal·signed draft를 각각 다시 수행한다는 gate를 확인해 주세요.

이 PR은 Stage 4 재개에 필요한 communication과 release record를 `devel`에 반영하는 중간 gate입니다. Issue #441 이슈를 닫지 않으며 tag 재지정, workflow 실행, GitHub Release 공개, Pages/Sparkle 배포와 Homebrew 반영을 수행하지 않습니다.

## PR base

- base: `devel`
- head: `publish/task441`
- source base: PR #448 merge commit `f2a78b799f62985d2767afc9ba4434581e9b10be`

## 변경 내역

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| 사용자 문구 | README와 `docs/updates/v0.1.9.html`에 Finder Thumbnail 안정성 수정 추가 | 기술 내부 계약보다 사용자 증상 중심으로 설명 |
| 릴리스 상태 | release index와 오늘할일을 Stage 4 재검증 상태로 갱신 | public 완료로 오인할 표현 없음 |
| 릴리스 기록 | PR #444~#448, 기존 tag/draft 폐기 근거와 새 candidate gate 기록 | old artifact를 승인 근거로 재사용하지 않음 |
| 배포 경계 | candidate PR, tag 재지정, Rehearsal, signed draft를 미완료 gate로 유지 | 각 외부 mutation은 별도 승인 후 진행 |

- 릴리스 기록: `mydocs/release/v0.1.9.md`
- 사용자 릴리즈 노트: `docs/updates/v0.1.9.html`
- 작업 상태: `mydocs/orders/20260729.md`

## 핵심 리뷰 포인트

- 기존 annotated `v0.1.9` tag는 `1e7f5df59684713745cb9d59c0a0e9dfdaaf0272`를 가리키며 PR #448 변경을 포함하지 않습니다.
- 기존 signed draft run `30432036513`과 SHA256 `e854cedb59b8708d412151414ea877605209710ba850306d1f315c0a61d6e75a`는 폐기 상태로 기록했습니다.
- 새 후보는 PR #448 merge commit `f2a78b799f62985d2767afc9ba4434581e9b10be` 이후의 exact `main` merge commit으로 확정해야 합니다.
- tag 강제 재지정, 새 Rehearsal, 새 signed draft와 official publish는 이 PR의 범위가 아니며 각각 별도 승인 gate입니다.

## 검증

- `rhwp-core.lock`, bundled studio와 `RhwpCoreBuildInfo`: `rhwp v0.8.2` / resolved commit 일치
- RustBridge build lock, generated header/XCFramework와 공개 FFI 15개 symbol 검증 통과
- Rust test 7/7, `ExternalImageTests` 27/27 통과
- HostApp, QLExtension, ThumbnailExtension Release build 통과
- representative HWP/HWPX renderer 5/5 통과
- local `0.1.9 (15)` universal package와 ZIP 무결성 검증 통과
- app/extension `x86_64 arm64`, 법적 고지 3종 원본 일치, ad-hoc codesign 검증 통과
- local ZIP SHA256 `34f5f8a08dc81f541e5ec04e29569fa9f8e8eb36519cfef8f21ed1992ef4b8ee`
- registration hygiene issue 0, development registration 0
- release helper, GitHub body와 version notice 검증 및 `git diff --check` 통과

## 관련 이슈와 PR

- [#441: v0.1.9 public release 준비와 배포 실행](https://github.com/postmelee/alhangeul-macos/issues/441)
- [#447: rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정](https://github.com/postmelee/alhangeul-macos/issues/447)
- [PR #448: Task #447 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정](https://github.com/postmelee/alhangeul-macos/pull/448)

## 남은 리스크

- 새 `main` candidate, annotated tag 재지정, Rehearsal과 signed/notarized draft는 아직 실행하지 않았습니다.
- signed candidate의 실제 Finder provider, external sibling fallback, 장문서 repaint와 인쇄/PDF 경로는 새 draft DMG에서 다시 확인해야 합니다.
- Intel Mac 실기기 설치·실행은 아직 확인하지 않았습니다.

Refs #441