### PR TITLE
Task #441: v0.1.9 Homebrew·릴리즈 종료 기록을 main에 승격

### DIFF
--- a/Casks/alhangeul.rb
+++ b/Casks/alhangeul.rb
@@ -1,6 +1,6 @@
 cask "alhangeul" do
-  version "0.1.7"
-  sha256 "332208ff6f68c78a49d0fc60b895eeabb41d4996dad38fde158fa1935ab4b09d"
+  version "0.1.9"
+  sha256 "8110dc4cc2d965b4fe4d0a8cd6b285488a1fb5443f5bda606a35207c5bccc6ca"
 
   url "https://github.com/postmelee/alhangeul-macos/releases/download/v#{version}/alhangeul-macos-#{version}.dmg"
   name "알한글"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Maintained with support from **OpenAI’s [Codex for Open Source](https://develo
 
 - GitHub Release: [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9)
 - 업데이트 페이지: [알한글 v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html)
-- Homebrew Cask: public DMG SHA256 확정 후 별도 배포 단계에서 반영
+- Homebrew Cask: [`postmelee/tap/alhangeul`](https://github.com/postmelee/homebrew-tap)에서 v0.1.9 배포 중
 - 포함된 `rhwp`: [`v0.8.2`](https://github.com/edwardkim/rhwp/releases/tag/v0.8.2) (`rhwp-core.lock`, bundled `rhwp-studio` manifest 기준)
 - Sparkle update 기준: short version은 `0.1.9`, build는 `15`입니다.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -209,7 +209,7 @@
           <p>상단 다운로드 버튼은 최신 공식 릴리즈의 DMG 파일을 바로 내려받도록 연결됩니다. v0.1.9 공식 DMG도 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다. 파일이 준비되지 않았거나 이전 버전이
             필요하면 <a href="https://github.com/postmelee/alhangeul-macos/releases/latest" target="_blank"
               rel="noreferrer">GitHub Releases</a>에서 배포 상태를 확인할 수 있습니다.</p>
-          <p>Homebrew Cask는 별도 배포 단계에서 최신 DMG 기준으로 반영합니다. 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.</p>
+          <p>Homebrew 사용자는 <code>brew install --cask postmelee/tap/alhangeul</code>로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
         </details>
         <details>
           <summary>앱 업데이트는 어떻게 확인하나요?</summary>

--- a/docs/updates/index.html
+++ b/docs/updates/index.html
@@ -69,7 +69,7 @@
 
       <section class="updates-section" aria-labelledby="homebrew-title">
         <h2 id="homebrew-title">Homebrew Cask</h2>
-        <p>Homebrew Cask는 GitHub Release DMG 공개 뒤 별도 배포 단계에서 반영합니다. 최신 v0.1.9가 필요하면 위 DMG 다운로드를 사용하세요.</p>
+        <p><code>brew install --cask postmelee/tap/alhangeul</code>로 최신 v0.1.9의 signed/notarized universal DMG를 설치할 수 있습니다.</p>
       </section>
 
       <section class="updates-section" aria-labelledby="release-notes-title">

--- a/docs/updates/v0.1.9.html
+++ b/docs/updates/v0.1.9.html
@@ -113,7 +113,7 @@
       <section class="updates-section" aria-labelledby="release-install-title">
         <h2 id="release-install-title">설치와 업데이트</h2>
         <p>DMG 파일을 내려받아 앱을 Applications 폴더로 옮긴 뒤, 앱을 한 번 실행합니다. v0.1.9 공식 DMG는 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다.</p>
-        <p>Homebrew Cask 반영은 별도 배포 단계에서 진행합니다. 반영 전에는 GitHub Release의 DMG를 직접 내려받아 설치하세요.</p>
+        <p>Homebrew 사용자는 <code>brew install --cask postmelee/tap/alhangeul</code>로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
         <p>설치한 앱에서는 메뉴 막대의 <code>알한글 &gt; 업데이트 확인...</code>을 선택해 새 버전을 확인할 수 있습니다.</p>
       </section>
     </div>

--- a/mydocs/orders/20260729.md
+++ b/mydocs/orders/20260729.md
@@ -16,4 +16,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #441 | v0.1.9 public release 준비와 배포 실행 | 진행중 | M900, Stage 4 재개 · PR #448 merge `f2a78b7` 반영 · 새 signed candidate 준비 |
+| #441 | v0.1.9 public release 준비와 배포 실행 | 완료 | M900, official v0.1.9·Sparkle·Homebrew 배포와 Stage 6 최종 보고 완료 · devel/main Pages 승격 후속 · 완료: 12:40 |

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.9` | 후보 · Stage 4 재검증중 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
+| `v0.1.9` | 공개 완료 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
 | `v0.1.8` | 공개 완료 | [Alhangeul v0.1.8](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) | [v0.1.8](https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html) | [`v0.1.8.md`](v0.1.8.md) |
 | `v0.1.7` | 공개 완료 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |
 | `v0.1.6` | 공개 완료 | [Alhangeul v0.1.6](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.6) | [v0.1.6](https://postmelee.github.io/alhangeul-macos/updates/v0.1.6.html) | [`v0.1.6.md`](v0.1.6.md) |

--- a/mydocs/release/v0.1.9.md
+++ b/mydocs/release/v0.1.9.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.9` build `15` official stable publish와 public app/Finder/update gate 통과, Homebrew 별도 승인 대기 |
+| 상태 | `v0.1.9` build `15` official stable publish, public app/Finder/update와 Homebrew gate 통과, Stage 6 정리 대기 |
 | 목표 Git tag | `v0.1.9` |
 | 목표 app version | `0.1.9` |
 | 목표 build | `15` |
@@ -38,7 +38,7 @@
 | Public DMG SHA256 | `8110dc4cc2d965b4fe4d0a8cd6b285488a1fb5443f5bda606a35207c5bccc6ca` |
 | Stable appcast SHA256 | `c80b7f52571780bc23f095f436a39d1e177a3ed935488d47bcdad8d1bd2e372d` |
 | Sparkle update | clean official `v0.1.8 (14) -> v0.1.9 (15)` 통과, extension registration repair `0` |
-| Homebrew Cask | 미진행, 별도 승인 후 public DMG URL/SHA256로 반영 |
+| Homebrew Cask | [`postmelee/homebrew-tap` commit `b8c7b6a`](https://github.com/postmelee/homebrew-tap/commit/b8c7b6a544989a32da9034ca7c6e6d4e241d3d10), `0.1.9` / public DMG SHA256 반영 |
 | Release 실행 이슈 | [#441](https://github.com/postmelee/alhangeul-macos/issues/441) |
 | expected rhwp | `v0.8.2` / `9b16aa9e23f476e2b335d7c029fc9f24a199d63c` |
 | upstream latest | `v0.8.2`, candidate lock과 일치 |
@@ -58,7 +58,9 @@ draft Release는 `draft=true`, `prerelease=false`이며 asset download count는 
 
 2026-07-31 별도 승인으로 exact `v0.1.9` tag에서 official Publish run [`30559705357`](https://github.com/postmelee/alhangeul-macos/actions/runs/30559705357)을 `require_latest_rhwp=true`, `draft=false`, `prerelease=false`로 실행했다. release job과 Pages deploy job이 모두 성공했고, GitHub Release는 non-draft/non-prerelease latest가 됐다. 새로 생성된 public DMG의 SHA256은 `8110dc4c...c6ca`이며 Stage 4 draft digest와 구분한다.
 
-공개 Pages와 stable appcast는 workflow artifact와 byte-identical이고 `0.1.9 (15)`, tag-fixed DMG URL, `164,565,695` bytes와 EdDSA signature를 함께 가리킨다. clean official `v0.1.8 (14)` 설치본에서 Sparkle로 `v0.1.9 (15)`를 설치·재실행했고 Preview/Thumbnail provider가 registration repair 없이 `/Applications/Alhangeul.app`의 새 버전으로 갱신됐다. Homebrew Cask는 별도 승인 gate를 유지해 실행하지 않았다.
+공개 Pages와 stable appcast는 workflow artifact와 byte-identical이고 `0.1.9 (15)`, tag-fixed DMG URL, `164,565,695` bytes와 EdDSA signature를 함께 가리킨다. clean official `v0.1.8 (14)` 설치본에서 Sparkle로 `v0.1.9 (15)`를 설치·재실행했고 Preview/Thumbnail provider가 registration repair 없이 `/Applications/Alhangeul.app`의 새 버전으로 갱신됐다.
+
+이후 별도 승인으로 같은 public DMG URL과 SHA256을 `postmelee/homebrew-tap`에 반영했다. maintainer tap 기준 `brew style`, 일반 audit, `--new` audit와 install/uninstall smoke가 모두 통과했고, Homebrew 설치본의 앱·확장 version/build, 실행 파일, 서명·공증과 extension refresh가 official DMG 설치본과 일치했다.
 
 ## 사용자용 요약
 
@@ -175,7 +177,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | [#442](https://github.com/postmelee/alhangeul-macos/issues/442) | [#443](https://github.com/postmelee/alhangeul-macos/pull/443) | merge·close 완료 | HostApp responsive toolbar와 WKWebView override 경계 수정 |
 | [#447](https://github.com/postmelee/alhangeul-macos/issues/447) | [#448](https://github.com/postmelee/alhangeul-macos/pull/448) | merge·close 완료 | RustBridge image data 수명 회귀와 Thumbnail crash 수정 |
 | [#439](https://github.com/postmelee/alhangeul-macos/issues/439) | 없음 | Open | sync workflow provenance 자동화 후속 |
-| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | [#444](https://github.com/postmelee/alhangeul-macos/pull/444), [#445](https://github.com/postmelee/alhangeul-macos/pull/445), [#446](https://github.com/postmelee/alhangeul-macos/pull/446), [#449](https://github.com/postmelee/alhangeul-macos/pull/449), [#450](https://github.com/postmelee/alhangeul-macos/pull/450) | 진행중 | official stable publish와 public app/Finder/update gate 완료, Homebrew·Stage 6 대기 |
+| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | [#444](https://github.com/postmelee/alhangeul-macos/pull/444), [#445](https://github.com/postmelee/alhangeul-macos/pull/445), [#446](https://github.com/postmelee/alhangeul-macos/pull/446), [#449](https://github.com/postmelee/alhangeul-macos/pull/449), [#450](https://github.com/postmelee/alhangeul-macos/pull/450) | 진행중 | official stable publish, public app/Finder/update와 Homebrew gate 완료, Stage 6 대기 |
 
 ## 검증 기준
 
@@ -198,7 +200,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | Signed editor | 장문서 repaint, 인쇄 preview와 PDF 시작 경로 | HWP/HWPX, 115쪽 end reach와 112쪽 repaint, 인쇄 1/1과 PDF save panel 진입 통과 |
 | Public release | GitHub Release, public DMG/checksum, Pages와 stable appcast | run `30559705357`, public stable/latest와 public surface 정합성 통과 |
 | Public update | v0.1.8 -> v0.1.9 Sparkle와 extension refresh | clean official baseline에서 설치·재실행, app/Preview/Thumbnail `0.1.9 (15)`, repair `0` 통과 |
-| Homebrew | official public DMG URL/SHA256과 install/uninstall | 미진행, 별도 승인 필요 |
+| Homebrew | official public DMG URL/SHA256과 install/uninstall | `postmelee/homebrew-tap` 게시, style/audit/install/uninstall과 extension refresh 통과 |
 
 ## Release metadata
 
@@ -243,9 +245,9 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - [x] 별도 승인 후 official stable Publish workflow 실행
 - [x] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
 - [x] v0.1.8에서 v0.1.9 Sparkle update와 extension refresh 확인
-- [ ] 별도 승인 후 Homebrew Cask 반영과 install/uninstall smoke
+- [x] 별도 승인 후 Homebrew Cask 반영과 install/uninstall smoke
 
-## Stage 5 official publish 결과
+## Stage 5 official publish·Homebrew 결과
 
 - official workflow: [`Release Publish DMG` run `30559705357`](https://github.com/postmelee/alhangeul-macos/actions/runs/30559705357), exact head `v0.1.9` / `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b`
 - release job: `90929268201`, success
@@ -260,7 +262,17 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - public 앱 직접 열기: 업데이트된 `/Applications/Alhangeul.app`에서 HWP `1`쪽을 `232.0ms`, HWPX `9`쪽을 `132.0ms`에 렌더하고 실제 문서 화면 확인
 - 업데이트 재확인: `알한글 0.1.9 이(가) 현재 최신 버전입니다.` 안내 확인
 - 설치본 보안: universal `x86_64 + arm64`, deep signature, app/DMG staple과 Gatekeeper `Notarized Developer ID` 통과, Team ID `XH6JHKYXV8`, CDHash `30d6332479839f45ea74709c46cf303404f94e14`
-- Homebrew: 공개 digest는 확정했지만 별도 승인 전이므로 Cask 수정·install/uninstall을 실행하지 않음
+- Homebrew source: `Casks/alhangeul.rb`를 `version "0.1.9"`와 public DMG SHA256 `8110dc4c...c6ca`로 갱신
+- Homebrew tap: [`postmelee/homebrew-tap` commit `b8c7b6a`](https://github.com/postmelee/homebrew-tap/commit/b8c7b6a544989a32da9034ca7c6e6d4e241d3d10)으로 같은 Cask 게시
+- Homebrew lint: `brew style --cask alhangeul`, `brew audit --cask alhangeul`, 참고 기준인 `brew audit --cask --new alhangeul` 모두 통과
+- Homebrew install: `brew install --cask postmelee/tap/alhangeul` 통과, 앱·Preview·Thumbnail 모두 `0.1.9 (15)`이고 official public 설치본과 실행 파일 byte 일치
+- Homebrew 보안: deep/strict signature, app staple, Gatekeeper `Notarized Developer ID`, Team ID `XH6JHKYXV8`, CDHash `30d6332479839f45ea74709c46cf303404f94e14` 통과
+- Homebrew 실행·extension: 최초 앱 화면 로드와 `scripts/smoke-sparkle-extension-refresh.sh` 통과, registration repair `0`
+- Homebrew uninstall: `brew uninstall --cask alhangeul` 통과, Cask와 테스트 설치본 제거 확인
+- 설치본 복구: smoke 전 official `/Applications/Alhangeul.app` `0.1.9 (15)`와 기존 `/Users/melee/Applications/Alhangeul.app` `0.1.8 (14)`를 원래 위치로 복구
+- 복구 후 final gate: official `/Applications` provider로 extension refresh 재통과, registration hygiene issue `0`, 관련 신규 crash `0`
+- 사용자 안내: public GitHub Release의 Homebrew 문단을 검증된 설치 명령으로 갱신하고 README와 Pages source도 같은 명령으로 보정
+- Pages source 검증: `scripts/ci/prepare-pages-artifact.sh` 재실행 통과, 세 사용자 페이지의 Homebrew 명령 일치와 appcast SHA256 `c80b7f...e372d` 보존 확인
 
 ## 알려진 제한 사항과 후속 이슈
 
@@ -274,7 +286,8 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - strict local `librhwp.a` byte reference mismatch가 남아 있다. Stage 3에서 portable source/Cargo/header/FFI/XCFramework 검증과 분리해 기록하고, workflow의 문서화된 portable release artifact 경계를 허용했다.
 - 초기 `v0.1.9` tag와 draft run `30432036513`은 PR #448 미포함 근거이므로 계속 폐기한다. 현재 tag와 유효 draft 근거는 각각 `ab7a74b...`와 run `30522259476`이다.
 - Skia Thumbnail/Quick Look 경로의 production default 전환은 이번 release 범위가 아니다.
-- official public DMG SHA256과 stable appcast EdDSA signature는 Stage 5에서 확정했다. Homebrew Cask 반영과 install/uninstall은 별도 승인 전이므로 아직 완료로 단정하지 않는다.
+- Homebrew 배포는 maintainer tap `postmelee/homebrew-tap` 기준이다. `Homebrew/homebrew-cask` 공식 저장소 신규 제출은 이번 release 범위가 아니다.
+- README와 Pages source의 Homebrew 안내는 현재 Task #441 브랜치에 반영돼 있다. public Pages에는 Task #441 변경의 `devel` 통합과 후속 `main` docs 승격 전까지 기존 “별도 배포 예정” 문구가 남는다.
 - Intel Mac 실기기 설치·실행은 아직 수행하지 않았다. universal slice 자동 검증과 별개 잔여 위험으로 유지한다.
 
 ## Release communication checklist
@@ -298,4 +311,4 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - [x] installed signed candidate의 Finder/Preview/editor 차단 gate와 draft의 Sparkle/Pages skip 확인
 - [x] public DMG와 SHA256 기록
 - [x] public GitHub Release와 Pages/Sparkle 확인
-- [ ] Homebrew Cask 반영과 검증
+- [x] Homebrew Cask 반영과 검증

--- a/mydocs/release/v0.1.9.md
+++ b/mydocs/release/v0.1.9.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.9` build `15` official stable publish, public app/Finder/update와 Homebrew gate 통과, Stage 6 정리 대기 |
+| 상태 | `v0.1.9` build `15` official stable publish, public app/Finder/update와 Homebrew gate 및 Stage 6 기록 완료, devel/main Pages 승격 대기 |
 | 목표 Git tag | `v0.1.9` |
 | 목표 app version | `0.1.9` |
 | 목표 build | `15` |
@@ -177,7 +177,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | [#442](https://github.com/postmelee/alhangeul-macos/issues/442) | [#443](https://github.com/postmelee/alhangeul-macos/pull/443) | merge·close 완료 | HostApp responsive toolbar와 WKWebView override 경계 수정 |
 | [#447](https://github.com/postmelee/alhangeul-macos/issues/447) | [#448](https://github.com/postmelee/alhangeul-macos/pull/448) | merge·close 완료 | RustBridge image data 수명 회귀와 Thumbnail crash 수정 |
 | [#439](https://github.com/postmelee/alhangeul-macos/issues/439) | 없음 | Open | sync workflow provenance 자동화 후속 |
-| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | [#444](https://github.com/postmelee/alhangeul-macos/pull/444), [#445](https://github.com/postmelee/alhangeul-macos/pull/445), [#446](https://github.com/postmelee/alhangeul-macos/pull/446), [#449](https://github.com/postmelee/alhangeul-macos/pull/449), [#450](https://github.com/postmelee/alhangeul-macos/pull/450) | 진행중 | official stable publish, public app/Finder/update와 Homebrew gate 완료, Stage 6 대기 |
+| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | [#444](https://github.com/postmelee/alhangeul-macos/pull/444), [#445](https://github.com/postmelee/alhangeul-macos/pull/445), [#446](https://github.com/postmelee/alhangeul-macos/pull/446), [#449](https://github.com/postmelee/alhangeul-macos/pull/449), [#450](https://github.com/postmelee/alhangeul-macos/pull/450) | 진행중 | release·Homebrew·Stage 6 기록 완료, devel/main Pages 승격과 공개 문구 확인 대기 |
 
 ## 검증 기준
 
@@ -312,3 +312,5 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - [x] public DMG와 SHA256 기록
 - [x] public GitHub Release와 Pages/Sparkle 확인
 - [x] Homebrew Cask 반영과 검증
+- [x] Stage 6 최종 보고서와 오늘할일 완료 처리
+- [ ] 종료 정리 변경의 `devel -> main` 승격과 public Pages Homebrew 문구 확인

--- a/mydocs/release/v0.1.9.md
+++ b/mydocs/release/v0.1.9.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.9` build `15` Stage 4 재개, PR #448 반영 candidate 재생성중 |
+| 상태 | `v0.1.9` build `15` Stage 4 signed candidate 차단 gate 통과, Stage 5 승인 대기 |
 | 목표 Git tag | `v0.1.9` |
 | 목표 app version | `0.1.9` |
 | 목표 build | `15` |
@@ -16,15 +16,22 @@
 | PR #443 병합 `origin/devel` | `e2aef4c232a48963f7e2abcaaca4bc4230b3b454` |
 | Task #441 로컬 통합 commit | `a9760bbe067be5e9c3dbc9d2b29aa75a7456c2e1` |
 | Stage 3 exact candidate | `07b9f34cb14827223e085bc583406ba2654171c0` |
-| 유효 rehearsal | run `30424930226`, SHA256 `e5b03e67a03d1e4aecada0f78fc351dfeb904158a7259bdea5a3b6d8988f7db0` |
+| Stage 3 rehearsal | run `30424930226`, SHA256 `e5b03e67a03d1e4aecada0f78fc351dfeb904158a7259bdea5a3b6d8988f7db0` |
 | 폐기한 rehearsal 후보 | run `30365232108`, candidate `1d358103a877a9d0b6c924a280b84e60e94d6739` — PR #443 미포함 |
-| Stage 4 source / back-merge / release PR | PR #444 / PR #445 / PR #446 |
-| 기존 `main` release commit | `1e7f5df59684713745cb9d59c0a0e9dfdaaf0272` |
-| 기존 annotated tag | `v0.1.9` -> `1e7f5df59684713745cb9d59c0a0e9dfdaaf0272`, PR #448 미포함 |
+| 초기 Stage 4 source / back-merge / release PR | PR #444 / PR #445 / PR #446 |
+| 초기 `main` release commit | `1e7f5df59684713745cb9d59c0a0e9dfdaaf0272`, PR #448 미포함 |
+| 초기 annotated tag | `v0.1.9` -> `1e7f5df59684713745cb9d59c0a0e9dfdaaf0272`, 이후 final candidate로 재지정 |
 | 폐기한 signed draft | run `30432036513`, SHA256 `e854cedb59b8708d412151414ea877605209710ba850306d1f315c0a61d6e75a` |
 | Task #447 수정 PR / merge commit | PR #448 / `f2a78b799f62985d2767afc9ba4434581e9b10be` |
-| 새 candidate 기준 | `origin/devel` / `f2a78b799f62985d2767afc9ba4434581e9b10be`, `main` 반영·tag 재지정 전 |
+| candidate 갱신 source PR / `devel` | PR #449 / `485c76cf32486d148fa88e30717e18c9794e810f` |
+| final release PR / `main` | PR #450 / `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| final annotated tag | `v0.1.9` -> `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| final rehearsal | run `30520836152`, SHA256 `175ebb4ee421220ea6159bba4b9ecefa0c51d35ab7a7555412f59398023e1830` |
+| signed draft Publish | run `30522259476`, `draft=true`, `prerelease=false` |
+| signed draft DMG | `164,565,668` bytes, SHA256 `e65c3697ff46542137ee79fbfed0cf9f3c5f5b6ce7ef8e337f7b7b9be19a793f` |
+| signed candidate | Developer ID signing/notarization/staple/Gatekeeper와 signed smoke 통과 |
 | GitHub Release 후보 | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9 |
+| 비공개 draft Release | https://github.com/postmelee/alhangeul-macos/releases/tag/untagged-43fc1d315706a98311c2 |
 | Pages 릴리즈 노트 후보 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html |
 | Public DMG 후보 | `alhangeul-macos-0.1.9.dmg` |
 | Public DMG SHA256 | official stable publish 후 기록 |
@@ -42,7 +49,9 @@
 
 기존 tag에서 실행한 signed/notarized draft run [`30432036513`](https://github.com/postmelee/alhangeul-macos/actions/runs/30432036513)은 workflow 자체는 성공했지만 image data 수명 회귀로 Thumbnail crash가 확인돼 폐기했다. 해당 draft release는 비공개 상태이고 asset download count는 0이지만, DMG와 checksum은 새 후보의 서명·공증·smoke 근거로 재사용하지 않는다.
 
-Task #447 수정 PR #448 변경은 `devel` merge commit `f2a78b7...`에 반영됐다. 새 final candidate는 이 commit을 `main`에 반영하는 추가 release candidate PR, annotated tag 재지정, 새 Rehearsal과 새 signed draft를 모두 거쳐야 한다. tag 재지정과 workflow 실행은 release owner의 별도 승인 전에는 수행하지 않는다. candidate URL과 DMG 경로는 official publish 전까지 실제 public asset을 뜻하지 않는다.
+Task #447 수정 PR #448 변경은 PR #449를 거쳐 `devel` commit `485c76c...`에 반영했고, PR #450 merge commit `ab7a74b...`을 final `main` candidate로 확정했다. annotated `v0.1.9` tag도 이 commit을 가리킨다. final tag에서 Release Rehearsal run [`30520836152`](https://github.com/postmelee/alhangeul-macos/actions/runs/30520836152)과 signed/notarized draft Publish run [`30522259476`](https://github.com/postmelee/alhangeul-macos/actions/runs/30522259476)이 성공했고 signed candidate 수동 차단 gate를 통과했다.
+
+draft Release는 `draft=true`, `prerelease=false`이며 asset download count는 0이다. 이 실행에서는 stable appcast 생성과 Pages 배포가 정책대로 skip됐고 최신 공개 앱은 계속 `v0.1.8`이다. 위 draft URL과 DMG SHA256은 Stage 4 비공개 후보의 검증 근거이며 official public asset을 뜻하지 않는다.
 
 ## 사용자용 요약
 
@@ -52,7 +61,7 @@ HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는
 
 ## 직전 공개 릴리즈 대비 변경점
 
-기준 범위는 `v0.1.8^{}..origin/devel`이다. Stage 2 시작 시 `origin/devel`은 `76c86fc76a9e2b7291f80e57b8b85c7c1e1ff525`였고, PR #443 병합 뒤 `e2aef4c232a48963f7e2abcaaca4bc4230b3b454`, PR #444 및 PR #445 병합 뒤 `1b1213db5a0bd75638f54bf03d49fbf4cb63edcc`, PR #448 병합 뒤 현재 기준은 `f2a78b799f62985d2767afc9ba4434581e9b10be`다. 새 `main` release candidate가 확정되면 포함 PR 분석과 delta checklist를 다시 생성한다.
+최종 기준 범위는 `v0.1.8^{}..v0.1.9^{}`이다. Stage 2 시작 시 `origin/devel`은 `76c86fc76a9e2b7291f80e57b8b85c7c1e1ff525`였고, PR #443 병합 뒤 `e2aef4c232a48963f7e2abcaaca4bc4230b3b454`, PR #444 및 PR #445 병합 뒤 `1b1213db5a0bd75638f54bf03d49fbf4cb63edcc`, PR #448과 PR #449 병합 뒤 `485c76cf32486d148fa88e30717e18c9794e810f`가 됐다. PR #450은 이를 final `main` commit `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b`에 반영했다. final tag 기준 포함 PR 분석과 delta checklist를 다시 생성했고 candidate commit이 일치함을 확인했다.
 
 | 영역 | 변경 |
 |------|------|
@@ -66,7 +75,7 @@ HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는
 | 직전 release closeout | PR #428: `v0.1.8` official publish 이후 운영 기록. 신규 `v0.1.9` 사용자 변화에서는 제외 |
 | Release metadata | Task #441 Stage 1: app/extension을 `0.1.9 (15)`, workflow 기본 입력을 `v0.1.9` / `v0.1.8` / `v0.8.2`로 정렬 |
 
-`main`에는 PR #432 변경의 Pages 승격 내용이 전용 commit으로 남아 있다. Stage 4에서 양쪽 tree를 다시 비교하고, 필요한 경우 reviewed `main -> devel` back-merge로 보존한 뒤 release PR을 만든다.
+`main` 전용 PR #432 Pages 승격 이력은 PR #445의 reviewed `main -> devel` back-merge로 보존했다. final PR #450 merge 뒤 `origin/main...origin/devel`은 `2 0`이며 두 전용 commit은 PR #446과 PR #450 release transport뿐이다. 두 branch의 tree는 byte-identical이다.
 
 ## 포함 PR 분석
 
@@ -85,7 +94,8 @@ HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는
 | `#444` | `Task #441: v0.1.9 release candidate source 준비` | 운영/배포 | 아니오 | 아니오 | 없음 | `#441` | PR body, Stage 1~3 보고서 | version/build, communication과 preflight 기록을 `devel`에 반영 |
 | `#445` | `Task #441: main release 이력 역병합` | 운영/배포 | 아니오 | 아니오 | 없음 | `#441` | PR body | `main` 전용 이력을 `devel`에 보존 |
 | `#446` | `Release: Alhangeul v0.1.9` | 운영/배포 | 아니오 | 아니오 | 없음 | `#441` | PR body | 초기 release transport, PR #448 미포함으로 새 candidate PR 필요 |
-| Task #441 후보 갱신 PR 예정 | `v0.1.9 candidate에 PR #448 반영` | 운영/배포 | 아니오 | 아니오 | 진행중 `#441` | `#447` | Issue body, `mydocs/plans/task_m900_441_impl.md` | 새 `main` commit과 tag를 확정하는 transport |
+| `#449` | `Task #441 Stage 4.1: PR #448 반영과 v0.1.9 후보 재검증 준비` | 운영/배포 | 아니오 | 아니오 | 없음 | `#441`, `#447` | PR body, `mydocs/report/task_m020_447_report.md` | crash 수정과 release communication을 final `devel` candidate에 반영 |
+| `#450` | `Release: Alhangeul v0.1.9 후보 갱신 (PR #448 반영)` | 운영/배포 | 아니오 | 아니오 | 없음 | `#441` | PR body | final `main` release transport와 annotated tag 기준 |
 
 PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈는 PR body에서 후속 fixture/visual suite로만 참조되며 현재 OPEN이다. 따라서 해결된 Issue에서 제외하고 참고/연관 Issue로 보정했다.
 
@@ -144,9 +154,9 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 
 - PR #436 변경은 `v0.7.18`에서 `v0.8.2`까지 네 개 upstream release의 누적 변경을 반영한다.
 - PR #443 변경은 기존 rehearsal 뒤 발견된 HostApp 툴바 차단 회귀를 수정했다. run `30365232108`과 candidate `1d358103...`는 폐기했고, 새 exact candidate `07b9f34...`의 run `30424930226`에서 source preflight와 rehearsal을 다시 통과했다.
-- PR #448 변경은 기존 signed draft에서 확인한 RustBridge image data use-after-free를 caller-owned allocation과 Swift exact free로 수정했다. run `30432036513`, 당시 tag commit `1e7f5df...`와 DMG는 폐기하며, PR #448 변경을 포함한 candidate에서 Rehearsal과 signed draft를 모두 다시 실행한다.
+- PR #448 변경은 기존 signed draft에서 확인한 RustBridge image data use-after-free를 caller-owned allocation과 Swift exact free로 수정했다. run `30432036513`, 당시 tag commit `1e7f5df...`와 DMG는 폐기했다. PR #448 변경을 포함한 final candidate `ab7a74b...`에서 Rehearsal run `30520836152`와 signed draft run `30522259476`을 모두 다시 실행했다.
 - strict local `librhwp.a` byte hash/size는 기존 lock reference와 다르지만 source tag/commit, Cargo resolution, generated header와 15개 FFI symbol은 일치했다. Stage 3에서 strict와 portable 결과를 분리해 portable release artifact 경계를 허용했다.
-- upstream `v0.8.2`에는 studio PDF 안내 modal 관련 Issue #3450 이슈와 page-local repaint 관련 Issue #3412 이슈가 알려진 문제로 남아 있다. 실제 알한글 장문서·인쇄/PDF 경로는 signed candidate gate 전까지 통과로 기록하지 않는다.
+- upstream `v0.8.2`에는 studio PDF 안내 modal 관련 Issue #3450 이슈와 page-local repaint 관련 Issue #3412 이슈가 알려진 문제로 남아 있다. signed candidate에서 115쪽 장문서의 112쪽 실제 내용 repaint와 115쪽 도달, 인쇄 preview 1/1, PDF export save panel 진입을 확인했다. 전체 인쇄·PDF 파일 생성은 Stage 4 범위에 포함하지 않았다.
 
 ## 연결된 Issue/PR
 
@@ -158,7 +168,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | [#442](https://github.com/postmelee/alhangeul-macos/issues/442) | [#443](https://github.com/postmelee/alhangeul-macos/pull/443) | merge·close 완료 | HostApp responsive toolbar와 WKWebView override 경계 수정 |
 | [#447](https://github.com/postmelee/alhangeul-macos/issues/447) | [#448](https://github.com/postmelee/alhangeul-macos/pull/448) | merge·close 완료 | RustBridge image data 수명 회귀와 Thumbnail crash 수정 |
 | [#439](https://github.com/postmelee/alhangeul-macos/issues/439) | 없음 | Open | sync workflow provenance 자동화 후속 |
-| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | [#444](https://github.com/postmelee/alhangeul-macos/pull/444), [#445](https://github.com/postmelee/alhangeul-macos/pull/445), [#446](https://github.com/postmelee/alhangeul-macos/pull/446), 후보 갱신 PR 예정 | 진행중 | PR #448 포함 candidate와 public release 실행 |
+| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | [#444](https://github.com/postmelee/alhangeul-macos/pull/444), [#445](https://github.com/postmelee/alhangeul-macos/pull/445), [#446](https://github.com/postmelee/alhangeul-macos/pull/446), [#449](https://github.com/postmelee/alhangeul-macos/pull/449), [#450](https://github.com/postmelee/alhangeul-macos/pull/450) | 진행중 | signed candidate gate 완료, official public release 승인 대기 |
 
 ## 검증 기준
 
@@ -168,17 +178,17 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | Core lock | `rhwp_release_tag=v0.8.2`, commit `9b16aa9e...` | Stage 1 통과 |
 | Studio asset | bundled manifest가 `v0.8.2` / `9b16aa9e...` | Stage 1 통과 |
 | Workflow default | `0.1.9`, `v0.1.8`, `v0.8.2` | Stage 1 통과 |
-| Release PR analysis | `v0.1.8..candidate` merge PR과 Task #441 transport | PR #448 포함 초안 보정, final `main` candidate에서 반복 필요 |
+| Release PR analysis | `v0.1.8..candidate` merge PR과 Task #441 transport | final tag `ab7a74b...`에서 재생성, PR #448/#449/#450 포함과 owner 판정 보정 |
 | Release communication | README, Pages home/update, release index/record | PR #443 및 PR #448 사용자 영향 보정 |
 | Static archive | strict byte reference와 portable source/header/FFI를 분리 | strict mismatch 기록, portable 검증 통과·허용 |
 | Shared Swift boundary | `Sources/RhwpCoreBridge` AppKit/UIKit 의존 없음 | Stage 3 통과 |
 | Rust/Swift tests | RustBridge와 ExternalImageTests | PR #448 기준 `7/7`, `27/27` 통과 |
-| Release build/render | 세 target build, representative renderer와 image visual harness | PR #448 기준 통과, final candidate에서 release gate 반복 필요 |
-| Rehearsal DMG | unsigned rehearsal layout/checksum | run `30424930226`, checksum/integrity/universal 통과 |
-| Signed draft DMG | Developer ID signing/notarization/staple/Gatekeeper | run `30432036513`은 PR #448 미포함으로 폐기, 새 candidate 필요 |
-| Signed Finder/Preview | 실제 provider path, HWP/HWPX, external sibling fallback | PR #448 포함 새 Stage 4 차단 gate |
-| Image-heavy Thumbnail | HWP 3종 + HWPX 1종 반복, crash 0 | PR #448 local candidate 20/20, 새 signed provider에서 반복 필요 |
-| Signed editor | 장문서 repaint, 인쇄 preview와 PDF 시작 경로 | Stage 4 차단 gate |
+| Release build/render | 세 target build, representative renderer와 image visual harness | PR #448 기준 통과, final tag workflow에서 source/header/ABI와 package 재검증 통과 |
+| Rehearsal DMG | unsigned rehearsal layout/checksum | final tag run `30520836152`, SHA256/checksum/integrity/universal 통과 |
+| Signed draft DMG | Developer ID signing/notarization/staple/Gatekeeper | final tag run `30522259476`, SHA256/checksum/integrity/universal과 보안 gate 통과 |
+| Signed Finder/Preview | 실제 provider path, HWP/HWPX, external sibling fallback | exact candidate provider 분리 검증 통과, external sibling `permissionDenied=3`과 764쪽 main fallback 확인 |
+| Image-heavy Thumbnail | 대표 HWP/HWPX 반복, crash 0 | exact signed provider에서 6개 HWP/HWPX PNG 생성, 새 crash 0 |
+| Signed editor | 장문서 repaint, 인쇄 preview와 PDF 시작 경로 | HWP/HWPX, 115쪽 end reach와 112쪽 repaint, 인쇄 1/1과 PDF save panel 진입 통과 |
 | Public update | v0.1.8 -> v0.1.9 Sparkle와 extension refresh | Stage 5 예정 |
 | Homebrew | official public DMG URL/SHA256과 install/uninstall | 별도 승인 필요 |
 
@@ -198,7 +208,8 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | release title 후보 | `Alhangeul v0.1.9 (rhwp v0.8.2)` |
 | `require_latest_rhwp` | `true` |
 | `include_rhwp_in_title` | `true` |
-| `draft` / `prerelease` 기본값 | `false` / `false` |
+| Stage 4 draft gate | `draft=true`, `prerelease=false` |
+| Stage 5 official 목표 | `draft=false`, `prerelease=false` |
 | core lock | `rhwp-core.lock` |
 | studio manifest | `Sources/HostApp/Resources/rhwp-studio/manifest.json` |
 
@@ -215,11 +226,12 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - [x] 초기 `devel -> main` release PR #446 merge와 annotated `v0.1.9` tag 생성
 - [x] 초기 `draft=true`, `prerelease=false` run `30432036513` 실행
 - [x] 초기 signed candidate crash를 Issue #447 이슈로 분리하고 PR #448 변경으로 `devel`에 수정
-- [ ] PR #448 포함 `devel -> main` candidate 갱신 PR merge
-- [ ] 별도 승인 후 정확한 새 final candidate로 annotated `v0.1.9` tag 재지정
-- [ ] 새 final candidate에서 Release Rehearsal 재실행
-- [ ] 새 final candidate에서 `draft=true`, `prerelease=false` Publish workflow 재실행
-- [ ] signed/notarized draft DMG의 앱, Finder, Preview, editor와 Sparkle 차단 gate 통과
+- [x] PR #449 / PR #450으로 PR #448 포함 `devel -> main` final candidate merge
+- [x] 별도 승인 후 annotated `v0.1.9` tag를 final `main` commit `ab7a74b...`로 재지정
+- [x] 새 final candidate에서 Release Rehearsal run `30520836152` 재실행
+- [x] 새 final candidate에서 `draft=true`, `prerelease=false` Publish run `30522259476` 재실행
+- [x] signed/notarized draft DMG의 앱, Finder, Preview와 editor 차단 gate 통과
+- [x] draft 실행에서 stable appcast와 Pages 배포 skip 및 public `v0.1.8` 유지 확인
 - [ ] 별도 승인 후 official stable Publish workflow 실행
 - [ ] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
 - [ ] v0.1.8에서 v0.1.9 Sparkle update와 extension refresh 확인
@@ -233,11 +245,11 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - actual registered Quick Look은 macOS 26.5.2 검증에서 external sibling read가 `permissionDenied=3`이었다. external image는 누락되지만 main document render는 유지한다.
 - Thumbnail resolver와 HostApp WKWebView external image bridge는 각각 Issue #411 이슈와 Issue #413 이슈 전까지 지원을 보장하지 않는다. renderer diagnostic은 Issue #410 이슈, fixture suite는 Issue #412 이슈가 소유한다.
 - HOP 충돌 안내는 HOP Preview `0.2.0 -> rhwp v0.7.13`처럼 검증된 mapping만 사용하며 실제 활성 provider를 판정하거나 자동 변경하지 않는다.
-- upstream `v0.8.2` known issue인 page-local repaint Issue #3412 이슈와 PDF 안내 modal Issue #3450 이슈의 알한글 영향은 Stage 4 signed editor smoke 전까지 미확정이다.
+- upstream `v0.8.2` known issue인 page-local repaint Issue #3412 이슈와 PDF 안내 modal Issue #3450 이슈는 남아 있다. signed editor smoke에서는 115쪽 end reach, 112쪽 실제 내용 repaint, 인쇄 preview와 PDF save panel 진입이 정상이며 blocker를 재현하지 않았다.
 - strict local `librhwp.a` byte reference mismatch가 남아 있다. Stage 3에서 portable source/Cargo/header/FFI/XCFramework 검증과 분리해 기록하고, workflow의 문서화된 portable release artifact 경계를 허용했다.
-- 기존 `v0.1.9` tag와 draft release는 PR #448 미포함 commit을 가리킨다. 새 candidate PR merge, tag 재지정과 workflow 재실행 전까지 release 근거로 사용하지 않는다.
+- 초기 `v0.1.9` tag와 draft run `30432036513`은 PR #448 미포함 근거이므로 계속 폐기한다. 현재 tag와 유효 draft 근거는 각각 `ab7a74b...`와 run `30522259476`이다.
 - Skia Thumbnail/Quick Look 경로의 production default 전환은 이번 release 범위가 아니다.
-- public DMG SHA256, appcast EdDSA signature, notarization, signed provider provenance와 Homebrew digest는 Stage 2에서 단정하지 않는다.
+- signed draft DMG SHA256, notarization과 signed provider provenance는 Stage 4에서 확정했다. official public DMG SHA256, appcast EdDSA signature와 Homebrew digest는 Stage 5 전까지 단정하지 않는다.
 - Intel Mac 실기기 설치·실행은 아직 수행하지 않았다. universal slice 자동 검증과 별개 잔여 위험으로 유지한다.
 
 ## Release communication checklist
@@ -255,10 +267,10 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - [x] external sibling source-level 성립과 registered sandbox 제한을 분리
 - [x] PR #443 변경의 반응형 툴바 회귀 수정과 기존 rehearsal 무효화를 반영
 - [x] PR #448 변경의 Thumbnail crash 수정과 기존 signed draft 무효화를 반영
-- [x] strict artifact, signed Finder/editor, Intel Mac과 public digest를 미확정 gate로 유지
+- [x] strict artifact mismatch와 Intel Mac 실기기를 잔여 위험, official public digest를 Stage 5 gate로 유지하고 signed Finder/editor는 Stage 4 결과로 확정
 - [x] source preflight와 Rehearsal 검증
-- [ ] PR #448 포함 final candidate source preflight와 Rehearsal 재검증
-- [ ] installed signed candidate의 Finder/Preview/editor와 Sparkle 차단 gate
+- [x] PR #448 포함 final candidate source preflight와 Rehearsal 재검증
+- [x] installed signed candidate의 Finder/Preview/editor 차단 gate와 draft의 Sparkle/Pages skip 확인
 - [ ] public DMG와 SHA256 기록
 - [ ] public GitHub Release와 Pages/Sparkle 확인
 - [ ] Homebrew Cask 반영과 검증

--- a/mydocs/release/v0.1.9.md
+++ b/mydocs/release/v0.1.9.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.9` build `15` Stage 4 signed candidate 차단 gate 통과, Stage 5 승인 대기 |
+| 상태 | `v0.1.9` build `15` official stable publish와 public app/Finder/update gate 통과, Homebrew 별도 승인 대기 |
 | 목표 Git tag | `v0.1.9` |
 | 목표 app version | `0.1.9` |
 | 목표 build | `15` |
@@ -30,12 +30,15 @@
 | signed draft Publish | run `30522259476`, `draft=true`, `prerelease=false` |
 | signed draft DMG | `164,565,668` bytes, SHA256 `e65c3697ff46542137ee79fbfed0cf9f3c5f5b6ce7ef8e337f7b7b9be19a793f` |
 | signed candidate | Developer ID signing/notarization/staple/Gatekeeper와 signed smoke 통과 |
-| GitHub Release 후보 | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9 |
+| official stable Publish | run [`30559705357`](https://github.com/postmelee/alhangeul-macos/actions/runs/30559705357), `draft=false`, `prerelease=false` |
+| GitHub Release | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9 |
 | 비공개 draft Release | https://github.com/postmelee/alhangeul-macos/releases/tag/untagged-43fc1d315706a98311c2 |
-| Pages 릴리즈 노트 후보 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html |
-| Public DMG 후보 | `alhangeul-macos-0.1.9.dmg` |
-| Public DMG SHA256 | official stable publish 후 기록 |
-| Homebrew Cask | public DMG SHA256 확정 후 별도 승인으로 반영 |
+| Pages 릴리즈 노트 | https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html |
+| Public DMG | `alhangeul-macos-0.1.9.dmg`, `164,565,695` bytes |
+| Public DMG SHA256 | `8110dc4cc2d965b4fe4d0a8cd6b285488a1fb5443f5bda606a35207c5bccc6ca` |
+| Stable appcast SHA256 | `c80b7f52571780bc23f095f436a39d1e177a3ed935488d47bcdad8d1bd2e372d` |
+| Sparkle update | clean official `v0.1.8 (14) -> v0.1.9 (15)` 통과, extension registration repair `0` |
+| Homebrew Cask | 미진행, 별도 승인 후 public DMG URL/SHA256로 반영 |
 | Release 실행 이슈 | [#441](https://github.com/postmelee/alhangeul-macos/issues/441) |
 | expected rhwp | `v0.8.2` / `9b16aa9e23f476e2b335d7c029fc9f24a199d63c` |
 | upstream latest | `v0.8.2`, candidate lock과 일치 |
@@ -52,6 +55,10 @@
 Task #447 수정 PR #448 변경은 PR #449를 거쳐 `devel` commit `485c76c...`에 반영했고, PR #450 merge commit `ab7a74b...`을 final `main` candidate로 확정했다. annotated `v0.1.9` tag도 이 commit을 가리킨다. final tag에서 Release Rehearsal run [`30520836152`](https://github.com/postmelee/alhangeul-macos/actions/runs/30520836152)과 signed/notarized draft Publish run [`30522259476`](https://github.com/postmelee/alhangeul-macos/actions/runs/30522259476)이 성공했고 signed candidate 수동 차단 gate를 통과했다.
 
 draft Release는 `draft=true`, `prerelease=false`이며 asset download count는 0이다. 이 실행에서는 stable appcast 생성과 Pages 배포가 정책대로 skip됐고 최신 공개 앱은 계속 `v0.1.8`이다. 위 draft URL과 DMG SHA256은 Stage 4 비공개 후보의 검증 근거이며 official public asset을 뜻하지 않는다.
+
+2026-07-31 별도 승인으로 exact `v0.1.9` tag에서 official Publish run [`30559705357`](https://github.com/postmelee/alhangeul-macos/actions/runs/30559705357)을 `require_latest_rhwp=true`, `draft=false`, `prerelease=false`로 실행했다. release job과 Pages deploy job이 모두 성공했고, GitHub Release는 non-draft/non-prerelease latest가 됐다. 새로 생성된 public DMG의 SHA256은 `8110dc4c...c6ca`이며 Stage 4 draft digest와 구분한다.
+
+공개 Pages와 stable appcast는 workflow artifact와 byte-identical이고 `0.1.9 (15)`, tag-fixed DMG URL, `164,565,695` bytes와 EdDSA signature를 함께 가리킨다. clean official `v0.1.8 (14)` 설치본에서 Sparkle로 `v0.1.9 (15)`를 설치·재실행했고 Preview/Thumbnail provider가 registration repair 없이 `/Applications/Alhangeul.app`의 새 버전으로 갱신됐다. Homebrew Cask는 별도 승인 gate를 유지해 실행하지 않았다.
 
 ## 사용자용 요약
 
@@ -99,7 +106,7 @@ HOP과 알한글 Quick Look이 함께 설치된 검증 가능한 조합에서는
 
 PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈는 PR body에서 후속 fixture/visual suite로만 참조되며 현재 OPEN이다. 따라서 해결된 Issue에서 제외하고 참고/연관 Issue로 보정했다.
 
-## GitHub Release 본문 구조 후보
+## GitHub Release 본문 구조
 
 ### 변경 요약
 
@@ -168,7 +175,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | [#442](https://github.com/postmelee/alhangeul-macos/issues/442) | [#443](https://github.com/postmelee/alhangeul-macos/pull/443) | merge·close 완료 | HostApp responsive toolbar와 WKWebView override 경계 수정 |
 | [#447](https://github.com/postmelee/alhangeul-macos/issues/447) | [#448](https://github.com/postmelee/alhangeul-macos/pull/448) | merge·close 완료 | RustBridge image data 수명 회귀와 Thumbnail crash 수정 |
 | [#439](https://github.com/postmelee/alhangeul-macos/issues/439) | 없음 | Open | sync workflow provenance 자동화 후속 |
-| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | [#444](https://github.com/postmelee/alhangeul-macos/pull/444), [#445](https://github.com/postmelee/alhangeul-macos/pull/445), [#446](https://github.com/postmelee/alhangeul-macos/pull/446), [#449](https://github.com/postmelee/alhangeul-macos/pull/449), [#450](https://github.com/postmelee/alhangeul-macos/pull/450) | 진행중 | signed candidate gate 완료, official public release 승인 대기 |
+| [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | [#444](https://github.com/postmelee/alhangeul-macos/pull/444), [#445](https://github.com/postmelee/alhangeul-macos/pull/445), [#446](https://github.com/postmelee/alhangeul-macos/pull/446), [#449](https://github.com/postmelee/alhangeul-macos/pull/449), [#450](https://github.com/postmelee/alhangeul-macos/pull/450) | 진행중 | official stable publish와 public app/Finder/update gate 완료, Homebrew·Stage 6 대기 |
 
 ## 검증 기준
 
@@ -189,8 +196,9 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | Signed Finder/Preview | 실제 provider path, HWP/HWPX, external sibling fallback | exact candidate provider 분리 검증 통과, external sibling `permissionDenied=3`과 764쪽 main fallback 확인 |
 | Image-heavy Thumbnail | 대표 HWP/HWPX 반복, crash 0 | exact signed provider에서 6개 HWP/HWPX PNG 생성, 새 crash 0 |
 | Signed editor | 장문서 repaint, 인쇄 preview와 PDF 시작 경로 | HWP/HWPX, 115쪽 end reach와 112쪽 repaint, 인쇄 1/1과 PDF save panel 진입 통과 |
-| Public update | v0.1.8 -> v0.1.9 Sparkle와 extension refresh | Stage 5 예정 |
-| Homebrew | official public DMG URL/SHA256과 install/uninstall | 별도 승인 필요 |
+| Public release | GitHub Release, public DMG/checksum, Pages와 stable appcast | run `30559705357`, public stable/latest와 public surface 정합성 통과 |
+| Public update | v0.1.8 -> v0.1.9 Sparkle와 extension refresh | clean official baseline에서 설치·재실행, app/Preview/Thumbnail `0.1.9 (15)`, repair `0` 통과 |
+| Homebrew | official public DMG URL/SHA256과 install/uninstall | 미진행, 별도 승인 필요 |
 
 ## Release metadata
 
@@ -205,11 +213,11 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 | rhwp core commit | `9b16aa9e23f476e2b335d7c029fc9f24a199d63c` |
 | bundled rhwp-studio release tag | `v0.8.2` |
 | bundled rhwp-studio commit | `9b16aa9e23f476e2b335d7c029fc9f24a199d63c` |
-| release title 후보 | `Alhangeul v0.1.9 (rhwp v0.8.2)` |
+| release title | `Alhangeul v0.1.9 (rhwp v0.8.2)` |
 | `require_latest_rhwp` | `true` |
 | `include_rhwp_in_title` | `true` |
 | Stage 4 draft gate | `draft=true`, `prerelease=false` |
-| Stage 5 official 목표 | `draft=false`, `prerelease=false` |
+| Stage 5 official 실행 | `draft=false`, `prerelease=false`, run `30559705357` |
 | core lock | `rhwp-core.lock` |
 | studio manifest | `Sources/HostApp/Resources/rhwp-studio/manifest.json` |
 
@@ -232,10 +240,27 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - [x] 새 final candidate에서 `draft=true`, `prerelease=false` Publish run `30522259476` 재실행
 - [x] signed/notarized draft DMG의 앱, Finder, Preview와 editor 차단 gate 통과
 - [x] draft 실행에서 stable appcast와 Pages 배포 skip 및 public `v0.1.8` 유지 확인
-- [ ] 별도 승인 후 official stable Publish workflow 실행
-- [ ] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
-- [ ] v0.1.8에서 v0.1.9 Sparkle update와 extension refresh 확인
+- [x] 별도 승인 후 official stable Publish workflow 실행
+- [x] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
+- [x] v0.1.8에서 v0.1.9 Sparkle update와 extension refresh 확인
 - [ ] 별도 승인 후 Homebrew Cask 반영과 install/uninstall smoke
+
+## Stage 5 official publish 결과
+
+- official workflow: [`Release Publish DMG` run `30559705357`](https://github.com/postmelee/alhangeul-macos/actions/runs/30559705357), exact head `v0.1.9` / `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b`
+- release job: `90929268201`, success
+- Pages deploy job: `90933101471`, success
+- GitHub Release: [`Alhangeul v0.1.9 (rhwp v0.8.2)`](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9), non-draft / non-prerelease / latest
+- public DMG: [`alhangeul-macos-0.1.9.dmg`](https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.9/alhangeul-macos-0.1.9.dmg), `164,565,695` bytes, SHA256 `8110dc4cc2d965b4fe4d0a8cd6b285488a1fb5443f5bda606a35207c5bccc6ca`
+- public checksum asset: workflow checksum과 byte-identical, asset digest `052d91db0130513d58e0844d9a12b2e8b968f6b84293d65a85e0fc670c6d8ace`
+- stable appcast: SHA256 `c80b7f52571780bc23f095f436a39d1e177a3ed935488d47bcdad8d1bd2e372d`, version `15`, short version `0.1.9`, public DMG와 같은 URL/size, EdDSA signature 포함
+- Pages: home, `updates/`, `updates/v0.1.9.html`, 이전 `v0.1.8` 최신 안내가 tag source와 byte-identical
+- update smoke: clean official `v0.1.8 (14)`에서 Sparkle 설치·재실행 후 `/Applications/Alhangeul.app`과 두 extension이 모두 `v0.1.9 (15)`로 갱신
+- extension refresh: registration repair `0`, HWP/HWPX Thumbnail과 Quick Look을 `/Applications` provider process로 확인, 신규 Alhangeul crash `0`
+- public 앱 직접 열기: 업데이트된 `/Applications/Alhangeul.app`에서 HWP `1`쪽을 `232.0ms`, HWPX `9`쪽을 `132.0ms`에 렌더하고 실제 문서 화면 확인
+- 업데이트 재확인: `알한글 0.1.9 이(가) 현재 최신 버전입니다.` 안내 확인
+- 설치본 보안: universal `x86_64 + arm64`, deep signature, app/DMG staple과 Gatekeeper `Notarized Developer ID` 통과, Team ID `XH6JHKYXV8`, CDHash `30d6332479839f45ea74709c46cf303404f94e14`
+- Homebrew: 공개 digest는 확정했지만 별도 승인 전이므로 Cask 수정·install/uninstall을 실행하지 않음
 
 ## 알려진 제한 사항과 후속 이슈
 
@@ -249,7 +274,7 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - strict local `librhwp.a` byte reference mismatch가 남아 있다. Stage 3에서 portable source/Cargo/header/FFI/XCFramework 검증과 분리해 기록하고, workflow의 문서화된 portable release artifact 경계를 허용했다.
 - 초기 `v0.1.9` tag와 draft run `30432036513`은 PR #448 미포함 근거이므로 계속 폐기한다. 현재 tag와 유효 draft 근거는 각각 `ab7a74b...`와 run `30522259476`이다.
 - Skia Thumbnail/Quick Look 경로의 production default 전환은 이번 release 범위가 아니다.
-- signed draft DMG SHA256, notarization과 signed provider provenance는 Stage 4에서 확정했다. official public DMG SHA256, appcast EdDSA signature와 Homebrew digest는 Stage 5 전까지 단정하지 않는다.
+- official public DMG SHA256과 stable appcast EdDSA signature는 Stage 5에서 확정했다. Homebrew Cask 반영과 install/uninstall은 별도 승인 전이므로 아직 완료로 단정하지 않는다.
 - Intel Mac 실기기 설치·실행은 아직 수행하지 않았다. universal slice 자동 검증과 별개 잔여 위험으로 유지한다.
 
 ## Release communication checklist
@@ -271,6 +296,6 @@ PR #437 자동 초안이 해결된 Issue 후보로 분류한 Issue #412 이슈�
 - [x] source preflight와 Rehearsal 검증
 - [x] PR #448 포함 final candidate source preflight와 Rehearsal 재검증
 - [x] installed signed candidate의 Finder/Preview/editor 차단 gate와 draft의 Sparkle/Pages skip 확인
-- [ ] public DMG와 SHA256 기록
-- [ ] public GitHub Release와 Pages/Sparkle 확인
+- [x] public DMG와 SHA256 기록
+- [x] public GitHub Release와 Pages/Sparkle 확인
 - [ ] Homebrew Cask 반영과 검증

--- a/mydocs/report/task_m900_441_report.md
+++ b/mydocs/report/task_m900_441_report.md
@@ -1,0 +1,180 @@
+# Task M900 #441 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#441 `v0.1.9 public release 준비와 배포 실행`](https://github.com/postmelee/alhangeul-macos/issues/441) |
+| 마일스톤 | Release Operations |
+| 기준 브랜치 | `devel` |
+| 작업 브랜치 | `local/task441` |
+| 공개 릴리즈 | [Alhangeul v0.1.9 (rhwp v0.8.2)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) |
+| release commit | `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| release tag | annotated `v0.1.9` |
+| app / extension | `0.1.9 (15)` |
+| rhwp core / studio | `v0.8.2` / `9b16aa9e23f476e2b335d7c029fc9f24a199d63c` |
+| final Rehearsal | [run 30520836152](https://github.com/postmelee/alhangeul-macos/actions/runs/30520836152) |
+| signed draft | [run 30522259476](https://github.com/postmelee/alhangeul-macos/actions/runs/30522259476) |
+| official Publish | [run 30559705357](https://github.com/postmelee/alhangeul-macos/actions/runs/30559705357) |
+| Homebrew tap | [`postmelee/homebrew-tap` commit `b8c7b6a`](https://github.com/postmelee/homebrew-tap/commit/b8c7b6a544989a32da9034ca7c6e6d4e241d3d10) |
+| 단계 | 수행계획, 구현계획, Stage 1~6 |
+
+`v0.1.9` release source와 communication을 upstream `rhwp v0.8.2` 기준으로 정렬하고 source preflight, unsigned Rehearsal, signed/notarized draft 차단 gate를 거쳐 official stable release를 게시했다. public DMG, Pages, stable Sparkle appcast, 실제 `v0.1.8 -> v0.1.9` 업데이트와 Finder surface를 확인한 뒤 같은 official DMG를 maintainer Homebrew tap에도 배포했다.
+
+릴리스 과정에서 발견한 반응형 툴바 회귀와 Thumbnail image buffer 수명 회귀는 각각 Issue #442와 #447로 분리했다. PR #443과 #448 변경을 반영한 새 후보에서 영향을 받는 source, workflow와 수동 gate를 처음부터 다시 검증했으며, 결함이 있던 이전 candidate와 artifact는 공개 근거에서 제외했다.
+
+## 단계별 결과
+
+| 단계 | 커밋 | 결과 |
+|------|------|------|
+| 수행계획 | `a49facd` | `v0.1.9 (15)`, `rhwp v0.8.2`, 6단계 release gate와 외부 mutation 승인 경계 확정 |
+| 구현계획 | `8daf54d` | source, Rehearsal, signed draft, official publish, Homebrew와 종료 정리 절차 구체화 |
+| Stage 1 | `2e0529f` | app/extension과 workflow 기본 입력을 `0.1.9 (15)`, `v0.1.8`, `v0.8.2`로 정렬 |
+| Stage 2 | `1d35810` | 포함 PR 분석, README, Pages, release note와 내부 release record 작성 |
+| Stage 3 / 3.1 | `a9760bb`, `07b9f34`, `46a6703` | PR #443 반영, source preflight 재검증과 corrected Rehearsal 통과 |
+| Stage 4 / 4.1 | `c4fe6ec`, `f7bff92` | PR #448 포함 final candidate, tag, Rehearsal, signed draft와 수동 차단 gate 통과 |
+| Stage 5 | `9e5dcb8` | official stable publish, public artifact/Pages/appcast와 실제 Sparkle update 검증 |
+| Stage 5.1 | `63b7014` | Homebrew Cask 게시, audit/install/uninstall와 설치본 복구 |
+| Stage 6 | 이번 커밋 | 최종 release record, 최종 보고서와 오늘할일 완료 처리 |
+
+Stage 1~3 source와 communication은 PR [#444](https://github.com/postmelee/alhangeul-macos/pull/444)로 `devel`에 반영했다. PR [#445](https://github.com/postmelee/alhangeul-macos/pull/445)는 `main` 전용 Pages 이력을 `devel`에 보존했고, PR [#446](https://github.com/postmelee/alhangeul-macos/pull/446)은 초기 release candidate를 `main`에 반영했다.
+
+Thumbnail crash 수정 뒤 PR [#449](https://github.com/postmelee/alhangeul-macos/pull/449)로 final source를 `devel`에 반영하고 PR [#450](https://github.com/postmelee/alhangeul-macos/pull/450)으로 final `devel -> main` candidate를 확정했다. 이번 종료 정리 PR은 Stage 4~6 운영 기록과 official Homebrew/Pages source 보정을 다시 `devel`에 반영하는 범위다.
+
+## Release Identity와 Publish
+
+| 항목 | 값 |
+|------|----|
+| version / build | `0.1.9 (15)` |
+| previous release | `v0.1.8 (14)` |
+| tag peeled commit | `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| expected rhwp tag | `v0.8.2` |
+| expected rhwp commit | `9b16aa9e23f476e2b335d7c029fc9f24a199d63c` |
+| `require_latest_rhwp` | `true` |
+| `include_rhwp_in_title` | `true` |
+| `draft` / `prerelease` | `false` / `false` |
+| GitHub Release 상태 | non-draft, non-prerelease, latest stable |
+| published at | `2026-07-30T16:17:53Z` |
+
+official run `30559705357`의 release job `90929268201`과 Pages deploy job `90933101471`은 모두 성공했다. 실행 head는 annotated `v0.1.9`의 peeled commit `ab7a74b...`과 일치했다. release input validation, upstream latest guard, core/header/ABI lock, Developer ID signing, notarization, public artifact 검증, GitHub Release, stable appcast와 Pages deploy가 통과했다.
+
+## 무효화한 Candidate와 수정
+
+| 계층 | 무효화한 근거 | 발견한 문제 | 수정과 재검증 |
+|------|---------------|-------------|----------------|
+| Stage 3 Rehearsal | run `30365232108`, candidate `1d358103...` | 창 너비에 따라 상단 toolbar/style bar가 겹치거나 잘림 | Issue #442 / PR #443, run `30424930226`에서 source와 Rehearsal 재검증 |
+| 초기 Stage 4 signed draft | run `30432036513`, initial `main` `1e7f5df...` | external image data 수명 회귀로 Thumbnail crash | Issue #447 / PR #448, PR #449/#450으로 final candidate 갱신 |
+
+final candidate에서는 Rehearsal run `30520836152`와 signed draft run `30522259476`을 모두 새로 실행했다. 초기 tag 상태, 초기 Rehearsal과 signed draft의 URL·digest는 public release, Sparkle 또는 Homebrew 입력으로 사용하지 않았다.
+
+## Public Artifact
+
+| 항목 | 결과 |
+|------|------|
+| DMG | `alhangeul-macos-0.1.9.dmg` |
+| URL | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.9/alhangeul-macos-0.1.9.dmg |
+| size | 164,565,695 bytes |
+| SHA256 | `8110dc4cc2d965b4fe4d0a8cd6b285488a1fb5443f5bda606a35207c5bccc6ca` |
+| checksum asset digest | `052d91db0130513d58e0844d9a12b2e8b968f6b84293d65a85e0fc670c6d8ace` |
+| DMG integrity | checksum과 `hdiutil verify` 통과 |
+| code signature | deep/strict 검증과 Designated Requirement 통과 |
+| notarization | app/DMG staple validate와 Gatekeeper `Notarized Developer ID` accepted |
+| signing identity | Team ID `XH6JHKYXV8`, CDHash `30d6332479839f45ea74709c46cf303404f94e14` |
+| architecture | HostApp, Preview, Thumbnail 모두 `x86_64 + arm64` |
+| legal resources | `LICENSE`, `THIRD_PARTY_LICENSES.md`, `FONTS.md` 포함 |
+| mounted layout | `Alhangeul.app`, `/Applications` symlink와 배경 확인 |
+
+final Rehearsal DMG SHA256은 `175ebb4e...e1830`, signed draft DMG SHA256은 `e65c3697...a793f`다. official workflow가 public DMG를 새로 만들었으므로 공개 설치, Sparkle과 Homebrew에는 official SHA256 `8110dc4c...c6ca`만 사용한다.
+
+## Signed Candidate 차단 Gate
+
+| Gate | 결과 |
+|------|------|
+| source/header/ABI | final tag에서 core/studio `v0.8.2` provenance와 portable release artifact 경계 통과 |
+| app/extensions | 세 target `0.1.9 (15)`, universal, signed/notarized |
+| HWP/HWPX 앱 열기 | 실제 문서 화면과 page count 확인 |
+| Finder Thumbnail | 대표 HWP/HWPX 반복 생성, non-empty 이미지와 신규 crash `0` |
+| Finder Quick Look | HWP/HWPX 실제 provider path와 문서 내용 확인 |
+| external sibling | sandbox `permissionDenied=3`, 외부 그림 누락 상태에서도 764쪽 main document render 유지 |
+| 장문서 | 115쪽 도달, 원문상 비어 있지 않은 112쪽 실제 내용 repaint 확인 |
+| 인쇄/PDF | 인쇄 preview `1/1`, PDF export save panel 진입 확인 후 취소 |
+| 트랙패드 pinch zoom | 배율 숫자 변화, 반대 pinch로 약 `78%` 복귀와 문서 중심 유지 확인 |
+| registration hygiene | development/legacy registration issue `0` |
+
+local strict `librhwp.a` byte reference는 재현 환경 차이로 mismatch가 남았다. 이를 성공으로 바꾸어 기록하지 않았고, portable source/Cargo/header/FFI/XCFramework 결과와 release workflow의 문서화된 portable artifact 경계를 별도로 통과시켰다.
+
+## Pages와 Sparkle
+
+| surface | 결과 |
+|---------|------|
+| Pages home | 최신 다운로드가 tag-fixed public v0.1.9 DMG를 가리킴 |
+| release note | `updates/v0.1.9.html` 공개 및 사용자 변경 요약 확인 |
+| stable appcast SHA256 | `c80b7f52571780bc23f095f436a39d1e177a3ed935488d47bcdad8d1bd2e372d` |
+| appcast version | `sparkle:version=15`, `sparkle:shortVersionString=0.1.9` |
+| enclosure | public DMG URL, length `164565695`, non-empty EdDSA signature 일치 |
+| minimum macOS | `12.0` |
+
+clean official `/Applications/Alhangeul.app` `v0.1.8 (14)`에서 Sparkle UI로 `v0.1.9 (15)`를 설치하고 재실행했다. HostApp과 Preview/Thumbnail provider는 exact `/Applications`의 새 버전을 가리켰고 registration repair는 `0`이었다.
+
+업데이트된 public 앱은 HWP 1쪽을 `232.0ms`, HWPX 9쪽을 `132.0ms`에 열었다. fresh HWP/HWPX의 Finder Thumbnail과 Quick Look도 같은 public provider에서 실제 문서 내용으로 렌더링됐다.
+
+## Homebrew
+
+| 항목 | 결과 |
+|------|------|
+| 설치 명령 | `brew install --cask postmelee/tap/alhangeul` |
+| Cask version | `0.1.9` |
+| Cask SHA256 | official public DMG와 같은 `8110dc4c...c6ca` |
+| tap commit | `b8c7b6a544989a32da9034ca7c6e6d4e241d3d10` |
+| lint | `brew style`, 일반 `brew audit`, 참고용 `brew audit --new` 통과 |
+| install | Caskroom `0.1.9`, 앱과 두 extension `0.1.9 (15)` |
+| artifact 정합성 | 실행 파일, architecture, signature, notarization과 identity가 official 설치본과 일치 |
+| 실행/extension | 최초 앱 화면 로드, extension refresh와 registration repair `0` |
+| uninstall | Cask와 테스트 설치본 제거 확인 |
+
+smoke 전에 격리한 official `/Applications/Alhangeul.app` `0.1.9 (15)`와 기존 `/Users/melee/Applications/Alhangeul.app` `0.1.8 (14)`는 원래 위치로 복구했다. 최종 상태는 Homebrew Cask 미설치, official `/Applications` 앱 복구, HostApp 미실행과 rehearsal DMG 미마운트다.
+
+public GitHub Release의 Homebrew 문단은 검증된 설치 명령으로 갱신했다. 이 저장소의 README와 Pages source도 같은 명령으로 보정했지만, public Pages에는 아직 기존 “별도 배포 예정” 안내가 남는다. 현재 종료 정리 변경을 `devel`에 통합한 뒤 `main`으로 승격하고 docs-only Pages workflow를 실행해야 공개 문구가 최종 정렬된다.
+
+## 변경 파일과 기록
+
+| 경로 | 내용 |
+|------|------|
+| app/extension Info.plist | `0.1.9 (15)` identity 정렬 |
+| release workflow | `v0.1.9`, previous `v0.1.8`, expected rhwp `v0.8.2` 기본 입력 정렬 |
+| README, `docs/` | 최신 공개 릴리즈, Homebrew 설치 명령과 Pages update 안내 |
+| `Casks/alhangeul.rb` | official public DMG version과 SHA256 반영 |
+| `mydocs/release/v0.1.9.md` | candidate 이동, public artifact, signed/public/Homebrew 검증 기록 |
+| `mydocs/working/task_m900_441_stage1.md` ~ `stage5.md` | 단계별 source, Rehearsal, signed gate, publish와 Homebrew 기록 |
+| `mydocs/report/task_m900_441_report.md` | 전체 release 실행과 최종 판정 |
+| `mydocs/orders/20260729.md` | Task #441 완료 상태 |
+
+제품 source와 초기 release communication은 PR #444, #445, #446, #449와 #450을 통해 release commit에 반영됐다. 이번 최종 PR은 Stage 4~6 이후 확정된 공개 artifact, Homebrew/Pages source와 post-publish 검증 기록을 `devel`에 추가한다.
+
+## 미실행 항목과 잔여 위험
+
+| 항목 | 상태 | 후속 |
+|------|------|------|
+| Intel Mac 실기기 | 미실행 | universal `x86_64 + arm64` 자동 검증과 별도로 가능한 환경에서 runtime smoke |
+| Quick Look external sibling | registered sandbox에서 `permissionDenied=3` | 외부 그림이 없어도 main document 유지, 관련 후속 Issue 경계 유지 |
+| upstream #3412 / #3450 | 알려진 문제 | signed editor smoke에서 blocker 미재현, 다음 upstream sync에서 재평가 |
+| strict local archive | reference byte mismatch | portable source/header/FFI 경계 통과와 분리 유지 |
+| 공식 Homebrew Cask 저장소 | 미제출 | 이번 범위는 maintainer tap `postmelee/homebrew-tap`까지 |
+| public Pages Homebrew 안내 | source 보정 완료, live 반영 전 | `devel -> main` docs 승격과 Pages workflow 성공 뒤 확인 |
+| `build.noindex/` 개발 app | 미등록 bundle warning | 실제 provider는 process path와 PlugInKit 결과로 판정 |
+
+## 최종 결론
+
+`v0.1.9 (15)`는 release commit `ab7a74b...`, upstream `rhwp v0.8.2`와 일치하는 signed/notarized universal app으로 public 배포됐다. source preflight, final Rehearsal, signed 앱/Finder/editor 차단 gate, official GitHub Release, public DMG, Pages/appcast, 실제 Sparkle update와 maintainer Homebrew tap 배포에 신규 blocker가 없다.
+
+릴리스 과정에서 발견한 두 차단 회귀는 별도 Issue와 PR로 수정한 뒤 새 candidate에서 검증을 다시 수행했다. Intel Mac 실기기와 registered Quick Look external sibling 제한은 명시된 잔여 위험이며, official release와 Homebrew 배포 완료 판정을 뒤집는 blocker로 재현되지 않았다.
+
+Task #441의 release 준비, official publish와 Homebrew 배포 실행 목표는 달성했다. 다만 README/Pages의 Homebrew source 보정은 아직 public Pages에 반영되지 않았으므로, 종료 정리 PR의 `devel` merge 뒤 `main` docs 승격과 Pages 결과를 확인할 때까지 Issue #441은 자동으로 닫지 않는다.
+
+## 종료 및 정리 조건
+
+1. 이번 Stage 6 종료 정리 PR을 `devel`에 merge한다.
+2. `devel -> main` docs 승격 PR을 별도로 검토·merge한다.
+3. docs-only Pages workflow 성공과 공개 Homebrew 설치 문구를 확인한다.
+4. 위 공개 반영을 확인한 뒤 Issue #441을 close한다.
+5. PR merge 확인 후 `publish/task441`, `local/task441`과 불필요한 worktree를 `pr-merge-cleanup` 절차로 정리한다.

--- a/mydocs/working/task_m900_441_stage4.md
+++ b/mydocs/working/task_m900_441_stage4.md
@@ -1,0 +1,265 @@
+# Task M900 #441 Stage 4 완료보고서
+
+## 단계 목적
+
+Stage 1~3에서 검증한 `v0.1.9 (15)` source와 release communication을 `devel`에 반영하고, `main` 전용 이력을 보존한 final release candidate를 annotated `v0.1.9` tag로 확정한다. 이어서 exact tag의 unsigned Rehearsal과 signed/notarized draft DMG를 다시 생성하고, 실제 앱·Finder·Preview·Thumbnail·editor 차단 smoke를 통과하는지 확인한다.
+
+초기 signed candidate에서 발견한 Thumbnail crash는 Issue #447 / PR #448로 분리해 수정했다. 따라서 초기 `main` commit, tag 상태, Rehearsal과 signed draft를 final candidate 근거로 재사용하지 않고 PR #448 포함 candidate에서 모두 다시 검증했다.
+
+## 검증 기준점
+
+| 항목 | 값 |
+|------|----|
+| source PR | [#444](https://github.com/postmelee/alhangeul-macos/pull/444), head `46a67037147ddff887eaff92e3683d28b11a79fa`, merge `2b4c255b07c697dd101ddd4b2011391ef6833dcc` |
+| main back-merge PR | [#445](https://github.com/postmelee/alhangeul-macos/pull/445), head `32c1129477dfd3c812f1eac758654f1e591b1888`, merge `1b1213db5a0bd75638f54bf03d49fbf4cb63edcc` |
+| 초기 release PR | [#446](https://github.com/postmelee/alhangeul-macos/pull/446), merge `1e7f5df59684713745cb9d59c0a0e9dfdaaf0272`, PR #448 미포함으로 superseded |
+| blocker 수정 PR | [#448](https://github.com/postmelee/alhangeul-macos/pull/448), head `ce720c4e34f1da4dfc219d9d811ab2628cd94c60`, merge `f2a78b799f62985d2767afc9ba4434581e9b10be` |
+| candidate 갱신 PR | [#449](https://github.com/postmelee/alhangeul-macos/pull/449), head `c4fe6ecdec04d863a5506d3913b387a41835d62b`, merge `485c76cf32486d148fa88e30717e18c9794e810f` |
+| final release PR | [#450](https://github.com/postmelee/alhangeul-macos/pull/450), head `485c76cf32486d148fa88e30717e18c9794e810f`, merge `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| final `origin/devel` | `485c76cf32486d148fa88e30717e18c9794e810f` |
+| final `origin/main` | `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| annotated tag object | `v0.1.9` / `efc4423c6ab760024e2c8c92fbac0302e1f82c23` |
+| tag peeled commit | `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| app / extensions | `0.1.9 (15)` |
+| rhwp core / studio | `v0.8.2` / `9b16aa9e23f476e2b335d7c029fc9f24a199d63c` |
+| final Rehearsal | [run `30520836152`](https://github.com/postmelee/alhangeul-macos/actions/runs/30520836152) |
+| signed draft Publish | [run `30522259476`](https://github.com/postmelee/alhangeul-macos/actions/runs/30522259476), `draft=true`, `prerelease=false` |
+| 최신 공개 앱 | [`v0.1.8`](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8), non-draft / non-prerelease |
+| 최신 upstream | [`rhwp v0.8.2`](https://github.com/edwardkim/rhwp/releases/tag/v0.8.2), candidate lock과 일치 |
+| release issue | [#441](https://github.com/postmelee/alhangeul-macos/issues/441), `OPEN`, `Release Operations` |
+
+## 산출물
+
+### GitHub와 release candidate
+
+- PR #444, #445, #446, #448, #449, #450의 merge commit과 CI 결과
+- annotated `v0.1.9` tag와 final `main` release commit
+- exact tag의 final Rehearsal run `30520836152`
+- exact tag의 signed/notarized draft Publish run `30522259476`
+- 비공개 draft Release와 DMG/checksum asset
+
+### 로컬 검증 산출물
+
+- `build.noindex/task441-rehearsal-30520836152/`
+- `build.noindex/task441-signed-draft-30522259476/`
+- signed smoke 전 설치본 backup `build.noindex/task441-signed-draft-30522259476/pre-smoke-backup/Alhangeul.app`
+- 외부 연결 그림 fixture `build.noindex/task441-stage3-07b9f34-external/hwp3-sample10-hwpx.hwpx`
+
+`build.noindex/` 산출물은 검증 전용이며 Git 추적 대상이 아니다.
+
+### 추적 문서
+
+- 보정한 `mydocs/release/v0.1.9.md`
+- 이 Stage 4 완료보고서
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+이번 Stage 보고 commit은 제품 source, Xcode project, bundled studio asset과 public Pages 문서를 수정하지 않는다. 이미 merge된 exact candidate의 상태와 검증 결과만 release record와 단계 보고서에 반영한다.
+
+- 기존 사용자용 release 요약과 포함 PR 판정은 유지했다.
+- PR #448 이후 candidate 이동, final tag, workflow, draft DMG와 signed smoke 결과만 보정했다.
+- public `v0.1.8` 다운로드, stable appcast와 Pages는 변경하지 않았다.
+- official public DMG SHA256, appcast signature와 Homebrew digest는 여전히 미확정으로 남겼다.
+
+따라서 제품 본문과 public surface는 무손실이며 문서 상태만 Stage 4 실제 결과와 일치시켰다.
+
+## Source, main과 tag 정합성
+
+### PR 반영
+
+- PR #444는 `publish/task441 -> devel` source 반영이며 PR CI 4개 job이 모두 성공했다.
+- PR #445는 PR #432의 `main` 전용 Pages 이력을 `devel`에 보존한 reviewed back-merge다. docs-only 분류에 따라 macOS/release helper job은 skip되고 classify/script job은 성공했다.
+- PR #446은 최초 `devel -> main` transport였으나 뒤에 발견한 Thumbnail crash 수정 PR #448을 포함하지 않아 final candidate로 사용하지 않는다.
+- PR #448은 RustBridge image data caller-owned buffer와 Swift exact free를 반영했고 macOS validation을 포함한 관련 CI가 성공했다.
+- PR #449는 PR #448과 release communication을 final `devel` candidate로 묶었다. 변경 분류에 따른 macOS job skip을 제외하고 classify/script/release helper가 성공했다.
+- PR #450은 final `devel -> main` transport이며 PR CI 4개 job이 모두 성공했다.
+
+### Branch와 tree
+
+최종 조회 결과:
+
+```text
+origin/main  = ab7a74b5fc35dcdb56b121a8b74d00460a967e7b
+origin/devel = 485c76cf32486d148fa88e30717e18c9794e810f
+origin/main...origin/devel = 2 0
+```
+
+`main` 전용 두 commit은 PR #446과 PR #450의 release transport다. `git diff --exit-code origin/main^{tree} origin/devel^{tree}`가 통과해 양 branch tree는 같다.
+
+`git cat-file -t v0.1.9`은 `tag`이고, tag object `efc4423...`의 peeled commit은 final PR #450 merge commit `ab7a74b...`과 일치한다. annotation은 `Alhangeul v0.1.9`이다.
+
+## Final Release Rehearsal
+
+final tag에서 Rehearsal workflow를 처음부터 다시 실행했다.
+
+| 항목 | 결과 |
+|------|------|
+| run | [`30520836152`](https://github.com/postmelee/alhangeul-macos/actions/runs/30520836152) |
+| workflow / job | `Release Rehearsal DMG` / `Build rehearsal DMG` |
+| head | `v0.1.9` / `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| conclusion | `success` |
+| DMG | `alhangeul-macos-0.1.9-rehearsal.dmg` |
+| size | `163,109,772` bytes |
+| SHA256 | `175ebb4ee421220ea6159bba4b9ecefa0c51d35ab7a7555412f59398023e1830` |
+| checksum | `shasum -a 256 -c` 통과 |
+| DMG integrity | `hdiutil verify` / `VALID` |
+
+Workflow에서 release PR analysis, delta checklist, source/header/ABI lock, Rehearsal package와 artifact 검증이 모두 성공했다. 자동 분석의 candidate commit도 `ab7a74b...`과 일치한다.
+
+## Signed/notarized draft
+
+별도 승인으로 exact tag에서 `draft=true`, `prerelease=false` Publish workflow를 실행했다.
+
+| 항목 | 결과 |
+|------|------|
+| run | [`30522259476`](https://github.com/postmelee/alhangeul-macos/actions/runs/30522259476) |
+| head | `v0.1.9` / `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| latest guard | upstream latest `v0.8.2` 확인 성공 |
+| build job | signed/notarized DMG build와 release asset publish 성공 |
+| Release 상태 | `draft=true`, `prerelease=false`, `publishedAt=null` |
+| title | `Alhangeul v0.1.9 (rhwp v0.8.2)` |
+| DMG | `alhangeul-macos-0.1.9.dmg`, `164,565,668` bytes |
+| DMG SHA256 | `e65c3697ff46542137ee79fbfed0cf9f3c5f5b6ce7ef8e337f7b7b9be19a793f` |
+| asset download count | `0` |
+| stable appcast / Pages | 정책대로 skip |
+| Pages deploy job | skip |
+
+비공개 draft URL은 `https://github.com/postmelee/alhangeul-macos/releases/tag/untagged-43fc1d315706a98311c2`다. 이 URL과 digest는 Stage 4 후보 검증 근거이며 official public asset을 뜻하지 않는다.
+
+## Signed artifact 정적 gate
+
+다운로드한 draft artifact를 독립 재검증했다.
+
+| 검증 | 결과 |
+|------|------|
+| checksum file | `shasum -a 256 -c` 통과 |
+| DMG integrity | `hdiutil verify` / `VALID` |
+| HostApp / Preview / Thumbnail version | 모두 `0.1.9 (15)` |
+| HostApp architecture | `x86_64 + arm64` |
+| Preview architecture | `x86_64 + arm64` |
+| Thumbnail architecture | `x86_64 + arm64` |
+| app deep signature | `valid on disk`, designated requirement 충족 |
+| app staple | validate 성공 |
+| DMG staple | validate 성공 |
+| app Gatekeeper | `accepted`, `Notarized Developer ID` |
+| DMG Gatekeeper | `accepted`, `Notarized Developer ID` |
+| signing team | `XH6JHKYXV8` |
+| candidate CDHash | `30d6332479839f45ea74709c46cf303404f94e14` |
+| Legal | `LICENSE`, `THIRD_PARTY_LICENSES.md`, `FONTS.md` 포함 |
+| mounted layout | `Alhangeul.app`, `/Applications` link, background 확인 |
+
+제한된 sandbox 안에서 처음 호출한 `codesign`과 macOS 보안 서비스는 invalid/internal error를 반환했다. 동일 artifact의 절대 경로를 시스템 보안 서비스 권한으로 재실행하자 deep signature, staple와 Gatekeeper가 모두 통과했다. artifact 실패가 아니라 검증 환경 차이로 판정했다.
+
+## Installed signed candidate smoke
+
+### 후보 격리와 provenance
+
+기존 public `/Applications/Alhangeul.app`과 분리해 candidate를 `/Users/melee/Applications/Alhangeul.app`에 설치했다.
+
+- 실행 HostApp PID가 candidate 절대 경로를 가리킴을 확인했다.
+- Preview process가 candidate의 `AlhangeulPreview` 절대 경로를 가리킴을 확인했다.
+- Thumbnail process가 candidate의 `AlhangeulThumbnail` 절대 경로를 가리킴을 확인했다.
+- 초기 표준 helper smoke 한 번은 `/Applications`의 v0.1.8 provider를 사용한 false positive였으므로 결과를 무효화했다.
+- 이후 exact candidate provider만 남긴 상태에서 Finder 검증을 다시 수행했다.
+
+### Finder Thumbnail
+
+candidate Thumbnail provider에서 다음 6개 문서의 non-empty PNG를 생성했다.
+
+| 문서 | PNG SHA256 앞 8자리 |
+|------|---------------------|
+| `KTX.hwp` | `a6aeb454` |
+| `hwpx-01.hwpx` | `3ef08ff5` |
+| external HWPX fixture | `6186603a` |
+| `복학원서` HWP | `979482bb` |
+| `img-start-001` HWP | `cbd796a1` |
+| `hwp-img-001` HWP | `f4f0ffa1` |
+
+검증 기준선 이후 Alhangeul 관련 crash report는 생성되지 않았다. 다른 시스템 서비스 crash는 제품 결과에서 제외했다.
+
+### Finder Preview와 external fallback
+
+- `KTX.hwp` Finder Space preview에서 실제 문서가 표시됐다.
+- external fixture는 candidate Preview provider에서 `764`쪽 PDF를 만들었다.
+- OSLog는 `externalResource attempted total=3 injected=0 permissionDenied=3`을 기록했다.
+- 외부 그림 placeholder는 남았지만 main document는 fallback `0`, 출력 `78,138,983` bytes로 유지됐다.
+
+이는 registered Quick Look sandbox에서 sibling 접근이 거부되는 현재 제한과 main document fallback 계약이 함께 성립함을 뜻한다.
+
+### HostApp editor
+
+- `KTX.hwp`는 `1`쪽으로 정상 열렸다.
+- HWPX 앱 smoke에서는 `hwpx-02.hwpx`를 실제로 열었고 `7`쪽을 약 `137ms`에 렌더했다. Thumbnail의 `hwpx-01.hwpx`와 혼동하지 않는다.
+- `issue1949_giant_cell_nested_tables_perf.hwp`는 `115`쪽을 약 `1702ms`에 열고 `115/115`까지 이동했다.
+- 마지막 115쪽은 시각적으로 빈 페이지였지만 112쪽에서 실제 한글 내용 repaint를 확인했다. 따라서 end reach와 late-page repaint를 분리해 통과로 기록한다.
+- 인쇄 dialog에서 preview `1/1`을 확인하고 취소했다.
+- PDF export save panel에서 기본 파일명 `KTX.pdf`를 확인하고 취소했다.
+
+smoke-only autosave/recovery 변경은 저장하지 않고 앱을 종료했다.
+
+## 복구와 registration hygiene
+
+- `/Users/melee/Applications/Alhangeul.app`은 smoke 전 backup의 v0.1.8 build 14로 복원했다.
+- `/Applications/Alhangeul.app`은 기존 v0.1.8 build 14 설치본을 변경하지 않았다.
+- candidate extension과 nested Sparkle Updater의 개발 registration을 제거했다.
+- stale temporary Updater registration은 정확한 대상만 재구성해 unregister한 뒤 임시 app만 제거했다.
+- `scripts/check-extension-registration-hygiene.sh --check-only`는 development registration, legacy candidate와 issue가 모두 없다고 판정했다.
+- `build.noindex/`의 미등록 개발 app bundle 존재와 PlugInKit provider path 미보고는 warning으로만 남았다.
+- signed DMG는 detach했고 임시 mount point를 정리했다.
+
+## 검증 결과
+
+| Gate | 결과 |
+|------|------|
+| source PR과 CI | 통과 |
+| main-only 이력 보존 | PR #445 back-merge로 통과 |
+| final release PR과 branch tree | PR #450 merge, tree 동일 |
+| annotated tag identity | `v0.1.9^{}` = `ab7a74b...` |
+| final Rehearsal | run `30520836152` 성공 |
+| signed draft workflow | run `30522259476` 성공 |
+| checksum / DMG integrity | 통과 |
+| universal app / extensions | 통과 |
+| signing / notarization / staple / Gatekeeper | 통과 |
+| exact candidate app / Preview / Thumbnail provenance | 통과 |
+| HWP/HWPX app와 Finder smoke | 통과 |
+| external sibling permission fallback | 접근 거부와 main document 유지 확인 |
+| 장문서 repaint / 인쇄 / PDF 시작 경로 | 통과 |
+| crash | candidate 관련 신규 crash 0 |
+| registration·설치본 복구 | 통과 |
+| stable appcast / Pages 비변경 | draft 정책 skip, public v0.1.8 유지 |
+| `git diff --check` | 통과 |
+
+## 잔여 위험
+
+- Intel Mac 실기기 설치·실행은 수행하지 않았다. `x86_64 + arm64` 자동 검증과 별개 위험으로 유지한다.
+- registered Quick Look sandbox는 external sibling 3개 접근을 모두 거부했다. main document는 유지되지만 외부 그림은 표시되지 않는다.
+- 초기 helper smoke가 다른 설치본 provider를 선택했다. 이후 exact provider 격리로 다시 검증했지만 향후 release smoke도 process path와 registration을 함께 확인해야 한다.
+- 115쪽 문서의 마지막 페이지는 원문상 시각적으로 비어 있어 112쪽 실제 내용 repaint로 late-page gate를 보완했다. 전체 페이지 pixel regression suite는 이번 범위가 아니다.
+- signed draft digest는 확정했지만 official workflow가 새 DMG를 만들면 public digest를 별도로 다시 기록해야 한다.
+- `v0.1.8 -> v0.1.9` Sparkle update, public Pages/appcast와 Homebrew install/uninstall은 아직 실행하지 않았다.
+- upstream page-local repaint Issue #3412 이슈와 PDF 안내 modal Issue #3450 이슈는 남아 있으나 이번 signed smoke에서는 blocker를 재현하지 않았다.
+
+## 다음 단계 영향
+
+Stage 5는 source, tag 또는 draft release body가 바뀌지 않은 동일 `ab7a74b...` candidate에서 시작해야 한다. candidate가 이동하면 Rehearsal과 signed draft gate를 다시 수행한다.
+
+Stage 5 진입 뒤에도 다음 mutation은 분리한다.
+
+1. `draft=false`, `prerelease=false` official stable Publish workflow
+2. public GitHub Release, DMG/checksum, Pages와 stable appcast 검증
+3. clean public v0.1.8 기준 Sparkle update와 extension refresh
+4. 별도 승인된 Homebrew Cask 반영과 install/uninstall smoke
+
+## 판정
+
+- final `main`, annotated tag, Rehearsal과 signed draft가 같은 `ab7a74b...` candidate다.
+- PR #448 이전의 초기 tag 상태와 run `30432036513` artifact는 계속 폐기한다.
+- signed/notarized candidate의 앱, Finder, Preview, Thumbnail과 editor 차단 gate가 통과했다.
+- 설치본과 extension registration을 복구했고 public v0.1.8 surface는 유지됐다.
+- Stage 5 진입을 막는 미해결 Stage 4 blocker는 없다.
+
+## 승인 요청
+
+Stage 4 완료 결과를 승인하고 Stage 5 `Official stable publish와 public surface` 진입을 요청한다.
+
+Stage 5의 official Publish와 Homebrew 반영은 각각 별도 승인 gate를 유지한다.

--- a/mydocs/working/task_m900_441_stage5.md
+++ b/mydocs/working/task_m900_441_stage5.md
@@ -1,0 +1,213 @@
+# Task M900 #441 Stage 5 완료보고서
+
+## 단계 목적
+
+Stage 4 signed candidate 차단 gate를 통과한 exact `v0.1.9` tag를 official stable release로 게시하고, public GitHub Release·DMG·Pages·Sparkle와 실제 `v0.1.8 -> v0.1.9` 업데이트 뒤 앱·Preview·Thumbnail surface를 검증한다.
+
+Homebrew Cask는 public DMG URL과 SHA256 확정 뒤에도 별도 승인 gate를 유지하므로 이번 단계에서는 수정하거나 설치·제거하지 않는다.
+
+## 검증 기준점
+
+| 항목 | 값 |
+|------|----|
+| annotated tag | `v0.1.9` |
+| tag peeled commit | `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| final `origin/main` | `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| final `origin/devel` | `485c76cf32486d148fa88e30717e18c9794e810f` |
+| app / extensions | `0.1.9 (15)` |
+| rhwp core / studio | `v0.8.2` / `9b16aa9e23f476e2b335d7c029fc9f24a199d63c` |
+| Stage 4 signed draft | run [`30522259476`](https://github.com/postmelee/alhangeul-macos/actions/runs/30522259476) |
+| official Publish | run [`30559705357`](https://github.com/postmelee/alhangeul-macos/actions/runs/30559705357) |
+| 직전 public baseline | `v0.1.8 (14)` |
+| release issue | [#441](https://github.com/postmelee/alhangeul-macos/issues/441), `OPEN`, `Release Operations` |
+
+official 실행 전에 tag와 `origin/main`, release body, Pages source, 앱·확장 version, core/studio provenance가 Stage 4 이후 바뀌지 않았음을 확인했다. `README.md`, `docs/`, release workflow, 앱·확장 source와 `rhwp-core.lock`은 tag와 동일했다. upstream latest도 계속 `v0.8.2`였고, release environment의 필요한 variable·secret 이름은 값을 노출하지 않고 확인했다.
+
+## Official Publish 실행
+
+별도 승인으로 annotated tag `v0.1.9`에서 다음 입력으로 `Release Publish DMG` workflow를 실행했다.
+
+| 항목 | 값 |
+|------|----|
+| workflow run | [`30559705357`](https://github.com/postmelee/alhangeul-macos/actions/runs/30559705357) |
+| exact head | `v0.1.9` / `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| `version` | `0.1.9` |
+| `previous_release_ref` | `v0.1.8` |
+| `expected_rhwp_tag` | `v0.8.2` |
+| `require_latest_rhwp` | `true` |
+| `include_rhwp_in_title` | `true` |
+| `draft` / `prerelease` | `false` / `false` |
+| release job | `90929268201`, success |
+| Pages deploy job | `90933101471`, success |
+
+tag 입력 검증, upstream latest guard, source/header/ABI lock, signed/notarized DMG build, public artifact 검증, GitHub Release 게시, stable appcast 작성과 Pages artifact/deploy가 모두 성공했다. stable publish이므로 draft 정책용 skip 기록 step만 의도대로 skip됐다.
+
+run annotation에는 runner에 이미 존재한 untrusted `aws/tap` Homebrew warning이 한 건 있었지만 이번 workflow나 공개 artifact에는 영향을 주지 않았다. 이번 단계에서는 Homebrew 명령을 실행하지 않았다.
+
+## Public GitHub Release와 DMG
+
+| 항목 | 결과 |
+|------|------|
+| GitHub Release | [Alhangeul v0.1.9 (rhwp v0.8.2)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) |
+| 공개 상태 | non-draft, non-prerelease, latest |
+| published at | `2026-07-30T16:17:53Z` |
+| DMG | `alhangeul-macos-0.1.9.dmg`, `164,565,695` bytes |
+| DMG URL | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.9/alhangeul-macos-0.1.9.dmg |
+| SHA256 | `8110dc4cc2d965b4fe4d0a8cd6b285488a1fb5443f5bda606a35207c5bccc6ca` |
+| checksum asset digest | `052d91db0130513d58e0844d9a12b2e8b968f6b84293d65a85e0fc670c6d8ace` |
+| DMG integrity | checksum과 `hdiutil verify` 통과 |
+| version | HostApp, Preview, Thumbnail 모두 `0.1.9 (15)` |
+| architecture | HostApp, Preview, Thumbnail 모두 `x86_64 + arm64` |
+| signing | deep/strict codesign과 Designated Requirement 통과 |
+| notarization | app/DMG staple validate, Gatekeeper `Notarized Developer ID` accepted |
+| signing identity | Team ID `XH6JHKYXV8`, CDHash `30d6332479839f45ea74709c46cf303404f94e14` |
+| Legal | `LICENSE`, `THIRD_PARTY_LICENSES.md`, `FONTS.md` 포함 |
+| mounted layout | `Alhangeul.app`, `/Applications` symlink와 배경 확인 |
+
+workflow artifact는 `build.noindex/task441-official-30559705357/`에 내려받아 독립 검증했다. public DMG digest와 checksum asset은 workflow artifact와 일치했다. GitHub Release 본문도 official release note artifact와 일치했다.
+
+Stage 4 draft DMG는 `164,565,668` bytes와 SHA256 `e65c3697...793f`였고 official workflow가 public DMG를 새로 생성했다. 따라서 Stage 5의 확정 공개 digest는 `8110dc4c...c6ca`이며 draft digest와 혼용하지 않는다.
+
+## Pages와 Stable Appcast
+
+| surface | 결과 |
+|---------|------|
+| Pages home | 최신 다운로드가 tag-fixed public v0.1.9 DMG를 가리킴 |
+| v0.1.9 release note | https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html 접근 및 내용 확인 |
+| updates index | v0.1.9 최신 DMG와 release note를 가리킴 |
+| 이전 v0.1.8 note | v0.1.9 최신 안내와 링크 확인 |
+| stable appcast SHA256 | `c80b7f52571780bc23f095f436a39d1e177a3ed935488d47bcdad8d1bd2e372d` |
+| appcast version | `sparkle:version=15`, `sparkle:shortVersionString=0.1.9` |
+| enclosure | public DMG URL과 length `164565695` 일치 |
+| EdDSA | non-empty signature 확인 |
+| minimum system | `12.0` |
+| XML | `xmllint --noout` 통과 |
+
+public appcast는 workflow artifact와 byte-identical했다. Pages home, `updates/`, `updates/v0.1.9.html`과 `updates/v0.1.8.html`도 tag source와 byte-identical했다. 고정 tag URL과 latest DMG URL은 같은 공개 asset으로 해석됐다.
+
+## 실제 Sparkle Update와 Extension Refresh
+
+### Clean baseline
+
+기존 `/Applications/Alhangeul.app`은 official `v0.1.8 (14)` 설치본이었다.
+
+| 항목 | 결과 |
+|------|------|
+| version | `0.1.8 (14)` |
+| signature | deep/strict, staple와 Gatekeeper 통과 |
+| CDHash | `8a9f55ae5ec255ae1ea07617bf3c068606b04c10` |
+| Preview provider | `/Applications/Alhangeul.app`, `0.1.8` |
+| Thumbnail provider | `/Applications/Alhangeul.app`, `0.1.8` |
+| pre-update backup | `build.noindex/task441-official-30559705357/pre-update-backup/Alhangeul.app` |
+
+표준 registration hygiene helper로 이전 Stage 4/static mount의 정확한 개발 registration만 해제한 뒤 clean baseline을 확정했다. baseline 앱 자체는 다시 설치하거나 수정하지 않았다.
+
+### Sparkle UI
+
+`알한글 > 업데이트 확인...`에서 public stable appcast의 `0.1.9`와 `164.6 MB` 업데이트를 확인했다. `업데이트 설치`와 `설치 & 재실행`을 거쳐 exact `/Applications/Alhangeul.app`이 다시 실행됐다.
+
+| 항목 | 결과 |
+|------|------|
+| 설치본 | `/Applications/Alhangeul.app`, `0.1.9 (15)` |
+| HostApp provenance | 실행 PID가 exact `/Applications` executable을 가리킴 |
+| Preview provider | `/Applications/Alhangeul.app/Contents/PlugIns/AlhangeulPreview.appex`, `0.1.9 (15)` |
+| Thumbnail provider | `/Applications/Alhangeul.app/Contents/PlugIns/AlhangeulThumbnail.appex`, `0.1.9 (15)` |
+| registration repair | `0` |
+| refresh smoke | `scripts/smoke-sparkle-extension-refresh.sh` 통과 |
+| smoke 산출물 | `/private/tmp/alhangeul-sparkle-extension-refresh/20260731-012919` |
+| update 재확인 | `알한글 0.1.9 이(가) 현재 최신 버전입니다.` |
+
+자동 업데이트 preference는 변경하지 않았다. smoke용 문서에서 생긴 저장 상태는 원본에 기록하지 않고 `저장하지 않음`으로 종료했다.
+
+## Public 앱과 Finder 검증
+
+### Finder Thumbnail
+
+refresh helper가 만든 fresh HWP/HWPX에서 첫 시도에 non-empty Thumbnail을 생성했다.
+
+| 문서 | 크기 | SHA256 |
+|------|------|--------|
+| HWP | `345,577` bytes | `c502abade962875dfb6f341216c45e511841e0d155a4fe32e1e2975894d60ae3` |
+| HWPX | `188,846` bytes | `5d43725798a96458ed7535e54e67e810b34f5919643e57002563d756ac9d948d` |
+
+두 PNG를 직접 열어 실제 문서 내용이 정상 표시됨을 확인했다.
+
+### Finder Quick Look
+
+- HWP fresh sample은 KTX 노선도 1쪽을 정상 표시했다.
+- HWPX fresh sample은 기획재정부 보도자료 9쪽과 page thumbnail navigation을 정상 표시했다.
+- Quick Look 중 Preview process는 `/Applications/Alhangeul.app/.../AlhangeulPreview`를 가리켰다.
+- Thumbnail process도 `/Applications/Alhangeul.app/.../AlhangeulThumbnail`을 가리켰다.
+
+### HostApp 직접 열기
+
+Sparkle로 갱신된 public 설치본에서 같은 fresh sample을 직접 열었다.
+
+| 문서 | 결과 |
+|------|------|
+| HWP | KTX 노선도 `1`쪽을 `232.0ms`에 render, 실제 화면 확인 |
+| HWPX | 기획재정부 보도자료 `9`쪽을 `132.0ms`에 render, 실제 화면 확인 |
+
+두 문서 모두 `alhangeul-studio://app/index.html`의 current document revision으로 열렸고 상태 막대의 filename, page count와 render time이 일치했다. 테스트 후 앱은 종료했고 Finder 창은 검증 전의 다운로드 폴더로 복구했다.
+
+## 설치본·registration 복구
+
+- `/Applications/Alhangeul.app`은 실제 Sparkle update 결과인 official `v0.1.9 (15)`로 유지했다.
+- HostApp은 종료했으며 남은 Preview/Thumbnail process는 official `/Applications` 경로만 사용했다.
+- `scripts/check-extension-registration-hygiene.sh --check-only`는 development registration, legacy candidate와 issue가 모두 없다고 판정했다.
+- 최종 hygiene diagnostics는 `/private/tmp/alhangeul-extension-registration-hygiene/20260731-020110`이다.
+- `build.noindex/`의 미등록 개발 app bundle 존재와 PlugInKit provider path 미보고는 warning으로만 남았다.
+- official publish 시점 이후 Alhangeul, Preview, Thumbnail 관련 신규 crash report는 `0`개다.
+- signed DMG는 detach 상태이고 임시 mount registration은 남기지 않았다.
+
+## 미실행 항목
+
+- Homebrew Cask 수정과 `brew style/audit/install/uninstall`: public DMG URL과 SHA256은 확정했지만 별도 승인 전이라 실행하지 않음
+- Intel Mac 실기기 설치와 실행: universal slice 자동 검증과 Apple Silicon 실기기 smoke로 대체했으며 미실행
+
+## 검증 결과
+
+| Gate | 결과 |
+|------|------|
+| exact tag와 upstream latest | 통과 |
+| official release workflow | release / Pages jobs 성공 |
+| GitHub Release stable/latest | 통과 |
+| public DMG/checksum | SHA256, size와 asset 일치 |
+| signing/notarization/staple/Gatekeeper | 통과 |
+| universal app/extensions | 통과 |
+| Pages와 stable appcast | version/build/URL/size와 EdDSA 정합성 통과 |
+| v0.1.8 -> v0.1.9 Sparkle update | 통과 |
+| extension refresh | repair `0`, exact public provider 통과 |
+| HWP/HWPX 앱 직접 열기 | 통과 |
+| HWP/HWPX Thumbnail / Quick Look | 통과 |
+| 신규 crash | `0` |
+| registration hygiene | issue `0` |
+| Homebrew | 미진행, 별도 승인 gate |
+| `git diff --check` | 통과 |
+
+## 잔여 위험
+
+- Intel Mac 실기기 설치·실행은 수행하지 않았다. `x86_64 + arm64` 자동 검증과 별개 위험으로 유지한다.
+- registered Quick Look sandbox의 external sibling 접근 제한과 upstream Issue #3412, #3450은 Stage 4에 기록한 상태로 남는다. public update smoke에서 새 blocker는 재현하지 않았다.
+- public DMG와 appcast digest는 확정했지만 Homebrew Cask는 아직 이전 공개 상태일 수 있다. 반영 전에는 GitHub Release DMG를 공식 설치 경로로 사용한다.
+- helper가 발견하는 `build.noindex/` 개발 app bundle은 미등록 상태다. 실제 provider 검증은 process path와 PlugInKit 결과를 함께 사용했다.
+
+## 판단
+
+- official workflow의 release와 Pages job이 exact tag에서 성공했고 GitHub Release는 public stable/latest 상태다.
+- public DMG의 checksum, signing, notarization, staple, Gatekeeper, universal slice와 layout이 통과했다.
+- Pages와 stable appcast가 `0.1.9 (15)` 및 같은 public DMG URL과 size를 사용한다.
+- clean official `v0.1.8 (14)`에서 실제 Sparkle update가 성공했고 수동 registration repair 없이 app/Preview/Thumbnail이 `v0.1.9 (15)`로 갱신됐다.
+- public 설치본의 HWP/HWPX 앱 열기, Finder Thumbnail과 Quick Look이 exact `/Applications` provider에서 통과했다.
+- Homebrew Cask는 별도 승인 gate로 남긴다.
+- Stage 5 official publish와 post-publish public surface gate를 통과로 판정한다.
+
+## 다음 단계 영향
+
+Stage 6에서는 이 Stage 5 결과를 release record와 최종 보고서에 반영하고, Task #441 source/운영 기록을 `publish/task441` PR로 정리한다. Homebrew를 이번 타스크에 포함하려면 Stage 6 진입 전에 별도 승인을 받아 Cask 수정과 install/uninstall smoke를 먼저 수행해야 한다.
+
+## 승인 요청
+
+Stage 5 완료 결과를 승인하고 Stage 6 release record·최종 보고와 종료 정리 진행 승인을 요청한다.
+
+Homebrew Cask를 이번 타스크에 포함할지는 별도 승인으로 결정한다.

--- a/mydocs/working/task_m900_441_stage5.md
+++ b/mydocs/working/task_m900_441_stage5.md
@@ -4,7 +4,7 @@
 
 Stage 4 signed candidate 차단 gate를 통과한 exact `v0.1.9` tag를 official stable release로 게시하고, public GitHub Release·DMG·Pages·Sparkle와 실제 `v0.1.8 -> v0.1.9` 업데이트 뒤 앱·Preview·Thumbnail surface를 검증한다.
 
-Homebrew Cask는 public DMG URL과 SHA256 확정 뒤에도 별도 승인 gate를 유지하므로 이번 단계에서는 수정하거나 설치·제거하지 않는다.
+official publish 뒤 별도 승인으로 Homebrew Cask를 같은 public DMG URL과 SHA256에 맞추고, maintainer tap 게시와 install/uninstall smoke까지 Stage 5.1로 수행한다.
 
 ## 검증 기준점
 
@@ -42,7 +42,7 @@ official 실행 전에 tag와 `origin/main`, release body, Pages source, 앱·�
 
 tag 입력 검증, upstream latest guard, source/header/ABI lock, signed/notarized DMG build, public artifact 검증, GitHub Release 게시, stable appcast 작성과 Pages artifact/deploy가 모두 성공했다. stable publish이므로 draft 정책용 skip 기록 step만 의도대로 skip됐다.
 
-run annotation에는 runner에 이미 존재한 untrusted `aws/tap` Homebrew warning이 한 건 있었지만 이번 workflow나 공개 artifact에는 영향을 주지 않았다. 이번 단계에서는 Homebrew 명령을 실행하지 않았다.
+run annotation에는 runner에 이미 존재한 untrusted `aws/tap` Homebrew warning이 한 건 있었지만 이번 workflow나 공개 artifact에는 영향을 주지 않았다. official workflow 자체는 Homebrew 명령을 실행하지 않으며, Cask 배포는 아래 Stage 5.1에서 별도 승인으로 수행했다.
 
 ## Public GitHub Release와 DMG
 
@@ -150,19 +150,77 @@ Sparkle로 갱신된 public 설치본에서 같은 fresh sample을 직접 열었
 
 두 문서 모두 `alhangeul-studio://app/index.html`의 current document revision으로 열렸고 상태 막대의 filename, page count와 render time이 일치했다. 테스트 후 앱은 종료했고 Finder 창은 검증 전의 다운로드 폴더로 복구했다.
 
+## Homebrew Cask 배포와 검증 (Stage 5.1)
+
+### Cask와 tap 반영
+
+공식 checksum asset으로 `scripts/update-cask-sha256.sh --dry-run`을 먼저 통과한 뒤 이 저장소의 `Casks/alhangeul.rb`와 공개 tap의 같은 파일을 다음 값으로 맞췄다.
+
+| 항목 | 결과 |
+|------|------|
+| version | `0.1.9` |
+| SHA256 | `8110dc4cc2d965b4fe4d0a8cd6b285488a1fb5443f5bda606a35207c5bccc6ca` |
+| URL | tag-fixed official public universal DMG |
+| tap | [`postmelee/homebrew-tap`](https://github.com/postmelee/homebrew-tap) |
+| tap commit | [`b8c7b6a544989a32da9034ca7c6e6d4e241d3d10`](https://github.com/postmelee/homebrew-tap/commit/b8c7b6a544989a32da9034ca7c6e6d4e241d3d10) |
+| tap branch | `main`, push 뒤 remote/installed tap fast-forward 일치 |
+| trust | `postmelee/tap/alhangeul`이 기존 trusted Cask 목록에 있어 추가 trust 변경 없음 |
+
+Homebrew tap context에서 다음 검증이 모두 통과했다.
+
+- `brew style --cask alhangeul`
+- `brew audit --cask alhangeul`
+- 참고 기준인 `brew audit --cask --new alhangeul`
+
+기존 매뉴얼에는 `--new`에서 GitHub notability 경고 가능성을 기록했지만 이번 Homebrew 6 실행에서는 해당 경고 없이 통과했다. raw path style은 tap context를 요구해 거부됐고, 이는 가이드에 기록된 정상 경계이므로 tap token 기준 결과를 최종값으로 사용했다.
+
+### Install·실행·extension smoke
+
+기존 설치본을 삭제하지 않고 `build.noindex/task441-homebrew-v0.1.9/pre-smoke-original/`로 격리한 뒤 exact Cask를 설치했다.
+
+| 항목 | 결과 |
+|------|------|
+| install | `brew install --cask postmelee/tap/alhangeul` 통과 |
+| installed Cask | `alhangeul 0.1.9` |
+| Caskroom | `/opt/homebrew/Caskroom/alhangeul/0.1.9` |
+| app / extensions | HostApp, Preview, Thumbnail 모두 `0.1.9 (15)` |
+| architecture | HostApp `x86_64 + arm64` |
+| provenance | HostApp, Preview, Thumbnail executable이 pre-smoke official 앱과 byte-identical |
+| signing | deep/strict codesign 통과 |
+| notarization | app staple validate와 Gatekeeper `Notarized Developer ID` accepted |
+| identity | Team ID `XH6JHKYXV8`, CDHash `30d6332479839f45ea74709c46cf303404f94e14` |
+| first launch | `/Applications/Alhangeul.app`의 앱 창과 전체 viewer/editor UI 로드 확인 |
+| extension refresh | `scripts/smoke-sparkle-extension-refresh.sh` 통과, registration repair `0` |
+| smoke output | `/private/tmp/alhangeul-sparkle-extension-refresh/20260731-121932` |
+
+설치 과정에서 Homebrew 자체가 `6.0.12 -> 6.0.13`으로 자동 업데이트됐지만 Cask 내용이나 앱 검증 결과에는 영향을 주지 않았다.
+
+### Uninstall과 원상 복구
+
+- `brew uninstall --cask alhangeul`이 통과했고 Cask 목록과 `/Applications`의 테스트 설치본이 모두 제거됐다.
+- smoke 전에 보관한 official `/Applications/Alhangeul.app` `0.1.9 (15)`와 기존 `/Users/melee/Applications/Alhangeul.app` `0.1.8 (14)`를 각각 원래 위치로 되돌렸다.
+- 복원된 official 앱에서 extension refresh를 다시 실행해 registration repair `0`으로 통과했다. output은 `/private/tmp/alhangeul-sparkle-extension-refresh/20260731-122225`다.
+- final registration hygiene는 official `/Applications` 앱만 provider로 보고 issue `0`으로 통과했다. diagnostics는 `/private/tmp/alhangeul-extension-registration-hygiene/20260731-122147`이다.
+- smoke marker 이후 HostApp, Preview, Thumbnail 관련 신규 crash report는 `0`개다.
+- Stage 4에서 남아 있던 read-only rehearsal DMG `/dev/disk12`는 사용 process가 없음을 확인한 뒤 정상 detach했다.
+- 최종 상태는 Homebrew Cask 미설치, official `/Applications` 앱 `0.1.9 (15)` 복구, HostApp 미실행과 rehearsal DMG 미마운트다.
+- public GitHub Release의 Homebrew 문단은 검증된 설치 명령으로 즉시 갱신했다. README와 Pages source도 같은 명령으로 보정했으며, public Pages 반영은 Task #441 변경의 `devel` 통합과 후속 `main` docs 승격 뒤 수행한다.
+- `scripts/ci/prepare-pages-artifact.sh`를 `build.noindex/task441-homebrew-v0.1.9/pages-artifact` 대상으로 다시 실행해 home/updates/v0.1.9 세 페이지의 설치 명령과 stable appcast SHA256 `c80b7f...e372d` 보존을 확인했다.
+
 ## 설치본·registration 복구
 
-- `/Applications/Alhangeul.app`은 실제 Sparkle update 결과인 official `v0.1.9 (15)`로 유지했다.
+- `/Applications/Alhangeul.app`은 Homebrew smoke 전 보관한 official `v0.1.9 (15)`로 원상 복구했다.
+- 기존 `/Users/melee/Applications/Alhangeul.app` `v0.1.8 (14)`도 원래 위치로 복구했다.
+- Homebrew Cask는 uninstall돼 테스트 설치본과 Caskroom version이 남지 않았다.
 - HostApp은 종료했으며 남은 Preview/Thumbnail process는 official `/Applications` 경로만 사용했다.
 - `scripts/check-extension-registration-hygiene.sh --check-only`는 development registration, legacy candidate와 issue가 모두 없다고 판정했다.
-- 최종 hygiene diagnostics는 `/private/tmp/alhangeul-extension-registration-hygiene/20260731-020110`이다.
-- `build.noindex/`의 미등록 개발 app bundle 존재와 PlugInKit provider path 미보고는 warning으로만 남았다.
-- official publish 시점 이후 Alhangeul, Preview, Thumbnail 관련 신규 crash report는 `0`개다.
-- signed DMG는 detach 상태이고 임시 mount registration은 남기지 않았다.
+- 최종 hygiene diagnostics는 `/private/tmp/alhangeul-extension-registration-hygiene/20260731-122147`이다.
+- `build.noindex/`의 미등록 개발 app bundle 존재는 warning으로만 남았다.
+- Homebrew smoke marker 이후 Alhangeul, Preview, Thumbnail 관련 신규 crash report는 `0`개다.
+- signed/rehearsal DMG는 detach 상태이고 임시 mount registration은 남기지 않았다.
 
 ## 미실행 항목
 
-- Homebrew Cask 수정과 `brew style/audit/install/uninstall`: public DMG URL과 SHA256은 확정했지만 별도 승인 전이라 실행하지 않음
 - Intel Mac 실기기 설치와 실행: universal slice 자동 검증과 Apple Silicon 실기기 smoke로 대체했으며 미실행
 
 ## 검증 결과
@@ -182,14 +240,16 @@ Sparkle로 갱신된 public 설치본에서 같은 fresh sample을 직접 열었
 | HWP/HWPX Thumbnail / Quick Look | 통과 |
 | 신규 crash | `0` |
 | registration hygiene | issue `0` |
-| Homebrew | 미진행, 별도 승인 gate |
+| Homebrew | Cask/tap 게시, style/audit/install/uninstall과 extension refresh 통과 |
+| Pages source package | 세 Homebrew 명령 일치, stable appcast byte hash 보존 |
 | `git diff --check` | 통과 |
 
 ## 잔여 위험
 
 - Intel Mac 실기기 설치·실행은 수행하지 않았다. `x86_64 + arm64` 자동 검증과 별개 위험으로 유지한다.
 - registered Quick Look sandbox의 external sibling 접근 제한과 upstream Issue #3412, #3450은 Stage 4에 기록한 상태로 남는다. public update smoke에서 새 blocker는 재현하지 않았다.
-- public DMG와 appcast digest는 확정했지만 Homebrew Cask는 아직 이전 공개 상태일 수 있다. 반영 전에는 GitHub Release DMG를 공식 설치 경로로 사용한다.
+- Homebrew 배포는 maintainer tap `postmelee/homebrew-tap` 기준이다. `Homebrew/homebrew-cask` 공식 저장소 신규 제출은 이번 release 범위가 아니다.
+- public Pages에는 아직 Homebrew “별도 배포 예정” 문구가 남는다. 이 브랜치의 README/Pages source 보정이 `devel`과 `main`에 순서대로 통합되고 docs-only Pages workflow가 성공해야 공개 문구가 최종 정렬된다.
 - helper가 발견하는 `build.noindex/` 개발 app bundle은 미등록 상태다. 실제 provider 검증은 process path와 PlugInKit 결과를 함께 사용했다.
 
 ## 판단
@@ -199,15 +259,13 @@ Sparkle로 갱신된 public 설치본에서 같은 fresh sample을 직접 열었
 - Pages와 stable appcast가 `0.1.9 (15)` 및 같은 public DMG URL과 size를 사용한다.
 - clean official `v0.1.8 (14)`에서 실제 Sparkle update가 성공했고 수동 registration repair 없이 app/Preview/Thumbnail이 `v0.1.9 (15)`로 갱신됐다.
 - public 설치본의 HWP/HWPX 앱 열기, Finder Thumbnail과 Quick Look이 exact `/Applications` provider에서 통과했다.
-- Homebrew Cask는 별도 승인 gate로 남긴다.
-- Stage 5 official publish와 post-publish public surface gate를 통과로 판정한다.
+- Homebrew Cask가 official public universal DMG와 같은 URL/SHA256으로 게시됐고 maintainer tap gate를 통과했다.
+- Stage 5 official publish와 Homebrew 배포 gate를 통과로 판정한다. public Pages의 Homebrew 안내는 source 보정 완료·배포 승격 대기 상태로 분리한다.
 
 ## 다음 단계 영향
 
-Stage 6에서는 이 Stage 5 결과를 release record와 최종 보고서에 반영하고, Task #441 source/운영 기록을 `publish/task441` PR로 정리한다. Homebrew를 이번 타스크에 포함하려면 Stage 6 진입 전에 별도 승인을 받아 Cask 수정과 install/uninstall smoke를 먼저 수행해야 한다.
+Stage 6에서는 이 Stage 5와 Stage 5.1 결과를 최종 보고서에 반영하고, Task #441 source/운영 기록과 README/Pages 보정을 `publish/task441`의 `devel` 대상 PR로 정리한다. PR merge 뒤에는 `devel -> main` docs 승격과 Pages workflow 결과를 후속 release closeout으로 확인한다.
 
 ## 승인 요청
 
 Stage 5 완료 결과를 승인하고 Stage 6 release record·최종 보고와 종료 정리 진행 승인을 요청한다.
-
-Homebrew Cask를 이번 타스크에 포함할지는 별도 승인으로 결정한다.


### PR DESCRIPTION
## 요약

- PR #451 변경으로 `devel`에 반영한 v0.1.9 release closeout을 `main`에 승격합니다.
- official public DMG와 같은 URL/SHA256을 사용하는 Homebrew Cask와 설치 안내를 반영합니다.
- Stage 4~6 signed/public/Homebrew 검증 기록과 Task #441 최종 보고서를 보존합니다.
- `docs/**` 변경의 `main` merge로 `Docs-only Pages Deploy` workflow를 자동 실행해 공개 Homebrew 안내를 정렬합니다.

## 기준

| 항목 | 값 |
|------|----|
| base | `main` / `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
| head | `devel` / `9e564ff79410bd06c36b36d3dd3cd6fa2b6e4c49` |
| merge base | `485c76cf32486d148fa88e30717e18c9794e810f` |
| source PR | [#451](https://github.com/postmelee/alhangeul-macos/pull/451) |
| public release | [Alhangeul v0.1.9 (rhwp v0.8.2)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) |
| public DMG SHA256 | `8110dc4cc2d965b4fe4d0a8cd6b285488a1fb5443f5bda606a35207c5bccc6ca` |
| stable appcast SHA256 | `c80b7f52571780bc23f095f436a39d1e177a3ed935488d47bcdad8d1bd2e372d` |
| Homebrew tap commit | [`b8c7b6a`](https://github.com/postmelee/homebrew-tap/commit/b8c7b6a544989a32da9034ca7c6e6d4e241d3d10) |

`main` 전용 commit은 PR #446 및 PR #450 변경의 기존 release transport다. 현재 `main` tree는 merge base `485c76c...` tree와 동일하므로 이번 PR의 실질 변경은 PR #451 변경의 release closeout diff와 같다.

## 주요 변경

- `Casks/alhangeul.rb`
  - `version "0.1.9"`
  - official public DMG SHA256 반영
- README와 Pages
  - `brew install --cask postmelee/tap/alhangeul` 안내 반영
  - `docs/index.html`, `docs/updates/index.html`, `docs/updates/v0.1.9.html` 정렬
- release 운영 기록
  - final Rehearsal, signed draft와 official Publish 결과
  - Sparkle update, Finder/extension과 Homebrew install/uninstall smoke
  - 무효화한 초기 candidate와 PR #443/#448 수정 뒤 재검증 근거
- 최종 보고서
  - [`task_m900_441_report.md`](https://github.com/postmelee/alhangeul-macos/blob/9e564ff79410bd06c36b36d3dd3cd6fa2b6e4c49/mydocs/report/task_m900_441_report.md)

## 검증

- PR #451 CI
  - Classify changed files: success
  - Script syntax checks: success
  - Release helper checks: success
  - macOS validation: 변경 분류에 따라 의도대로 skip
- `git diff --check origin/main...origin/devel`: 통과
- `main` tree와 merge base tree 동일 확인
- GitHub compare
  - `devel` ahead 5 / behind 2
  - 변경 11개 파일, 824 additions / 56 deletions
- Cask
  - official checksum dry-run과 Ruby syntax 통과
  - maintainer tap Cask와 byte-identical
- Pages source package
  - 세 사용자 페이지의 Homebrew 명령 일치
  - stable appcast hash 보존과 XML parse 통과
- core/studio provenance
  - `v0.8.2` / `9b16aa9e...` 일치

## Merge 후 확인

1. `Docs-only Pages Deploy` workflow의 prepare/deploy job 성공을 확인합니다.
2. public v0.1.9 page에서 Homebrew 설치 명령이 표시되는지 확인합니다.
3. public appcast SHA256과 v0.1.9 enclosure가 보존됐는지 확인합니다.
4. 위 공개 반영 확인 뒤 Issue #441 이슈를 close하고 Task #441 branch/worktree를 정리합니다.

이 PR은 public Pages 확인 전 Issue #441 이슈를 자동 close하지 않도록 `Refs #441`로 연결합니다.

Refs #441