### PR TITLE
Release: Alhangeul v0.1.9 후보 갱신 (PR #448 반영)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Maintained with support from **OpenAI’s [Codex for Open Source](https://develo
 
 ### v0.1.9
 
-`v0.1.9`은 upstream `rhwp v0.8.2` core와 bundled 편집기를 반영해 복잡한 표·페이지 배치, 저장 뒤 서식 보존, 오래된 HWP 그림 표시와 편집기의 입력·실행취소 안정성을 보강하고, 창 너비에 따라 viewer/editor 상단 도구 모음이 겹치거나 잘리던 문제를 수정하는 patch release입니다. HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 미리보기가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내합니다. Quick Look의 외부 연결 그림은 macOS가 sibling file 접근을 허용할 때만 불러오며, 접근이 거부돼도 문서 본문 미리보기는 계속 표시합니다.
+`v0.1.9`은 upstream `rhwp v0.8.2` core와 bundled 편집기를 반영해 복잡한 표·페이지 배치, 저장 뒤 서식 보존, 오래된 HWP 그림 표시와 편집기의 입력·실행취소 안정성을 보강하고, 창 너비에 따라 viewer/editor 상단 도구 모음이 겹치거나 잘리던 문제를 수정하는 patch release입니다. HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 미리보기가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내합니다. Quick Look의 외부 연결 그림은 macOS가 sibling file 접근을 허용할 때만 불러오며, 접근이 거부돼도 문서 본문 미리보기는 계속 표시합니다. 외부 그림 데이터를 처리할 때 Finder 썸네일 확장이 종료될 수 있던 문제도 수정했습니다.
 
 - GitHub Release: [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9)
 - 업데이트 페이지: [알한글 v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html)

--- a/RustBridge/README.md
+++ b/RustBridge/README.md
@@ -24,7 +24,7 @@
 
 ## Core dependency 기준
 
-현재 `rhwp-core.lock`과 `RustBridge/Cargo.toml`은 release tag `v0.7.17`, resolved commit `03351190ec35436e58cbfee0aa9278a8fdc04a59`, feature `native-skia`를 기준으로 한다. Stable 기준은 release tag와 resolved commit을 함께 고정하며 branch/floating ref는 사용하지 않는다.
+현재 `rhwp-core.lock`과 `RustBridge/Cargo.toml`은 release tag `v0.8.2`, resolved commit `9b16aa9e23f476e2b335d7c029fc9f24a199d63c`, feature `native-skia`를 기준으로 한다. Stable 기준은 release tag와 resolved commit을 함께 고정하며 branch/floating ref는 사용하지 않는다.
 
 채널별 dependency 기준, lock 필드, compatibility gate 상세는 [`core_release_compatibility.md`](../mydocs/tech/core_release_compatibility.md)를 참조한다.
 
@@ -60,7 +60,8 @@ RustBridge는 external image 파일을 직접 찾거나 읽지 않는다. Swift/
 - filename, key, data, display path 입력 pointer는 caller-owned이며 호출 동안만 빌려 쓴다.
 - `rhwp_external_image_refs_json` 반환 문자열은 Rust-owned이며 `rhwp_free_string`으로 해제한다.
 - injection에 성공하면 upstream document가 image bytes를 복사해 소유한다.
-- `rhwp_image_data` 반환 pointer는 document-owned이므로 caller는 즉시 복사하고 setter/injection 같은 mutable 호출을 넘겨 보관하지 않는다.
+- `rhwp_image_data`가 반환한 non-null pointer는 caller-owned Rust allocation이다. caller는 bytes를 복사한 뒤 반환받은 동일 pointer와 length를 `rhwp_free_bytes`에 정확히 한 번 전달한다.
+- `rhwp_image_data` allocation은 document handle과 독립이며 `rhwp_free_bytes` 호출 전까지 유효하다. free 뒤 pointer를 보관하거나 다시 해제하지 않는다.
 - `originalPath`와 `display_path`는 bridge가 filesystem 접근 경로로 해석하지 않는다.
 
 pinned public API에는 embedded/external/missing/injected 전체 image 상태를 반환하는 함수가 없어 `rhwp_image_state_json`은 제공하지 않는다. External 상태는 refs JSON의 `loaded`로 전달하고 renderer missing/decode diagnostic은 downstream renderer 이슈에서 별도로 다룬다.

--- a/RustBridge/src/lib.rs
+++ b/RustBridge/src/lib.rs
@@ -351,31 +351,38 @@ pub extern "C" fn rhwp_image_data(
     handle: *const RhwpHandle,
     bin_data_id: u16,
     out_len: *mut usize,
-) -> *const u8 {
-    if handle.is_null() || out_len.is_null() || bin_data_id == 0 {
-        if !out_len.is_null() {
-            unsafe {
-                *out_len = 0;
-            }
-        }
-        return ptr::null();
+) -> *mut u8 {
+    if out_len.is_null() {
+        return ptr::null_mut();
     }
-    let h = unsafe { &*handle };
-    let idx = (bin_data_id - 1) as usize;
-    match h.doc.get_bin_data(idx) {
-        Some(data) => {
-            unsafe {
-                *out_len = data.len();
-            }
-            data.as_ptr()
-        }
-        None => {
-            unsafe {
-                *out_len = 0;
-            }
-            ptr::null()
-        }
+
+    unsafe {
+        *out_len = 0;
     }
+    if handle.is_null() || bin_data_id == 0 {
+        return ptr::null_mut();
+    }
+
+    let result = catch_unwind(AssertUnwindSafe(|| {
+        let h = unsafe { &*handle };
+        let idx = (bin_data_id - 1) as usize;
+        match h.doc.get_bin_data(idx) {
+            Some(data) if !data.is_empty() => {
+                let mut owned = data.into_boxed_slice();
+                let owned_len = owned.len();
+                let owned_ptr = owned.as_mut_ptr();
+                std::mem::forget(owned);
+
+                unsafe {
+                    *out_len = owned_len;
+                }
+                owned_ptr
+            }
+            Some(_) | None => ptr::null_mut(),
+        }
+    }));
+
+    result.unwrap_or(ptr::null_mut())
 }
 
 #[no_mangle]
@@ -485,9 +492,40 @@ mod tests {
         }
     }
 
+    struct TestBytes {
+        ptr: *mut u8,
+        len: usize,
+    }
+
+    impl TestBytes {
+        fn from_image(handle: *const RhwpHandle, bin_data_id: u16) -> Self {
+            let mut len = 0;
+            let ptr = rhwp_image_data(handle, bin_data_id, &mut len);
+            assert!(!ptr.is_null());
+            assert!(len > 0);
+            Self { ptr, len }
+        }
+
+        fn as_slice(&self) -> &[u8] {
+            unsafe { std::slice::from_raw_parts(self.ptr, self.len) }
+        }
+    }
+
+    impl Drop for TestBytes {
+        fn drop(&mut self) {
+            rhwp_free_bytes(self.ptr, self.len);
+        }
+    }
+
     fn open_fixture() -> TestHandle {
-        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../samples/basic/KTX.hwp");
-        let data = fs::read(fixture).expect("KTX fixture should be readable");
+        open_fixture_at("samples/basic/KTX.hwp")
+    }
+
+    fn open_fixture_at(relative_path: &str) -> TestHandle {
+        let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join(relative_path);
+        let data = fs::read(fixture).expect("fixture should be readable");
         let handle = rhwp_open(data.as_ptr(), data.len());
         assert!(!handle.is_null());
         TestHandle(handle)
@@ -645,5 +683,66 @@ mod tests {
             Err(())
         );
         assert_eq!(external_image_reference_loaded("{}", "binData:1"), Err(()));
+    }
+
+    #[test]
+    fn image_data_owned_buffer_survives_allocator_pressure_and_handle_close() {
+        let handle = open_fixture_at("samples/복학원서.hwp");
+
+        let expected = {
+            let bytes = TestBytes::from_image(handle.0, 1);
+            bytes.as_slice().to_vec()
+        };
+        assert!(!expected.is_empty());
+
+        let bytes = TestBytes::from_image(handle.0, 1);
+        let pressure: Vec<Vec<u8>> = (0..64)
+            .map(|index| vec![index as u8; expected.len() + index])
+            .collect();
+        std::hint::black_box(&pressure);
+        assert_eq!(bytes.as_slice(), expected);
+
+        drop(handle);
+
+        let more_pressure: Vec<Vec<u8>> = (0..64)
+            .map(|index| vec![index as u8; expected.len() + index + 64])
+            .collect();
+        std::hint::black_box(&more_pressure);
+        assert_eq!(bytes.as_slice(), expected);
+    }
+
+    #[test]
+    fn repeated_image_data_allocations_are_independently_owned() {
+        let handle = open_fixture_at("samples/복학원서.hwp");
+        let first = TestBytes::from_image(handle.0, 1);
+        let second = TestBytes::from_image(handle.0, 1);
+
+        assert_eq!(first.as_slice(), second.as_slice());
+        let expected = second.as_slice().to_vec();
+        drop(first);
+
+        let pressure: Vec<Vec<u8>> = (0..64)
+            .map(|index| vec![index as u8; expected.len() + index])
+            .collect();
+        std::hint::black_box(&pressure);
+        assert_eq!(second.as_slice(), expected);
+    }
+
+    #[test]
+    fn image_data_invalid_inputs_reset_output_length() {
+        let mut len = usize::MAX;
+        assert!(rhwp_image_data(ptr::null(), 1, &mut len).is_null());
+        assert_eq!(len, 0);
+
+        let handle = open_fixture_at("samples/복학원서.hwp");
+        len = usize::MAX;
+        assert!(rhwp_image_data(handle.0, 0, &mut len).is_null());
+        assert_eq!(len, 0);
+
+        len = usize::MAX;
+        assert!(rhwp_image_data(handle.0, u16::MAX, &mut len).is_null());
+        assert_eq!(len, 0);
+
+        assert!(rhwp_image_data(handle.0, 1, ptr::null_mut()).is_null());
     }
 }

--- a/Sources/RhwpCoreBridge/RhwpDocument.swift
+++ b/Sources/RhwpCoreBridge/RhwpDocument.swift
@@ -322,20 +322,32 @@ class RhwpDocument {
 
     /// 이미지 바이너리 데이터를 반환한다 (bin_data_id는 1-indexed).
     func imageData(binDataId: UInt16) -> Data? {
-        var len: Int = 0
+        var len: UInt = 0
         guard let ptr = rhwp_image_data(handle, binDataId, &len), len > 0 else {
             return nil
         }
-        return Data(bytes: ptr, count: len)
+        defer {
+            rhwp_free_bytes(ptr, len)
+        }
+        guard len <= UInt(Int.max) else {
+            return nil
+        }
+        return Data(bytes: ptr, count: Int(len))
     }
 
     /// 이미지 바이너리의 존재 여부와 길이만 확인한다 (bin_data_id는 1-indexed).
     func imageDataLength(binDataId: UInt16) -> Int? {
-        var len: Int = 0
-        guard rhwp_image_data(handle, binDataId, &len) != nil, len > 0 else {
+        var len: UInt = 0
+        guard let ptr = rhwp_image_data(handle, binDataId, &len), len > 0 else {
             return nil
         }
-        return len
+        defer {
+            rhwp_free_bytes(ptr, len)
+        }
+        guard len <= UInt(Int.max) else {
+            return nil
+        }
+        return Int(len)
     }
 
     func hasImageData(binDataId: UInt16) -> Bool {

--- a/Tests/ExternalImageTests/RhwpDocumentExternalImageBridgeTests.swift
+++ b/Tests/ExternalImageTests/RhwpDocumentExternalImageBridgeTests.swift
@@ -135,4 +135,63 @@ final class RhwpDocumentExternalImageBridgeTests: XCTestCase {
             XCTAssertEqual(try document.externalImageReferences(), [])
         }
     }
+
+    func testImageDataCopyAndLengthRemainStableUnderAllocationPressure() throws {
+        let document = try RhwpDocument(
+            data: ExternalImageTestSupport.sampleData(at: "samples/복학원서.hwp"),
+            filename: "복학원서.hwp"
+        )
+        let expected = try XCTUnwrap(document.imageData(binDataId: 1))
+
+        XCTAssertFalse(expected.isEmpty)
+        XCTAssertEqual(document.imageDataLength(binDataId: 1), expected.count)
+
+        for index in 0..<128 {
+            let pressure = Data(
+                repeating: UInt8(truncatingIfNeeded: index),
+                count: expected.count + index
+            )
+            XCTAssertEqual(document.imageData(binDataId: 1), expected)
+            XCTAssertEqual(document.imageDataLength(binDataId: 1), expected.count)
+            XCTAssertEqual(pressure.count, expected.count + index)
+        }
+    }
+
+    func testCopiedImageDataOutlivesDocument() throws {
+        let copiedImage: Data = try {
+            let document = try RhwpDocument(
+                data: ExternalImageTestSupport.sampleData(at: "samples/복학원서.hwp"),
+                filename: "복학원서.hwp"
+            )
+            return try XCTUnwrap(document.imageData(binDataId: 1))
+        }()
+
+        let expectedCount = copiedImage.count
+        let expectedPrefix = Data(copiedImage.prefix(32))
+        let pressure = (0..<128).map {
+            Data(repeating: UInt8(truncatingIfNeeded: $0), count: expectedCount + $0)
+        }
+        let reopenedDocument = try RhwpDocument(
+            data: ExternalImageTestSupport.sampleData(at: "samples/복학원서.hwp"),
+            filename: "복학원서.hwp"
+        )
+
+        XCTAssertFalse(copiedImage.isEmpty)
+        XCTAssertEqual(copiedImage.count, expectedCount)
+        XCTAssertEqual(Data(copiedImage.prefix(32)), expectedPrefix)
+        XCTAssertEqual(copiedImage, reopenedDocument.imageData(binDataId: 1))
+        XCTAssertEqual(pressure.count, 128)
+    }
+
+    func testImageDataRejectsInvalidIdentifiers() throws {
+        let document = try RhwpDocument(
+            data: ExternalImageTestSupport.sampleData(at: "samples/복학원서.hwp"),
+            filename: "복학원서.hwp"
+        )
+
+        XCTAssertNil(document.imageData(binDataId: 0))
+        XCTAssertNil(document.imageDataLength(binDataId: 0))
+        XCTAssertNil(document.imageData(binDataId: UInt16.max))
+        XCTAssertNil(document.imageDataLength(binDataId: UInt16.max))
+    }
 }

--- a/docs/updates/v0.1.9.html
+++ b/docs/updates/v0.1.9.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#ffffff" />
   <meta name="description" content="알한글 v0.1.9 릴리즈 노트입니다." />
   <meta property="og:title" content="알한글 v0.1.9 릴리즈 노트" />
-  <meta property="og:description" content="rhwp v0.8.2 문서 처리·편집 개선, 반응형 툴바 수정과 Quick Look 충돌 안내를 포함한 알한글 패치 릴리즈입니다." />
+  <meta property="og:description" content="rhwp v0.8.2 문서 처리·편집 개선, 반응형 툴바와 Finder 썸네일 안정성 수정을 포함한 알한글 패치 릴리즈입니다." />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html" />
   <meta property="og:image" content="https://postmelee.github.io/alhangeul-macos/assets/og-main.png" />
@@ -48,7 +48,7 @@
   <main id="main" class="updates-page">
     <section class="updates-hero" aria-labelledby="release-title">
       <h1 id="release-title">알한글 v0.1.9</h1>
-      <p><code>rhwp v0.8.2</code> 문서 처리·편집 개선, 반응형 툴바 수정과 Quick Look 충돌 안내를 포함한 패치 릴리즈입니다.</p>
+      <p><code>rhwp v0.8.2</code> 문서 처리·편집 개선, 반응형 툴바와 Finder 썸네일 안정성 수정을 포함한 패치 릴리즈입니다.</p>
       <div class="updates-actions" aria-label="릴리즈 주요 링크">
         <a class="page-action-button"
           href="https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.9/alhangeul-macos-0.1.9.dmg">
@@ -68,7 +68,7 @@
           <li>편집 뒤 저장할 때 문서 서식을 보존하는 범위와 편집기의 입력 반응성·실행취소 동작을 보강했습니다.</li>
           <li>창 너비가 바뀔 때 viewer/editor 상단 도구 모음과 서식 도구 모음이 겹치거나 잘리던 문제를 수정했습니다.</li>
           <li>HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 미리보기가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내합니다.</li>
-          <li>Quick Look에서 외부 연결 그림을 읽을 수 없는 경우에도 문서 본문 미리보기를 계속 표시하도록 처리 경계를 보강했습니다.</li>
+          <li>외부 연결 그림을 읽지 못해도 Quick Look 본문을 유지하고, 같은 그림을 처리하던 Finder 썸네일 확장이 종료될 수 있던 문제를 수정했습니다.</li>
         </ul>
       </section>
 
@@ -93,6 +93,7 @@
           <li>검증된 HOP Quick Look version이 알한글보다 오래된 <code>rhwp</code>를 포함하면 실행 안내와 About의 Quick Look 진단에서 버전 근거를 보여줍니다.</li>
           <li>알한글은 확장 프로그램 설정 화면만 열며 HOP이나 알한글 확장의 활성 상태를 자동으로 바꾸지 않습니다.</li>
           <li>Quick Look은 안전한 sibling filename만 외부 연결 그림 후보로 사용하고, 누락·권한 거부·크기 초과를 문서 전체 실패와 분리합니다.</li>
+          <li>Rust 이미지 데이터를 안전한 소유 버퍼로 전달해 외부 그림이 포함된 문서의 Finder 썸네일 안정성을 보강했습니다.</li>
           <li>설치본 version/build 기준은 <code>0.1.9 (15)</code>입니다.</li>
         </ul>
       </section>

--- a/mydocs/orders/20260729.md
+++ b/mydocs/orders/20260729.md
@@ -6,8 +6,14 @@
 |------|--------|------|------|
 | #442 | rhwp-studio v0.8.2 반영 후 HostApp 상단 툴바 겹침 수정 | 완료 | M010, 완료: 13:42 |
 
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #447 | rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+
 ## M900 — Release Operations
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #441 | v0.1.9 public release 준비와 배포 실행 | 진행중 | M900, Stage 3 source preflight·rehearsal 완료 · Stage 4 승인 대기 |
+| #441 | v0.1.9 public release 준비와 배포 실행 | 보류 | M900, Stage 4 signed candidate에서 #447 crash blocker 확인 · public publish 중단 |

--- a/mydocs/orders/20260729.md
+++ b/mydocs/orders/20260729.md
@@ -10,7 +10,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #447 | rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정 | 진행중 | M020, Stage 3 Swift free·artifact 정합성 27/27 PASS · Stage 4 승인 대기 |
+| #447 | rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정 | 진행중 | M020, Stage 4 exact-provider Thumbnail 20/20 PASS · Stage 5 승인 대기 |
 
 ## M900 — Release Operations
 

--- a/mydocs/orders/20260729.md
+++ b/mydocs/orders/20260729.md
@@ -16,4 +16,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #441 | v0.1.9 public release 준비와 배포 실행 | 보류 | M900, Stage 4 signed candidate에서 #447 crash blocker 확인 · public publish 중단 |
+| #441 | v0.1.9 public release 준비와 배포 실행 | 진행중 | M900, Stage 4 재개 · PR #448 merge `f2a78b7` 반영 · 새 signed candidate 준비 |

--- a/mydocs/orders/20260729.md
+++ b/mydocs/orders/20260729.md
@@ -10,7 +10,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #447 | rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정 | 진행중 | M020, 수행계획서 작성 후 승인 대기 |
+| #447 | rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정 | 진행중 | M020, Stage 1 ownership 계약 확정 · Stage 2 승인 대기 |
 
 ## M900 — Release Operations
 

--- a/mydocs/orders/20260729.md
+++ b/mydocs/orders/20260729.md
@@ -10,7 +10,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #447 | rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정 | 진행중 | M020, Stage 1 ownership 계약 확정 · Stage 2 승인 대기 |
+| #447 | rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정 | 진행중 | M020, Stage 2 Rust owned buffer 7/7 PASS · Stage 3 승인 대기 |
 
 ## M900 — Release Operations
 

--- a/mydocs/orders/20260729.md
+++ b/mydocs/orders/20260729.md
@@ -10,7 +10,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #447 | rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정 | 진행중 | M020, Stage 4 exact-provider Thumbnail 20/20 PASS · Stage 5 승인 대기 |
+| #447 | rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정 | 완료 | M020, owned buffer·Thumbnail 20/20 PASS · #441 인계 · 완료: 23:17 |
 
 ## M900 — Release Operations
 

--- a/mydocs/orders/20260729.md
+++ b/mydocs/orders/20260729.md
@@ -10,7 +10,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #447 | rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정 | 진행중 | M020, Stage 2 Rust owned buffer 7/7 PASS · Stage 3 승인 대기 |
+| #447 | rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정 | 진행중 | M020, Stage 3 Swift free·artifact 정합성 27/27 PASS · Stage 4 승인 대기 |
 
 ## M900 — Release Operations
 

--- a/mydocs/plans/task_m020_447.md
+++ b/mydocs/plans/task_m020_447.md
@@ -1,0 +1,305 @@
+# Task M020 #447 수행계획서
+
+## 목적
+
+rhwp v0.8.2의 `get_bin_data()` 소유권 변경 뒤 RustBridge가 해제된 임시
+`Vec<u8>`의 포인터를 Swift에 반환하는 수명 회귀를 수정한다.
+
+`rhwp_image_data`의 포인터·길이·해제 계약을 명시적으로 확정하고 반복 조회,
+allocator pressure, image-heavy Finder Thumbnail 생성에서도
+use-after-free가 발생하지 않도록 회귀 검증한다. 수정 결과는
+#441 이슈의 v0.1.9 signed release candidate 재생성과 public publish 재개 판단에
+인계한다.
+
+## 배경
+
+- GitHub Issue: [#447](https://github.com/postmelee/alhangeul-macos/issues/447)
+- 차단 대상: [#441](https://github.com/postmelee/alhangeul-macos/issues/441)
+- 관련 upstream sync: [#438](https://github.com/postmelee/alhangeul-macos/issues/438)
+- Milestone: `v0.2.x Skia Quick Look/Thumbnail Backend`
+- 문서 prefix: `task_m020_447`
+- 통합 브랜치: `devel`
+- 작업 브랜치: `local/task447`
+- 기준 통합 SHA: `1b1213db5a0bd75638f54bf03d49fbf4cb63edcc`
+
+#441 이슈의 v0.1.9 signed draft 후보 workflow run
+`30432036513`은 build, signing, notarization과 기본 설치본 smoke에 성공했다.
+그러나 Finder가 PDF 저장 패널의 image-heavy 폴더 항목을 연속으로
+Thumbnail 처리하던 중 다음 두 crash report가 생성됐다.
+
+- `AlhangeulThumbnail-2026-07-29-171601.ips`
+- `AlhangeulThumbnail-2026-07-29-171610.ips`
+
+두 보고서는 모두 AlhangeulThumbnail v0.1.9 build 15의
+`EXC_BAD_ACCESS / SIGSEGV`이며 대표 호출 경로는 다음과 같다.
+
+```text
+_platform_memmove
+→ Data.InlineSlice
+→ RhwpDocument.imageData(binDataId:)
+→ CGTreeRenderer.renderImage(...)
+```
+
+rhwp v0.8.2의 upstream Task #2263은 지연 로딩 때문에
+`DocumentCore::get_bin_data()` 반환형을 `Option<&[u8]>`에서
+`Option<Vec<u8>>`로 변경했다. 현재 `RustBridge/src/lib.rs`의
+`rhwp_image_data()`는 이 임시 소유값에서 `as_ptr()`를 반환하고 함수 종료 시
+`Vec`를 해제한다. Swift `Data(bytes:count:)`가 다음 문장에서 복사할 때는
+이미 포인터가 무효일 수 있으므로 실제 use-after-free가 된다.
+
+현재 `RustBridge/README.md`와 `mydocs/tech/project_architecture.md`는
+`rhwp_image_data` 포인터를 document-owned borrowed buffer로 설명한다.
+따라서 코드 수정과 함께 실제 구현에 맞는 ownership, 유효 수명, caller의
+copy/free 의무를 다시 고정해야 한다.
+
+## 범위
+
+포함:
+
+- `rhwp_image_data`의 pointer, length, ownership, invalid input 계약 확정
+- 임시 `Vec`의 포인터가 FFI 밖으로 탈출하지 않는 RustBridge 수정
+- 기존 opaque `RhwpHandle`과 공개 symbol의 호환성 검토
+- handle-owned 안정 저장소와 caller-owned buffer/free 두 대안의 ABI·메모리 비교
+- 반복 image data 조회, 다른 id 조회, allocator pressure, invalid id 회귀 테스트
+- image-heavy HWP/HWPX fixture를 이용한 Swift copy와 CoreGraphics render 확인
+- 필요 시 `RhwpDocument.imageData`와 `imageDataLength`의 명시적 free 처리
+- RustBridge ownership 문서와 프로젝트 아키텍처 FFI 계약 갱신
+- static archive 재생성 및 `rhwp-core.lock` reference artifact 정합성 갱신
+- Rust test, ExternalImageTests, HostApp, QLExtension, ThumbnailExtension 검증
+- task branch Release package 또는 승인된 signed candidate에서 반복 Finder Thumbnail smoke
+- 신규 crash report 부재와 active extension provider exact path 확인
+- #441 이슈에 fix merge SHA, 검증 결과와 signed candidate 재개 조건 인계
+
+제외:
+
+- upstream `edwardkim/rhwp` API 또는 지연 로딩 구현 변경
+- rhwp release tag, resolved commit, bundled rhwp-studio asset 변경
+- unrelated renderer visual parity, 툴바 UI, pinch zoom 개선
+- external image resolver/cache 정책과 Skia default 전환
+- v0.1.9 tag 이동·삭제·재작성 결정
+- GitHub Release 공개, Pages/Sparkle stable appcast, Homebrew Cask 게시
+- #441 이슈가 소유하는 public publish와 rollback 실행
+
+## 설계 방향
+
+첫째, 현재 borrowed-pointer C ABI를 유지하는 안을 기본으로 검토한다.
+`RhwpHandle`이 image bytes의 안정 저장소를 소유하고,
+`rhwp_image_data`는 core에서 받은 `Vec<u8>`를 포인터 반환 전에
+`Box<[u8]>` 같은 주소가 이동하지 않는 allocation으로 보관한다. cache map의
+rehash나 다른 image 조회 때문에 기존 allocation이 해제되지 않아야 하며,
+정상 경로에서는 같은 `bin_data_id`를 중복 저장하지 않는다.
+
+document mutation 뒤 같은 image id의 내용이 달라질 가능성이 있으면 current
+lookup map과 retained storage를 분리한다. mutation은 current entry를
+무효화할 수 있지만 이미 caller에 노출한 backing allocation은 handle close까지
+유지해 이전 pointer를 조기에 해제하지 않는다. `*const RhwpHandle` query에서
+cache를 갱신해야 하므로 interior mutability와 동시 접근 경계도 구현계획서에
+명시한다.
+
+둘째, handle-owned cache가 large BinData를 문서 수명 동안 중복 보유해 메모리
+상한을 과도하게 높이는지 Stage 1에서 비교한다. 비용이 허용되지 않으면
+core가 반환한 `Vec<u8>`의 소유권을 caller에게 넘기고 기존
+`rhwp_free_bytes`로 해제하는 owned-buffer 계약을 선택한다. 이 경우
+`RhwpDocument.imageData`는 `Data` 복사 직후 반드시 free하고,
+`imageDataLength`도 조회 allocation을 누수 없이 해제한다. 공개 symbol을 새로
+추가하지 않고 기존 caller를 모두 함께 갱신할 수 있는지 generated header와
+Swift compile로 확인한다.
+
+두 안을 혼합해 pointer마다 다른 ownership을 갖게 하지 않는다. Stage 1
+구현계획서에서 하나의 계약을 선택하고 다음 조건을 모두 만족시킨다.
+
+1. 반환 포인터가 명시된 유효 수명 전에 해제되지 않는다.
+2. `out_len`은 null/invalid id/failure에서 0으로 초기화된다.
+3. Swift가 bytes를 읽는 동안 allocator churn이 발생해도 값이 유지된다.
+4. handle close 또는 명시적 free 이후 pointer를 사용하지 않는 경계가 문서화된다.
+5. 공개 symbol 변경이 없으면 `rhwp-ffi-symbols.txt`는 byte-stable해야 한다.
+
+회귀 테스트는 실제 embedded image fixture를 열고 `bin_data_id`의 bytes를
+호출 직후 복사하지 않은 상태에서 allocator pressure를 만든 뒤 원본과
+비교한다. 같은 id 반복 조회와 여러 id 교차 조회도 포함한다. test fixture는
+기존 `samples/hwp-img-001.hwp`, `samples/img-start-001.hwp`,
+`samples/tac-img-02.hwp` 중 최소·결정적인 입력을 Stage 1에서 선정하며,
+새 대용량 fixture를 저장소에 추가하지 않는 것을 기본으로 한다.
+
+Finder 통합 판정은 Debug build만으로 통과 처리하지 않는다. Release package의
+exact app/extension version과 active provider path를 먼저 확인하고, 표준
+smoke helper 안에서만 등록·cache reset·cleanup을 수행한다. smoke 전후
+DiagnosticReports 파일 목록과 시각을 분리해 과거 두 crash를 신규 실패로
+오인하지 않는다.
+
+## 예상 변경 파일
+
+수행계획 단계:
+
+- `mydocs/orders/20260729.md`
+- `mydocs/plans/task_m020_447.md`
+
+수행계획 승인 후 예상 소스·계약 변경:
+
+- `RustBridge/src/lib.rs`
+- `RustBridge/README.md`
+- `mydocs/tech/project_architecture.md`
+- `rhwp-core.lock`
+- owned-buffer 계약을 선택할 경우
+  `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- Swift FFI 회귀 테스트가 필요한 경우
+  `Tests/ExternalImageTests/RhwpImageDataLifetimeTests.swift`
+- test target source 구성이 달라지는 경우에만 `project.yml`
+
+변경하지 않는 것을 기본으로 하는 파일:
+
+- `RustBridge/Cargo.toml`
+- `RustBridge/Cargo.lock`
+- `rhwp-ffi-symbols.txt`
+- `Sources/HostApp/Resources/rhwp-studio/**`
+
+생성·검증 대상이지만 git commit하지 않는 산출물:
+
+- `Frameworks/generated_rhwp.h`
+- `Frameworks/generated_rhwp_symbols.txt`
+- `Frameworks/universal/librhwp.a`
+- `Frameworks/Rhwp.xcframework/**`
+- `build.noindex/**`
+
+후속 문서 산출물:
+
+- `mydocs/plans/task_m020_447_impl.md`
+- `mydocs/working/task_m020_447_stage{N}.md`
+- `mydocs/report/task_m020_447_report.md`
+
+## 잠정 단계
+
+1. Stage 1: FFI lifetime contract와 재현 fixture 확정, 구현계획서 작성
+   - handle-owned 안정 저장소와 owned-buffer/free의 ABI·메모리 비용을 비교한다.
+   - 선택한 단일 계약, mutation/concurrency 경계, fixture와 단계별 gate를 고정한다.
+2. Stage 2: RustBridge 수명 수정과 allocator-pressure 회귀 테스트
+   - 임시 `Vec` pointer escape를 제거한다.
+   - invalid input, 반복·교차 image 조회와 allocator churn 테스트를 통과시킨다.
+3. Stage 3: Swift caller·계약 문서·generated artifact 정합성 갱신
+   - 선택 계약에 필요한 Swift copy/free 경계를 적용한다.
+   - ownership 문서와 아키텍처를 맞추고 archive와 lock metadata를 갱신한다.
+4. Stage 4: 세 제품 target, renderer와 실제 Finder Thumbnail 회귀 검증
+   - Rust/Swift test와 HostApp, Preview, Thumbnail compile·link를 확인한다.
+   - 승인된 package에서 image-heavy 반복 Thumbnail과 신규 crash 부재를 확인한다.
+5. Stage 5: 최종 보고서, `devel` 대상 PR 게시와 #441 release handoff
+   - 수정 계약, memory trade-off, 검증 결과와 잔여 리스크를 기록한다.
+   - merge SHA가 포함된 새 signed candidate 생성은 #441 이슈의 별도 승인으로 넘긴다.
+
+각 Stage 완료 후 단계 보고서와 검증 결과를 커밋하고 작업지시자 승인을 받은
+뒤 다음 Stage로 진행한다.
+
+## 검증 계획
+
+계획 문서:
+
+```bash
+git diff --check -- \
+  mydocs/orders/20260729.md \
+  mydocs/plans/task_m020_447.md
+rg -n "#447|rhwp_image_data|use-after-free|Stage 1|승인 요청" \
+  mydocs/orders/20260729.md \
+  mydocs/plans/task_m020_447.md
+```
+
+RustBridge 구현과 ABI:
+
+```bash
+cargo fmt --manifest-path RustBridge/Cargo.toml --check
+cargo check --manifest-path RustBridge/Cargo.toml --locked
+cargo test --manifest-path RustBridge/Cargo.toml --locked
+./scripts/build-rust-macos.sh --update-lock
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/verify-rhwp-core-build-info.sh
+diff -u rhwp-ffi-symbols.txt Frameworks/generated_rhwp_symbols.txt
+```
+
+Swift boundary와 제품 target:
+
+```bash
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task447-tests \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task447-host \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme QLExtension \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task447-ql \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ThumbnailExtension \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task447-thumbnail \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+./scripts/validate-stage3-render.sh
+```
+
+Finder 통합 smoke 후보:
+
+```bash
+scripts/check-extension-registration-hygiene.sh --check-only
+scripts/smoke-finder-integration.sh \
+  --skip-package \
+  --app build.noindex/release/Alhangeul.app \
+  --output-dir build.noindex/task447-finder-smoke \
+  --sample-hwp samples/hwp-img-001.hwp \
+  --sample-hwpx samples/hwpx/hwpx-01.hwpx
+```
+
+Finder smoke는 사용자 Applications 설치본과 extension registration을
+일시적으로 바꾸므로 Stage 4에서 package 경로와 복원 절차를 먼저 보고하고
+별도 승인을 받은 뒤 실행한다. signing, notarization 또는 GitHub release
+workflow가 필요한 검증은 #441 이슈의 release owner 승인 없이 실행하지 않는다.
+
+## 리스크
+
+- handle-owned cache는 ABI 호환성이 높지만 large BinData의 raw bytes를 handle
+  종료까지 중복 보유해 Thumbnail memory peak를 높일 수 있다.
+- owned-buffer/free는 메모리 회수가 명확하지만 Swift caller 하나라도 free를
+  누락하면 leak이 되고, 기존 borrowed contract의 source compatibility가 바뀐다.
+- `imageDataLength`도 core의 lazy bytes를 실제로 load하므로 존재 확인만으로 큰
+  allocation이 생길 수 있다. 이번 타스크에서 별도 metadata API를 임의 추가하지
+  않고 측정 결과가 필요하면 후속 이슈로 분리한다.
+- interior mutability를 추가해도 mutable document 호출과 borrowed pointer
+  사용의 동시성을 자동으로 안전하게 만들지는 못한다. 허용 concurrency와
+  caller 규칙을 구현계획서와 문서에 명시해야 한다.
+- Rust unit test가 포인터 값을 즉시 복사하면 실제 use-after-free를 재현하지
+  못한다. allocator churn을 포인터 반환과 copy 사이에 두어야 한다.
+- source test가 통과해도 Finder는 다른 설치본 extension을 선택할 수 있다.
+  active provider exact path를 확인하지 않으면 false positive가 된다.
+- 과거 crash report 두 건이 남아 있으므로 Stage 4는 시작 시각과 baseline 목록을
+  고정하고 그 이후 신규 보고서만 실패로 판정해야 한다.
+- static archive의 hash와 size는 toolchain과 build path에 민감하다. source와 ABI
+  실패를 환경별 artifact byte 차이와 분리해 판단한다.
+- v0.1.9 tag와 draft release가 이미 존재한다. tag 처리와 새 signed candidate
+  전략은 #441 이슈가 소유하며 이 타스크에서 추정해 변경하지 않는다.
+
+## 승인 요청 사항
+
+1. 기준 브랜치 `devel`, 작업 브랜치 `local/task447`, 문서 코드 `M020`으로
+   진행하는 범위 승인
+2. Stage 1에서 handle-owned 안정 저장소를 기본안으로 검증하고, large BinData
+   memory 비용이 과도하면 기존 `rhwp_free_bytes`를 쓰는 단일 owned-buffer
+   계약으로 확정하는 조건 승인
+3. 공개 symbol 추가 없이 RustBridge와 필요한 Swift caller, ownership 문서,
+   artifact lock만 최소 변경하는 방향 승인
+4. 기존 image fixture 기반 allocator-pressure test와 세 제품 target,
+   exact-provider Finder smoke를 필수 gate로 두는 범위 승인
+5. #447은 수정과 local/package 회귀 검증을 소유하고, merge SHA 기반 signed
+   candidate와 public publish는 #441 이슈에서 별도 승인받는 경계 승인
+6. 위 5개 잠정 Stage 승인
+
+수행계획서 승인 전에는 구현계획서 작성, RustBridge/Swift source 변경,
+generated artifact 갱신, Finder provider 등록과 release workflow 실행을
+진행하지 않는다.

--- a/mydocs/plans/task_m020_447_impl.md
+++ b/mydocs/plans/task_m020_447_impl.md
@@ -1,0 +1,486 @@
+# Task M020 #447 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_447.md`
+
+이 문서는 Stage 1 조사 결과를 바탕으로 `rhwp_image_data`의 ownership 계약과
+단계별 변경·검증 방법을 확정한다. 구현계획서 승인 전에는 RustBridge, Swift
+caller, generated artifact와 Finder 등록 상태를 변경하지 않는다. 승인 후
+Stage 1은 `task-stage-report` 절차로 조사 결과와 구현계획서를 묶어 종료하고,
+Stage 2 진입은 단계 보고서에서 다시 승인받는다.
+
+## 작업 개요
+
+- 이슈: #447 `rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정`
+- 마일스톤: M020 (`v0.2.x Skia Quick Look/Thumbnail Backend`)
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task447`
+- 기준 통합 SHA: `1b1213db5a0bd75638f54bf03d49fbf4cb63edcc`
+- upstream 기준: `v0.8.2` / `9b16aa9e23f476e2b335d7c029fc9f24a199d63c`
+- 차단 대상: #441 이슈의 v0.1.9 public release
+- 변경 소유 영역: app-owned RustBridge C ABI와 Swift `RhwpDocument` wrapper
+
+## Stage 1 조사 결론
+
+### 확인된 사실
+
+| 항목 | 확인 결과 | 판단 |
+|------|-----------|------|
+| upstream API | `DocumentCore::get_bin_data(&self, index)`가 `Option<Vec<u8>>` 반환 | caller에게 소유값을 전달하는 것이 v0.8.2 공개 계약이다. |
+| 변경 이유 | upstream Task #2263의 lazy BinData는 bytes를 빌려줄 수 없어 owned `Vec`를 반환 | downstream이 borrowed pointer로 되돌리려면 별도 장기 저장소가 필요하다. |
+| 현재 bridge | `Some(data) => data.as_ptr()` 뒤 함수 종료 | 반환 직후 `Vec` drop으로 pointer가 무효화된다. |
+| Swift copy | `rhwp_image_data` 반환 뒤 `Data(bytes:count:)` 실행 | 복사 시점이 Rust 함수 종료 뒤라 use-after-free다. |
+| crash 증거 | v0.1.9 build 15에서 두 번 `EXC_BAD_ACCESS`, `_platform_memmove → Data.InlineSlice → RhwpDocument.imageData` | 이론상 위험이 아니라 signed candidate에서 재현된 release blocker다. |
+| 기존 byte 해제 ABI | `rhwp_free_bytes(uint8_t *, uintptr_t)` 존재 | 새 free symbol 없이 owned byte contract를 제공할 수 있다. |
+| 기존 구현 패턴 | thumbnail/Skia PNG는 `Vec → Box<[u8]> → forget → rhwp_free_bytes` 사용 | 검증된 저장소 내 ownership 패턴을 재사용할 수 있다. |
+| C symbol lock | `rhwp_image_data`, `rhwp_free_bytes`가 이미 고정 | symbol 추가·삭제 없이 수정 가능하다. |
+| generated header | 현재 `rhwp_image_data`가 `const uint8_t *` 반환 | owned contract에서는 `uint8_t *`로 source signature가 명확해져야 한다. |
+| Swift caller | `RhwpDocument.imageData`, `imageDataLength` 두 wrapper가 직접 호출 | 모든 product caller를 한 곳에서 free-safe하게 바꿀 수 있다. |
+| renderer cache | `CGTreeRenderer`가 decode된 `CGImage`를 `binDataId`별 cache | bridge raw bytes cache는 정상 render에서 중복 보유가 된다. |
+| fixture | `samples/복학원서.hwp`는 id 1·2 embedded image와 기존 byte-count 기록이 있음 | 작고 결정적인 Rust/Swift lifetime fixture로 사용한다. |
+| Finder 실행 경계 | crash queue가 `com.postmelee.alhangeul.thumbnail-render` | Thumbnail exact-provider 반복 smoke가 필수다. |
+
+### 대안 비교와 선택
+
+| 대안 | 장점 | 문제 | 판단 |
+|------|------|------|------|
+| A. `RhwpHandle` stable cache | 기존 const pointer source contract 유지 | lazy BinData 원본 외 raw bytes를 handle 종료까지 중복 보유하고 interior mutability·mutation invalidation 계약이 추가됨 | 제외 |
+| B. 신규 `rhwp_image_data_copy` 추가 | 기존 borrowed symbol을 그대로 보존 | 안전하지 않은 기존 symbol이 계속 남고 ABI/test/document 경로가 이중화됨 | 제외 |
+| C. 기존 `rhwp_image_data`를 caller-owned buffer로 전환 | upstream owned `Vec`와 일치, 즉시 free 가능, 새 symbol 없음 | Swift 두 wrapper와 ownership 문서를 함께 바꿔야 함 | 채택 |
+
+수행계획서의 기본안은 handle-owned 안정 저장소였지만, Stage 1 조사에서
+`CGTreeRenderer`가 이미 decoded image를 cache하고 있고 upstream lazy loading
+자체가 장기 raw-byte 보유를 피하기 위한 변경임을 확인했다. handle cache는
+특히 multi-page Quick Look과 large BinData에서 image 원본 크기만큼의 bridge
+복사본을 문서 handle 종료까지 유지한다. 반면 기존 `rhwp_free_bytes` 경로를
+사용하면 Swift `Data` 복사 직후 raw allocation을 회수할 수 있다.
+
+따라서 대안 C를 구현안으로 확정한다. 반환 pointer의 const/mut 구분은 C
+machine ABI에서 같은 pointer representation이고 symbol 이름과 인자 목록도
+유지된다. 다만 generated C header와 Swift imported type은 달라지므로
+RustBridge, generated header, Swift wrapper와 test를 항상 같은 build에서
+검증한다. 별도 배포 SDK나 dynamic library 호환을 전제로 하지 않고 앱의
+static XCFramework를 세 target과 함께 재빌드한다.
+
+## 확정 ownership 계약
+
+### Rust C ABI
+
+```rust
+#[no_mangle]
+pub extern "C" fn rhwp_image_data(
+    handle: *const RhwpHandle,
+    bin_data_id: u16,
+    out_len: *mut usize,
+) -> *mut u8
+```
+
+성공 계약:
+
+1. core가 반환한 non-empty `Vec<u8>`를 `Box<[u8]>`로 바꿔 allocation 크기를
+   `len`에 맞춘다.
+2. `as_mut_ptr()`와 length를 caller에게 전달하고 box는 `forget`한다.
+3. pointer는 `rhwp_free_bytes(pointer, len)` 호출 전까지 유효하다.
+4. pointer allocation은 document handle과 독립이므로 handle close가 먼저
+   일어나더라도 explicit free 전까지 bytes는 유효하다.
+5. caller는 정확히 한 번, 반환받은 동일 pointer와 length로 free해야 한다.
+
+실패 계약:
+
+- null handle
+- null `out_len`
+- `bin_data_id == 0`
+- core lookup 실패
+- empty bytes
+- panic
+
+`out_len`이 non-null이면 함수 시작 시 0으로 초기화한다. 실패에서는 null
+pointer와 length 0을 반환한다. panic은 FFI 경계 밖으로 전파하지 않고 null/0으로
+격리한다.
+
+`rhwp_free_bytes(null, len)`은 no-op이다. non-null pointer에는 반드시
+`rhwp_image_data`, `rhwp_render_page_png`, `rhwp_extract_thumbnail` 등 같은
+RustBridge가 반환한 pointer와 정확한 length만 전달한다.
+
+### Swift wrapper
+
+`RhwpDocument.imageData(binDataId:)`는 다음 구조를 사용한다.
+
+```swift
+var length = 0
+guard let pointer = rhwp_image_data(handle, binDataId, &length),
+      length > 0 else {
+    return nil
+}
+defer {
+    rhwp_free_bytes(pointer, length)
+}
+return Data(bytes: pointer, count: length)
+```
+
+`imageDataLength(binDataId:)`도 query가 owned allocation을 반환하므로
+pointer를 사용하지 않더라도 같은 `defer` free를 수행한다. `hasImageData`는
+기존처럼 `imageDataLength`를 사용해 의미를 유지한다.
+
+Swift가 반환하는 `Data`는 독립 복사본이다. 따라서 `RhwpDocument` deinit과
+Rust allocation free 뒤에도 유효하다. pointer나 `UnsafeBufferPointer`를 Swift
+객체에 저장하지 않는다.
+
+## 회귀 테스트 확정안
+
+### Rust unit test
+
+`RustBridge/src/lib.rs`의 기존 test module에 다음을 추가한다.
+
+1. `open_fixture_at(relative_path:)` helper로
+   `samples/복학원서.hwp`를 연다.
+2. `bin_data_id = 1`에서 non-null pointer와 non-zero length를 확인한다.
+3. 첫 allocation을 즉시 복사해 expected bytes를 만들고 free한다.
+4. 두 번째 allocation을 받은 뒤 다른 크기의 `Vec` allocation을 반복 생성해
+   allocator pressure를 만든다.
+5. pressure 뒤 pointer bytes를 expected와 비교하고 free한다.
+6. 같은 id의 두 allocation을 동시에 유지하고 한쪽을 free한 뒤에도 다른 쪽
+   bytes가 유지되는지 확인한다.
+7. image pointer를 받은 뒤 handle을 close하고, bytes 비교 뒤 pointer를
+   free해 allocation이 handle과 독립임을 확인한다.
+8. null handle, id 0, lookup 불가 id에서 null/0을 확인한다.
+
+test code는 pointer를 `from_raw_parts`로 읽을 때 free 전인지 명시하고,
+각 성공 pointer는 test 종료 경로에서 정확히 한 번 해제한다. panic으로 test가
+중간 종료될 때 leak은 process 종료로 회수되지만, 정상·assertion 전 순서에서
+가능한 한 RAII test wrapper를 사용한다.
+
+### Swift `ExternalImageTests`
+
+기존
+`Tests/ExternalImageTests/RhwpDocumentExternalImageBridgeTests.swift`에
+다음을 추가한다.
+
+1. `samples/복학원서.hwp`에서 image id 1의 `Data`와 length가 일치한다.
+2. 같은 id를 반복 조회해 bytes가 동일하다.
+3. 중간에 여러 `Data` allocation을 만들어도 결과가 동일하다.
+4. document scope 밖으로 반환한 copied `Data`가 유지된다.
+5. id 0과 lookup 불가 id가 nil이다.
+6. 기존 external refs/injection 6개 test가 그대로 통과한다.
+
+새 test target이나 source 구성은 만들지 않는다. 기존
+`ExternalImageTests` target이 `RhwpDocument.swift`, sample helper와
+`Rhwp.xcframework`를 이미 포함하므로 `project.yml`은 변경하지 않는다.
+
+## Stage 1. Ownership 계약과 구현 경계 확정
+
+### 목표
+
+signed candidate crash 증거, upstream API, bridge/Swift caller와 fixture를
+대조해 위 owned-buffer 계약과 단계별 작업 범위를 승인 가능한 상태로 고정한다.
+
+### 대상
+
+- `mydocs/plans/task_m020_447_impl.md`
+- `mydocs/working/task_m020_447_stage1.md`
+- `mydocs/orders/20260729.md`
+
+### 작업
+
+1. upstream v0.8.2 `get_bin_data` 반환형과 변경 사유를 기록한다.
+2. 현재 `rhwp_image_data → Data(bytes:count:)`의 drop/copy 순서를 기록한다.
+3. 두 crash report의 exact version, queue와 대표 stack을 교차 확인한다.
+4. handle cache, 신규 copy symbol, 기존 symbol owned 전환을 비교한다.
+5. existing free ABI와 Swift caller 수를 확인해 대안 C를 확정한다.
+6. `samples/복학원서.hwp`의 기존 image id 1·2 기록을 test fixture 근거로
+   고정한다.
+7. Stage 2~5의 파일, 검증, 중단 조건과 커밋 메시지를 확정한다.
+
+### 검증
+
+```bash
+rg -n "pub fn get_bin_data|Option<Vec<u8>>|지연 로딩" \
+  /Users/melee/Documents/projects/forks/rhwp/src/document_core/queries/rendering.rs
+rg -n "rhwp_image_data|rhwp_free_bytes|imageData\\(|imageDataLength" \
+  RustBridge/src/lib.rs \
+  Frameworks/generated_rhwp.h \
+  Sources/RhwpCoreBridge/RhwpDocument.swift \
+  rhwp-ffi-symbols.txt
+rg -n "binDataId|byteCount" \
+  mydocs/working/task_m014_116_stage1.md
+rg -n "_platform_memmove|Data.InlineSlice|RhwpDocument.imageData|thumbnail-render" \
+  ~/Library/Logs/DiagnosticReports/AlhangeulThumbnail-2026-07-29-171601.ips \
+  ~/Library/Logs/DiagnosticReports/AlhangeulThumbnail-2026-07-29-171610.ips
+rg -n "owned-buffer|rhwp_free_bytes|Stage 2|Stage 3|Stage 4|Stage 5" \
+  mydocs/plans/task_m020_447_impl.md
+git diff --check
+```
+
+### 완료 조건
+
+- 임시 `Vec` pointer escape가 직접 원인임이 코드와 crash stack으로 연결된다.
+- caller-owned buffer/free 계약이 단일 구현안으로 고정된다.
+- symbol 추가 없이 generated header와 Swift caller를 함께 바꾸는 경계가
+  명시된다.
+- Rust와 Swift가 공유할 fixture 및 lifetime test matrix가 확정된다.
+- Stage 2 진입 전 RustBridge와 Swift source에는 변경이 없다.
+
+### 커밋
+
+```text
+Task #447 Stage 1: image data ownership 계약과 구현 경계 확정
+```
+
+## Stage 2. RustBridge owned image buffer와 unit test
+
+### 목표
+
+`rhwp_image_data`가 유효한 caller-owned allocation을 반환하도록 수정하고,
+allocator pressure와 handle lifetime을 포함한 Rust 회귀 test로 계약을
+고정한다.
+
+### 대상
+
+- `RustBridge/src/lib.rs`
+- `mydocs/working/task_m020_447_stage2.md`
+- `mydocs/orders/20260729.md`
+
+### 작업
+
+1. `rhwp_image_data` 반환형을 `*mut u8`로 변경한다.
+2. out length를 query 시작 시 0으로 초기화한다.
+3. core lookup과 owned allocation 전환을 `catch_unwind` 경계 안에 둔다.
+4. empty bytes는 allocation을 넘기지 않고 null/0으로 정규화한다.
+5. non-empty `Vec`는 `Box<[u8]>`로 바꾼 뒤 pointer/length를 반환한다.
+6. `rhwp_free_bytes`와 같은 allocation layout을 사용한다.
+7. `open_fixture_at`과 owned image lifetime test를 추가한다.
+8. invalid input, repeated simultaneous allocation, handle close 전후와
+   allocator pressure matrix를 실행한다.
+9. 기존 external context와 rendering test를 모두 유지한다.
+
+### 검증
+
+```bash
+cargo fmt --manifest-path RustBridge/Cargo.toml --check
+cargo check --manifest-path RustBridge/Cargo.toml --locked
+cargo test --manifest-path RustBridge/Cargo.toml --locked
+rg -n "rhwp_image_data|into_boxed_slice|rhwp_free_bytes|복학원서|allocator|pressure" \
+  RustBridge/src/lib.rs
+git diff --check -- RustBridge/src/lib.rs mydocs
+```
+
+### 완료 조건
+
+- `rhwp_image_data`가 임시 Vec pointer를 반환하지 않는다.
+- 성공 pointer는 explicit free 전까지 유효하고 handle lifetime과 독립이다.
+- 모든 성공 test allocation이 정확히 한 번 해제된다.
+- null/zero/missing/panic 경로가 null/0으로 정규화된다.
+- 전체 locked Rust test가 통과한다.
+
+### 커밋
+
+```text
+Task #447 Stage 2: RustBridge image data ownership 회귀 수정
+```
+
+## Stage 3. Swift free 계약, 문서와 artifact 정합성
+
+### 목표
+
+Swift caller가 owned pointer를 모든 경로에서 해제하게 하고, generated header,
+static archive, lock metadata와 ownership 문서를 같은 source 상태로 맞춘다.
+
+### 대상
+
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `Tests/ExternalImageTests/RhwpDocumentExternalImageBridgeTests.swift`
+- `RustBridge/README.md`
+- `mydocs/tech/project_architecture.md`
+- `rhwp-core.lock`
+- `mydocs/working/task_m020_447_stage3.md`
+- `mydocs/orders/20260729.md`
+
+### 작업
+
+1. `imageData`가 `defer rhwp_free_bytes` 뒤 Swift `Data`를 반환하게 한다.
+2. `imageDataLength`도 pointer를 즉시 free하게 한다.
+3. document deinit 뒤 copied Data, 반복 query와 invalid id Swift test를 추가한다.
+4. RustBridge README의 image data ownership과 current v0.8.2 provenance를
+   실제 lock에 맞춘다.
+5. project architecture의 borrowed document buffer 설명을 caller-owned
+   allocation/free 계약으로 갱신한다.
+6. Rust static archive와 generated header를 재생성한다.
+7. generated header가 `uint8_t *rhwp_image_data`를 제공하는지 확인한다.
+8. symbol 목록이 기존 15개와 byte-identical한지 확인한다.
+9. `rhwp-core.lock`의 archive/header hash, size와 built_at만 갱신하고
+   core tag/commit/features는 유지한다.
+10. `project.yml`과 `Alhangeul.xcodeproj`에는 Task #447 diff가 없는지 확인한다.
+
+### 검증
+
+```bash
+./scripts/build-rust-macos.sh --update-lock
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/verify-rhwp-core-build-info.sh
+diff -u rhwp-ffi-symbols.txt Frameworks/generated_rhwp_symbols.txt
+rg -n "uint8_t \\*rhwp_image_data|rhwp_free_bytes" \
+  Frameworks/generated_rhwp.h
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ExternalImageTests \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task447-stage3-tests \
+  CODE_SIGNING_ALLOWED=NO \
+  test
+git diff --exit-code -- project.yml Alhangeul.xcodeproj/project.pbxproj
+git diff --check
+```
+
+### 완료 조건
+
+- Swift의 두 image data wrapper가 성공 allocation을 항상 free한다.
+- copied Data가 document와 Rust allocation lifetime에서 독립이다.
+- ExternalImageTests 전체가 통과한다.
+- generated header는 owned mutable pointer contract를 나타낸다.
+- FFI symbol 목록과 core tag/commit/features는 변하지 않는다.
+- lock metadata와 ownership 문서가 새 artifact와 일치한다.
+
+### 커밋
+
+```text
+Task #447 Stage 3: Swift image buffer 해제와 ABI 문서 정합성 반영
+```
+
+## Stage 4. 제품 target과 Finder Thumbnail crash 회귀 검증
+
+### 목표
+
+수정 artifact를 사용하는 App, Preview, Thumbnail을 build하고 renderer 및
+exact-provider Finder 반복 smoke에서 신규 crash가 발생하지 않는지 확인한다.
+
+### 자동 build와 renderer 검증
+
+```bash
+cargo test --manifest-path RustBridge/Cargo.toml --locked
+./scripts/build-rust-macos.sh --verify-lock
+./scripts/check-no-appkit.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task447-stage4-host \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme QLExtension \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task447-stage4-ql \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme ThumbnailExtension \
+  -configuration Debug \
+  -derivedDataPath build.noindex/DerivedData-task447-stage4-thumbnail \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+./scripts/validate-stage3-render.sh
+./scripts/preview-visual-diff-harness.sh \
+  build.noindex/task447-stage4-images \
+  --page 1 \
+  samples/복학원서.hwp \
+  samples/hwp-img-001.hwp \
+  samples/img-start-001.hwp \
+  samples/hwpx/hwpx-01.hwpx
+```
+
+### Finder/package 검증
+
+Stage 4 진입 시 다음 상태를 먼저 보고한다.
+
+- 사용할 candidate app absolute path, version/build와 code-sign identity
+- 현재 `/Users/melee/Applications/Alhangeul.app` 존재 여부와 backup 경로
+- active Preview/Thumbnail provider 목록
+- 기존 두 crash report와 Stage 4 시작 시각
+- smoke 후 candidate unregister와 사용자 설치본 복원 절차
+
+사용자 Applications와 extension registration을 바꾸는 실제 smoke, package
+signing 또는 release workflow는 작업지시자의 명시 승인 뒤에만 실행한다.
+승인되면 표준 helper를 사용한다.
+
+```bash
+scripts/check-extension-registration-hygiene.sh --check-only
+scripts/smoke-finder-integration.sh \
+  --skip-package \
+  --app build.noindex/release/Alhangeul.app \
+  --output-dir build.noindex/task447-stage4-finder \
+  --sample-hwp samples/복학원서.hwp \
+  --sample-hwpx samples/hwpx/hwpx-01.hwpx
+```
+
+표준 smoke 뒤 Finder 또는 save panel에서 image-heavy sample 폴더를 반복
+표시한다. 다음을 함께 확인한다.
+
+- 실제 Thumbnail process가 candidate appex path에서 실행됨
+- `복학원서.hwp`, `hwp-img-001.hwp`, `img-start-001.hwp`, HWPX thumbnail 생성
+- 반복 cache miss/reload 뒤에도 thumbnail 생성
+- Stage 4 시작 시각 이후 신규 `AlhangeulThumbnail-*.ips` 없음
+- candidate unregister와 이전 app/provider 복원
+- 개발 산출물 provider 잔존 없음
+
+### 완료 조건
+
+- Rust, ExternalImageTests와 세 제품 target이 모두 통과한다.
+- image-heavy renderer harness에 crash/FAIL이 없다.
+- exact candidate provider가 HWP/HWPX thumbnail을 반복 생성한다.
+- Stage 4 baseline 이후 신규 Thumbnail crash report가 없다.
+- smoke 종료 뒤 사용자 설치본과 provider가 원래 상태로 복원된다.
+- signing/notarization/GitHub workflow를 승인 없이 실행하지 않는다.
+
+### 커밋
+
+```text
+Task #447 Stage 4: image-heavy Thumbnail crash 회귀 검증
+```
+
+## Stage 5. 최종 보고, PR 게시와 #441 인계
+
+### 작업
+
+1. 선택한 ownership 계약, source/header 차이와 memory trade-off를 최종
+   보고서에 기록한다.
+2. Rust/Swift test, artifact provenance, target build, renderer와 Finder
+   exact-provider 결과를 정리한다.
+3. #441 이슈에 전달할 fix commit, PR/merge SHA와 candidate 재생성 조건을
+   명시한다.
+4. `task-final-report` 절차로 오늘할일 완료, 최종 커밋,
+   `publish/task447` push와 `devel` 대상 ready PR을 생성한다.
+5. PR CI에서 Rust locked test, ABI/provenance, ExternalImageTests와 macOS
+   target gate를 확인한다.
+6. merge는 작업지시자의 별도 승인을 기다린다.
+7. merge 뒤 #441 이슈는 이전 v0.1.9 draft artifact를 재사용하지 않고 새 merge
+   SHA가 포함된 signed candidate를 별도 release 승인으로 생성한다.
+
+Task #447은 release source crash 수정과 package regression까지만 소유한다.
+v0.1.9 tag 처리, GitHub Release publish, Pages/Sparkle와 Homebrew는 #441
+이슈가 소유한다.
+
+### 완료 조건
+
+- 최종 보고서와 PR body가 Issue #447 범위와 검증 결과를 일치하게 설명한다.
+- `devel` 대상 ready PR의 필수 CI가 통과한다.
+- 기존 unsafe borrowed-pointer 설명이 source와 문서에 남지 않는다.
+- #441 이슈가 새 merge SHA로 candidate를 재생성할 충분한 handoff를 받는다.
+
+## 중단·재승인 조건
+
+- `rhwp_image_data` pointer mutability 변경으로 예상 밖의 C/Swift caller가
+  compile되지 않음
+- 기존 `rhwp_free_bytes`가 `Box<[u8]>` allocation을 정확히 해제하지 못함
+- caller-owned contract에서 symbol 추가 또는 dependency 변경이 필요함
+- `RustBridge/Cargo.toml`, `Cargo.lock`, core tag/commit/features 변경이 필요함
+- `project.yml` 또는 Xcode target 구성 변경이 필요함
+- `imageDataLength`의 full bytes load가 별도 metadata ABI 없이는 허용할 수 없는
+  memory 회귀로 측정됨
+- source test는 통과하지만 image-heavy renderer/Finder에서 crash가 재현됨
+- active provider exact path를 확정할 수 없어 Finder 결과가 모호함
+- 사용자 설치본을 안전하게 backup/복원할 수 없음
+- release tag, signing/notarization 또는 GitHub workflow 변경이 필요함
+
+이 조건 중 하나가 발생하면 관련 범위를 임의로 확장하지 않고 실패 증거,
+영향과 최소 대안을 보고해 수행·구현계획 수정 또는 release owner 승인을
+요청한다.

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.9` | 후보 · Stage 3 완료 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
+| `v0.1.9` | 후보 · Stage 4 재검증중 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
 | `v0.1.8` | 공개 완료 | [Alhangeul v0.1.8](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) | [v0.1.8](https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html) | [`v0.1.8.md`](v0.1.8.md) |
 | `v0.1.7` | 공개 완료 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |
 | `v0.1.6` | 공개 완료 | [Alhangeul v0.1.6](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.6) | [v0.1.6](https://postmelee.github.io/alhangeul-macos/updates/v0.1.6.html) | [`v0.1.6.md`](v0.1.6.md) |

--- a/mydocs/release/v0.1.9.md
+++ b/mydocs/release/v0.1.9.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.9` build `15` Stage 3 완료, Stage 4 source PR 승인 대기 |
+| 상태 | `v0.1.9` build `15` Stage 4 재개, PR #448 반영 candidate 재생성중 |
 | 목표 Git tag | `v0.1.9` |
 | 목표 app version | `0.1.9` |
 | 목표 build | `15` |
@@ -18,6 +18,12 @@
 | Stage 3 exact candidate | `07b9f34cb14827223e085bc583406ba2654171c0` |
 | 유효 rehearsal | run `30424930226`, SHA256 `e5b03e67a03d1e4aecada0f78fc351dfeb904158a7259bdea5a3b6d8988f7db0` |
 | 폐기한 rehearsal 후보 | run `30365232108`, candidate `1d358103a877a9d0b6c924a280b84e60e94d6739` — PR #443 미포함 |
+| Stage 4 source / back-merge / release PR | PR #444 / PR #445 / PR #446 |
+| 기존 `main` release commit | `1e7f5df59684713745cb9d59c0a0e9dfdaaf0272` |
+| 기존 annotated tag | `v0.1.9` -> `1e7f5df59684713745cb9d59c0a0e9dfdaaf0272`, PR #448 미포함 |
+| 폐기한 signed draft | run `30432036513`, SHA256 `e854cedb59b8708d412151414ea877605209710ba850306d1f315c0a61d6e75a` |
+| Task #447 수정 PR / merge commit | PR #448 / `f2a78b799f62985d2767afc9ba4434581e9b10be` |
+| 새 candidate 기준 | `origin/devel` / `f2a78b799f62985d2767afc9ba4434581e9b10be`, `main` 반영·tag 재지정 전 |
 | GitHub Release 후보 | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9 |
 | Pages 릴리즈 노트 후보 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html |
 | Public DMG 후보 | `alhangeul-macos-0.1.9.dmg` |
@@ -28,29 +34,32 @@
 | upstream latest | `v0.8.2`, candidate lock과 일치 |
 | latest guard | `require_latest_rhwp=true`, 예외 계획 없음 |
 
-2026-07-28 live 조회에서 `v0.1.8`은 non-draft/non-prerelease public release이며, upstream latest는 `rhwp v0.8.2`였다. 2026-07-29에는 HostApp 툴바 회귀를 수정한 PR #443 변경이 merge돼 `origin/devel`이 `e2aef4c...`로 이동했고, Task #441 브랜치는 이를 `a9760bbe...`에서 통합했다. `v0.1.9` tag는 아직 없다.
+2026-07-28 live 조회에서 `v0.1.8`은 non-draft/non-prerelease public release이며, upstream latest는 `rhwp v0.8.2`였다. 2026-07-29에는 HostApp 툴바 회귀를 수정한 PR #443 변경을 통합한 뒤 PR #444 source 반영, PR #445 `main -> devel` back-merge와 PR #446 `devel -> main` release merge를 완료했다. annotated `v0.1.9` tag는 당시 `main` release commit `1e7f5df...`에 생성했다.
 
 기존 Release Rehearsal run `30365232108`은 PR #443 변경을 포함하지 않은 candidate `1d358103...`에서 실행됐다. workflow 자체는 성공했지만 릴리스 소유자 visual QA에서 차단 회귀가 확인됐으므로 해당 run과 artifact를 공개 릴리스 승인 근거로 재사용하지 않는다.
 
 새 exact candidate `07b9f34...`에서 source preflight를 다시 수행하고 Release Rehearsal run [`30424930226`](https://github.com/postmelee/alhangeul-macos/actions/runs/30424930226)을 실행했다. workflow, checksum, universal slice, DMG integrity/layout과 수동 앱 줌 smoke가 통과했다. rehearsal은 unsigned 검증 계층이며 signing/notarization 또는 public asset 근거가 아니다.
 
-최종 release candidate commit은 Task #441 Stage 1~3 source/communication PR, 필요한 `main -> devel` back-merge와 `devel -> main` release PR이 모두 반영된 뒤 확정한다. Stage 2의 candidate URL과 DMG 경로는 official publish 전까지 실제 public asset을 뜻하지 않는다.
+기존 tag에서 실행한 signed/notarized draft run [`30432036513`](https://github.com/postmelee/alhangeul-macos/actions/runs/30432036513)은 workflow 자체는 성공했지만 image data 수명 회귀로 Thumbnail crash가 확인돼 폐기했다. 해당 draft release는 비공개 상태이고 asset download count는 0이지만, DMG와 checksum은 새 후보의 서명·공증·smoke 근거로 재사용하지 않는다.
+
+Task #447 수정 PR #448 변경은 `devel` merge commit `f2a78b7...`에 반영됐다. 새 final candidate는 이 commit을 `main`에 반영하는 추가 release candidate PR, annotated tag 재지정, 새 Rehearsal과 새 signed draft를 모두 거쳐야 한다. tag 재지정과 workflow 실행은 release owner의 별도 승인 전에는 수행하지 않는다. candidate URL과 DMG 경로는 official publish 전까지 실제 public asset을 뜻하지 않는다.
 
 ## 사용자용 요약
 
 `v0.1.9`은 upstream `rhwp v0.8.2` core와 bundled 편집기를 반영해 복잡한 표·페이지 배치, 저장 뒤 서식 보존, 오래된 HWP 그림 표시와 편집기의 입력·실행취소 안정성을 보강하고, 창 너비에 따라 viewer/editor 상단 도구 모음이 겹치거나 잘리던 문제를 수정하는 patch release다.
 
-HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 provider가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내한다. Quick Look의 외부 연결 그림은 macOS가 sibling file 접근을 허용할 때만 불러오며, 접근이 거부돼도 문서 본문 미리보기는 계속 표시한다.
+HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 provider가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내한다. Quick Look의 외부 연결 그림은 macOS가 sibling file 접근을 허용할 때만 불러오며, 접근이 거부돼도 문서 본문 미리보기는 계속 표시한다. 외부 그림 데이터를 처리할 때 Finder Thumbnail extension이 종료될 수 있던 image buffer 수명 회귀도 수정했다.
 
 ## 직전 공개 릴리즈 대비 변경점
 
-기준 범위는 `v0.1.8^{}..origin/devel`이다. Stage 2 시작 시 `origin/devel`은 `76c86fc76a9e2b7291f80e57b8b85c7c1e1ff525`였고, PR #443 merge 뒤 현재 기준은 `e2aef4c232a48963f7e2abcaaca4bc4230b3b454`다. Task #441 타스크의 local metadata/communication commit과 final release transport는 final candidate 확정 시 다시 분석한다.
+기준 범위는 `v0.1.8^{}..origin/devel`이다. Stage 2 시작 시 `origin/devel`은 `76c86fc76a9e2b7291f80e57b8b85c7c1e1ff525`였고, PR #443 병합 뒤 `e2aef4c232a48963f7e2abcaaca4bc4230b3b454`, PR #444 및 PR #445 병합 뒤 `1b1213db5a0bd75638f54bf03d49fbf4cb63edcc`, PR #448 병합 뒤 현재 기준은 `f2a78b799f62985d2767afc9ba4434581e9b10be`다. 새 `main` release candidate가 확정되면 포함 PR 분석과 delta checklist를 다시 생성한다.
 
 | 영역 | 변경 |
 |------|------|
 | Upstream core/studio | PR #436: native core, RustBridge와 bundled `rhwp-studio`를 `v0.8.2` / `9b16aa9e...`로 full sync |
 | Sync 통합 검증 | PR #440: latest `devel` 결합에서 provenance, ABI, app target, renderer, Finder와 Release package를 검증하고 generated project drift를 정합화 |
 | HostApp 반응형 툴바 | PR #443: stale WKWebView layout override를 select 표시 보정으로 축소해 창 너비별 toolbar/style bar 겹침과 clipping을 수정하고 ownership guard 추가 |
+| Finder Thumbnail 안정성 | PR #448: RustBridge image data를 caller-owned buffer로 바꾸고 Swift exact free를 적용해 외부 그림 처리 중 use-after-free crash 수정 |
 | Quick Look external image | PR #437: Swift wrapper와 basename-only sibling resolver, privacy-safe report, permission failure의 main document fallback 추가 |
 | Quick Look 충돌 안내 | PR #434: HOP과 알한글의 검증된 `rhwp` provenance를 비교해 실행 안내, About 진단과 시스템 설정 진입 제공 |
 | Pages 문구 | PR #431: 프로젝트 철학 섹션과 Open Graph 설명 보강. 앱 릴리즈 주요 변화에서는 제외 |
@@ -65,6 +74,7 @@ HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는
 
 | PR | 제목 | 분류 | 사용자-facing | 공개 요약 반영 | 해결된 Issue | 참고/연관 Issue | 근거 문서 | 비고 |
 |----|------|------|---------------|----------------|---------------|-----------------|-----------|------|
+| `#448` | `Task #447: RustBridge image data 수명 회귀와 Thumbnail 크래시 수정` | 사용자-facing | 예 | 예 | `#447` | `#441` | PR body, `mydocs/report/task_m020_447_report.md` | caller-owned image buffer와 Swift exact free, signed candidate 재생성 필요 |
 | `#443` | `Task #442: rhwp-studio v0.8.2 HostApp 툴바 회귀 수정` | 사용자-facing | 예 | 예 | `#442` | `#441` | PR body, `mydocs/report/task_m010_442_report.md` | upstream responsive layout ownership 복원과 breakpoint별 visual 검증 |
 | `#440` | `Task #438: rhwp v0.8.2 sync 통합 검증과 Xcode project 정합화` | 개발자-facing | 아니오 | 예 | `#438` | `#409`, `#439` | PR body, `mydocs/report/task_m020_438_report.md` | 주요 변화 자체가 아니라 #436 결합과 release readiness 검증 근거 |
 | `#436` | `Sync rhwp upstream v0.8.2` | upstream sync | 예 | 예 | 없음 | `#438` | PR body, upstream `v0.7.19`~`v0.8.2` release note, `mydocs/report/task_m020_438_report.md` | core/studio 누적 개선과 provenance 갱신 |
@@ -72,7 +82,10 @@ HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는
 | `#434` | `Task #433: HOP Quick Look 충돌 가능성 감지와 최신 rhwp 안내 UI 추가` | 사용자-facing | 예 | 예 | `#433` | 없음 | PR body, `mydocs/report/task_m040_433_report.md` | provider를 강제 변경하지 않는 사용자 안내 |
 | `#431` | `Task #430: GitHub Pages 철학 문구와 Open Graph 설명 보강` | 문서-only | 예 | 아니오 | `#430` | 없음 | PR body, `mydocs/report/task_m010_430_report.md` | Pages 사용자 표면이지만 v0.1.9 앱 주요 변화와 분리 |
 | `#428` | `Task #424 Stage 4-6: v0.1.8 official publish 완료 기록` | 운영/배포 | 아니오 | 아니오 | `#424` | upstream `#2396`, PR `#2398` | PR body, `mydocs/report/task_m900_424_report.md` | 직전 public release closeout |
-| Task #441 PR 예정 | `v0.1.9 public release 준비와 배포 실행` | 운영/배포 | 아니오 | 아니오 | 진행중 `#441` | `#438`, `#439` | Issue body, `mydocs/plans/task_m900_441_impl.md` | version/build, communication과 release gate |
+| `#444` | `Task #441: v0.1.9 release candidate source 준비` | 운영/배포 | 아니오 | 아니오 | 없음 | `#441` | PR body, Stage 1~3 보고서 | version/build, communication과 preflight 기록을 `devel`에 반영 |
+| `#445` | `Task #441: main release 이력 역병합` | 운영/배포 | 아니오 | 아니오 | 없음 | `#441` | PR body | `main` 전용 이력을 `devel`에 보존 |
+| `#446` | `Release: Alhangeul v0.1.9` | 운영/배포 | 아니오 | 아니오 | 없음 | `#441` | PR body | 초기 release transport, PR #448 미포함으로 새 candidate PR 필요 |
+| Task #441 후보 갱신 PR 예정 | `v0.1.9 candidate에 PR #448 반영` | 운영/배포 | 아니오 | 아니오 | 진행중 `#441` | `#447` | Issue body, `mydocs/plans/task_m900_441_impl.md` | 새 `main` commit과 tag를 확정하는 transport |
 
 PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈는 PR body에서 후속 fixture/visual suite로만 참조되며 현재 OPEN이다. 따라서 해결된 Issue에서 제외하고 참고/연관 Issue로 보정했다.
 
@@ -84,7 +97,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - 편집 뒤 저장할 때 문서 서식을 보존하는 범위와 편집기의 입력 반응성·실행취소 동작을 보강했습니다.
 - 창 너비가 바뀔 때 viewer/editor 상단 도구 모음과 서식 도구 모음이 겹치거나 잘리던 문제를 수정했습니다.
 - HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는 예상과 다른 미리보기가 선택될 수 있음을 알리고 확장 프로그램 설정 경로를 안내합니다.
-- Quick Look에서 외부 연결 그림을 읽을 수 없는 경우에도 문서 본문 미리보기를 계속 표시하도록 처리 경계를 보강했습니다.
+- 외부 연결 그림을 읽지 못해도 Quick Look 본문을 유지하고, 같은 그림을 처리하던 Finder 썸네일 확장이 종료될 수 있던 문제를 수정했습니다.
 
 ### 포함된 rhwp 변화
 
@@ -103,11 +116,13 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - 알한글은 확장 프로그램 설정 화면만 열며 HOP이나 알한글 확장의 활성 상태를 자동으로 바꾸지 않습니다.
 - Quick Look은 안전한 sibling filename만 외부 연결 그림 후보로 사용하고, 누락·권한 거부·크기 초과를 문서 전체 실패와 분리합니다.
 - registered Quick Look sandbox가 sibling file 접근을 허용하지 않으면 외부 연결 그림은 빠지지만 문서 본문 미리보기는 유지됩니다.
+- RustBridge image data를 caller-owned buffer로 전달하고 Swift가 복사 직후 해제하도록 정렬해 외부 그림이 포함된 문서의 Finder 썸네일 안정성을 보강했습니다.
 
 ### 릴리즈 요약에 반영된 PR
 
 - [#436: Sync rhwp upstream v0.8.2](https://github.com/postmelee/alhangeul-macos/pull/436) - core와 bundled editor의 v0.8.2 반영 근거입니다.
 - [#443: Task #442: rhwp-studio v0.8.2 HostApp 툴바 회귀 수정](https://github.com/postmelee/alhangeul-macos/pull/443) - 창 너비별 툴바 배치와 WKWebView 보정 경계를 수정한 근거입니다.
+- [#448: Task #447: RustBridge image data 수명 회귀와 Thumbnail 크래시 수정](https://github.com/postmelee/alhangeul-macos/pull/448) - 외부 그림 처리 중 Finder 썸네일 확장이 종료될 수 있던 문제를 수정한 근거입니다.
 - [#434: Task #433: HOP Quick Look 충돌 가능성 감지와 최신 rhwp 안내 UI 추가](https://github.com/postmelee/alhangeul-macos/pull/434) - HOP과 알한글 Quick Look 충돌 안내 근거입니다.
 - [#437: Task #409: Swift external image wrapper/resolver와 Quick Look Preview 적용](https://github.com/postmelee/alhangeul-macos/pull/437) - 외부 연결 그림 resolver와 permission fallback 근거입니다.
 - [#440: Task #438: rhwp v0.8.2 sync 통합 검증과 Xcode project 정합화](https://github.com/postmelee/alhangeul-macos/pull/440) - v0.8.2와 최신 앱 경로의 통합 검증 근거입니다.
@@ -116,6 +131,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 
 - [#438: rhwp v0.8.2 full sync와 최신 devel 통합 검증](https://github.com/postmelee/alhangeul-macos/issues/438) - v0.8.2 core/studio 동기화와 앱 통합 검증을 완료했습니다.
 - [#442: rhwp-studio v0.8.2 반영 후 HostApp 상단 툴바 겹침 수정](https://github.com/postmelee/alhangeul-macos/issues/442) - 창 너비별 툴바 겹침·clipping 회귀를 수정했습니다.
+- [#447: rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정](https://github.com/postmelee/alhangeul-macos/issues/447) - image data 소유권 회귀와 signed candidate 차단 크래시를 수정했습니다.
 - [#433: HOP Quick Look 충돌 가능성 감지와 최신 rhwp 안내 UI 추가](https://github.com/postmelee/alhangeul-macos/issues/433) - 충돌 가능성 안내와 사용자 설정 경로를 추가했습니다.
 - [#409: Swift external image wrapper/resolver와 Quick Look Preview 적용](https://github.com/postmelee/alhangeul-macos/issues/409) - Swift resolver와 Quick Look fallback 계약을 완료했습니다.
 
@@ -128,6 +144,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 
 - PR #436 변경은 `v0.7.18`에서 `v0.8.2`까지 네 개 upstream release의 누적 변경을 반영한다.
 - PR #443 변경은 기존 rehearsal 뒤 발견된 HostApp 툴바 차단 회귀를 수정했다. run `30365232108`과 candidate `1d358103...`는 폐기했고, 새 exact candidate `07b9f34...`의 run `30424930226`에서 source preflight와 rehearsal을 다시 통과했다.
+- PR #448 변경은 기존 signed draft에서 확인한 RustBridge image data use-after-free를 caller-owned allocation과 Swift exact free로 수정했다. run `30432036513`, 당시 tag commit `1e7f5df...`와 DMG는 폐기하며, PR #448 변경을 포함한 candidate에서 Rehearsal과 signed draft를 모두 다시 실행한다.
 - strict local `librhwp.a` byte hash/size는 기존 lock reference와 다르지만 source tag/commit, Cargo resolution, generated header와 15개 FFI symbol은 일치했다. Stage 3에서 strict와 portable 결과를 분리해 portable release artifact 경계를 허용했다.
 - upstream `v0.8.2`에는 studio PDF 안내 modal 관련 Issue #3450 이슈와 page-local repaint 관련 Issue #3412 이슈가 알려진 문제로 남아 있다. 실제 알한글 장문서·인쇄/PDF 경로는 signed candidate gate 전까지 통과로 기록하지 않는다.
 
@@ -139,8 +156,9 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | [#433](https://github.com/postmelee/alhangeul-macos/issues/433) | [#434](https://github.com/postmelee/alhangeul-macos/pull/434) | merge·close 완료 | HOP Quick Look 충돌 안내 |
 | [#438](https://github.com/postmelee/alhangeul-macos/issues/438) | [#436](https://github.com/postmelee/alhangeul-macos/pull/436), [#440](https://github.com/postmelee/alhangeul-macos/pull/440) | merge·close 완료 | `rhwp v0.8.2` full sync와 통합 검증 |
 | [#442](https://github.com/postmelee/alhangeul-macos/issues/442) | [#443](https://github.com/postmelee/alhangeul-macos/pull/443) | merge·close 완료 | HostApp responsive toolbar와 WKWebView override 경계 수정 |
+| [#447](https://github.com/postmelee/alhangeul-macos/issues/447) | [#448](https://github.com/postmelee/alhangeul-macos/pull/448) | merge·close 완료 | RustBridge image data 수명 회귀와 Thumbnail crash 수정 |
 | [#439](https://github.com/postmelee/alhangeul-macos/issues/439) | 없음 | Open | sync workflow provenance 자동화 후속 |
-| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | 예정 | 진행중 | `v0.1.9` release candidate와 public release 실행 |
+| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | [#444](https://github.com/postmelee/alhangeul-macos/pull/444), [#445](https://github.com/postmelee/alhangeul-macos/pull/445), [#446](https://github.com/postmelee/alhangeul-macos/pull/446), 후보 갱신 PR 예정 | 진행중 | PR #448 포함 candidate와 public release 실행 |
 
 ## 검증 기준
 
@@ -150,14 +168,16 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | Core lock | `rhwp_release_tag=v0.8.2`, commit `9b16aa9e...` | Stage 1 통과 |
 | Studio asset | bundled manifest가 `v0.8.2` / `9b16aa9e...` | Stage 1 통과 |
 | Workflow default | `0.1.9`, `v0.1.8`, `v0.8.2` | Stage 1 통과 |
-| Release PR analysis | `v0.1.8..candidate` merge PR 7개 + Task #441 | `07b9f34...`에서 재생성 통과, final candidate에서 반복 필요 |
-| Release communication | README, Pages home/update, release index/record | PR #443 사용자 영향 보정 완료 |
+| Release PR analysis | `v0.1.8..candidate` merge PR과 Task #441 transport | PR #448 포함 초안 보정, final `main` candidate에서 반복 필요 |
+| Release communication | README, Pages home/update, release index/record | PR #443 및 PR #448 사용자 영향 보정 |
 | Static archive | strict byte reference와 portable source/header/FFI를 분리 | strict mismatch 기록, portable 검증 통과·허용 |
 | Shared Swift boundary | `Sources/RhwpCoreBridge` AppKit/UIKit 의존 없음 | Stage 3 통과 |
-| Rust/Swift tests | RustBridge와 ExternalImageTests | `4/4`, `24/24` 통과 |
-| Release build/render | 세 target Release build, representative renderer와 policy | Stage 3 통과 |
+| Rust/Swift tests | RustBridge와 ExternalImageTests | PR #448 기준 `7/7`, `27/27` 통과 |
+| Release build/render | 세 target build, representative renderer와 image visual harness | PR #448 기준 통과, final candidate에서 release gate 반복 필요 |
 | Rehearsal DMG | unsigned rehearsal layout/checksum | run `30424930226`, checksum/integrity/universal 통과 |
-| Signed Finder/Preview | 실제 provider path, HWP/HWPX, external sibling fallback | Stage 4 차단 gate |
+| Signed draft DMG | Developer ID signing/notarization/staple/Gatekeeper | run `30432036513`은 PR #448 미포함으로 폐기, 새 candidate 필요 |
+| Signed Finder/Preview | 실제 provider path, HWP/HWPX, external sibling fallback | PR #448 포함 새 Stage 4 차단 gate |
+| Image-heavy Thumbnail | HWP 3종 + HWPX 1종 반복, crash 0 | PR #448 local candidate 20/20, 새 signed provider에서 반복 필요 |
 | Signed editor | 장문서 repaint, 인쇄 preview와 PDF 시작 경로 | Stage 4 차단 gate |
 | Public update | v0.1.8 -> v0.1.9 Sparkle와 extension refresh | Stage 5 예정 |
 | Homebrew | official public DMG URL/SHA256과 install/uninstall | 별도 승인 필요 |
@@ -190,11 +210,15 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - [x] 포함 PR 자동 분석과 release owner 판정 작성
 - [x] source preflight, strict/portable artifact와 universal package 검증
 - [x] 별도 승인 후 Rehearsal workflow 실행과 artifact 검증
-- [ ] Task #441 source PR을 `devel`에 merge
-- [ ] `main` 전용 PR #432 변경의 reviewed back-merge 필요 여부 확정
-- [ ] 별도 승인 후 `devel -> main` release PR merge
-- [ ] 별도 승인 후 정확한 final candidate에 annotated `v0.1.9` tag 생성
-- [ ] 별도 승인 후 `draft=true`, `prerelease=false` Publish workflow 실행
+- [x] Task #441 source PR #444 변경을 `devel`에 merge
+- [x] `main` 전용 이력을 PR #445 변경으로 `devel`에 back-merge
+- [x] 초기 `devel -> main` release PR #446 merge와 annotated `v0.1.9` tag 생성
+- [x] 초기 `draft=true`, `prerelease=false` run `30432036513` 실행
+- [x] 초기 signed candidate crash를 Issue #447 이슈로 분리하고 PR #448 변경으로 `devel`에 수정
+- [ ] PR #448 포함 `devel -> main` candidate 갱신 PR merge
+- [ ] 별도 승인 후 정확한 새 final candidate로 annotated `v0.1.9` tag 재지정
+- [ ] 새 final candidate에서 Release Rehearsal 재실행
+- [ ] 새 final candidate에서 `draft=true`, `prerelease=false` Publish workflow 재실행
 - [ ] signed/notarized draft DMG의 앱, Finder, Preview, editor와 Sparkle 차단 gate 통과
 - [ ] 별도 승인 후 official stable Publish workflow 실행
 - [ ] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
@@ -211,6 +235,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - HOP 충돌 안내는 HOP Preview `0.2.0 -> rhwp v0.7.13`처럼 검증된 mapping만 사용하며 실제 활성 provider를 판정하거나 자동 변경하지 않는다.
 - upstream `v0.8.2` known issue인 page-local repaint Issue #3412 이슈와 PDF 안내 modal Issue #3450 이슈의 알한글 영향은 Stage 4 signed editor smoke 전까지 미확정이다.
 - strict local `librhwp.a` byte reference mismatch가 남아 있다. Stage 3에서 portable source/Cargo/header/FFI/XCFramework 검증과 분리해 기록하고, workflow의 문서화된 portable release artifact 경계를 허용했다.
+- 기존 `v0.1.9` tag와 draft release는 PR #448 미포함 commit을 가리킨다. 새 candidate PR merge, tag 재지정과 workflow 재실행 전까지 release 근거로 사용하지 않는다.
 - Skia Thumbnail/Quick Look 경로의 production default 전환은 이번 release 범위가 아니다.
 - public DMG SHA256, appcast EdDSA signature, notarization, signed provider provenance와 Homebrew digest는 Stage 2에서 단정하지 않는다.
 - Intel Mac 실기기 설치·실행은 아직 수행하지 않았다. universal slice 자동 검증과 별개 잔여 위험으로 유지한다.
@@ -229,8 +254,10 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - [x] HOP provider 자동 변경을 주장하지 않음
 - [x] external sibling source-level 성립과 registered sandbox 제한을 분리
 - [x] PR #443 변경의 반응형 툴바 회귀 수정과 기존 rehearsal 무효화를 반영
+- [x] PR #448 변경의 Thumbnail crash 수정과 기존 signed draft 무효화를 반영
 - [x] strict artifact, signed Finder/editor, Intel Mac과 public digest를 미확정 gate로 유지
 - [x] source preflight와 Rehearsal 검증
+- [ ] PR #448 포함 final candidate source preflight와 Rehearsal 재검증
 - [ ] installed signed candidate의 Finder/Preview/editor와 Sparkle 차단 gate
 - [ ] public DMG와 SHA256 기록
 - [ ] public GitHub Release와 Pages/Sparkle 확인

--- a/mydocs/report/task_m020_447_report.md
+++ b/mydocs/report/task_m020_447_report.md
@@ -1,0 +1,282 @@
+# Task M020 #447 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#447 rhwp v0.8.2 반영 후 RustBridge image data 수명 회귀와 Thumbnail 크래시 수정](https://github.com/postmelee/alhangeul-macos/issues/447) |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 기준 브랜치 | `devel` |
+| 작업 브랜치 | `local/task447` |
+| 기준 통합 SHA | `1b1213db5a0bd75638f54bf03d49fbf4cb63edcc` |
+| upstream core/studio | `v0.8.2` / `9b16aa9e23f476e2b335d7c029fc9f24a199d63c` |
+| 차단 대상 | [#441 v0.1.9 public release 준비와 배포 실행](https://github.com/postmelee/alhangeul-macos/issues/441) |
+| 단계 | 수행계획, 구현계획, Stage 1~4, 최종 보고 |
+
+rhwp v0.8.2에서 `get_bin_data()`가 owned `Vec<u8>`를 반환하도록 바뀐 뒤
+RustBridge가 함수 종료와 함께 해제되는 임시 bytes의 pointer를 Swift에 넘기던
+use-after-free를 수정했다. 기존 `rhwp_image_data` symbol을 caller-owned
+allocation 계약으로 전환하고 Swift가 `Data` 복사 직후
+`rhwp_free_bytes(pointer, length)`로 해제하도록 source, generated header와
+문서를 일치시켰다.
+
+핵심 결론:
+
+- `rhwp_image_data`는 non-empty bytes를 독립 `Box<[u8]>` allocation으로
+  넘기며 explicit free 전까지 document handle 수명과 독립적으로 유효하다.
+- Swift `imageData`와 `imageDataLength`는 성공 pointer를 모든 경로에서
+  정확히 한 번 해제한다.
+- 공개 C ABI symbol은 기존 15개를 유지하고 새 symbol을 추가하지 않았다.
+- Rust 7개와 Swift 27개 test, 세 제품 target, representative renderer와
+  image visual harness가 통과했다.
+- v0.1.9 candidate-only provider로 HWP/HWPX thumbnail 20건을 반복 생성했고
+  Stage 4 baseline 이후 신규 알한글 Preview/Thumbnail crash가 없다.
+- 사용자 설치본과 active provider를 원래 v0.1.8
+  `/Applications/Alhangeul.app` 상태로 복원했고 development registration은
+  0건이다.
+- Developer ID signed/notarized candidate와 public publish는 실행하지 않았다.
+  Task #447 merge SHA를 포함한 새 후보 생성은 #441 이슈에 인계한다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `RustBridge/src/lib.rs` | `rhwp_image_data`를 caller-owned mutable allocation으로 전환하고 null/empty/panic 계약과 allocator-pressure·handle-close Rust test 추가 |
+| `Sources/RhwpCoreBridge/RhwpDocument.swift` | image bytes copy와 length query가 성공 pointer를 exact length로 즉시 free하도록 수정 |
+| `Tests/ExternalImageTests/RhwpDocumentExternalImageBridgeTests.swift` | 반복 query, allocator pressure, document deinit 뒤 copied `Data`와 invalid id test 추가 |
+| `RustBridge/README.md` | rhwp v0.8.2 provenance와 image allocation copy/free 계약 반영 |
+| `mydocs/tech/project_architecture.md` | stale borrowed document buffer 설명을 caller-owned allocation 경계로 갱신 |
+| `rhwp-core.lock` | 같은 v0.8.2 source로 재생성한 archive/header hash, size와 build 시각 반영 |
+| `mydocs/plans/task_m020_447.md` | use-after-free 증거, 범위, 5단계 계획과 release 인계 경계 기록 |
+| `mydocs/plans/task_m020_447_impl.md` | owned-buffer 선택, ABI·Swift 계약, test matrix와 단계별 gate 확정 |
+| `mydocs/working/task_m020_447_stage1.md` | upstream API, crash stack과 구현 대안 조사 기록 |
+| `mydocs/working/task_m020_447_stage2.md` | RustBridge owned allocation 구현과 Rust lifetime test 결과 기록 |
+| `mydocs/working/task_m020_447_stage3.md` | Swift free, generated artifact와 ownership 문서 정합성 기록 |
+| `mydocs/working/task_m020_447_stage4.md` | 세 제품 target, exact-provider Finder 반복 smoke와 복원 결과 기록 |
+| `mydocs/report/task_m020_447_report.md` | 전체 수용 기준, 정량 비교, #441 signed candidate 재개 조건 기록 |
+| `mydocs/orders/20260729.md` | #447 진행 단계와 완료 시각 반영 |
+
+제품 동작 변경은 RustBridge FFI 한 함수와 Swift wrapper 두 함수로 제한된다.
+upstream `rhwp`, Cargo dependency, bundled `rhwp-studio`, `project.yml`, Xcode
+target 구성, app version/build와 release workflow에는 Task #447 diff가 없다.
+
+## 단계별 결과
+
+| 단계 | 커밋 | 결과 |
+|------|------|------|
+| 수행계획 | `9e92331` | #447 원인, 범위, branch와 오늘할일 등록 |
+| Stage 1 | `a148dd2` | owned-buffer/free를 단일 계약으로 선택하고 구현계획 확정 |
+| Stage 2 | `ae74a2a` | 임시 Vec pointer escape 제거, Rust lifetime test 7/7 통과 |
+| Stage 3 | `2224542` | Swift exact free, generated artifact와 문서 정합화, Swift 27/27 통과 |
+| Stage 4 | `ccc87a1` | 세 target, image renderer와 candidate-only Thumbnail 20/20 검증 |
+| 최종 보고 | 이번 커밋 | 전체 수용 기준, PR 범위와 #441 release handoff 정리 |
+
+## Ownership 계약과 설계 판단
+
+### 변경 전
+
+```text
+core Option<Vec<u8>>
+→ local Vec.as_ptr()
+→ Rust 함수 종료와 Vec drop
+→ Swift Data(bytes:count:)가 해제된 pointer를 복사
+```
+
+v0.1.9 build 15 crash 두 건은 `_platform_memmove → Data.InlineSlice →
+RhwpDocument.imageData → CGTreeRenderer.renderImage`에서 발생했다. source의
+drop/copy 순서와 crash stack이 같은 use-after-free 경계를 가리킨다.
+
+### 변경 후
+
+```text
+core Option<Vec<u8>>
+→ Vec.into_boxed_slice()
+→ pointer/length ownership을 caller에게 전달
+→ Swift Data 독립 복사
+→ defer rhwp_free_bytes(pointer, length)
+```
+
+성공 계약:
+
+1. non-empty bytes만 caller-owned allocation으로 반환한다.
+2. pointer는 `rhwp_free_bytes` 전까지 유효하고 document handle과 독립이다.
+3. Swift caller는 반환받은 동일 pointer와 exact length를 정확히 한 번 free한다.
+4. Swift가 반환하는 `Data`는 Rust allocation과 document 수명에서 독립적이다.
+
+실패 계약:
+
+- null `out_len`은 null pointer를 반환한다.
+- non-null `out_len`은 query 시작 시 0으로 초기화한다.
+- null handle, id 0, missing id, empty bytes와 panic은 null/0으로 정규화한다.
+
+handle-owned raw-byte cache는 decoded `CGImage` cache와 image 원본을 문서
+종료까지 중복 보유하고 upstream lazy BinData의 메모리 절감 의도와 충돌한다.
+기존 `rhwp_free_bytes`를 재사용하는 caller-owned 계약은 Swift 복사 직후
+원본 allocation을 회수하므로 별도 cache와 새 FFI symbol을 만들지 않는다.
+
+## 변경 전·후 정량 비교
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| image pointer lifetime | 함수 종료 시 임시 Vec와 함께 해제 | explicit `rhwp_free_bytes` 전까지 유효 |
+| document handle 의존 | 실제로는 유효 수명 보장 없음 | allocation이 handle close와 독립 |
+| RustBridge `lib.rs` | 649줄 | 748줄 |
+| Swift `RhwpDocument.swift` | 409줄 | 421줄 |
+| Swift bridge test file | 138줄 | 197줄 |
+| RustBridge 전체 test | 4개 | 7개 |
+| Swift `ExternalImageTests` | 24개 | 27개 |
+| 공개 FFI symbol | 15개 | 15개, byte-identical |
+| generated C 반환형 | `const uint8_t *` | `uint8_t *` |
+| generated header | 3,310 bytes / `c4cba072…` | 3,242 bytes / `5dab4c02…` |
+| universal archive | 212,505,600 bytes / `b35e9352…` | 212,514,840 bytes / `5083f2a0…` |
+| candidate 반복 thumbnail | crash blocker 2건 | 4문서 × 5회, 20/20 PASS |
+| Stage 4 이후 app-extension crash | 기준 crash 2건 | 신규 0건 |
+
+최종 보고서 작성 전 `origin/devel..ccc87a1` 범위는 13개 파일,
+`+1687 / -42`다. 이 중 실제 source·test·contract 6개 파일은
+`+212 / -41`이며 나머지는 계획·단계 검증 기록이다.
+
+## 검증 결과
+
+### 최종 통합 검증
+
+최종 PR head 후보에서 통합 검증을 다시 실행했다.
+
+| 검증 | 결과 | 핵심 출력 |
+|------|------|-----------|
+| `cargo fmt --check` | OK | 출력 없음 |
+| `cargo check --locked` | OK | RustBridge와 rhwp v0.8.2 check 완료 |
+| `cargo test --locked` | OK | 7 passed, 0 failed |
+| `build-rust-macos.sh --verify-lock` | OK | archive/header/XCFramework와 lock 일치 |
+| core build info | OK | tag, commit, features와 lock 일치 |
+| FFI symbol diff | OK | 15개, expected/generated SHA-256 동일 |
+| no-AppKit boundary | OK | shared Swift AppKit/UIKit 의존 없음 |
+| `xcodegen generate` | OK | tracked project drift 없음 |
+| `ExternalImageTests` | OK | 27 passed, 0 failed, 0 unexpected |
+| HostApp Debug build | OK | `BUILD SUCCEEDED` |
+| QLExtension Debug build | OK | `BUILD SUCCEEDED` |
+| ThumbnailExtension Debug build | OK | `BUILD SUCCEEDED` |
+| representative render | OK | KTX, request, exam_kor 통과 |
+| image visual harness | OK | HWP 3종, HWPX 1종 모두 OK |
+| registration hygiene | OK | active `/Applications`, development registration 0건 |
+| `git diff --check` | OK | whitespace 오류 없음 |
+
+build가 Sparkle embedded `Updater.app`을 LaunchServices에 등록한 세 경로는
+app/appex 단위 표준 cleanup과 exact Updater path unregister로 제거했다.
+Quick Look cache를 reset한 뒤 active Preview/Thumbnail provider는 다시
+`/Applications/Alhangeul.app` v0.1.8만 남았고 사용자 앱도 기존
+v0.1.8 build 14/CDHash로 유지된다.
+
+### 수용 기준
+
+| 수용 기준 | 판정 | 근거 |
+|-----------|------|------|
+| image pointer가 명시 수명 동안 유효 | OK | allocator pressure와 handle close 뒤 Rust bytes 동일 |
+| 반복 query가 독립 allocation을 제공 | OK | 두 allocation 동시 유지와 한쪽 free 뒤 bytes 동일 |
+| Swift copy/free 계약 | OK | 128회 pressure, document deinit, invalid id test 통과 |
+| 공개 ABI 호환 경계 | OK | symbol 15개 유지, header/caller 같은 build로 갱신 |
+| App/Preview/Thumbnail build | OK | 세 target 모두 Debug compile/link 통과 |
+| image-heavy renderer | OK | HWP 3종과 HWPX 1종 visual harness OK |
+| exact candidate Thumbnail | OK | candidate-only provider path, 20/20 output과 안정 hash |
+| 신규 Thumbnail crash 없음 | OK | Stage 4 baseline 이후 알한글 extension report 0건 |
+| 설치본/provider 복원 | OK | 사용자 v0.1.8과 `/Applications` provider 복원 |
+| signed/notarized 최종 candidate | #441 후속 gate | merge SHA를 포함한 새 후보가 필요하므로 release owner 절차로 인계 |
+
+Issue 초기 완료 기준의 signed candidate smoke는 Task #447 merge 전
+artifact로 완료 처리하지 않는다. 승인된 구현계획은 #447 작업에서 local Release
+package와 exact-provider 회귀를 통과시키고, fix merge SHA가 생긴 뒤 #441
+이슈에서 Developer ID signed/notarized candidate를 새로 생성하도록 범위를
+구체화했다.
+
+## Finder 검증과 Preview CLI 진단
+
+HEAD `2224542` 기준 로컬 v0.1.9 build 15 ad-hoc package는 deep codesign,
+arm64+x86_64 app/appex와 표준 HWP/HWPX Finder smoke를 통과했다.
+candidate-only 상태에서 active path는 다음과 같았다.
+
+```text
+/Users/melee/Applications/Alhangeul.app/Contents/PlugIns/AlhangeulPreview.appex
+/Users/melee/Applications/Alhangeul.app/Contents/PlugIns/AlhangeulThumbnail.appex
+```
+
+`복학원서.hwp`, `hwp-img-001.hwp`, `img-start-001.hwp`,
+`hwpx-01.hwpx`를 cache reset과 함께 다섯 번씩 생성했다. 총 20개 output이
+생성됐고 같은 문서의 PNG SHA-256은 매회 동일했다.
+
+출력형 Preview 진단 `qlmanage -p -x -o`는 candidate에서 Apple
+`ExtensionFoundation`의 nil dictionary key 예외로 종료됐다. 기존 Developer
+ID v0.1.8을 단독 provider로 바꾼 비교 실행도 같은 `qlmanage` process,
+같은 stack과 exit 134를 재현했다. 알한글 provider code 진입 전 Apple tool
+경로이므로 Task #447 신규 회귀로 판정하지 않았지만, #441 signed candidate에서
+Finder Space 입력의 실제 Preview UI를 수동으로 다시 확인한다.
+
+## #441 Release Operations 인계
+
+Task #447 PR merge만으로 v0.1.9 public publish가 승인되는 것은 아니다.
+#441 이슈에서 다음 순서를 지킨다.
+
+1. Task #447 PR merge commit을 포함한 최신 `devel`을 candidate 기준으로
+   확정한다.
+2. 기존 signed draft workflow run `30432036513`, merge 전 v0.1.9 DMG,
+   Task #447 로컬 ad-hoc app/zip을 재사용하지 않는다.
+3. 새 candidate SHA로 Release Rehearsal과 Developer ID signed/notarized
+   draft DMG를 다시 생성한다.
+4. app과 Preview/Thumbnail의 `0.1.9 (15)`, universal slice, signature,
+   notarization과 Gatekeeper를 확인한다.
+5. image-heavy HWP 3종과 HWPX 1종을 실제 signed Thumbnail provider에서
+   반복 표시하고 신규 `AlhangeulThumbnail` crash가 없는지 확인한다.
+6. Finder Space Preview, 앱 HWP/HWPX open, bundled editor repaint와
+   저장·공유·인쇄/PDF 시작 경로를 다시 확인한다.
+7. 작업지시자의 #441 승인 gate 전에는 GitHub Release, Pages/Sparkle,
+   Homebrew와 official stable publish를 실행하지 않는다.
+
+Task #447 이슈의 PR head와 merge SHA, CI 결과는 PR 생성·merge 뒤 #441 이슈에
+추가 기록한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- upstream `edwardkim/rhwp` source, release tag, resolved commit과
+  `native-skia` feature는 변경하지 않았다.
+- bundled `rhwp-studio` asset, HostApp UI, Quick Look/Thumbnail renderer
+  policy와 production CoreGraphics default는 유지했다.
+- 기존 Rust 4개와 Swift 24개 test는 삭제·완화하지 않고 lifetime test
+  3개씩만 추가했다.
+- `rhwp-ffi-symbols.txt`는 수정하지 않았고 generated symbol 파일과
+  byte-identical하다.
+- `project.yml`과 generated Xcode project에는 Task #447 diff가 없다.
+- app version/build, release record, workflow input, release tag, public
+  artifact, appcast와 Cask를 변경하지 않았다.
+- build, package, visual, Finder와 registration 진단은 `build.noindex/`
+  아래 ignored artifact로만 생성했다.
+
+## 잔여 위험과 후속 작업
+
+| 항목 | 상태 | 후속 |
+|------|------|------|
+| signed/notarized v0.1.9 candidate | 미생성 | #447 merge SHA를 포함해 #441 승인 gate로 새로 생성 |
+| Finder Preview 자동 CLI | 기존 v0.1.8도 동일 Apple tool crash | #441 signed candidate에서 실제 Finder Space UI 수동 확인 |
+| Intel Mac runtime | 미실행 | universal slice 확인 완료, 가능한 Intel 환경에서 smoke |
+| `imageDataLength` 비용 | full lazy bytes allocation 유지 | 성능 문제가 측정되면 별도 metadata ABI 이슈로 분리 |
+| raw FFI 신규 caller | exact pointer/length free 의무 | architecture/README 계약을 적용하고 regression test 추가 |
+| 로컬 build 산출물 | unregistered 상태로 존재 | PR merge 뒤 task cleanup에서 불필요 artifact 정리 |
+
+새 기능 이슈는 필요하지 않다. v0.1.9 signed candidate 재생성과 public
+release 재개는 이미 열려 있는 #441 이슈가 소유한다.
+
+## 최종 결론
+
+rhwp v0.8.2의 owned BinData API와 불일치하던 borrowed-pointer 구현이
+v0.1.9 Thumbnail crash의 직접 원인이었다. 기존 symbol을 caller-owned
+allocation으로 전환하고 Swift exact free를 적용해 use-after-free를 제거했다.
+Rust/Swift lifetime test, ABI/artifact provenance, 세 제품 target, renderer와
+candidate-only image-heavy Thumbnail 20/20에서 신규 blocker가 없다.
+
+Task #447 source와 local package 회귀 gate는 완료됐다. public release는
+Task #447 merge commit을 포함한 새 signed/notarized candidate 검증 전까지
+계속 차단하며, 후속 실행은 #441 승인 절차를 따른다.
+
+## 작업지시자 승인 요청
+
+최종 보고서와 `devel` 대상 ready PR을 검토하고 merge 여부를 승인 요청한다.
+merge 전에는 #441 release candidate 갱신, Release Rehearsal과 public publish를
+실행하지 않는다.

--- a/mydocs/tech/project_architecture.md
+++ b/mydocs/tech/project_architecture.md
@@ -95,8 +95,8 @@ mydocs/                       # hyper-waterfall 작업 문서와 운영 매뉴�
 - 현재 v0.1.0 목표는 Demo/Preview release다.
 - Demo/Preview 배포는 필요한 bridge API가 포함된 resolved commit을 `rev`로 고정하는 commit-pinned git dependency를 허용한다.
 - Stable 안정 기준은 `edwardkim/rhwp` release tag와 resolved commit을 함께 고정하는 것이다.
-- 현재 lock은 `v0.7.18` Stable release tag pin 상태다. `rhwp-core.lock`은 release tag `v0.7.18`과 resolved commit `93862a4e16df59834ebce46d91e948cd739208e9`를 함께 기록한다.
-- `v0.7.18`에는 현재 `RustBridge`가 사용하는 page/render/image API와 `set_file_name`, `get_external_image_references`, `inject_external_image_by_key` external image context API가 포함되어 있다.
+- 현재 lock은 `v0.8.2` Stable release tag pin 상태다. `rhwp-core.lock`은 release tag `v0.8.2`와 resolved commit `9b16aa9e23f476e2b335d7c029fc9f24a199d63c`를 함께 기록한다.
+- `v0.8.2`에는 현재 `RustBridge`가 사용하는 page/render/image API와 `set_file_name`, `get_external_image_references`, `inject_external_image_by_key` external image context API가 포함되어 있다.
 - branch/floating ref는 배포 기준으로 사용하지 않는다.
 
 ### RustBridge
@@ -215,9 +215,9 @@ External image context ABI는 #409 Swift wrapper/Quick Look 적용 전까지 제
 - `rhwp_render_page_tree`와 `rhwp_render_page_svg`가 반환한 문자열은 반드시 `rhwp_free_string`으로 해제한다.
 - `rhwp_external_image_refs_json`이 반환한 문자열도 반드시 `rhwp_free_string`으로 해제한다.
 - filename, external key, image bytes, display path 입력 pointer는 caller-owned이며 FFI 호출 동안 유효해야 한다.
-- `rhwp_image_data`는 내부 문서 버퍼를 가리키므로, Swift에서는 즉시 `Data`로 복사해 사용한다.
-- `rhwp_image_data` pointer는 filename setter나 external image injection 같은 mutable 호출을 넘겨 보관하지 않는다.
-- `rhwp_extract_thumbnail`이 반환한 byte buffer는 Swift에서 복사 후 `rhwp_free_bytes`로 해제한다.
+- `rhwp_image_data`가 반환한 non-null pointer는 caller-owned allocation이다. Swift에서는 즉시 `Data`로 복사하고 반환받은 동일 pointer와 length를 `rhwp_free_bytes`로 정확히 한 번 해제한다.
+- `rhwp_image_data` allocation은 document handle과 독립이며 `rhwp_free_bytes` 호출 전까지 유효하다. free 뒤 pointer를 보관하거나 재사용하지 않는다.
+- `rhwp_extract_thumbnail`이 반환한 byte buffer도 Swift에서 복사 후 `rhwp_free_bytes`로 해제한다.
 - 이미지 조회의 `bin_data_id`는 1-indexed 규칙을 유지한다.
 
 ## 렌더링 구조

--- a/mydocs/working/task_m020_447_stage1.md
+++ b/mydocs/working/task_m020_447_stage1.md
@@ -1,0 +1,140 @@
+# Task M020 #447 Stage 1 완료보고서
+
+## 단계 목적
+
+v0.1.9 signed candidate의 Thumbnail crash와 rhwp v0.8.2 BinData API 변경을
+코드 수준에서 연결하고, `rhwp_image_data`가 따라야 할 단일 ownership 계약,
+회귀 fixture와 Stage 2~5 구현·검증 경계를 확정한다.
+
+Stage 1은 조사와 구현계획 작성만 수행한다. RustBridge, Swift caller,
+generated artifact, 앱과 extension 등록 상태는 변경하지 않는다.
+
+## 산출물
+
+| 파일 | 변경 | 요약 |
+|------|------|------|
+| `mydocs/plans/task_m020_447_impl.md` | 신규 486줄 | caller-owned buffer/free 계약, Rust·Swift test matrix, Stage 1~5와 중단 조건 확정 |
+| `mydocs/working/task_m020_447_stage1.md` | 신규 | 조사 근거, 대안 판단, 검증 결과와 Stage 2 승인 요청 기록 |
+| `mydocs/orders/20260729.md` | 1행 갱신 | #447 상태를 Stage 1 완료·Stage 2 승인 대기로 전환 |
+
+### 조사 결론
+
+1. upstream v0.8.2의 `DocumentCore::get_bin_data()`는 지연 로딩 도입으로
+   `Option<Vec<u8>>`를 반환한다.
+2. 현재 RustBridge는 이 임시 `Vec`의 `as_ptr()`를 반환하고 함수 종료 시
+   allocation을 해제한다.
+3. Swift의 `Data(bytes:count:)` 복사는 Rust 함수가 돌아온 뒤 실행되므로
+   해제된 pointer를 읽을 수 있다.
+4. 실제 v0.1.9 build 15 crash 두 건은 모두
+   `_platform_memmove → Data.InlineSlice → RhwpDocument.imageData`와
+   `com.postmelee.alhangeul.thumbnail-render` queue를 가리킨다.
+5. 기존 `rhwp_free_bytes`가 있고 직접 caller는
+   `RhwpDocument.imageData`와 `imageDataLength` 두 곳이므로 새 symbol 없이
+   explicit ownership으로 전환할 수 있다.
+
+### 대안 판정
+
+| 대안 | 판정 | 근거 |
+|------|------|------|
+| `RhwpHandle` stable cache | 제외 | upstream lazy loading의 메모리 절감 목적과 달리 raw bytes를 handle 종료까지 중복 보유하며 mutation/interior mutability 계약이 추가된다. |
+| 신규 copy symbol | 제외 | unsafe 기존 symbol을 남기고 API·test·문서 경로를 이중화한다. |
+| 기존 symbol caller-owned 전환 | 채택 | upstream owned `Vec`와 의미가 맞고 Swift 복사 직후 기존 free ABI로 회수하며 symbol 목록을 유지한다. |
+
+확정 계약은 다음과 같다.
+
+- `rhwp_image_data` 성공 반환형은 mutable byte pointer다.
+- pointer는 caller-owned이며 `rhwp_free_bytes(pointer, len)` 전까지 유효하다.
+- allocation은 document handle과 독립이다.
+- 실패·empty·panic은 null pointer와 length 0으로 정규화한다.
+- Swift는 `Data` 복사 직후 `defer`로 pointer를 정확히 한 번 해제한다.
+- `imageDataLength`도 bytes allocation을 받으므로 길이만 사용한 뒤 해제한다.
+
+### 회귀 fixture
+
+`samples/복학원서.hwp`를 최소 lifetime fixture로 확정했다. 기존 metadata
+보고에 다음 embedded image 근거가 남아 있다.
+
+| binDataId | mime | byteCount | 용도 |
+|----------:|------|----------:|------|
+| 1 | `image/png` | 44,860 | Rust/Swift 반복 data 조회 기본 fixture |
+| 2 | `image/png` | 253,602 | 두 번째 id와 교차 조회 확장 fixture |
+
+Stage 2 Rust test는 id 1 pointer를 explicit free 전에 allocator pressure에
+노출하고, 동시 두 allocation과 handle close 뒤 유효성을 확인한다. Stage 3
+Swift test는 copied `Data`의 document lifetime 독립성과 반복 조회를 확인한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 source, Rust dependency, core/studio provenance와 generated artifact
+  변경은 없다.
+- `RustBridge/src/lib.rs`, `RhwpDocument.swift`, test source는 읽기만 했다.
+- 기존 수행계획서 본문은 변경하지 않았다.
+- 오늘할일의 기존 #441 보류와 #442 완료 행은 보존하고 #447 비고만 현재
+  승인 단계로 갱신했다.
+- 로컬 crash report는 증거로만 읽었고 이동·삭제·수정하지 않았다.
+- `/Users/melee/Documents/projects/forks/rhwp`의 사용자 변경은 건드리지 않았다.
+
+## 검증 결과
+
+구현계획서 Stage 1에 고정한 검증 명령을 그대로 실행했고 모두 exit code 0으로
+통과했다.
+
+| 검증 | 결과 | 핵심 출력 |
+|------|------|-----------|
+| upstream API | PASS | line 1227~1228에서 지연 로딩과 `Option<Vec<u8>>` 확인 |
+| FFI symbol·caller inventory | PASS | 기존 `rhwp_image_data`, `rhwp_free_bytes`, Swift wrapper 두 곳 확인 |
+| fixture 근거 | PASS | `복학원서.hwp` id 1·2와 byteCount 표 확인 |
+| crash evidence | PASS | 두 `.ips`에서 `_platform_memmove`, `Data.InlineSlice`, `RhwpDocument.imageData`, thumbnail-render queue 확인 |
+| 구현계획 단계·계약 | PASS | owned-buffer, free ABI, Stage 2~5와 중단 조건 확인 |
+| whitespace/diff | PASS | `git diff --check` 오류 없음 |
+
+crash header 교차 확인:
+
+| 시각 | 앱 | 버전/build | Incident |
+|------|----|------------|----------|
+| 2026-07-29 17:16:01 KST | AlhangeulThumbnail | 0.1.9 / 15 | `BFC71233-F2CA-4FE8-A54F-6BC29B2A2172` |
+| 2026-07-29 17:16:10 KST | AlhangeulThumbnail | 0.1.9 / 15 | `31487801-6D12-4CF6-A0BD-1BFB216A3226` |
+
+두 보고서의 slice UUID는
+`dbbe01a1-bbdf-3219-8d8a-2fc2e8b9e70d`로 동일하다. 서로 다른 코드 버전의
+우연한 crash를 합친 것이 아니다.
+
+## 잔여 위험
+
+- 아직 unsafe RustBridge source는 수정되지 않았으므로 현재 branch에서
+  `rhwp_image_data`를 호출하면 같은 use-after-free 가능성이 남아 있다.
+- mutable pointer 반환은 machine ABI representation을 유지하지만 generated
+  header와 Swift imported type이 함께 갱신돼야 한다.
+- `Box<[u8]>`로 넘긴 allocation을 기존 `rhwp_free_bytes`가 정확한 length로
+  해제하는지 Stage 2 unit test와 Stage 3 artifact test가 필요하다.
+- `imageDataLength`는 길이 확인을 위해 lazy bytes 전체를 load한다. 이 타스크는
+  별도 metadata ABI를 추가하지 않으며 실제 memory 문제가 확인되면 후속
+  이슈로 분리한다.
+- Rust/Swift source test 통과만으로 Finder extension crash 해결을 확정할 수
+  없다. Stage 4 exact-provider package smoke와 신규 crash report 부재가
+  최종 제품 gate다.
+- v0.1.9 tag와 draft release 처리 전략은 #441 이슈 소유이며 Stage 1에서
+  변경하지 않았다.
+
+## 다음 단계 영향
+
+Stage 2 범위는 `RustBridge/src/lib.rs` 하나와 단계 문서로 제한한다.
+
+1. `rhwp_image_data`를 caller-owned mutable pointer 반환으로 전환한다.
+2. out length를 진입 시 0으로 초기화하고 panic을 null/0으로 격리한다.
+3. non-empty Vec를 `Box<[u8]>` allocation으로 넘긴다.
+4. `복학원서.hwp` 기반 invalid/repeated/allocator-pressure/handle-close test를
+   추가한다.
+5. 전체 locked Rust test를 통과시킨다.
+
+Stage 2에서는 Swift caller, generated header, `rhwp-core.lock`, README와
+architecture 문서를 아직 변경하지 않는다. 이 변경은 Stage 3에서 regenerated
+XCFramework와 함께 원자적으로 검증한다.
+
+## 승인 요청
+
+Stage 1 조사와 구현계획을 승인하고, 구현계획서의 Stage 2
+`RustBridge owned image buffer와 unit test`에 진입할지 승인 요청한다.
+
+Stage 2 승인 전에는 `RustBridge/src/lib.rs`를 수정하거나 Rust artifact를
+재생성하지 않는다.

--- a/mydocs/working/task_m020_447_stage2.md
+++ b/mydocs/working/task_m020_447_stage2.md
@@ -1,0 +1,153 @@
+# Task M020 #447 Stage 2 완료보고서
+
+## 단계 목적
+
+`rhwp_image_data`가 rhwp v0.8.2의 owned `Vec<u8>`에서 해제될 임시 pointer를
+반환하지 않도록 RustBridge를 수정한다. 성공 bytes를 caller-owned allocation으로
+전환하고 invalid input, allocator pressure, 동시 allocation과 document handle
+종료 경계를 Rust unit test로 고정한다.
+
+Stage 2는 RustBridge source와 Rust test만 소유한다. Swift free caller,
+generated header/XCFramework, artifact lock과 ownership 문서는 Stage 3에서
+같은 regenerated artifact를 기준으로 갱신한다.
+
+## 산출물
+
+| 파일 | 변경 | 요약 |
+|------|------|------|
+| `RustBridge/src/lib.rs` | `+123 / -24` | `rhwp_image_data` owned pointer 전환, panic/null/empty 정규화, RAII test buffer와 3개 lifetime test 추가 |
+| `mydocs/working/task_m020_447_stage2.md` | 신규 | Stage 2 구현·검증과 잔여 위험 기록 |
+| `mydocs/orders/20260729.md` | 1행 갱신 | #447을 Stage 2 완료·Stage 3 승인 대기로 전환 |
+
+### FFI 변경
+
+기존 구현은 core가 반환한 local `Vec<u8>`의 `as_ptr()`를 반환하고 함수
+종료 시 Vec를 drop했다. 새 구현은 다음 순서를 사용한다.
+
+1. `out_len`이 null이면 즉시 null pointer를 반환한다.
+2. non-null `out_len`은 함수 진입 시 0으로 초기화한다.
+3. null handle과 `bin_data_id == 0`은 null/0으로 반환한다.
+4. core lookup을 `catch_unwind(AssertUnwindSafe(...))` 안에서 실행한다.
+5. non-empty `Vec<u8>`를 `Box<[u8]>`로 전환한다.
+6. mutable pointer와 exact length를 얻은 뒤 box를 `forget`해 caller에게
+   allocation ownership을 넘긴다.
+7. empty/missing/panic은 null/0으로 정규화한다.
+
+반환형은 `*const u8`에서 `*mut u8`로 바뀌었다. symbol 이름과 parameter
+목록은 유지하며, mutable pointer는 기존 `rhwp_free_bytes`로 해제할 수 있음을
+source type에 드러낸다.
+
+### Test support
+
+`TestBytes` RAII wrapper를 추가했다.
+
+- `rhwp_image_data`에서 non-null/non-zero allocation을 받는다.
+- `as_slice()`는 explicit free 전 범위에서만 raw bytes를 읽는다.
+- `Drop`은 pointer와 exact length를 `rhwp_free_bytes`에 전달한다.
+
+기존 `open_fixture()`는 그대로 KTX fixture를 열며, 공통
+`open_fixture_at(relative_path:)`를 추가해 image lifetime fixture로
+`samples/복학원서.hwp`를 사용한다.
+
+### 신규 test
+
+| Test | 검증 내용 |
+|------|-----------|
+| `image_data_owned_buffer_survives_allocator_pressure_and_handle_close` | id 1 expected bytes, 64개 유사 크기 allocation pressure 두 차례, handle close 뒤 pointer 유효성 |
+| `repeated_image_data_allocations_are_independently_owned` | 같은 id의 두 allocation 동시 유지, 첫 allocation free 뒤 두 번째 bytes 보존 |
+| `image_data_invalid_inputs_reset_output_length` | null handle, id 0, missing id, null out-length와 null/0 계약 |
+
+기존 filename, external refs JSON, injection과 loaded-state test 4개도 같은 전체
+suite에서 다시 통과했다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 source 변경은 `RustBridge/src/lib.rs` 한 파일로 제한했다.
+- upstream `rhwp` source와 사용자 fork 변경은 건드리지 않았다.
+- `RustBridge/Cargo.toml`, `Cargo.lock`, `rhwp-core.lock`의 tag, commit,
+  feature와 artifact metadata는 변경하지 않았다.
+- `rhwp-ffi-symbols.txt`, generated header/XCFramework와 Swift source는
+  Stage 2에서 변경하지 않았다.
+- 기존 4개 Rust test는 삭제·완화하지 않고 3개를 추가했다.
+- KTX test helper의 의미는 유지하고 fixture path만 공통 helper로 분리했다.
+- app, Preview, Thumbnail 실행·등록과 사용자 Applications 상태는 변경하지
+  않았다.
+
+## 검증 결과
+
+구현계획서 Stage 2에 고정한 검증을 최종 source 상태에서 다시 실행했다.
+
+| 검증 | 결과 | 핵심 출력 |
+|------|------|-----------|
+| `cargo fmt --check` | PASS | 출력 없음, exit 0 |
+| `cargo check --locked` | PASS | `rhwp_mac_bridge` dev profile 완료 |
+| `cargo test --locked` | PASS | 7 passed, 0 failed, 0 ignored |
+| ownership/source marker | PASS | owned box, free ABI, fixture와 allocator-pressure test 위치 확인 |
+| `git diff --check` | PASS | whitespace 오류 없음 |
+
+최종 Rust test:
+
+```text
+running 7 tests
+test tests::external_reference_lookup_reads_loaded_state ... ok
+test tests::external_refs_json_has_owned_string_lifecycle ... ok
+test tests::image_data_owned_buffer_survives_allocator_pressure_and_handle_close ... ok
+test tests::image_data_invalid_inputs_reset_output_length ... ok
+test tests::filename_context_validates_handle_and_utf8 ... ok
+test tests::injection_validates_inputs_and_missing_reference ... ok
+test tests::repeated_image_data_allocations_are_independently_owned ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored
+```
+
+첫 병렬 검증의 `cargo check`는 sandbox에서 Skia binary 다운로드 DNS가
+차단돼 실패했다. 같은 source의 `cargo test`는 cached artifact로 7/7
+통과했고, `cargo check --locked`를 네트워크 허용 환경에서 재실행해
+`skia-bindings`, `rhwp v0.8.2`, `rhwp_mac_bridge` 전체 check가 통과했다.
+이후 Stage 2 종료 검증에서 동일 `cargo check --locked`가 cache 상태에서도
+다시 exit 0으로 완료됐다. 제품/source 실패로 판정하지 않는다.
+
+## 잔여 위험
+
+- checked-in generated header는 아직 `const uint8_t *rhwp_image_data`를
+  나타내고, `Frameworks/Rhwp.xcframework`도 Stage 2 이전 archive다.
+  Rust source와 generated artifact는 Stage 3 재생성 전까지 의도적으로
+  비동기 상태다.
+- Swift `RhwpDocument.imageData`와 `imageDataLength`는 아직 owned pointer를
+  free하지 않는다. Stage 2 source로 XCFramework만 재생성해 기존 Swift와
+  결합하면 leak이 발생하므로 Stage 3에서 원자적으로 갱신해야 한다.
+- Rust unit test는 explicit free와 handle 독립성을 검증하지만 실제 Swift
+  `Data` copy, ImageIO decode와 Finder extension process는 아직 검증하지
+  않았다.
+- `imageDataLength`가 전체 lazy bytes allocation을 요구하는 기존 비용은
+  그대로다. 별도 length metadata ABI는 이번 단계에서 추가하지 않았다.
+- `rhwp_free_bytes`에는 caller가 exact pointer와 length를 전달해야 한다.
+  Stage 3 Swift wrapper와 generated header test가 이 계약을 고정해야 한다.
+
+## 다음 단계 영향
+
+Stage 3은 Rust source와 앱이 소비하는 artifact/caller를 다시 일치시킨다.
+
+1. `RhwpDocument.imageData`와 `imageDataLength`에 성공 pointer
+   `defer rhwp_free_bytes`를 추가한다.
+2. `복학원서.hwp` 기반 Swift copy/length/repeated/deinit test를 기존
+   `ExternalImageTests`에 추가한다.
+3. RustBridge README와 project architecture의 borrowed pointer 설명을
+   caller-owned/free 계약으로 바꾼다.
+4. Rust static archive와 generated header/XCFramework를 재생성한다.
+5. `rhwp-core.lock`의 artifact hash, size와 built_at을 새 source 기준으로
+   갱신한다.
+6. generated header의 mutable pointer, 15개 symbol 불변과
+   ExternalImageTests 전체 통과를 확인한다.
+
+Stage 3에서 core tag/commit/features, Cargo dependency, `project.yml` 또는
+symbol 집합 변경이 필요하면 계획대로 중단하고 재승인을 요청한다.
+
+## 승인 요청
+
+Stage 2 RustBridge owned buffer 구현과 7/7 Rust test 결과를 승인하고,
+구현계획서의 Stage 3 `Swift free 계약, 문서와 artifact 정합성`에 진입할지
+승인 요청한다.
+
+Stage 3 승인 전에는 Swift caller, ownership 문서, generated framework와
+`rhwp-core.lock`을 변경하지 않는다.

--- a/mydocs/working/task_m020_447_stage3.md
+++ b/mydocs/working/task_m020_447_stage3.md
@@ -1,0 +1,167 @@
+# Task M020 #447 Stage 3 완료보고서
+
+## 단계 목적
+
+Stage 2에서 caller-owned allocation으로 전환한 `rhwp_image_data`를 Swift
+caller가 모든 성공 경로에서 정확히 한 번 해제하도록 수정한다. 같은 Rust
+source 상태로 static archive, generated header와 XCFramework를 다시 만들고,
+artifact lock·ownership 문서·Swift 회귀 test를 함께 맞춘다.
+
+Stage 3은 Swift wrapper, 기존 `ExternalImageTests`, ownership 문서와 생성
+artifact 정합성까지 소유한다. 제품 target build와 Finder exact-provider 반복
+smoke는 Stage 4에서 수행한다.
+
+## 산출물
+
+| 파일 | 변경 | 요약 |
+|------|------|------|
+| `Sources/RhwpCoreBridge/RhwpDocument.swift` | `+17 / -5` | image data 두 wrapper에 exact pointer/length free와 안전한 `UInt`→`Int` 변환 추가 |
+| `Tests/ExternalImageTests/RhwpDocumentExternalImageBridgeTests.swift` | `+59` | 반복 query, allocator pressure, document deinit과 invalid id 회귀 test 3개 추가 |
+| `RustBridge/README.md` | `+3 / -2` | v0.8.2 provenance와 caller-owned image allocation 계약 반영 |
+| `mydocs/tech/project_architecture.md` | `+5 / -5` | current core pin과 image buffer copy/free 경계 갱신 |
+| `rhwp-core.lock` | `+5 / -5` | 새 archive/header의 built_at, hash와 size 반영 |
+| `mydocs/working/task_m020_447_stage3.md` | 신규 | Stage 3 변경·검증과 잔여 위험 기록 |
+| `mydocs/orders/20260729.md` | 1행 갱신 | #447을 Stage 3 완료·Stage 4 승인 대기로 전환 |
+
+### Swift free 경계
+
+`RhwpDocument.imageData(binDataId:)`와
+`imageDataLength(binDataId:)`는 generated C header의 `uintptr_t`와 맞도록
+length를 `UInt`로 받는다. non-null/non-zero 성공 allocation을 받은 직후
+`defer rhwp_free_bytes(pointer, length)`를 설치하고, Swift `Int` 범위를
+검사한 다음 `Data` 또는 length를 반환한다.
+
+- `imageData`가 반환하는 `Data`는 Rust allocation과 독립된 복사본이다.
+- `imageDataLength`도 query 결과 pointer를 사용하지 않더라도 즉시 해제한다.
+- `hasImageData`는 기존처럼 `imageDataLength`를 사용하므로 같은 free 계약을
+  따른다.
+- null/zero/missing id는 기존 의미대로 `nil`을 반환한다.
+
+### Swift 회귀 test
+
+`samples/복학원서.hwp`의 embedded image id 1을 공통 fixture로 사용했다.
+
+| Test | 검증 내용 |
+|------|-----------|
+| `testImageDataCopyAndLengthRemainStableUnderAllocationPressure` | Data와 length 일치, 128회 반복 query와 유사 크기 Data allocation 뒤 byte 안정성 |
+| `testCopiedImageDataOutlivesDocument` | document scope 종료 뒤 copied Data 보존, 128개 allocation pressure 뒤 재개방 결과와 byte 동일성 |
+| `testImageDataRejectsInvalidIdentifiers` | id 0과 `UInt16.max`에서 Data/length 모두 nil |
+
+기존 external reference, injection, resolver test는 삭제하거나 완화하지 않았다.
+전체 `ExternalImageTests`는 기존 24개와 신규 3개를 합쳐 27개다.
+
+### Generated artifact와 lock
+
+`./scripts/build-rust-macos.sh --update-lock`으로 arm64와 x86_64 static archive,
+universal archive, generated C header와 `Rhwp.xcframework`를 같은 source에서
+재생성했다.
+
+| Artifact | 결과 |
+|----------|------|
+| `Frameworks/universal/librhwp.a` | arm64 + x86_64, 212,514,840 bytes, SHA-256 `5083f2a087bc390937c7b852ee832a10410d9f61e2cf5463affde8b0a737d9ca` |
+| `Frameworks/generated_rhwp.h` | 3,242 bytes, SHA-256 `5dab4c02225c0d6b94e6ae07ed36aa8d6f496386dde3892e811e49f0c7bda614` |
+| `rhwp_image_data` header | `uint8_t *` caller-owned mutable pointer |
+| 공개 FFI | 기존 15개 symbol과 byte-identical |
+
+`rhwp-core.lock`의 provenance는 release tag `v0.8.2`, resolved commit
+`9b16aa9e23f476e2b335d7c029fc9f24a199d63c`, feature `native-skia`로
+유지했다. 변경 필드는 `built_at`과 두 artifact의 hash·size뿐이다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 source 변경은 `RhwpDocument.swift`의 image data wrapper 두 곳으로
+  제한했다.
+- 기존 Swift test 24개는 삭제·완화하지 않고 lifetime test 3개만 추가했다.
+- RustBridge ownership 문서는 기존 external image 정책을 유지하면서 stale
+  borrowed-pointer 문장과 core provenance만 현재 계약으로 교체했다.
+- upstream `rhwp` source, `RustBridge/Cargo.toml`, `Cargo.lock`,
+  `rhwp-ffi-symbols.txt`는 변경하지 않았다.
+- `project.yml`을 원본으로 `xcodegen generate`를 실행했으며
+  `project.yml`과 `Alhangeul.xcodeproj/project.pbxproj`에는 diff가 없다.
+- App, Preview, Thumbnail 실행·등록, 사용자 Applications와 release
+  signing/notarization 상태는 변경하지 않았다.
+
+## 검증 결과
+
+구현계획서 Stage 3에 고정한 검증 명령을 단계 종료 source 상태에서 다시
+실행했다.
+
+| 검증 | 결과 | 핵심 출력 |
+|------|------|-----------|
+| `build-rust-macos.sh --update-lock` | PASS | arm64/x86_64 staticlib, universal archive와 XCFramework 생성 |
+| `build-rust-macos.sh --verify-lock` | PASS | `Verified: rhwp-core.lock` |
+| `verify-rhwp-core-build-info.sh` | PASS | `RhwpCoreBuildInfo matches rhwp-core.lock` |
+| FFI symbol diff | PASS | diff 출력 없음, 기존 15개 유지 |
+| generated header marker | PASS | line 78 mutable `rhwp_image_data`, line 82 `rhwp_free_bytes` |
+| `check-no-appkit.sh` | PASS | shared Swift code에 AppKit/UIKit 의존 없음 |
+| `xcodegen generate` | PASS | project 생성 성공 |
+| `ExternalImageTests` | PASS | 27 passed, 0 failed, 0 unexpected |
+| project diff gate | PASS | `project.yml`, generated pbxproj diff 없음 |
+| `git diff --check` | PASS | whitespace 오류 없음 |
+
+최종 Swift test 요약:
+
+```text
+Test Suite 'HwpExternalImageResolverTests' passed
+Executed 18 tests, with 0 failures
+
+Test Suite 'RhwpDocumentExternalImageBridgeTests' passed
+Executed 9 tests, with 0 failures
+
+Test Suite 'All tests' passed
+Executed 27 tests, with 0 failures (0 unexpected)
+** TEST SUCCEEDED **
+```
+
+XCFramework 생성 중 sandbox의 CoreSimulator service 접근 경고가 출력됐지만,
+이 단계는 macOS universal static library 생성 경로이며 command는 exit 0으로
+완료됐다. 네트워크 허용 환경에서 실행한 macOS `ExternalImageTests`도 build와
+runtime test를 모두 통과했으므로 제품/source 실패로 판정하지 않는다.
+
+## 잔여 위험
+
+- Stage 3 test는 Swift bridge 단위의 copy/free 계약을 검증한다. HostApp,
+  QLExtension, ThumbnailExtension 전체 target build는 아직 수행하지 않았다.
+- image-heavy renderer harness와 Finder가 실제로 선택한 Thumbnail provider
+  process에서는 수정 archive를 아직 반복 검증하지 않았다.
+- 기존 v0.1.9 build 15 crash report 두 건 이후 동일 candidate 조건에서 신규
+  crash가 없는지는 Stage 4 baseline 시각과 exact-provider smoke로 확인해야
+  한다.
+- `imageDataLength`는 안전하게 allocation을 free하지만 upstream API 특성상
+  length 확인에도 전체 lazy bytes allocation이 발생한다. 성능 최적화용 별도
+  metadata ABI는 이번 타스크 범위가 아니다.
+- `rhwp_free_bytes`는 반환받은 동일 pointer와 exact length를 한 번 전달해야
+  한다. 현재 두 Swift wrapper와 test는 이 경계를 지키지만 신규 raw caller가
+  추가되면 같은 규칙을 적용해야 한다.
+- x86_64 slice는 archive 생성과 symbol 검증까지 통과했으며 실제 XCTest
+  runtime은 현재 arm64 Mac에서 실행했다.
+
+## 다음 단계 영향
+
+Stage 4는 새 artifact를 실제 제품 경로에서 검증한다.
+
+1. locked Rust test와 artifact lock을 다시 확인한다.
+2. HostApp, QLExtension, ThumbnailExtension Debug target을 각각 build한다.
+3. native renderer와 image-heavy visual diff harness를 실행한다.
+4. Finder smoke 전 candidate app 경로·version/build·서명, 현재 사용자
+   설치본과 active provider, 기존 crash baseline을 보고한다.
+5. 사용자 Applications와 extension registration 변경은 별도 명시 승인 후
+   표준 smoke helper로만 수행한다.
+6. `복학원서.hwp` 등 HWP/HWPX thumbnail을 exact candidate provider로
+   반복 생성하고 baseline 이후 신규 `AlhangeulThumbnail-*.ips`가 없는지
+   확인한다.
+7. smoke 종료 후 candidate를 unregister하고 사용자 설치본/provider 상태를
+   복원한다.
+
+Stage 4에서 core dependency, FFI symbol, 제품 동작 변경 또는 signing/
+notarization/release workflow 실행이 필요하면 계획대로 중단하고 재승인을
+요청한다.
+
+## 승인 요청
+
+Stage 3 Swift free 계약, generated artifact 정합성과 27/27 test 결과를
+승인하고, 구현계획서의 Stage 4 `제품 target과 Finder Thumbnail crash 회귀
+검증`에 진입할지 승인 요청한다.
+
+Stage 4 승인 전에는 제품 target build, Finder provider 등록, 사용자
+Applications 변경과 release workflow를 실행하지 않는다.

--- a/mydocs/working/task_m020_447_stage4.md
+++ b/mydocs/working/task_m020_447_stage4.md
@@ -1,0 +1,217 @@
+# Task M020 #447 Stage 4 완료보고서
+
+## 단계 목적
+
+Stage 3에서 재생성한 caller-owned image buffer artifact를 HostApp, Preview,
+Thumbnail 제품 target과 native renderer에서 검증한다. 로컬 Release candidate를
+실제 Finder provider로 단독 등록해 image-heavy HWP/HWPX thumbnail을 반복
+생성하고, Stage 4 baseline 이후 `AlhangeulThumbnail` crash가 재발하지 않는지
+확인한다.
+
+Stage 4는 제품 source를 바꾸지 않고 build, renderer, package와 Finder
+exact-provider 회귀 검증만 소유한다. public release signing, notarization,
+GitHub Release와 Homebrew 배포는 #441 Release Operations 범위로 유지한다.
+
+## 산출물
+
+| 파일 또는 진단 | 변경 | 요약 |
+|----------------|------|------|
+| `build.noindex/release/Alhangeul.app` | 로컬 검증 산출물 | HEAD `2224542` 기준 v0.1.9 build 15 ad-hoc Release candidate |
+| `build.noindex/release/alhangeul-macos-0.1.9.zip` | 로컬 검증 산출물 | Finder smoke 입력과 재현용 로컬 package |
+| `build.noindex/task447-stage4-images/summary.md` | 로컬 검증 산출물 | HWP 3종과 HWPX 1종 native/studio visual diff 결과 |
+| `build.noindex/task447-stage4-finder/` | 로컬 검증 산출물 | 표준 Finder HWP/HWPX smoke 출력과 진단 |
+| `build.noindex/task447-stage4-finder-repeated/` | 로컬 검증 산출물 | candidate-only provider의 5회 × 4문서 thumbnail 출력 |
+| `build.noindex/task447-stage4-hygiene-final/` | 로컬 검증 산출물 | 복원 후 provider와 LaunchServices hygiene 진단 |
+| `mydocs/working/task_m020_447_stage4.md` | 신규 | Stage 4 build·renderer·Finder 검증과 복원 결과 기록 |
+| `mydocs/orders/20260729.md` | 1행 갱신 | #447을 Stage 4 완료·Stage 5 승인 대기로 전환 |
+
+`build.noindex/` 산출물은 Git 추적 대상이 아니다. Stage 4 커밋에는 완료보고서와
+오늘할일 상태만 포함하며 제품 source와 generated artifact는 Stage 3 commit
+상태를 유지한다.
+
+### Candidate와 baseline
+
+Stage 4 baseline은 `2026-07-29 18:37:17 KST`로 기록했다. baseline 이전
+`AlhangeulThumbnail` crash report는 다음 두 건이었다.
+
+- `AlhangeulThumbnail-2026-07-29-171601.ips`
+- `AlhangeulThumbnail-2026-07-29-171610.ips`
+
+로컬 package는 Stage 3 HEAD
+`2224542f9cf2293ccaf076c7645a200f008d1daa`에서
+`./scripts/package-release.sh 0.1.9`로 다시 생성했다.
+
+| 항목 | 결과 |
+|------|------|
+| App version/build | `0.1.9` / `15` |
+| App signature | ad-hoc, `TeamIdentifier=not set` |
+| App CDHash | `5369570fde44c892080c07ceea9e7f40f89f4008` |
+| Architecture | App, Preview, Thumbnail 모두 arm64 + x86_64 |
+| Zip SHA-256 | `26e8c01c89ccb0b187bf435ba2d6c337e4490175006b3ab5dda2e82334a2bd69` |
+
+이 package는 로컬 smoke 전용이다. Developer ID signing, notarization과 public
+release workflow는 실행하지 않았다.
+
+### Exact-provider Finder 검증
+
+표준 helper가 v0.1.9과 기존 `/Applications` v0.1.8 provider를 함께 보고해
+결과가 모호해지지 않도록, 기존 앱 파일은 유지한 채 해당 extension 등록만
+일시 해제했다. candidate를 다시 등록한 뒤 다음 두 경로만 표시되는 것을
+확인했다.
+
+```text
+/Users/melee/Applications/Alhangeul.app/Contents/PlugIns/AlhangeulPreview.appex
+/Users/melee/Applications/Alhangeul.app/Contents/PlugIns/AlhangeulThumbnail.appex
+```
+
+표준 Finder smoke는 `복학원서.hwp`와 `hwpx-01.hwpx` thumbnail을 모두
+생성하고 exit 0으로 완료됐다. 이어 매 회 Quick Look cache를 reset한 뒤
+다음 네 문서를 5회씩 생성했다.
+
+| 문서 | 반복 결과 | 매회 동일한 SHA-256 |
+|------|-----------|---------------------|
+| `복학원서.hwp` | 5/5 PASS | `979482bbc5c2d12cdb5e3930554a5851d23df6c35846e2a781f9b27b9c4464af` |
+| `hwp-img-001.hwp` | 5/5 PASS | `f4f0ffa1d6e2fe5d905f26c14ec1c86fa3e8b7783d4e257361e0efe477c23435` |
+| `img-start-001.hwp` | 5/5 PASS | `cbd796a108c30da91e4c9e1217281b5bedac0cad48dab27039ec6b3782af764b` |
+| `hwpx-01.hwpx` | 5/5 PASS | `3ef08ff54aaac5419a4efcdf21d874407d86640ee24b793fbb78b6848daad6b0` |
+
+총 20개 thumbnail이 생성됐고 문서별 output hash는 다섯 회 모두
+byte-identical했다. Stage 4 baseline 이후 신규
+`AlhangeulThumbnail-*.ips` 또는 `AlhangeulPreview-*.ips`는 발생하지 않았다.
+
+### 사용자 설치본과 provider 복원
+
+smoke 전 사용자 설치본
+`/Users/melee/Applications/Alhangeul.app`을
+`build.noindex/task447-stage4-backup/Alhangeul.app`에 보존했다. smoke 종료
+뒤 candidate app/appex를 unregister하고 백업을 원래 위치에 복원했다.
+
+| 복원 항목 | 결과 |
+|-----------|------|
+| 사용자 앱 | v0.1.8 build 14, ad-hoc |
+| 사용자 앱 CDHash | `13eb26f8958c5b94d5c2dbad2fadd0f162374cb6` |
+| `/Applications` 앱 | v0.1.8 build 14, Developer ID Application |
+| `/Applications` 앱 CDHash | `8a9f55ae5ec255ae1ea07617bf3c068606b04c10` |
+| active Preview provider | `/Applications/Alhangeul.app/Contents/PlugIns/AlhangeulPreview.appex` |
+| active Thumbnail provider | `/Applications/Alhangeul.app/Contents/PlugIns/AlhangeulThumbnail.appex` |
+| 최종 registration hygiene | issue 없음, development registration 없음 |
+
+`build.noindex` 아래 Debug/Release app bundle은 검증 산출물로 존재하지만
+LaunchServices 또는 PlugInKit provider로 등록된 항목은 없다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- Stage 4에서는 Rust, Swift, Xcode target, generated header/XCFramework와
+  `rhwp-core.lock`을 변경하지 않았다.
+- `xcodegen generate` 뒤 `project.yml`과
+  `Alhangeul.xcodeproj/project.pbxproj`에는 diff가 없다.
+- 기존 Rust 7개와 Swift 27개 test는 삭제·완화하지 않고 같은 Stage 3 source
+  상태에서 다시 통과했다.
+- Finder smoke는 표준 helper와 candidate app/appex 단위의
+  `lsregister`/`pluginkit` 조작만 사용했다. 전역 LaunchServices reset이나
+  Quick Look daemon kill은 수행하지 않았다.
+- 사용자 설치본은 version, build, CDHash와 deep code signature까지 확인한
+  백업으로 복원했다.
+- release tag, Developer ID signing, notarization, GitHub Release, Sparkle
+  feed와 Homebrew Cask는 변경하지 않았다.
+
+## 검증 결과
+
+구현계획서 Stage 4에 고정한 build, renderer와 Finder 검증을 같은 source
+상태에서 실행했다.
+
+| 검증 | 결과 | 핵심 출력 |
+|------|------|-----------|
+| `cargo test --locked` | PASS | 7 passed, 0 failed |
+| `build-rust-macos.sh --verify-lock` | PASS | checked-in artifact와 lock 일치 |
+| `check-no-appkit.sh` | PASS | shared Swift code의 AppKit/UIKit 의존 없음 |
+| `xcodegen generate` | PASS | project 생성 성공, project diff 없음 |
+| HostApp Debug build | PASS | `CODE_SIGNING_ALLOWED=NO`, build 성공 |
+| QLExtension Debug build | PASS | `CODE_SIGNING_ALLOWED=NO`, build 성공 |
+| ThumbnailExtension Debug build | PASS | `CODE_SIGNING_ALLOWED=NO`, build 성공 |
+| `ExternalImageTests` | PASS | 27 passed, 0 failed, 0 unexpected |
+| `validate-stage3-render.sh` | PASS | KTX, request, exam_kor 모두 OK |
+| image visual diff harness | PASS | HWP 3종, HWPX 1종 모두 OK |
+| release package integrity | PASS | app/appex deep codesign과 universal architecture 확인 |
+| 표준 Finder smoke | PASS | HWP/HWPX thumbnail 생성 |
+| candidate-only 반복 thumbnail | PASS | 5회 × 4문서, 20/20 생성 및 hash 안정 |
+| crash report gate | PASS | baseline 이후 신규 알한글 Preview/Thumbnail crash 없음 |
+| 복원 후 hygiene | PASS | active provider `/Applications`, development registration 없음 |
+| `git diff --check` | PASS | whitespace 오류 없음 |
+
+최종 Swift test:
+
+```text
+Test Suite 'HwpExternalImageResolverTests' passed
+Executed 18 tests, with 0 failures
+
+Test Suite 'RhwpDocumentExternalImageBridgeTests' passed
+Executed 9 tests, with 0 failures
+
+Test Suite 'All tests' passed
+Executed 27 tests, with 0 failures (0 unexpected)
+** TEST SUCCEEDED **
+```
+
+### Preview CLI 비교 진단
+
+계획의 Thumbnail crash gate와 별도로 Preview extension을 출력형
+`qlmanage -p -x -o`로 자동 확인하려 했다. candidate v0.1.9에서
+`qlmanage`가 exit 134로 종료됐지만, 기존 Developer ID 서명 v0.1.8을
+단독 provider로 등록한 비교 실행에서도 같은 예외와 stack으로 종료됐다.
+
+```text
+NSInvalidArgumentException
+-[EXConcreteExtension makeExtensionContextAndXPCConnectionForRequest:error:]
+-[QLExtension _setupConnectionIfNeededWithCompletionHandler:]
+```
+
+두 crash report의 process는 알한글 extension이 아니라 Apple
+`com.apple.quicklook.qlmanage`이고, stack은 알한글 provider code 진입 전
+`ExtensionFoundation`에만 있다. 따라서 Task #447 source 또는 v0.1.9
+candidate의 신규 회귀로 판정하지 않았다. 이 비교로 생성된
+`qlmanage-2026-07-29-185622.ips`와
+`qlmanage-2026-07-29-185759.ips`는 원인 구분 증거로 보존했다.
+
+## 잔여 위험
+
+- `qlmanage -p -x -o`는 현재 macOS 환경에서 기존 v0.1.8과 candidate 모두
+  Apple `ExtensionFoundation` 예외로 사용할 수 없다. #441의 실제
+  Developer ID signed candidate에서는 Finder/Space 입력의 Preview UI를
+  수동으로 다시 확인한다.
+- 이번 exact-provider gate는 Task #447의 crash queue였던 Thumbnail
+  extension과 image-heavy 문서에 집중했다. 앱의 전체 사용자 동작과 배포
+  채널 검증은 #441 release rehearsal이 소유한다.
+- x86_64는 Rust universal archive와 세 제품 bundle slice까지 검증했으며
+  runtime test는 arm64 Mac에서 수행했다.
+- 로컬 ad-hoc zip은 public 배포 산출물이 아니다. #441은 Task #447 merge
+  SHA를 포함해 signed candidate를 새로 생성해야 하며 기존 draft artifact나
+  이 로컬 zip을 재사용하면 안 된다.
+- `imageDataLength`의 full lazy-byte allocation 비용과 exact length free
+  계약은 Stage 3에서 기록한 범위를 유지한다.
+
+## 다음 단계 영향
+
+Stage 5는 Task #447의 최종 보고와 #441 Release Operations 인계를 수행한다.
+
+1. caller-owned allocation 선택과 memory trade-off를 최종 보고서에 정리한다.
+2. Rust/Swift test, artifact provenance, 세 target, renderer와
+   exact-provider 결과를 PR body와 일치시킨다.
+3. #441에 Task #447 fix commit과 PR/merge SHA, 새 signed candidate 생성
+   조건을 전달한다.
+4. `task-final-report` 절차로 오늘할일 완료, 최종 커밋,
+   `publish/task447` push와 `devel` 대상 ready PR을 생성한다.
+5. PR CI 완료와 merge는 작업지시자의 별도 승인 절차를 따른다.
+
+Stage 5 전에는 원격 branch push, PR 생성, #441 공개 코멘트, release signing,
+notarization 또는 배포 workflow를 실행하지 않는다.
+
+## 승인 요청
+
+Stage 4 제품 build, image renderer와 candidate-only Thumbnail 20/20 결과,
+신규 알한글 extension crash 없음 및 사용자 설치본/provider 복원을 승인하고,
+구현계획서의 Stage 5 `최종 보고, PR 게시와 #441 인계`에 진입할지 승인
+요청한다.
+
+Stage 5 승인 전에는 최종 보고서, 원격 `publish/task447`, GitHub PR과 #441
+인계 작업을 시작하지 않는다.

--- a/rhwp-core.lock
+++ b/rhwp-core.lock
@@ -4,15 +4,15 @@ rhwp_ref_kind = "release-tag"
 rhwp_release_tag = "v0.8.2"
 rhwp_commit = "9b16aa9e23f476e2b335d7c029fc9f24a199d63c"
 rhwp_enabled_features = "native-skia"
-built_at = "2026-07-27T04:39:01Z"
+built_at = "2026-07-29T09:33:34Z"
 ffi_symbols_file = "rhwp-ffi-symbols.txt"
 
 [[artifacts]]
 path = "Frameworks/universal/librhwp.a"
-sha256 = "b35e935283f97c20d41f634f559e623ccd510f54f1341ca83d0f2108345a58eb"
-size = 212505600
+sha256 = "5083f2a087bc390937c7b852ee832a10410d9f61e2cf5463affde8b0a737d9ca"
+size = 212514840
 
 [[artifacts]]
 path = "Frameworks/generated_rhwp.h"
-sha256 = "c4cba0728b7e443ba78541dc1184d6aa286b91b72006e423e9283d998c31d8e5"
-size = 3310
+sha256 = "5dab4c02225c0d6b94e6ae07ed36aa8d6f496386dde3892e811e49f0c7bda614"
+size = 3242


### PR DESCRIPTION
## 요약

Refs #441

PR #448 변경의 Finder Thumbnail crash 수정을 포함한 새 `v0.1.9` release candidate를 `main`에 반영하는 갱신 PR입니다.

- release candidate commit: `485c76cf32486d148fa88e30717e18c9794e810f`
- current `main`: `1e7f5df59684713745cb9d59c0a0e9dfdaaf0272`
- candidate merge tree: `c08f8c815f25bd079093cd75ffe96c9aac03d752`
- previous public release: `v0.1.8`
- app version/build: `0.1.9 (15)`
- included rhwp core/studio: `v0.8.2` / `9b16aa9e23f476e2b335d7c029fc9f24a199d63c`

기존 annotated `v0.1.9` tag와 signed draft는 current `main`을 가리키며 PR #448 변경을 포함하지 않습니다. 이 PR은 새 candidate source를 `main`에 반영하기 위한 gate일 뿐 Issue #441 이슈를 닫지 않으며, tag 재지정·workflow 실행·GitHub Release 공개·Pages/Sparkle 배포와 Homebrew 반영을 수행하지 않습니다.

## 주요 변경

- RustBridge의 `rhwp_image_data`를 caller-owned allocation으로 전환하고 Swift가 복사 직후 exact length로 해제해 외부 그림 처리 중 Finder Thumbnail use-after-free crash를 수정했습니다.
- Rust allocator pressure·handle close와 Swift 반복 allocation·document lifetime 회귀 test를 추가했습니다.
- generated header, XCFramework, artifact lock과 ownership 문서를 같은 15-symbol ABI 계약으로 정렬했습니다.
- README와 v0.1.9 Pages/release record에 Finder Thumbnail 안정성 수정과 기존 tag/draft 폐기 근거를 반영했습니다.

## 포함 PR과 release owner 판정

| PR | 분류 | 공개 요약 | 비고 |
|----|------|-----------|------|
| [#448: RustBridge image data 수명 회귀와 Thumbnail 크래시 수정](https://github.com/postmelee/alhangeul-macos/pull/448) | 사용자-facing 버그 수정 | 반영 | caller-owned image buffer와 Swift exact free |
| [#449: PR #448 반영과 v0.1.9 후보 재검증 준비](https://github.com/postmelee/alhangeul-macos/pull/449) | 운영/배포 | 제외 | 기존 후보 폐기와 새 Stage 4 gate 기록 |

## candidate 정합성

- `origin/main...origin/devel`: main 전용 `1`, devel 전용 `9`
- current `main` 전용 commit은 기존 release PR #446 merge commit뿐입니다.
- three-way merge tree 생성 결과 충돌이 없으며 merge tree `c08f8c8...`는 exact `devel` tree와 일치합니다.
- `main...devel` 제품 diff는 18개 파일, `+2020/-65`이며 PR #448 수정과 PR #449 communication으로 한정됩니다.
- 포함 PR 분석을 candidate `485c76c...`에서 다시 생성해 PR #448 및 PR #449 merge transport를 확인했습니다.

## 검증

- RustBridge build lock, generated header/XCFramework와 공개 FFI 15개 symbol 검증 통과
- Rust test 7/7, `ExternalImageTests` 27/27 통과
- HostApp, QLExtension, ThumbnailExtension Release build 통과
- representative HWP/HWPX renderer 5/5 통과
- local `0.1.9 (15)` universal package와 ZIP 무결성 검증 통과
- app/extension `x86_64 arm64`, 법적 고지 3종 원본 일치, ad-hoc codesign 검증 통과
- image-heavy Thumbnail HWP 3종·HWPX 1종 20/20, 신규 Preview/Thumbnail crash 0건
- PR #449 CI의 classification, script syntax와 Release helper checks 통과
- release PR analysis, delta checklist, version notice와 `git diff --check` 통과

local ad-hoc ZIP SHA256 `34f5f8a08dc81f541e5ec04e29569fa9f8e8eb36519cfef8f21ed1992ef4b8ee`는 source 검증 기록일 뿐 public DMG 또는 Homebrew digest로 사용하지 않습니다.

## 아직 실행하지 않는 항목

이 PR을 merge한 뒤에도 아래 항목은 각각 별도 승인 gate에서 진행합니다.

- 새 exact `main` merge commit으로 annotated `v0.1.9` tag 강제 재지정
- 새 candidate에서 Release Rehearsal 실행
- `require_latest_rhwp=true`, `draft=true`, `prerelease=false` Publish workflow 실행
- signed/notarized DMG의 checksum, signing, notarization, staple, Gatekeeper와 universal 검증
- signed candidate의 HWP/HWPX 앱 열기, Finder Quick Look/Thumbnail provider provenance와 external sibling fallback
- bundled editor 장문서 후반 repaint, 인쇄 preview와 PDF export 시작 경로
- official stable GitHub Release와 Pages/Sparkle publish
- v0.1.8 → v0.1.9 Sparkle update와 extension refresh
- Homebrew Cask SHA256 반영

## 남은 리스크

- 기존 `v0.1.9` tag와 draft asset은 이 PR merge commit으로 재지정·재생성되기 전까지 release 근거로 사용할 수 없습니다.
- signed Finder provider provenance, Developer ID, notarization과 Gatekeeper는 local ad-hoc package로 대체할 수 없습니다.
- Intel Mac 실기기 설치·실행은 아직 확인하지 않았습니다.
- 이 PR의 `devel` head가 이동하면 release 분석, PR CI와 candidate SHA를 다시 확인해야 합니다.