### PR TITLE
Prevent nested body overflow replay amplification

### DIFF
--- a/Sources/RhwpCoreBridge/CGTreeRenderer.swift
+++ b/Sources/RhwpCoreBridge/CGTreeRenderer.swift
@@ -55,6 +55,7 @@ class CGTreeRenderer {
     private var pageBounds: BBox?
     private var pageHeight: Double = 0
     private var renderMode: CGTreeRenderMode = .complete
+    private var isReplayingBodyOverflowControls = false
 
     private struct BuiltPath {
         let path: CGPath
@@ -421,6 +422,7 @@ class CGTreeRenderer {
         renderChildren(node, in: ctx)
         ctx.restoreGState()
 
+        guard !isReplayingBodyOverflowControls else { return }
         renderBodyOverflowControls(node, bodyClip: clip, in: ctx)
     }
 
@@ -428,12 +430,17 @@ class CGTreeRenderer {
         let candidates = bodyOverflowReplayCandidates(in: bodyNode, bodyClip: bodyClip)
         guard !candidates.isEmpty else { return }
 
+        let wasReplayingBodyOverflowControls = isReplayingBodyOverflowControls
+        isReplayingBodyOverflowControls = true
         ctx.saveGState()
+        defer {
+            ctx.restoreGState()
+            isReplayingBodyOverflowControls = wasReplayingBodyOverflowControls
+        }
         ctx.clip(to: bodyOverflowReplayClipRect(bodyClip))
         for candidate in candidates {
             renderNode(candidate, in: ctx)
         }
-        ctx.restoreGState()
     }
 
     private func bodyOverflowReplayCandidates(in bodyNode: RenderNode, bodyClip: BBox) -> [RenderNode] {


### PR DESCRIPTION
### Motivation
- Fix an availability bug where replaying horizontally-overflowing child subtrees could recursively trigger additional body-overflow replays in nested container trees, causing exponential rendering work and potential CPU exhaustion when rendering untrusted documents.

### Description
- Add a replay state flag `isReplayingBodyOverflowControls` to `CGTreeRenderer` and early-return from `renderBody` when a body overflow replay is already in progress to suppress nested replay triggers.
- In `renderBodyOverflowControls` set the flag for the duration of the replay and restore it with `defer`, and use `defer` to restore the CoreGraphics state reliably after the replay pass.
- Preserve the existing semantics of the top-level overflow replay (wider page-level clip for overflowing controls) while preventing nested amplification.

### Testing
- Ran `git diff --check` which reported no whitespace/file issues and succeeded.  
- Ran `./scripts/check-no-appkit.sh` which succeeded (shared Swift code has no AppKit/UIKit dependencies).  
- Ran `./scripts/validate-stage3-render.sh --help` which executed and printed usage (smoke test harness available).  
- Attempted full native build (`xcodebuild`) and renderer smoke runs but they could not be executed in this Linux environment because `xcodebuild` / Apple CoreGraphics/CoreText are unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7b2be3bc748333935b24fc9656a20a)