### PR TITLE
Task #375: source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -97,6 +97,12 @@ jobs:
           set -euo pipefail
           scripts/ci/test-rhwp-core-build-info.sh
 
+      - name: Check studio Cargo.lock verification fixtures
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+
       - name: Verify tracked core build info
         shell: bash
         run: |

--- a/.github/workflows/rhwp-upstream-sync-pr.yml
+++ b/.github/workflows/rhwp-upstream-sync-pr.yml
@@ -88,6 +88,7 @@ jobs:
           bash -n scripts/ci/read-rhwp-core-lock.sh
           bash -n scripts/ci/rhwp-core-build-info-common.sh
           bash -n scripts/ci/test-rhwp-core-build-info.sh
+          bash -n scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
           bash -n scripts/ci/write-rhwp-full-sync-pr-body.sh
           bash -n scripts/sync-rhwp-studio.sh
           bash -n scripts/update-rhwp-core-build-info.sh
@@ -101,6 +102,7 @@ jobs:
           scripts/verify-rhwp-core-build-info.sh --help
           scripts/verify-rhwp-studio-assets.sh --help
           scripts/ci/test-rhwp-core-build-info.sh
+          scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
 
       - name: Resolve current and target rhwp release
         id: resolve
@@ -584,7 +586,8 @@ jobs:
 
           scripts/verify-rhwp-studio-assets.sh \
             --tag "$target_tag" \
-            --commit "$target_commit"
+            --commit "$target_commit" \
+            --upstream-dir "$upstream_dir"
 
           git diff --check
 
@@ -597,7 +600,7 @@ jobs:
             echo "\`scripts/verify-rhwp-core-build-info.sh\`: OK"
             echo "\`scripts/check-no-appkit.sh\`: OK"
             echo "\`scripts/sync-rhwp-studio.sh --tag $target_tag --commit $target_commit\`: OK"
-            echo "\`scripts/verify-rhwp-studio-assets.sh --tag $target_tag --commit $target_commit\`: OK"
+            echo "\`scripts/verify-rhwp-studio-assets.sh --tag $target_tag --commit $target_commit --upstream-dir <target-checkout>\`: Cargo.lock fingerprint match OK"
             echo "\`git diff --check\`: OK"
           } > "$verification_file"
 

--- a/mydocs/manual/build_run_guide.md
+++ b/mydocs/manual/build_run_guide.md
@@ -265,7 +265,7 @@ scripts/verify-rhwp-studio-assets.sh \
   --commit <resolved-commit>
 ```
 
-`--upstream-dir`를 사용하면 manifest field와 target checkout의 root `Cargo.lock`이 모두 필수다. malformed sha256은 형식 오류로, 값 불일치는 manifest 값·실제 값·비교한 `Cargo.lock` 경로를 포함한 provenance mismatch로 구분해 실패한다. `scripts/sync-rhwp-studio.sh`도 후보 asset을 만든 직후 같은 strict 비교를 자체 실행한다.
+`--upstream-dir`를 사용하면 해당 directory는 `--commit` 또는 manifest `source_resolved_commit`과 HEAD가 일치하는 Git checkout이어야 하며, manifest field와 root `Cargo.lock`도 모두 필수다. Non-Git directory와 stale checkout은 hash 비교 전에 실패한다. malformed sha256은 형식 오류로, 값 불일치는 manifest 값·실제 값·비교한 `Cargo.lock` 경로를 포함한 provenance mismatch로 구분해 실패한다. `scripts/sync-rhwp-studio.sh`도 후보 asset을 만든 직후 같은 strict 비교를 자체 실행한다.
 
 fallback 경로를 바꾼 경우에는 source resource를 건드리지 않고 Debug app 복사본만 훼손해 negative smoke를 수행한다.
 

--- a/mydocs/manual/build_run_guide.md
+++ b/mydocs/manual/build_run_guide.md
@@ -256,7 +256,16 @@ pgrep -x Alhangeul
 
 `/absolute/path/to/Alhangeul.app`은 현재 worktree의 `build.noindex/DerivedData/Build/Products/Debug/Alhangeul.app`로 바꾼다. 이 smoke는 local launch, document open handoff, WKWebView bundle resource 연결의 최소 확인이다. 실제 문서 내용의 시각 정합성은 foreground 앱에서 수동 확인하거나 별도 UI 자동화로 보강한다.
 
-`rhwp-studio` manifest에 `source_cargo_lock_sha256`이 있으면 `scripts/verify-rhwp-studio-assets.sh`는 sha256 형식을 검증한다. 실제 upstream target `Cargo.lock`과의 값 일치는 sync PR reviewer checklist에서 target checkout 기준으로 확인한다.
+`rhwp-studio` manifest에 `source_cargo_lock_sha256`이 있으면 `scripts/verify-rhwp-studio-assets.sh`는 sha256 형식을 검증한다. 일반 앱 build처럼 upstream checkout이 없는 resource-only 검증은 기존 manifest와의 하위 호환을 위해 이 필드를 필수로 요구하지 않는다. upstream sync 후보를 검증할 때는 target checkout을 함께 넘겨 실제 root `Cargo.lock`과 자동 비교한다.
+
+```bash
+scripts/verify-rhwp-studio-assets.sh \
+  --upstream-dir /absolute/path/to/target-rhwp-checkout \
+  --tag <release-tag> \
+  --commit <resolved-commit>
+```
+
+`--upstream-dir`를 사용하면 manifest field와 target checkout의 root `Cargo.lock`이 모두 필수다. malformed sha256은 형식 오류로, 값 불일치는 manifest 값·실제 값·비교한 `Cargo.lock` 경로를 포함한 provenance mismatch로 구분해 실패한다. `scripts/sync-rhwp-studio.sh`도 후보 asset을 만든 직후 같은 strict 비교를 자체 실행한다.
 
 fallback 경로를 바꾼 경우에는 source resource를 건드리지 않고 Debug app 복사본만 훼손해 negative smoke를 수행한다.
 

--- a/mydocs/manual/ci_workflow_guide.md
+++ b/mydocs/manual/ci_workflow_guide.md
@@ -75,7 +75,7 @@ PR CI는 외부 PR에서도 안전하게 실행할 수 있는 검증만 수행�
 
 ### docs-only skip 기준
 
-docs-only PR에서도 `classify-changes`와 `script-checks`는 실행한다. 따라서 build-info helper fixture와 studio Cargo.lock fingerprint fixture는 항상 실행되지만 tracked Swift source verifier는 관련 변경이 `run_macos_build=true`를 켰을 때 macOS validation에서 실행한다. studio fixture는 production resource를 수정하지 않고 resource-only 하위 호환, strict 일치, 누락, malformed sha256, 실제 값 mismatch와 sync self-check를 독립적으로 검증한다. `run_macos_build=false`이면 `macos-validation` job은 skipped 상태가 된다. 단, release 관련 문서나 Pages/appcast 파일은 문서여도 `run_release_checks=true`가 될 수 있다.
+docs-only PR에서도 `classify-changes`와 `script-checks`는 실행한다. 따라서 build-info helper fixture와 studio Cargo.lock fingerprint fixture는 항상 실행되지만 tracked Swift source verifier는 관련 변경이 `run_macos_build=true`를 켰을 때 macOS validation에서 실행한다. studio fixture는 production resource를 수정하지 않고 resource-only 하위 호환, strict commit/hash 일치, stale checkout, non-Git directory, 누락, malformed sha256, 실제 값 mismatch와 sync self-check를 독립적으로 검증한다. `run_macos_build=false`이면 `macos-validation` job은 skipped 상태가 된다. 단, release 관련 문서나 Pages/appcast 파일은 문서여도 `run_release_checks=true`가 될 수 있다.
 
 ### PR CI 로컬 재현
 
@@ -317,7 +317,7 @@ bash scripts/ci/check-rhwp-upstream-release.sh --target-tag <rhwp-tag> --run-com
 - upstream WASM/studio build는 Ubuntu runner에서 수행하고, native RustBridge/core lock update는 macOS runner에서 수행한다.
 - `Frameworks/` 생성 산출물은 commit하지 않고, `scripts/build-rust-macos.sh --update-lock`가 산출물 hash/size를 `rhwp-core.lock`에 기록한다.
 - complete lock 생성 직후 `scripts/update-rhwp-core-build-info.sh`와 verifier를 실행하고 `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift`를 후보 PR에 명시적으로 stage한다. 옵션 없는 writer 실행은 이 sync candidate 생성 경로에만 둔다.
-- bundled studio sync 직후 `scripts/verify-rhwp-studio-assets.sh --upstream-dir <target-checkout> --tag <tag> --commit <commit>`를 실행한다. manifest fingerprint 누락, malformed sha256, target root `Cargo.lock` 누락, 실제 값 mismatch 중 하나라도 있으면 후보 branch push와 PR 생성을 진행하지 않는다.
+- bundled studio sync 직후 `scripts/verify-rhwp-studio-assets.sh --upstream-dir <target-checkout> --tag <tag> --commit <commit>`를 실행한다. Non-Git directory, checkout HEAD/expected commit mismatch, manifest fingerprint 누락, malformed sha256, target root `Cargo.lock` 누락, 실제 값 mismatch 중 하나라도 있으면 후보 branch push와 PR 생성을 진행하지 않는다.
 - generated PR body와 Actions summary에는 build-info writer/verifier 결과와 target `Cargo.lock` fingerprint 자동 비교 결과를 기록한다. Maintainer checklist는 lock/Cargo resolved commit, generated build info, 자동 검증된 bundled studio provenance와 app-facing impact를 사람이 함께 확인하도록 유지한다.
 - `GITHUB_TOKEN` fallback으로 실제 PR을 생성하지 않는다. token variable/secret이 없으면 `dry_run=false` 실행은 실패해야 한다.
 
@@ -368,6 +368,6 @@ scripts/verify-rhwp-studio-assets.sh \
 - `Release Rehearsal DMG` 실패: public release 전 core lock/build-info drift, packaging/release script 또는 ref delta 입력을 수정한다.
 - `Release Publish DMG` 실패: core lock/build-info와 public release 산출물 상태를 먼저 확인하고, 필요한 경우 GitHub Release asset/appcast/Pages/Homebrew 반영을 중단한다.
 - `Docs-only Pages Deploy` 실패: public appcast 다운로드/XML 검증 실패, Pages artifact 조립 실패, `github-pages` environment policy, 또는 `deploy-pages` 실패를 먼저 확인한다. stale `docs/appcast.xml` fallback으로 우회하지 않는다.
-- `rhwp Upstream Sync PR` 실패: target release 조회, core/studio current 판정, upstream checkout/build, studio manifest의 `source_cargo_lock_sha256` strict 비교, macOS core lock/build-info update, GitHub App token 설정, 기존 automation branch/PR 상태를 먼저 확인한다. fingerprint 실패는 malformed manifest field와 실제 target `Cargo.lock` mismatch를 verifier 진단으로 구분한다.
+- `rhwp Upstream Sync PR` 실패: target release 조회, core/studio current 판정, upstream checkout/build, checkout HEAD/expected commit과 studio manifest `source_cargo_lock_sha256` strict 비교, macOS core lock/build-info update, GitHub App token 설정, 기존 automation branch/PR 상태를 먼저 확인한다. Strict 실패는 checkout identity, malformed manifest field와 실제 target `Cargo.lock` mismatch를 verifier 진단으로 구분한다.
 
 실패 증상, 재현 조건, 원인, 재발 방지 절차가 명확해진 경우에만 `mydocs/troubleshootings/`에 별도 문서로 남긴다.

--- a/mydocs/manual/ci_workflow_guide.md
+++ b/mydocs/manual/ci_workflow_guide.md
@@ -75,7 +75,7 @@ PR CI는 외부 PR에서도 안전하게 실행할 수 있는 검증만 수행�
 
 ### docs-only skip 기준
 
-docs-only PR에서도 `classify-changes`와 `script-checks`는 실행한다. 따라서 build-info helper fixture는 항상 실행되지만 tracked Swift source verifier는 관련 변경이 `run_macos_build=true`를 켰을 때 macOS validation에서 실행한다. `run_macos_build=false`이면 `macos-validation` job은 skipped 상태가 된다. 단, release 관련 문서나 Pages/appcast 파일은 문서여도 `run_release_checks=true`가 될 수 있다.
+docs-only PR에서도 `classify-changes`와 `script-checks`는 실행한다. 따라서 build-info helper fixture와 studio Cargo.lock fingerprint fixture는 항상 실행되지만 tracked Swift source verifier는 관련 변경이 `run_macos_build=true`를 켰을 때 macOS validation에서 실행한다. studio fixture는 production resource를 수정하지 않고 resource-only 하위 호환, strict 일치, 누락, malformed sha256, 실제 값 mismatch와 sync self-check를 독립적으로 검증한다. `run_macos_build=false`이면 `macos-validation` job은 skipped 상태가 된다. 단, release 관련 문서나 Pages/appcast 파일은 문서여도 `run_release_checks=true`가 될 수 있다.
 
 ### PR CI 로컬 재현
 
@@ -97,6 +97,7 @@ bash scripts/update-rhwp-core-build-info.sh --help
 bash scripts/verify-rhwp-core-build-info.sh --help
 bash scripts/verify-rhwp-studio-assets.sh --help
 scripts/ci/test-rhwp-core-build-info.sh
+scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
 scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check
 ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path); puts "Parsed #{path}" }'
 ```
@@ -128,7 +129,7 @@ Rust/core 변경이 있으면 `./scripts/build-rust-macos.sh` 대신 다음 lock
 
 PR CI의 macOS validation은 GitHub-hosted runner/toolchain 차이를 고려해 `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`을 설정한다. 이 값은 `Frameworks/universal/librhwp.a` byte hash/size 비교만 제외한다. `rhwp` source provenance, `RustBridge/Cargo.lock`, generated header hash/size, `rhwp-ffi-symbols.txt` 검증은 계속 실패 가능한 gate로 남는다.
 
-Build-info fixture와 tracked source verifier는 Ubuntu `script-checks`에서 먼저 실행해 canonical drift를 Rust build 전에 차단한다. 같은 verifier를 macOS validation에서도 다시 실행한다. Verifier는 `rhwp-core.lock`에서 canonical `RhwpCoreBuildInfo.swift` 전체를 생성해 tracked source와 byte 비교하며 파일을 자동 수정하지 않는다. 존재하는 빈 `rhwp_enabled_features`는 유효하지만 key 누락, malformed token, source member/comment 누락·여분은 실패한다.
+Build-info fixture와 studio Cargo.lock fingerprint fixture는 Ubuntu `script-checks`에서 먼저 실행해 canonical drift와 provenance verifier 회귀를 Rust build 전에 차단한다. tracked build-info verifier는 macOS validation에서도 다시 실행한다. Build-info verifier는 `rhwp-core.lock`에서 canonical `RhwpCoreBuildInfo.swift` 전체를 생성해 tracked source와 byte 비교하며 파일을 자동 수정하지 않는다. 존재하는 빈 `rhwp_enabled_features`는 유효하지만 key 누락, malformed token, source member/comment 누락·여분은 실패한다.
 
 `RustBridge/examples/*` 같은 benchmark/helper 변경은 macOS build는 요구할 수 있지만 lock-level `run_rust_verify`는 켜지 않는다.
 
@@ -316,7 +317,8 @@ bash scripts/ci/check-rhwp-upstream-release.sh --target-tag <rhwp-tag> --run-com
 - upstream WASM/studio build는 Ubuntu runner에서 수행하고, native RustBridge/core lock update는 macOS runner에서 수행한다.
 - `Frameworks/` 생성 산출물은 commit하지 않고, `scripts/build-rust-macos.sh --update-lock`가 산출물 hash/size를 `rhwp-core.lock`에 기록한다.
 - complete lock 생성 직후 `scripts/update-rhwp-core-build-info.sh`와 verifier를 실행하고 `Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift`를 후보 PR에 명시적으로 stage한다. 옵션 없는 writer 실행은 이 sync candidate 생성 경로에만 둔다.
-- generated PR body와 Actions summary에는 writer/verifier 결과를 기록한다. Maintainer checklist는 lock/Cargo resolved commit, generated build info, bundled studio provenance와 app-facing impact를 사람이 함께 확인하도록 유지한다.
+- bundled studio sync 직후 `scripts/verify-rhwp-studio-assets.sh --upstream-dir <target-checkout> --tag <tag> --commit <commit>`를 실행한다. manifest fingerprint 누락, malformed sha256, target root `Cargo.lock` 누락, 실제 값 mismatch 중 하나라도 있으면 후보 branch push와 PR 생성을 진행하지 않는다.
+- generated PR body와 Actions summary에는 build-info writer/verifier 결과와 target `Cargo.lock` fingerprint 자동 비교 결과를 기록한다. Maintainer checklist는 lock/Cargo resolved commit, generated build info, 자동 검증된 bundled studio provenance와 app-facing impact를 사람이 함께 확인하도록 유지한다.
 - `GITHUB_TOKEN` fallback으로 실제 PR을 생성하지 않는다. token variable/secret이 없으면 `dry_run=false` 실행은 실패해야 한다.
 
 입력:
@@ -348,19 +350,24 @@ bash scripts/update-rhwp-core-build-info.sh --help
 bash scripts/verify-rhwp-core-build-info.sh --help
 bash scripts/verify-rhwp-studio-assets.sh --help
 scripts/ci/test-rhwp-core-build-info.sh
+scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
 ./scripts/verify-rhwp-core-build-info.sh
 scripts/verify-rhwp-studio-assets.sh
+scripts/verify-rhwp-studio-assets.sh \
+  --upstream-dir /absolute/path/to/target-rhwp-checkout \
+  --tag <release-tag> \
+  --commit <resolved-commit>
 ```
 
 ## 실패 해석 기준
 
 - `classify-changes` 실패: base/head ref나 변경 범위 helper 문제를 먼저 확인한다.
-- `script-checks` 실패: shell syntax, helper interface 또는 build-info fixture 회귀다. macOS build 전 수정한다.
+- `script-checks` 실패: shell syntax, helper interface, build-info fixture 또는 studio Cargo.lock fingerprint fixture 회귀다. macOS build 전 수정한다.
 - `macos-validation` 실패: 앱 build, XcodeGen 입력, shared Swift boundary, Rust lock/build info, renderer smoke 중 하나가 깨진 것이다.
 - `release-checks` 실패: release helper, release note template, delta checklist, Sparkle appcast XML 생성 경계가 깨진 것이다.
 - `Release Rehearsal DMG` 실패: public release 전 core lock/build-info drift, packaging/release script 또는 ref delta 입력을 수정한다.
 - `Release Publish DMG` 실패: core lock/build-info와 public release 산출물 상태를 먼저 확인하고, 필요한 경우 GitHub Release asset/appcast/Pages/Homebrew 반영을 중단한다.
 - `Docs-only Pages Deploy` 실패: public appcast 다운로드/XML 검증 실패, Pages artifact 조립 실패, `github-pages` environment policy, 또는 `deploy-pages` 실패를 먼저 확인한다. stale `docs/appcast.xml` fallback으로 우회하지 않는다.
-- `rhwp Upstream Sync PR` 실패: target release 조회, core/studio current 판정, upstream checkout/build, macOS core lock/build-info update, GitHub App token 설정, 기존 automation branch/PR 상태를 먼저 확인한다.
+- `rhwp Upstream Sync PR` 실패: target release 조회, core/studio current 판정, upstream checkout/build, studio manifest의 `source_cargo_lock_sha256` strict 비교, macOS core lock/build-info update, GitHub App token 설정, 기존 automation branch/PR 상태를 먼저 확인한다. fingerprint 실패는 malformed manifest field와 실제 target `Cargo.lock` mismatch를 verifier 진단으로 구분한다.
 
 실패 증상, 재현 조건, 원인, 재발 방지 절차가 명확해진 경우에만 `mydocs/troubleshootings/`에 별도 문서로 남긴다.

--- a/mydocs/manual/core_dependency_operation_guide.md
+++ b/mydocs/manual/core_dependency_operation_guide.md
@@ -114,8 +114,8 @@ xcodebuild -project Alhangeul.xcodeproj \
 - `.github/workflows/rhwp-upstream-sync-pr.yml`은 upstream target release를 `devel` 대상 `automation/rhwp-<tag>-full-sync` branch에 반영하는 full sync 후보 PR을 만든다. current 판정은 `devel` content의 core lock과 bundled studio manifest 기준으로 수행한다.
 - sync workflow는 같은 target의 open PR 또는 PR 없는 branch-only 상태를 중복 생성 blocker로 취급한다. merge 완료 PR의 head branch가 남아 있으면 blocker가 아니라 cleanup 후보로 표시하며, 실제 원격 branch 삭제는 별도 승인 또는 merge 후 cleanup 절차에서 수행한다.
 - sync workflow는 `scripts/update-rhwp-core.sh --check --channel stable --tag <tag>`로 target release compatibility를 먼저 조회하고, 실제 PR 생성 단계에서는 `scripts/update-rhwp-core.sh --channel stable --tag <tag>`와 `scripts/build-rust-macos.sh --update-lock`로 `RustBridge/Cargo.toml`, `RustBridge/Cargo.lock`, `rhwp-core.lock`을 갱신한다. complete lock 직후 build info writer와 verifier를 실행하고 `RhwpCoreBuildInfo.swift`를 후보 PR에 명시적으로 stage한다.
-- sync workflow는 같은 target commit에서 upstream WASM/studio asset을 빌드하고 `scripts/sync-rhwp-studio.sh`로 bundled `rhwp-studio` manifest와 asset을 갱신한다. 이때 upstream root `Cargo.lock`의 sha256은 manifest의 `source_cargo_lock_sha256`에 기록해 studio/WASM dependency graph provenance로 검토한다.
-- full sync 변경 PR은 PR CI에서 build info fixture와 tracked source verifier, `scripts/verify-rhwp-studio-assets.sh`, HostApp build, Rust/core provenance verify, release helper dry-run을 확인한다. PR CI와 release rehearsal/publish는 build info를 자동 수정하지 않는다.
+- sync workflow는 같은 target commit에서 upstream WASM/studio asset을 빌드하고 `scripts/sync-rhwp-studio.sh`로 bundled `rhwp-studio` manifest와 asset을 갱신한다. 이때 upstream root `Cargo.lock`의 sha256을 manifest의 `source_cargo_lock_sha256`에 기록하고, target checkout을 넘긴 verifier가 기록값과 실제 파일을 자동 비교한다.
+- full sync 변경 PR은 후보 생성 단계에서 `scripts/verify-rhwp-studio-assets.sh --upstream-dir <target-checkout>` strict gate를 통과해야 한다. 일반 PR CI는 upstream checkout이 없으므로 resource-only verifier와 별도 fixture로 strict 비교의 정상·누락·malformed·mismatch 경계를 검증한다. HostApp build, Rust/core provenance verify, release helper dry-run도 함께 확인하며 PR CI와 release rehearsal/publish는 build info를 자동 수정하지 않는다.
 - signed/notarized DMG, GitHub Release, Sparkle appcast, Homebrew Cask 반영은 별도 release 승인과 보호 workflow가 필요하다.
 
 ## 업데이트 후 확인 항목
@@ -128,7 +128,7 @@ xcodebuild -project Alhangeul.xcodeproj \
 - `RhwpCoreBuildInfo.releaseTag`가 Stable의 `rhwp_release_tag` 또는 Demo/Preview의 `rhwp_latest_checked_release_tag`와 일치
 - `RhwpCoreBuildInfo.commit`, `enabledFeatures`가 실제 lock의 `rhwp_commit`, `rhwp_enabled_features`와 일치하고 `./scripts/verify-rhwp-core-build-info.sh` 통과
 - `rhwp-core.lock`의 `Frameworks/universal/librhwp.a` reference metadata와 `Frameworks/generated_rhwp.h` sha256/size 기록 갱신 여부
-- bundled `rhwp-studio` manifest의 `source_cargo_lock_sha256`이 target upstream root `Cargo.lock`과 일치하는지 여부
+- `scripts/verify-rhwp-studio-assets.sh --upstream-dir <target-checkout> --tag <tag> --commit <commit>`가 통과하고 bundled `rhwp-studio` manifest의 `source_cargo_lock_sha256`이 target upstream root `Cargo.lock`과 일치하는지 여부
 - `rhwp-ffi-symbols.txt` 변경 여부와 의도성
 - Swift `RenderTree` 모델과 core JSON 구조 호환성
 - Quick Look/Thumbnail smoke test 필요 여부

--- a/mydocs/manual/core_dependency_operation_guide.md
+++ b/mydocs/manual/core_dependency_operation_guide.md
@@ -114,8 +114,8 @@ xcodebuild -project Alhangeul.xcodeproj \
 - `.github/workflows/rhwp-upstream-sync-pr.yml`은 upstream target release를 `devel` 대상 `automation/rhwp-<tag>-full-sync` branch에 반영하는 full sync 후보 PR을 만든다. current 판정은 `devel` content의 core lock과 bundled studio manifest 기준으로 수행한다.
 - sync workflow는 같은 target의 open PR 또는 PR 없는 branch-only 상태를 중복 생성 blocker로 취급한다. merge 완료 PR의 head branch가 남아 있으면 blocker가 아니라 cleanup 후보로 표시하며, 실제 원격 branch 삭제는 별도 승인 또는 merge 후 cleanup 절차에서 수행한다.
 - sync workflow는 `scripts/update-rhwp-core.sh --check --channel stable --tag <tag>`로 target release compatibility를 먼저 조회하고, 실제 PR 생성 단계에서는 `scripts/update-rhwp-core.sh --channel stable --tag <tag>`와 `scripts/build-rust-macos.sh --update-lock`로 `RustBridge/Cargo.toml`, `RustBridge/Cargo.lock`, `rhwp-core.lock`을 갱신한다. complete lock 직후 build info writer와 verifier를 실행하고 `RhwpCoreBuildInfo.swift`를 후보 PR에 명시적으로 stage한다.
-- sync workflow는 같은 target commit에서 upstream WASM/studio asset을 빌드하고 `scripts/sync-rhwp-studio.sh`로 bundled `rhwp-studio` manifest와 asset을 갱신한다. 이때 upstream root `Cargo.lock`의 sha256을 manifest의 `source_cargo_lock_sha256`에 기록하고, target checkout을 넘긴 verifier가 기록값과 실제 파일을 자동 비교한다.
-- full sync 변경 PR은 후보 생성 단계에서 `scripts/verify-rhwp-studio-assets.sh --upstream-dir <target-checkout>` strict gate를 통과해야 한다. 일반 PR CI는 upstream checkout이 없으므로 resource-only verifier와 별도 fixture로 strict 비교의 정상·누락·malformed·mismatch 경계를 검증한다. HostApp build, Rust/core provenance verify, release helper dry-run도 함께 확인하며 PR CI와 release rehearsal/publish는 build info를 자동 수정하지 않는다.
+- sync workflow는 같은 target commit에서 upstream WASM/studio asset을 빌드하고 `scripts/sync-rhwp-studio.sh`로 bundled `rhwp-studio` manifest와 asset을 갱신한다. 이때 upstream root `Cargo.lock`의 sha256을 manifest의 `source_cargo_lock_sha256`에 기록하고, target checkout을 넘긴 verifier가 checkout HEAD와 expected commit을 결합한 뒤 기록값과 실제 파일을 자동 비교한다.
+- full sync 변경 PR은 후보 생성 단계에서 `scripts/verify-rhwp-studio-assets.sh --upstream-dir <target-checkout>` strict gate를 통과해야 한다. 일반 PR CI는 upstream checkout이 없으므로 resource-only verifier와 별도 fixture로 strict 비교의 정상·stale checkout·non-Git directory·누락·malformed·mismatch 경계를 검증한다. HostApp build, Rust/core provenance verify, release helper dry-run도 함께 확인하며 PR CI와 release rehearsal/publish는 build info를 자동 수정하지 않는다.
 - signed/notarized DMG, GitHub Release, Sparkle appcast, Homebrew Cask 반영은 별도 release 승인과 보호 workflow가 필요하다.
 
 ## 업데이트 후 확인 항목
@@ -128,7 +128,7 @@ xcodebuild -project Alhangeul.xcodeproj \
 - `RhwpCoreBuildInfo.releaseTag`가 Stable의 `rhwp_release_tag` 또는 Demo/Preview의 `rhwp_latest_checked_release_tag`와 일치
 - `RhwpCoreBuildInfo.commit`, `enabledFeatures`가 실제 lock의 `rhwp_commit`, `rhwp_enabled_features`와 일치하고 `./scripts/verify-rhwp-core-build-info.sh` 통과
 - `rhwp-core.lock`의 `Frameworks/universal/librhwp.a` reference metadata와 `Frameworks/generated_rhwp.h` sha256/size 기록 갱신 여부
-- `scripts/verify-rhwp-studio-assets.sh --upstream-dir <target-checkout> --tag <tag> --commit <commit>`가 통과하고 bundled `rhwp-studio` manifest의 `source_cargo_lock_sha256`이 target upstream root `Cargo.lock`과 일치하는지 여부
+- `scripts/verify-rhwp-studio-assets.sh --upstream-dir <target-checkout> --tag <tag> --commit <commit>`가 checkout HEAD/expected commit과 bundled `rhwp-studio` manifest/target root `Cargo.lock` hash 일치를 함께 확인하는지 여부
 - `rhwp-ffi-symbols.txt` 변경 여부와 의도성
 - Swift `RenderTree` 모델과 core JSON 구조 호환성
 - Quick Look/Thumbnail smoke test 필요 여부

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -10,4 +10,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #375 | source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가 | 진행중 | M040, Stage 1 조사 완료, Stage 2 verifier/fixture 진행 |
+| #375 | source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가 | 진행중 | M040, Stage 2 verifier/fixture 완료, Stage 3 workflow 연결 진행 |

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -10,4 +10,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #375 | source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가 | 진행중 | M040, 수행계획 및 Stage 1 조사 진행 |
+| #375 | source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가 | 진행중 | M040, Stage 1 조사 완료, Stage 2 verifier/fixture 진행 |

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -5,3 +5,9 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #439 | rhwp Upstream Sync PR에 RhwpCoreBuildInfo 갱신과 검증 gate 추가 | 완료 | M020, Stage 1~4 및 통합 검증 완료, 완료: 05:02 |
+
+## M040 — v0.4
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #375 | source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가 | 진행중 | M040, 수행계획 및 Stage 1 조사 진행 |

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -10,4 +10,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #375 | source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가 | 진행중 | M040, Stage 3 workflow/body 연결 완료, Stage 4 문서·통합 검증 진행 |
+| #375 | source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가 | 진행중 | M040, Stage 1~4 및 통합 검증 완료, 최종 보고 진행 |

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -10,4 +10,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #375 | source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가 | 진행중 | M040, Stage 2 verifier/fixture 완료, Stage 3 workflow 연결 진행 |
+| #375 | source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가 | 진행중 | M040, Stage 3 workflow/body 연결 완료, Stage 4 문서·통합 검증 진행 |

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -10,4 +10,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #375 | source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가 | 진행중 | M040, Stage 1~4 및 통합 검증 완료, 최종 보고 진행 |
+| #375 | source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가 | 완료 | M040, Stage 1~4 및 통합 검증 완료, 완료: 06:21 |

--- a/mydocs/plans/task_m040_375.md
+++ b/mydocs/plans/task_m040_375.md
@@ -1,0 +1,95 @@
+# Task #375 수행계획서
+
+## 목적
+
+Bundled `rhwp-studio` manifest의 `source_cargo_lock_sha256`을 형식만 확인하는 현재 검증을 확장해, target upstream checkout의 root `Cargo.lock` 실제 SHA-256과 자동 비교한다. Upstream full/studio sync 후보가 서로 다른 dependency graph provenance를 기록하거나 수동 checklist에만 의존하는 경로를 차단한다.
+
+## 배경
+
+[Issue #375](https://github.com/postmelee/alhangeul-macos/issues/375)는 Task #370과 PR #374의 후속 작업이다. `scripts/sync-rhwp-studio.sh`는 upstream root `Cargo.lock` fingerprint를 manifest에 기록하지만 `scripts/verify-rhwp-studio-assets.sh`는 현재 64자리 SHA-256 형식만 검사한다. 실제 target checkout과의 일치 여부는 full/studio sync PR checklist에 남아 있어 자동화 gate가 아니다.
+
+Task #439와 PR #464가 upstream sync candidate의 core build-info 정합성 gate를 먼저 완성했다. 이번 작업은 같은 candidate 생성 경로에 studio/WASM dependency graph provenance 비교를 추가하고, 기존 fingerprint 없는 bundled asset의 호환 검증은 유지한다.
+
+## 범위
+
+### 포함
+
+- `scripts/verify-rhwp-studio-assets.sh`에 optional upstream checkout 검증 입력 추가
+- Manifest fingerprint 형식 오류, upstream `Cargo.lock` 누락, 실제 fingerprint mismatch의 구분된 실패 진단
+- `source_cargo_lock_sha256`이 없는 기존 manifest의 기본 검증 호환 유지
+- Fingerprint 존재/부재, match/mismatch, malformed, upstream 입력 오류를 다루는 isolated fixture
+- Upstream full/studio sync candidate에서 이미 준비한 target checkout을 verifier에 전달
+- Generated PR body와 maintainer checklist를 수동 비교에서 자동 gate 확인 기준으로 정렬
+- Build/core/CI 운영 문서와 Task #375 단계·최종 보고서 갱신
+
+### 제외
+
+- `edwardkim/rhwp` upstream 저장소 수정
+- `rhwp` core pin, `rhwp-core.lock`, bundled `rhwp-studio` asset 또는 manifest provenance 값 갱신
+- Upstream root `Cargo.lock`이 없는 release를 대상으로 한 legacy sync mode 추가
+- `RustBridge/Cargo.lock` 책임 변경과 `librhwp.a` byte reproducibility 정책 변경
+- 기존 PR #463 정리, upstream sync workflow 재실행, public release 실행
+
+## 설계 방향
+
+1. 기존 `verify-rhwp-studio-assets.sh`가 resource integrity의 진실 원천이므로 별도 verifier를 중복 생성하기보다 optional `--upstream-dir` 계약을 우선 검토한다.
+2. `--upstream-dir`이 없으면 기존 resource-only 검증을 유지한다. 값이 있으면 checkout root `Cargo.lock` 존재와 manifest fingerprint 존재를 요구하고 실제 SHA-256을 byte 기준으로 비교한다.
+3. Manifest field 형식 오류와 실제 fingerprint mismatch는 서로 다른 오류 메시지로 분리한다.
+4. Sync writer가 기록한 값과 verifier가 계산한 값의 해석 drift를 막기 위해 hash 계산 방식과 호출 순서를 조사해 단일 계약으로 정렬한다.
+5. Full/studio sync workflow는 target checkout이 이미 있으므로 candidate 생성 직후 verifier에 경로를 전달한다. 일반 PR CI와 release 검증은 upstream checkout이 없으므로 resource-only 검증을 유지한다.
+6. Fixture는 production asset과 upstream checkout을 수정하지 않는 임시 resource/upstream directory에서 정상·오류 계약을 검증한다.
+
+## 예상 변경 파일
+
+| 파일 | 예상 변경 |
+|------|-----------|
+| `scripts/verify-rhwp-studio-assets.sh` | Optional upstream checkout 입력과 Cargo.lock fingerprint 실제 비교 |
+| `scripts/sync-rhwp-studio.sh` | Sync 완료 verifier에 target upstream 경로 전달 및 hash 계약 정렬 검토 |
+| `scripts/ci/test-rhwp-studio-cargo-lock-verification.sh` | Isolated provenance verification fixture 신규 추가 후보 |
+| `.github/workflows/pr-ci.yml` | 신규 fixture syntax/interface 실행 또는 분류 gate 연결 검토 |
+| `.github/workflows/rhwp-upstream-sync-pr.yml` | Full/studio candidate verifier에 target checkout 전달 및 summary 갱신 |
+| `scripts/ci/write-rhwp-full-sync-pr-body.sh` | 자동 검증 결과와 maintainer checklist 문구 정렬 |
+| `scripts/ci/write-rhwp-studio-sync-pr-body.sh` | 자동 검증 결과와 maintainer checklist 문구 정렬 |
+| `scripts/ci/classify-pr-changes.sh` | 신규 helper/test가 필수 CI 범위를 건너뛰지 않는지 검토 |
+| `mydocs/manual/build_run_guide.md` | Resource-only/target-upstream 검증 명령과 실패 의미 |
+| `mydocs/manual/core_dependency_operation_guide.md` | Upstream root lock fingerprint 자동 gate 책임 |
+| `mydocs/manual/ci_workflow_guide.md` | Sync mutation과 PR/release verification 경계 |
+| `mydocs/plans/task_m040_375_impl.md` | 단계별 구현계획 |
+| `mydocs/working/task_m040_375_stage{N}.md` | 단계별 완료 보고 |
+| `mydocs/report/task_m040_375_report.md` | 최종 결과와 후속 #463/sync handoff |
+
+## 잠정 단계
+
+1. **Stage 1 — 현행 provenance 경로 조사와 계약 확정**
+   - Manifest 생성·검증, full/studio sync checkout lifecycle, PR body와 CI 호출 graph를 조사한다.
+2. **Stage 2 — Verifier 실제 비교와 fixture 구현**
+   - Optional upstream 입력, 구분된 진단, compatibility 경계와 isolated fixture를 구현한다.
+3. **Stage 3 — Sync workflow와 generated PR body 연결**
+   - Full/studio candidate가 target checkout 기준 검증을 수행하고 결과를 summary/body에 노출하도록 연결한다.
+4. **Stage 4 — 운영 문서 정렬과 통합 검증**
+   - Build/core/CI 문서를 갱신하고 전체 수용 기준, no-mutation, workflow syntax를 검증한다.
+
+## 검증 계획
+
+- 관련 shell script `bash -n`, `shellcheck`, `--help` interface 검증
+- Resource fixture에서 fingerprint 없는 legacy manifest의 기본 검증 성공
+- Fingerprint가 존재하고 upstream root `Cargo.lock`과 같은 경우 성공
+- Malformed fingerprint, fingerprint mismatch, upstream `Cargo.lock` 누락, manifest fingerprint 누락의 구분된 실패
+- Sync `--check` 또는 최소 fixture에서 기록된 fingerprint와 verifier 계산값 일치
+- Production bundled resource 기본 검증 성공과 tracked asset/manifest 무변경
+- 전체 workflow YAML parse와 `actionlint`
+- Full/studio PR body fixture가 자동 gate 결과를 표시하고 수동 hash 비교 checklist를 제거했는지 확인
+- 관련 변경 path가 macOS/Rust/release gate를 건너뛰지 않는지 classification 확인
+- `git diff --check`와 통합 브랜치 대비 변경 범위 확인
+
+## 리스크
+
+- `--upstream-dir`을 모든 호출 경로에서 필수화하면 일반 PR CI, app bundle, release artifact처럼 checkout이 없는 검증을 깨뜨릴 수 있다.
+- Manifest fingerprint가 없는 legacy resource와 upstream 경로가 제공된 strict candidate 검증의 정책 경계가 모호하면 잘못된 성공 또는 호환성 회귀가 생길 수 있다.
+- Writer와 verifier가 서로 다른 hash 도구·입력 파일을 사용하면 같은 checkout에서도 drift가 발생할 수 있다.
+- Full sync와 studio-only 경로가 workflow 안에서 다른 checkout lifecycle을 사용하면 한쪽만 gate에 연결될 수 있다.
+- 기존 PR #463은 새 gate 이전 candidate이므로 이번 PR에 섞지 않고 Task #375 merge 뒤 별도 정리·재생성해야 한다.
+
+## 승인 요청 사항
+
+작업지시자는 Issue #375를 PR 생성까지 진행하도록 명시했다. 이를 수행계획과 이후 Stage 1~4 진행 승인으로 간주하되, 범위는 upstream Cargo.lock fingerprint 자동 비교와 관련 검증·문서에 한정한다. 기존 PR #463 정리, upstream sync workflow 재실행과 public release는 별도 승인 범위로 남긴다.

--- a/mydocs/plans/task_m040_375_impl.md
+++ b/mydocs/plans/task_m040_375_impl.md
@@ -27,10 +27,11 @@
 | `--upstream-dir` 없음 | 있음 | Fingerprint 형식만 검증하고 resource integrity 검증 성공 |
 | `--upstream-dir DIR` | 없음 | Strict candidate 검증 실패: 비교에 필요한 manifest field 누락 |
 | `--upstream-dir DIR` | malformed | 형식 오류로 실패 |
+| `--upstream-dir DIR` | valid, hash match but HEAD mismatch | Stale/wrong checkout provenance 실패 |
 | `--upstream-dir DIR` | valid, match | 실제 `DIR/Cargo.lock` SHA-256 일치 성공 |
 | `--upstream-dir DIR` | valid, mismatch | Provenance mismatch로 실패하고 manifest/actual 값을 구분 출력 |
 
-`--upstream-dir`이 제공되면 directory와 root `Cargo.lock` 존재를 각각 확인한다. Git repository 여부나 checkout HEAD 검증은 `sync-rhwp-studio.sh`가 이미 tag/commit 계약으로 담당하므로 asset verifier는 파일 provenance 비교에만 집중한다.
+`--upstream-dir`이 제공되면 directory와 root `Cargo.lock` 존재뿐 아니라 유효한 Git checkout인지, checkout HEAD가 manifest/`--commit`의 resolved commit과 같은지를 먼저 확인한다. 그 뒤 root `Cargo.lock` actual hash를 비교해 `(resolved commit, Cargo.lock hash)`를 하나의 strict provenance 계약으로 묶는다. `sync-rhwp-studio.sh`도 writer 실행 전에 같은 commit identity를 검증하며, 최종 verifier 재실행은 generated manifest의 quoting/copy drift와 결합 계약 회귀를 방어한다.
 
 ### Mutation boundary
 
@@ -44,10 +45,13 @@
 - `manifest source_cargo_lock_sha256 must be a lowercase sha256 hex string`
 - `missing upstream directory: <path>`
 - `missing upstream root Cargo.lock: <path>`
+- `upstream directory is not a git checkout: <path>`
+- `expected upstream commit is not available in checkout: <commit>`
+- `upstream checkout HEAD does not match expected commit`
 - `manifest missing source_cargo_lock_sha256 required for upstream comparison`
 - `manifest source_cargo_lock_sha256 does not match upstream root Cargo.lock`
 
-Mismatch 진단에는 resource manifest 값, 실제 upstream 값, 비교한 `Cargo.lock` path를 함께 출력한다.
+Checkout mismatch 진단에는 expected commit, actual HEAD와 checkout path를 출력한다. Hash mismatch 진단에는 resource manifest 값, 실제 upstream 값, 비교한 `Cargo.lock` path를 함께 출력한다.
 
 ## Stage 1 — 현행 provenance 경로 조사와 계약 확정
 
@@ -90,8 +94,8 @@ git diff --check
 
 1. Verifier에 optional `--upstream-dir DIR` interface와 help를 추가한다.
 2. Resource-only optional field 호환과 strict candidate field 필수 조건을 분리한다.
-3. Upstream directory/Cargo.lock 존재, format, actual hash match를 순서대로 검증한다.
-4. Mismatch에 manifest/actual/path 진단을 출력한다.
+3. Upstream directory/Cargo.lock 존재, Git checkout HEAD/expected commit 결합, format, actual hash match를 순서대로 검증한다.
+4. Checkout mismatch에는 expected/actual/path, hash mismatch에는 manifest/actual/path 진단을 출력한다.
 5. Sync writer의 최종 verifier 호출에 같은 `UPSTREAM_DIR`을 전달한다.
 6. 최소 resource/upstream fixture로 정상·오류·interface case와 production 무손실을 검증한다.
 
@@ -113,7 +117,7 @@ git diff --check
 ### 수용 기준
 
 - Legacy missing field는 resource-only mode에서 성공한다.
-- Strict mode의 match는 성공하고 mismatch/field 누락/Cargo.lock 누락/malformed는 구분된 메시지로 실패한다.
+- Strict mode의 match는 성공하고 stale checkout/non-Git directory/mismatch/field 누락/Cargo.lock 누락/malformed는 구분된 메시지로 실패한다.
 - Production bundled resource는 변경되지 않고 기본 verifier가 통과한다.
 
 ### 커밋
@@ -137,7 +141,7 @@ git diff --check
 1. PR CI Ubuntu script-checks와 upstream sync preflight에서 신규 fixture를 실행한다.
 2. Full sync candidate의 explicit verifier에 restored target `upstream_dir`을 전달한다.
 3. Workflow verification summary에 strict comparison command/result를 기록한다.
-4. Full/studio PR body의 수동 hash equality checkbox를 자동 verifier 결과 확인 기준으로 바꾼다.
+4. Full PR body는 automatic verifier 결과, 현재 활성 workflow가 없는 studio helper는 전달된 verification 결과 확인 기준으로 수동 hash equality checkbox를 바꾼다.
 5. 신규 fixture 변경이 macOS/Rust/release gate를 skip하지 않도록 classification을 보강한다.
 
 ### 검증
@@ -159,7 +163,7 @@ git diff --check
 ### 수용 기준
 
 - Workflow가 `--upstream-dir` strict 비교 실패 시 candidate PR 생성 전에 중단한다.
-- Verification summary/body는 automatic match result를 포함한다.
+- Full sync verification summary/body는 automatic match result를 포함하고 studio helper는 verification 결과 기록을 요구한다.
 - Maintainer checklist가 수동 hash 재계산을 요구하지 않는다.
 
 ### 커밋

--- a/mydocs/plans/task_m040_375_impl.md
+++ b/mydocs/plans/task_m040_375_impl.md
@@ -1,0 +1,239 @@
+# Task #375 구현계획서
+
+## 구현 목표
+
+`source_cargo_lock_sha256`의 형식 검증과 실제 target upstream root `Cargo.lock` byte hash 비교를 하나의 명시적 verifier 계약으로 연결한다. 일반 resource/app/release 검증은 checkout 없이 계속 동작하고, sync candidate 생성 경로는 target checkout을 제공해 fingerprint 존재와 일치를 blocking gate로 강제한다.
+
+## 현행 기준
+
+| 영역 | 현행 | 문제 |
+|------|------|------|
+| Manifest writer | `sync-rhwp-studio.sh`가 upstream root `Cargo.lock`을 `shasum -a 256`으로 기록 | 기록 직후 실제 upstream file과 다시 비교하지 않음 |
+| Asset verifier | Fingerprint가 있으면 lowercase 64자 형식만 확인 | 다른 유효 SHA-256 값도 통과 |
+| Legacy resource | Fingerprint가 없어도 resource-only 검증 성공 | 유지해야 하는 호환 경로 |
+| Full sync workflow | Target checkout을 복원하고 sync 후 verifier 실행 | 두 verifier 호출 모두 `--upstream-dir`을 전달하지 않음 |
+| PR body | Maintainer가 실제 hash 일치를 수동 checklist로 확인 | 자동 gate 결과와 책임 중복 |
+| Test | Production verifier와 Stage 370 일회성 fixture만 존재 | Match/mismatch/누락 진단을 고정하는 지속 fixture 없음 |
+
+현재 bundled manifest는 `v0.8.2`/`9b16aa9...`와 `source_cargo_lock_sha256=64ff4041...`을 기록한다. Task #375는 이 값이나 asset을 갱신하지 않는다.
+
+## 핵심 계약
+
+### Verifier mode
+
+| 입력 | Manifest fingerprint | 동작 |
+|------|----------------------|------|
+| `--upstream-dir` 없음 | 없음 | Legacy resource-only 호환 검증 성공 |
+| `--upstream-dir` 없음 | 있음 | Fingerprint 형식만 검증하고 resource integrity 검증 성공 |
+| `--upstream-dir DIR` | 없음 | Strict candidate 검증 실패: 비교에 필요한 manifest field 누락 |
+| `--upstream-dir DIR` | malformed | 형식 오류로 실패 |
+| `--upstream-dir DIR` | valid, match | 실제 `DIR/Cargo.lock` SHA-256 일치 성공 |
+| `--upstream-dir DIR` | valid, mismatch | Provenance mismatch로 실패하고 manifest/actual 값을 구분 출력 |
+
+`--upstream-dir`이 제공되면 directory와 root `Cargo.lock` 존재를 각각 확인한다. Git repository 여부나 checkout HEAD 검증은 `sync-rhwp-studio.sh`가 이미 tag/commit 계약으로 담당하므로 asset verifier는 파일 provenance 비교에만 집중한다.
+
+### Mutation boundary
+
+- `verify-rhwp-studio-assets.sh`와 fixture는 tracked resource/manifest를 수정하지 않는다.
+- `sync-rhwp-studio.sh`만 manifest writer다. 기록 직후 같은 upstream directory를 verifier에 전달해 writer output을 self-check한다.
+- General PR CI, app bundle, rehearsal/publish는 target checkout이 없으므로 기존 resource-only verifier를 유지한다.
+- `rhwp Upstream Sync PR` candidate 생성은 target checkout이 있으므로 strict verifier를 명시 실행한다.
+
+### Failure taxonomy
+
+- `manifest source_cargo_lock_sha256 must be a lowercase sha256 hex string`
+- `missing upstream directory: <path>`
+- `missing upstream root Cargo.lock: <path>`
+- `manifest missing source_cargo_lock_sha256 required for upstream comparison`
+- `manifest source_cargo_lock_sha256 does not match upstream root Cargo.lock`
+
+Mismatch 진단에는 resource manifest 값, 실제 upstream 값, 비교한 `Cargo.lock` path를 함께 출력한다.
+
+## Stage 1 — 현행 provenance 경로 조사와 계약 확정
+
+### 산출물
+
+- `mydocs/working/task_m040_375_stage1.md`
+- `mydocs/orders/20260813.md` 상태 비고
+
+### 작업
+
+1. Task #370/PR #374의 writer/format-verifier 책임을 재확인한다.
+2. Full sync workflow의 resolve/build/create job별 checkout lifecycle과 artifact 복원을 확인한다.
+3. `sync-rhwp-studio.sh`, verifier, PR body helper, PR CI/classification 호출 graph를 기록한다.
+4. 위 verifier mode, mutation boundary, failure taxonomy를 Stage 2~4 기준으로 확정한다.
+
+### 검증
+
+```bash
+rg -n "source_cargo_lock_sha256|verify-rhwp-studio-assets|sync-rhwp-studio|upstream_dir" \
+  scripts .github/workflows/rhwp-upstream-sync-pr.yml \
+  mydocs/manual mydocs/tech/core_release_compatibility.md
+git diff --check
+```
+
+### 커밋
+
+`Task #375 Stage 1: Cargo.lock fingerprint 검증 경로 조사`
+
+## Stage 2 — Verifier 실제 비교와 isolated fixture 구현
+
+### 산출물
+
+- `scripts/verify-rhwp-studio-assets.sh`
+- `scripts/sync-rhwp-studio.sh`
+- `scripts/ci/test-rhwp-studio-cargo-lock-verification.sh`
+- `mydocs/working/task_m040_375_stage2.md`
+- `mydocs/orders/20260813.md` 상태 비고
+
+### 작업
+
+1. Verifier에 optional `--upstream-dir DIR` interface와 help를 추가한다.
+2. Resource-only optional field 호환과 strict candidate field 필수 조건을 분리한다.
+3. Upstream directory/Cargo.lock 존재, format, actual hash match를 순서대로 검증한다.
+4. Mismatch에 manifest/actual/path 진단을 출력한다.
+5. Sync writer의 최종 verifier 호출에 같은 `UPSTREAM_DIR`을 전달한다.
+6. 최소 resource/upstream fixture로 정상·오류·interface case와 production 무손실을 검증한다.
+
+### 검증
+
+```bash
+bash -n scripts/verify-rhwp-studio-assets.sh \
+  scripts/sync-rhwp-studio.sh \
+  scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+shellcheck scripts/verify-rhwp-studio-assets.sh \
+  scripts/sync-rhwp-studio.sh \
+  scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+scripts/verify-rhwp-studio-assets.sh --help
+scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+scripts/verify-rhwp-studio-assets.sh
+git diff --check
+```
+
+### 수용 기준
+
+- Legacy missing field는 resource-only mode에서 성공한다.
+- Strict mode의 match는 성공하고 mismatch/field 누락/Cargo.lock 누락/malformed는 구분된 메시지로 실패한다.
+- Production bundled resource는 변경되지 않고 기본 verifier가 통과한다.
+
+### 커밋
+
+`Task #375 Stage 2: upstream Cargo.lock fingerprint 실제 비교 구현`
+
+## Stage 3 — Sync workflow와 generated PR body 연결
+
+### 산출물
+
+- `.github/workflows/pr-ci.yml`
+- `.github/workflows/rhwp-upstream-sync-pr.yml`
+- `scripts/ci/classify-pr-changes.sh`
+- `scripts/ci/write-rhwp-full-sync-pr-body.sh`
+- `scripts/ci/write-rhwp-studio-sync-pr-body.sh`
+- `mydocs/working/task_m040_375_stage3.md`
+- `mydocs/orders/20260813.md` 상태 비고
+
+### 작업
+
+1. PR CI Ubuntu script-checks와 upstream sync preflight에서 신규 fixture를 실행한다.
+2. Full sync candidate의 explicit verifier에 restored target `upstream_dir`을 전달한다.
+3. Workflow verification summary에 strict comparison command/result를 기록한다.
+4. Full/studio PR body의 수동 hash equality checkbox를 자동 verifier 결과 확인 기준으로 바꾼다.
+5. 신규 fixture 변경이 macOS/Rust/release gate를 skip하지 않도록 classification을 보강한다.
+
+### 검증
+
+```bash
+bash -n scripts/ci/classify-pr-changes.sh \
+  scripts/ci/write-rhwp-full-sync-pr-body.sh \
+  scripts/ci/write-rhwp-studio-sync-pr-body.sh
+ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path) }'
+actionlint .github/workflows/pr-ci.yml .github/workflows/rhwp-upstream-sync-pr.yml
+scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+# Temporary fixture inputs로 full/studio PR body 생성
+scripts/validate-github-body.sh <generated-full-body>
+scripts/validate-github-body.sh <generated-studio-body>
+# HEAD^..HEAD 또는 임시 commit pair로 classification flag assertion
+git diff --check
+```
+
+### 수용 기준
+
+- Workflow가 `--upstream-dir` strict 비교 실패 시 candidate PR 생성 전에 중단한다.
+- Verification summary/body는 automatic match result를 포함한다.
+- Maintainer checklist가 수동 hash 재계산을 요구하지 않는다.
+
+### 커밋
+
+`Task #375 Stage 3: upstream sync provenance gate 연결`
+
+## Stage 4 — 운영 문서 정렬과 통합 검증
+
+### 산출물
+
+- `mydocs/manual/build_run_guide.md`
+- `mydocs/manual/core_dependency_operation_guide.md`
+- `mydocs/manual/ci_workflow_guide.md`
+- `mydocs/tech/core_release_compatibility.md` 필요 구간
+- `mydocs/working/task_m040_375_stage4.md`
+- `mydocs/orders/20260813.md` 상태 비고
+
+### 작업
+
+1. Resource-only compatibility와 `--upstream-dir` strict candidate 검증 명령을 문서화한다.
+2. Manual reviewer checklist 문구를 automatic gate + maintainer provenance review 경계로 바꾼다.
+3. Failure taxonomy와 `RustBridge/Cargo.lock`과의 책임 차이를 정렬한다.
+4. 전체 shell/workflow/body/classification/production no-mutation 검증을 재실행한다.
+
+### 통합 검증
+
+```bash
+for script in scripts/*.sh scripts/ci/*.sh; do bash -n "$script"; done
+shellcheck scripts/verify-rhwp-studio-assets.sh \
+  scripts/sync-rhwp-studio.sh \
+  scripts/ci/test-rhwp-studio-cargo-lock-verification.sh \
+  scripts/ci/classify-pr-changes.sh \
+  scripts/ci/write-rhwp-full-sync-pr-body.sh \
+  scripts/ci/write-rhwp-studio-sync-pr-body.sh
+scripts/ci/test-rhwp-core-build-info.sh
+scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+./scripts/check-no-appkit.sh
+ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path) }'
+actionlint
+git diff --check
+```
+
+### 수용 기준
+
+- Issue #375의 목표·범위 항목이 각각 code/test/workflow/body/doc 증거로 충족된다.
+- `rhwp-core.lock`, bundled `rhwp-studio` asset/manifest, RustBridge source/artifact는 변경하지 않는다.
+- 기존 PR #463, automation branch, workflow run과 public release 상태는 변경하지 않는다.
+
+### 커밋
+
+`Task #375 Stage 4: Cargo.lock provenance 운영 문서와 통합 검증 완료`
+
+## 최종 보고와 PR
+
+모든 Stage 보고서 커밋 뒤 `task-final-report` 절차로 다음을 수행한다.
+
+1. 통합 검증 재확인
+2. `mydocs/report/task_m040_375_report.md` 작성
+3. 오늘할일 #375를 `완료`와 `완료: HH:mm`으로 갱신
+4. 최종 보고 커밋
+5. `local/task375:publish/task375` push
+6. `devel` 대상 Open PR 생성
+
+PR 본문은 Stage 보고서/commit과 수행·구현·최종 문서를 immutable head SHA URL로 연결하고, 검증 결과와 #463 정리 → upstream sync 재실행 handoff를 명시한다.
+
+## 변경 금지 경계
+
+- `Sources/HostApp/Resources/rhwp-studio/**`
+- `RustBridge/**`, `Frameworks/**`, `rhwp-core.lock`, `RhwpCoreBuildInfo.swift`
+- PR #463과 `automation/rhwp-v0.8.4-full-sync` 상태
+- Release rehearsal/publish, GitHub Release, Pages/Sparkle, Homebrew Cask
+
+## 승인 근거
+
+작업지시자가 Issue #375 작업과 PR 생성까지 명시했다. 본 구현계획은 수행계획 범위를 구체화하며, 별도 외부 상태 변경은 `publish/task375` push와 Task #375 PR 생성까지만 수행한다.

--- a/mydocs/report/task_m040_375_report.md
+++ b/mydocs/report/task_m040_375_report.md
@@ -12,17 +12,17 @@
 | 단계 | Stage 1~4 |
 | Production studio identity | `v0.8.2` / `9b16aa9e23f476e2b335d7c029fc9f24a199d63c` |
 
-Bundled `rhwp-studio` manifest의 `source_cargo_lock_sha256`을 target upstream checkout root `Cargo.lock` 실제 SHA-256과 자동 비교하는 strict 검증 경로를 추가했다. 일반 앱·PR·release의 checkout 없는 resource-only 검증은 기존 field 누락 호환을 유지하고, upstream sync candidate 생성 경로만 fingerprint 존재와 actual match를 blocking gate로 강제한다.
+Bundled `rhwp-studio` manifest의 resolved commit과 `source_cargo_lock_sha256`을 target upstream Git checkout HEAD와 root `Cargo.lock` 실제 SHA-256에 결합하는 strict 검증 경로를 추가했다. 일반 앱·PR·release의 checkout 없는 resource-only 검증은 기존 field 누락 호환을 유지하고, upstream sync candidate 생성 경로만 checkout identity, fingerprint 존재와 actual match를 blocking gate로 강제한다.
 
 핵심 결과:
 
-- `scripts/verify-rhwp-studio-assets.sh`에 optional `--upstream-dir` 실제 hash 비교를 추가했다.
+- `scripts/verify-rhwp-studio-assets.sh`에 optional `--upstream-dir` checkout commit binding과 실제 hash 비교를 추가했다.
 - Resource-only legacy 호환과 strict candidate 필수 조건을 분리했다.
 - Malformed SHA-256과 실제 provenance mismatch를 구분하고 mismatch에 manifest 값·actual 값·비교 경로를 출력한다.
 - `scripts/sync-rhwp-studio.sh`가 manifest 기록 직후 같은 target checkout으로 self-check한다.
 - Full sync workflow가 target checkout을 explicit verifier에 전달하고 PR 생성 전 strict gate로 사용한다.
 - Ubuntu PR CI와 upstream sync preflight에서 isolated fixture를 실행한다.
-- Generated full/studio PR body와 Actions summary를 자동 비교 결과 기준으로 갱신했다.
+- Generated full PR body와 Actions summary를 automatic 비교 결과 기준으로, 활성 workflow가 없는 studio helper는 전달된 verification 결과 기준으로 갱신했다.
 - Production `v0.8.2` upstream tracked `Cargo.lock` blob과 checkout file을 독립 계산해 manifest fingerprint 일치를 확인했다.
 - Core dependency, build, CI와 compatibility 운영 문서를 같은 책임 계약으로 정렬했다.
 
@@ -30,13 +30,13 @@ Bundled `rhwp-studio` manifest의 `source_cargo_lock_sha256`을 target upstream 
 
 | 영역 | 파일 | 영향 |
 |------|------|------|
-| Verifier | `scripts/verify-rhwp-studio-assets.sh` | `--upstream-dir`, field/file 존재와 actual hash 비교, 구분된 오류 진단 |
+| Verifier | `scripts/verify-rhwp-studio-assets.sh` | `--upstream-dir`, checkout HEAD/expected commit과 field/file actual hash 비교, 구분된 오류 진단 |
 | Manifest writer | `scripts/sync-rhwp-studio.sh` | 생성 결과 verifier에 같은 upstream directory 전달 |
-| Fixture | `scripts/ci/test-rhwp-studio-cargo-lock-verification.sh` | Compatibility, strict match/mismatch/누락/malformed/interface/sync/no-mutation 검증 |
+| Fixture | `scripts/ci/test-rhwp-studio-cargo-lock-verification.sh` | Compatibility, strict commit/hash match, stale/non-Git/mismatch/누락/malformed/interface/sync/no-mutation 검증 |
 | PR CI | `.github/workflows/pr-ci.yml` | Ubuntu script-checks에 신규 fixture gate 추가 |
 | Upstream sync | `.github/workflows/rhwp-upstream-sync-pr.yml` | Preflight fixture, candidate strict verifier, verification summary 연결 |
 | 분류 | `scripts/ci/classify-pr-changes.sh` | 신규 provenance fixture에 macOS/Rust/release gate 활성화 |
-| Generated body | `scripts/ci/write-rhwp-full-sync-pr-body.sh`, `scripts/ci/write-rhwp-studio-sync-pr-body.sh` | 수동 hash 재계산 대신 automatic verifier result checklist |
+| Generated body | `scripts/ci/write-rhwp-full-sync-pr-body.sh`, `scripts/ci/write-rhwp-studio-sync-pr-body.sh` | 수동 hash 재계산 대신 full automatic/studio verification result checklist |
 | 운영 문서 | `mydocs/manual/build_run_guide.md`, `mydocs/manual/core_dependency_operation_guide.md`, `mydocs/manual/ci_workflow_guide.md`, `mydocs/tech/core_release_compatibility.md` | Resource-only/strict 경계, 자동 gate, 실패 taxonomy와 재현 명령 |
 | 작업 기록 | 수행·구현 계획서, Stage 1~4 보고서, 최종 보고서, 오늘할일 | 조사·구현·검증·후속 순서 기록 |
 
@@ -52,6 +52,7 @@ Task #375는 `Sources/HostApp/Resources/rhwp-studio/**`, `RustBridge/**`, `Frame
 | Stage 2 | `fd989f5` | Actual hash verifier, sync self-check와 isolated fixture 구현 |
 | Stage 3 | `1b529c0` | PR CI/upstream sync gate, classification과 generated body 연결 |
 | Stage 4 | `e5378ba` | 운영 문서 정렬, 실제 upstream과 전체 통합 검증 완료 |
+| PR 리뷰 반영 | 후속 커밋 | Strict checkout commit binding, stale fixture, studio body 문구와 self-check 설명 보정 |
 
 ## 핵심 동작 계약
 
@@ -63,10 +64,11 @@ Task #375는 `Sources/HostApp/Resources/rhwp-studio/**`, `RustBridge/**`, `Frame
 | `--upstream-dir` 없음 | 있음 | Lowercase 64자 SHA-256 형식과 asset integrity 검증 |
 | `--upstream-dir DIR` | 없음 | Strict candidate field 누락 실패 |
 | `--upstream-dir DIR` | malformed | Manifest 형식 오류 실패 |
+| `--upstream-dir DIR` | valid, hash match but HEAD mismatch | Stale/wrong checkout provenance 실패 |
 | `--upstream-dir DIR` | valid, match | `DIR/Cargo.lock` actual SHA-256 일치 성공 |
 | `--upstream-dir DIR` | valid, mismatch | Provenance mismatch와 manifest/actual/path 진단 실패 |
 
-Verifier는 파일을 수정하지 않는다. Manifest writer는 `sync-rhwp-studio.sh` 하나로 유지하며 생성 직후 strict verifier를 실행한다.
+Strict verifier는 Git checkout HEAD가 expected resolved commit과 같은지 확인한 뒤 Cargo.lock hash를 비교하고 파일을 수정하지 않는다. Manifest writer는 `sync-rhwp-studio.sh` 하나로 유지하며 생성 직후 strict verifier를 실행한다. 이 self-check는 writer의 quoting/copy drift를 잡고 commit/hash 결합을 독립적으로 재확인한다.
 
 ### Workflow 책임
 
@@ -81,12 +83,12 @@ Verifier는 파일을 수정하지 않는다. Manifest writer는 `sync-rhwp-stud
 
 | Issue 요구사항 | 판정 | 권위 있는 증거 |
 |------|------|------|
-| Fingerprint와 target root `Cargo.lock` 자동 비교 | 완료 | Verifier actual `shasum` 비교, match/mismatch fixture, actual `v0.8.2` strict 검증 |
+| Fingerprint와 target root `Cargo.lock` 자동 비교 | 완료 | Checkout HEAD/expected commit 결합, verifier actual `shasum` 비교, match/stale/mismatch fixture, actual `v0.8.2` strict 검증 |
 | Existing missing-field asset 호환 | 완료 | Resource-only legacy fixture 성공, production default verifier 성공 |
-| Full/studio sync target checkout 비교 | 완료 | Sync writer self-check와 full sync restored checkout explicit verifier |
+| Full/studio sync target checkout 비교 | 완료 | Sync writer self-check와 full sync restored checkout explicit verifier가 commit/hash identity를 함께 확인 |
 | Workflow verification 결과 포함 | 완료 | `Cargo.lock fingerprint match OK` verification file/Actions summary와 generated body |
 | Mismatch와 malformed field 오류 구분 | 완료 | 별도 오류 메시지와 isolated failure fixture |
-| 운영 문서와 PR checklist 갱신 | 완료 | 운영 문서 4종과 full/studio body writer 자동 gate 문구 |
+| 운영 문서와 PR checklist 갱신 | 완료 | 운영 문서 4종, full automatic gate와 studio verification-result body 문구 |
 | Upstream/core/asset/reproducibility 제외 범위 유지 | 완료 | 해당 source/lock/asset diff와 외부 상태 변경 없음 |
 
 ## 실제 upstream 검증
@@ -104,6 +106,7 @@ git show 9b16aa9e...:Cargo.lock | shasum -a 256:
 64ff4041c1874c01c7a901b28df2639082836ced44df392cd37b3227d4772279
 
 Strict verifier:
+OK: upstream checkout HEAD matches 9b16aa9e23f476e2b335d7c029fc9f24a199d63c
 OK: manifest source_cargo_lock_sha256 matches <v0.8.2-checkout>/Cargo.lock
 OK: rhwp-studio assets verified
 ```
@@ -117,7 +120,7 @@ Actual checkout은 ignored `build.noindex/`에만 두었고 tracked production r
 | 전체 `scripts/*.sh`, `scripts/ci/*.sh` `bash -n` | OK |
 | Task 관련 6개 helper `shellcheck -e SC2129` | OK |
 | Core build-info fixture | `OK: RhwpCoreBuildInfo writer and verifier fixtures passed` |
-| Studio Cargo.lock fixture | `OK: rhwp-studio Cargo.lock fingerprint verification fixtures passed` |
+| Studio Cargo.lock fixture | Commit/hash match, stale checkout, non-Git directory와 fingerprint 오류 case 포함해 OK |
 | Production core build-info verifier | OK |
 | Production studio resource verifier | OK |
 | Shared Swift AppKit/UIKit boundary | OK |
@@ -127,13 +130,28 @@ Actual checkout은 ignored `build.noindex/`에만 두었고 tracked production r
 | Change classification | macOS=true, Rust=true, render=false, release=true |
 | 실제 upstream strict verifier | OK |
 | `git diff --check` | OK |
-| 원격 base 관계 | `origin/devel` 대비 behind 0, ahead 6 |
+| 원격 base 관계 | Review-fix commit 기준 `origin/devel` 대비 behind 0, ahead 8 |
 
 `SC2129`는 기존 body writer의 반복 append style에 대한 기존 제외다. GitHub-hosted macOS build와 `build-rust-macos.sh --verify-lock`은 PR에서 분류된 원격 gate로 확인한다.
 
 ## 변경 규모
 
 Stage 4 커밋 기준 `origin/devel...HEAD` diff는 19 files, `+1,146 / -20`이다. 이 중 신규 isolated fixture는 216줄이고 verifier는 30줄 증가했다. 나머지 큰 증가는 수행·구현·단계 보고 문서다. 제품 Swift/Rust source, bundled asset과 lock diff는 0이다.
+
+## PR 리뷰 반영
+
+[PR #465 리뷰 코멘트](https://github.com/postmelee/alhangeul-macos/pull/465#issuecomment-5275363459)의 merge 전 권고와 함께 요청된 소규모 보완을 반영했다.
+
+| 리뷰 항목 | 반영 결과 |
+|----------|-----------|
+| Strict verifier가 `--upstream-dir`와 expected commit을 결합하지 않음 | Git checkout HEAD와 manifest/`--commit` resolved commit을 먼저 비교하고, 일치할 때만 root `Cargo.lock` hash를 확인한다. |
+| Cargo.lock이 같은 stale checkout이 통과 | Cargo.lock을 변경하지 않고 fixture HEAD만 전진시켜 expected/actual/path 진단과 실패를 고정했다. Non-Git directory도 strict mode에서 실패한다. |
+| Studio-only body가 존재하지 않는 자동 workflow를 전제 | 활성 workflow를 주장하지 않고 전달된 Verification 결과에 fingerprint 일치가 기록됐는지 확인하도록 문구를 바꿨다. |
+| Sync self-check가 구조상 동일 값을 재비교 | Generated manifest를 다시 읽어 writer quoting/copy drift를 방어하고 upstream HEAD를 독립 재확인한다는 주석을 추가했다. |
+
+Full sync workflow의 독립 verifier 호출은 명시적 candidate 사후 gate와 verification summary 근거이므로 유지했다. 구체적 classification 진단, 현재 control flow에서 참인 summary 고정 문구와 기존 option compatibility도 유지했다.
+
+리뷰 보정 후 전체 shell syntax, 관련 helper `shellcheck -e SC2129`, core/studio isolated fixture, production verifier, 실제 upstream `v0.8.2` commit/hash strict 검증, shared Swift boundary, 전체 workflow Psych parse, 수정 workflow actionlint, full/studio generated body validator, change classification과 `git diff --check`가 통과했다. Initial PR head의 GitHub-hosted PR CI 4개도 모두 성공했으며 review-fix push 뒤 같은 gate를 다시 확인한다.
 
 ## 잔여 위험과 후속 작업
 

--- a/mydocs/report/task_m040_375_report.md
+++ b/mydocs/report/task_m040_375_report.md
@@ -1,0 +1,167 @@
+# Task #375 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#375 source_cargo_lock_sha256 upstream Cargo.lock 자동 비교 검증 추가](https://github.com/postmelee/alhangeul-macos/issues/375) |
+| 마일스톤 | M040 `v0.4` |
+| 기준 통합 브랜치 | `devel` |
+| 작업 브랜치 | `local/task375` |
+| 게시 브랜치 | `publish/task375` |
+| 단계 | Stage 1~4 |
+| Production studio identity | `v0.8.2` / `9b16aa9e23f476e2b335d7c029fc9f24a199d63c` |
+
+Bundled `rhwp-studio` manifest의 `source_cargo_lock_sha256`을 target upstream checkout root `Cargo.lock` 실제 SHA-256과 자동 비교하는 strict 검증 경로를 추가했다. 일반 앱·PR·release의 checkout 없는 resource-only 검증은 기존 field 누락 호환을 유지하고, upstream sync candidate 생성 경로만 fingerprint 존재와 actual match를 blocking gate로 강제한다.
+
+핵심 결과:
+
+- `scripts/verify-rhwp-studio-assets.sh`에 optional `--upstream-dir` 실제 hash 비교를 추가했다.
+- Resource-only legacy 호환과 strict candidate 필수 조건을 분리했다.
+- Malformed SHA-256과 실제 provenance mismatch를 구분하고 mismatch에 manifest 값·actual 값·비교 경로를 출력한다.
+- `scripts/sync-rhwp-studio.sh`가 manifest 기록 직후 같은 target checkout으로 self-check한다.
+- Full sync workflow가 target checkout을 explicit verifier에 전달하고 PR 생성 전 strict gate로 사용한다.
+- Ubuntu PR CI와 upstream sync preflight에서 isolated fixture를 실행한다.
+- Generated full/studio PR body와 Actions summary를 자동 비교 결과 기준으로 갱신했다.
+- Production `v0.8.2` upstream tracked `Cargo.lock` blob과 checkout file을 독립 계산해 manifest fingerprint 일치를 확인했다.
+- Core dependency, build, CI와 compatibility 운영 문서를 같은 책임 계약으로 정렬했다.
+
+## 변경 파일과 영향 범위
+
+| 영역 | 파일 | 영향 |
+|------|------|------|
+| Verifier | `scripts/verify-rhwp-studio-assets.sh` | `--upstream-dir`, field/file 존재와 actual hash 비교, 구분된 오류 진단 |
+| Manifest writer | `scripts/sync-rhwp-studio.sh` | 생성 결과 verifier에 같은 upstream directory 전달 |
+| Fixture | `scripts/ci/test-rhwp-studio-cargo-lock-verification.sh` | Compatibility, strict match/mismatch/누락/malformed/interface/sync/no-mutation 검증 |
+| PR CI | `.github/workflows/pr-ci.yml` | Ubuntu script-checks에 신규 fixture gate 추가 |
+| Upstream sync | `.github/workflows/rhwp-upstream-sync-pr.yml` | Preflight fixture, candidate strict verifier, verification summary 연결 |
+| 분류 | `scripts/ci/classify-pr-changes.sh` | 신규 provenance fixture에 macOS/Rust/release gate 활성화 |
+| Generated body | `scripts/ci/write-rhwp-full-sync-pr-body.sh`, `scripts/ci/write-rhwp-studio-sync-pr-body.sh` | 수동 hash 재계산 대신 automatic verifier result checklist |
+| 운영 문서 | `mydocs/manual/build_run_guide.md`, `mydocs/manual/core_dependency_operation_guide.md`, `mydocs/manual/ci_workflow_guide.md`, `mydocs/tech/core_release_compatibility.md` | Resource-only/strict 경계, 자동 gate, 실패 taxonomy와 재현 명령 |
+| 작업 기록 | 수행·구현 계획서, Stage 1~4 보고서, 최종 보고서, 오늘할일 | 조사·구현·검증·후속 순서 기록 |
+
+Task #375는 `Sources/HostApp/Resources/rhwp-studio/**`, `RustBridge/**`, `Frameworks/**`, `rhwp-core.lock`, `RhwpCoreBuildInfo.swift`를 변경하지 않았다. Upstream 저장소, PR #463, automation branch, workflow run과 public release 상태도 변경하지 않았다.
+
+## 단계별 결과
+
+| 단계 | 커밋 | 결과 |
+|------|------|------|
+| 수행 계획 | `4b4abf9` | Issue scope, 변경 금지 경계, 4단계 계획과 오늘할일 등록 |
+| 구현 계획 | `48b7545` | Compatibility/strict mode, mutation boundary와 failure taxonomy 확정 |
+| Stage 1 | `e9b95f8` | Full sync checkout lifecycle, helper/workflow/body/classification 호출 경로 조사 |
+| Stage 2 | `fd989f5` | Actual hash verifier, sync self-check와 isolated fixture 구현 |
+| Stage 3 | `1b529c0` | PR CI/upstream sync gate, classification과 generated body 연결 |
+| Stage 4 | `e5378ba` | 운영 문서 정렬, 실제 upstream과 전체 통합 검증 완료 |
+
+## 핵심 동작 계약
+
+### Verifier mode
+
+| 입력 | Manifest fingerprint | 결과 |
+|------|----------------------|------|
+| `--upstream-dir` 없음 | 없음 | Legacy resource-only 호환 성공 |
+| `--upstream-dir` 없음 | 있음 | Lowercase 64자 SHA-256 형식과 asset integrity 검증 |
+| `--upstream-dir DIR` | 없음 | Strict candidate field 누락 실패 |
+| `--upstream-dir DIR` | malformed | Manifest 형식 오류 실패 |
+| `--upstream-dir DIR` | valid, match | `DIR/Cargo.lock` actual SHA-256 일치 성공 |
+| `--upstream-dir DIR` | valid, mismatch | Provenance mismatch와 manifest/actual/path 진단 실패 |
+
+Verifier는 파일을 수정하지 않는다. Manifest writer는 `sync-rhwp-studio.sh` 하나로 유지하며 생성 직후 strict verifier를 실행한다.
+
+### Workflow 책임
+
+| 경로 | Target checkout | 검증 | 실패 영향 |
+|------|-----------------|------|-----------|
+| PR CI script-checks | 없음 | Isolated fixture | Verifier contract 회귀를 조기 차단 |
+| 일반 app/release verifier | 없음 | Resource-only | Existing asset integrity와 optional field format 확인 |
+| Upstream sync preflight | 없음 | Isolated fixture | Target build 전 helper contract 회귀 차단 |
+| Upstream sync candidate | 있음 | Writer self-check + explicit strict verifier | Stage·commit·push·PR 생성 전 중단 |
+
+## 요구사항 완료 감사
+
+| Issue 요구사항 | 판정 | 권위 있는 증거 |
+|------|------|------|
+| Fingerprint와 target root `Cargo.lock` 자동 비교 | 완료 | Verifier actual `shasum` 비교, match/mismatch fixture, actual `v0.8.2` strict 검증 |
+| Existing missing-field asset 호환 | 완료 | Resource-only legacy fixture 성공, production default verifier 성공 |
+| Full/studio sync target checkout 비교 | 완료 | Sync writer self-check와 full sync restored checkout explicit verifier |
+| Workflow verification 결과 포함 | 완료 | `Cargo.lock fingerprint match OK` verification file/Actions summary와 generated body |
+| Mismatch와 malformed field 오류 구분 | 완료 | 별도 오류 메시지와 isolated failure fixture |
+| 운영 문서와 PR checklist 갱신 | 완료 | 운영 문서 4종과 full/studio body writer 자동 gate 문구 |
+| Upstream/core/asset/reproducibility 제외 범위 유지 | 완료 | 해당 source/lock/asset diff와 외부 상태 변경 없음 |
+
+## 실제 upstream 검증
+
+Production manifest와 upstream `v0.8.2`를 다음 세 경로로 대조했다.
+
+```text
+Manifest source_cargo_lock_sha256:
+64ff4041c1874c01c7a901b28df2639082836ced44df392cd37b3227d4772279
+
+shasum -a 256 <v0.8.2-checkout>/Cargo.lock:
+64ff4041c1874c01c7a901b28df2639082836ced44df392cd37b3227d4772279
+
+git show 9b16aa9e...:Cargo.lock | shasum -a 256:
+64ff4041c1874c01c7a901b28df2639082836ced44df392cd37b3227d4772279
+
+Strict verifier:
+OK: manifest source_cargo_lock_sha256 matches <v0.8.2-checkout>/Cargo.lock
+OK: rhwp-studio assets verified
+```
+
+Actual checkout은 ignored `build.noindex/`에만 두었고 tracked production resource는 수정하지 않았다.
+
+## 통합 검증 결과
+
+| 검증 | 결과 |
+|------|------|
+| 전체 `scripts/*.sh`, `scripts/ci/*.sh` `bash -n` | OK |
+| Task 관련 6개 helper `shellcheck -e SC2129` | OK |
+| Core build-info fixture | `OK: RhwpCoreBuildInfo writer and verifier fixtures passed` |
+| Studio Cargo.lock fixture | `OK: rhwp-studio Cargo.lock fingerprint verification fixtures passed` |
+| Production core build-info verifier | OK |
+| Production studio resource verifier | OK |
+| Shared Swift AppKit/UIKit boundary | OK |
+| 전체 workflow 6개 Psych parse | OK |
+| 수정 workflow 2개 actionlint | OK |
+| Generated full/studio PR body validator | OK |
+| Change classification | macOS=true, Rust=true, render=false, release=true |
+| 실제 upstream strict verifier | OK |
+| `git diff --check` | OK |
+| 원격 base 관계 | `origin/devel` 대비 behind 0, ahead 6 |
+
+`SC2129`는 기존 body writer의 반복 append style에 대한 기존 제외다. GitHub-hosted macOS build와 `build-rust-macos.sh --verify-lock`은 PR에서 분류된 원격 gate로 확인한다.
+
+## 변경 규모
+
+Stage 4 커밋 기준 `origin/devel...HEAD` diff는 19 files, `+1,146 / -20`이다. 이 중 신규 isolated fixture는 216줄이고 verifier는 30줄 증가했다. 나머지 큰 증가는 수행·구현·단계 보고 문서다. 제품 Swift/Rust source, bundled asset과 lock diff는 0이다.
+
+## 잔여 위험과 후속 작업
+
+### Task #375 PR
+
+- PR 생성 후 GitHub-hosted macOS/Rust/release checks를 확인한다.
+- PR CI가 모두 통과한 뒤에만 `devel` merge를 승인한다.
+- Merge 후 Issue close와 branch cleanup은 `pr-merge-cleanup` 절차로 수행한다.
+
+### 기존 PR #463과 upstream sync
+
+Task #375는 기존 [PR #463](https://github.com/postmelee/alhangeul-macos/pull/463)을 수정하거나 merge하지 않았다. 권장 후속 순서는 다음과 같다.
+
+1. Task #375 PR merge
+2. 별도 승인 후 기존 #463 close와 `automation/rhwp-v0.8.4-full-sync` branch 정리
+3. 최신 `devel`의 upstream sync workflow 재실행
+4. 새 candidate에서 build info와 Cargo.lock fingerprint automatic gate 확인
+5. 새 sync PR merge 후 release 작업 진행
+
+### Public release
+
+Task #375는 signing/notarization, GitHub Release, Pages/Sparkle, Homebrew Cask 작업을 실행하지 않았다. 새 upstream sync PR merge 뒤 별도 release 승인과 runbook을 따른다.
+
+## 작업지시자 검토 요청
+
+Task #375 PR에서 다음을 중점 확인해 달라.
+
+1. Resource-only legacy 호환과 sync candidate strict gate의 책임 분리
+2. Manifest 형식 오류와 actual provenance mismatch의 구분된 진단
+3. Upstream sync가 target checkout으로 PR 생성 전 자동 차단하는 경계
+4. #463을 재사용하지 않고 Task #375 merge 뒤 cleanup·workflow 재실행하는 후속 순서

--- a/mydocs/tech/core_release_compatibility.md
+++ b/mydocs/tech/core_release_compatibility.md
@@ -272,7 +272,7 @@ scripts/verify-rhwp-studio-assets.sh \
   --commit <resolved-commit>
 ```
 
-upstream checkout이 없는 일반 앱 검증에서는 resource-only 모드를 유지해 기존 manifest의 field 누락을 허용한다. strict 모드에서는 field 누락, malformed sha256, upstream root `Cargo.lock` 누락, 실제 hash mismatch를 서로 다른 오류로 보고한다.
+upstream checkout이 없는 일반 앱 검증에서는 resource-only 모드를 유지해 기존 manifest의 field 누락을 허용한다. strict 모드는 Git checkout HEAD와 expected resolved commit을 먼저 결합하고, non-Git directory, stale checkout, field 누락, malformed sha256, upstream root `Cargo.lock` 누락, 실제 hash mismatch를 서로 다른 오류로 보고한다.
 
 ### 7. artifact hash/size 확인
 
@@ -388,7 +388,7 @@ Demo/Preview를 이유로 `main` 또는 `devel` branch dependency를 사용하�
 |------|------|------|------|
 | `missing core API` | RustBridge가 요구하는 core API가 target release에 없다. | `no method named build_page_render_tree`, `no method named get_bin_data` | Stable 전환 금지. Demo/Preview는 API가 포함된 별도 commit을 `rev`로 고정할 때만 진행한다. |
 | `Cargo.lock mismatch` | Cargo가 해석한 git dependency commit과 `rhwp-core.lock` 기준이 다르다. | `RustBridge/Cargo.lock` source hash와 `rhwp-core.lock.rhwp_commit` 불일치 | `RustBridge/Cargo.lock`/`rhwp-core.lock` 갱신 순서를 보정한다. |
-| `upstream Cargo.lock provenance mismatch` | bundled studio/WASM manifest fingerprint와 target upstream checkout root `Cargo.lock`이 다르다. | strict verifier가 manifest 값·실제 값·비교 경로를 출력하고 실패 | sync 대상 checkout과 manifest 생성 시점을 다시 확인한 뒤 후보 asset을 재생성한다. hash를 수동 보정하지 않는다. |
+| `upstream Cargo.lock provenance mismatch` | bundled studio/WASM manifest identity가 target upstream checkout commit 또는 root `Cargo.lock`과 다르다. | strict verifier가 expected/actual checkout identity 또는 manifest/actual hash와 비교 경로를 출력하고 실패 | sync 대상 checkout과 manifest 생성 시점을 다시 확인한 뒤 후보 asset을 재생성한다. commit/hash를 수동 보정하지 않는다. |
 | `artifact hash mismatch` | 현재 빌드 산출물과 `rhwp-core.lock` artifact hash/size가 다르다. | `./scripts/build-rust-macos.sh --verify-lock` 실패 | 의도한 변경이면 `--update-lock`, 아니면 산출물 재생성/rollback을 검토한다. |
 | `FFI symbol diff` | generated C ABI symbol set이 기대값과 다르다. | `diff -u rhwp-ffi-symbols.txt Frameworks/generated_rhwp_symbols.txt` 실패 | Swift 영향 분석과 ABI 의도성 확인 전 merge 금지. |
 | `render smoke failure` | build는 되지만 native render tree 렌더 결과가 깨진다. | decode 실패, page size 0, 이미지 조회 실패, smoke script 실패 | render tree schema/Swift renderer/core output을 분리 조사한다. |
@@ -426,7 +426,7 @@ Stable release tag 전환:
 - [ ] generated FFI symbol set이 `rhwp-ffi-symbols.txt`와 일치하거나, ABI 변경 계획이 별도로 승인되었다.
 - [ ] render smoke가 앱 저장소 루트 `samples/` 기준으로 통과한다.
 - [ ] `RustBridge/Cargo.lock`과 `rhwp-core.lock`의 repo, release tag, resolved commit 정합성 검증 방법이 준비되어 있다.
-- [ ] bundled `rhwp-studio`를 함께 sync하는 경우 target checkout을 넘긴 strict verifier가 manifest의 `source_cargo_lock_sha256`과 root `Cargo.lock` 실제 hash 일치를 자동 확인한다.
+- [ ] bundled `rhwp-studio`를 함께 sync하는 경우 target checkout을 넘긴 strict verifier가 checkout HEAD/expected commit과 manifest `source_cargo_lock_sha256`/root `Cargo.lock` 실제 hash 일치를 자동 확인한다.
 - [ ] `rhwp-core.lock`에 release tag, resolved commit, artifact hash/size를 기록할 수 있다.
 - [ ] native render tree 경로가 HostApp, Quick Look, Thumbnail의 기준 경로로 유지된다.
 

--- a/mydocs/tech/core_release_compatibility.md
+++ b/mydocs/tech/core_release_compatibility.md
@@ -261,9 +261,18 @@ release tag dependency 전환 후에는 다음 항목이 서로 일치해야 한
 - `rhwp-core.lock`의 `rhwp_release_tag`
 - `rhwp-core.lock`의 `rhwp_commit`
 - bundled `rhwp-studio` manifest의 `source_release_tag`, `source_resolved_commit`
-- manifest에 `source_cargo_lock_sha256`이 있으면 target upstream root `Cargo.lock` sha256
+- bundled studio를 sync하는 경우 manifest의 `source_cargo_lock_sha256`과 target upstream root `Cargo.lock` sha256
 
-불일치하면 `Cargo.lock mismatch`로 기록한다.
+RustBridge dependency lock 불일치는 `Cargo.lock mismatch`로 기록한다. bundled studio provenance는 target checkout을 보존한 상태에서 다음 strict verifier로 확인하고, 불일치는 별도 `upstream Cargo.lock provenance mismatch`로 기록한다.
+
+```bash
+scripts/verify-rhwp-studio-assets.sh \
+  --upstream-dir /absolute/path/to/target-rhwp-checkout \
+  --tag <release-tag> \
+  --commit <resolved-commit>
+```
+
+upstream checkout이 없는 일반 앱 검증에서는 resource-only 모드를 유지해 기존 manifest의 field 누락을 허용한다. strict 모드에서는 field 누락, malformed sha256, upstream root `Cargo.lock` 누락, 실제 hash mismatch를 서로 다른 오류로 보고한다.
 
 ### 7. artifact hash/size 확인
 
@@ -379,7 +388,7 @@ Demo/Preview를 이유로 `main` 또는 `devel` branch dependency를 사용하�
 |------|------|------|------|
 | `missing core API` | RustBridge가 요구하는 core API가 target release에 없다. | `no method named build_page_render_tree`, `no method named get_bin_data` | Stable 전환 금지. Demo/Preview는 API가 포함된 별도 commit을 `rev`로 고정할 때만 진행한다. |
 | `Cargo.lock mismatch` | Cargo가 해석한 git dependency commit과 `rhwp-core.lock` 기준이 다르다. | `RustBridge/Cargo.lock` source hash와 `rhwp-core.lock.rhwp_commit` 불일치 | `RustBridge/Cargo.lock`/`rhwp-core.lock` 갱신 순서를 보정한다. |
-| `upstream Cargo.lock provenance mismatch` | bundled studio/WASM manifest fingerprint와 target upstream checkout root `Cargo.lock`이 다르다. | `source_cargo_lock_sha256` 값이 target `Cargo.lock` sha256과 불일치 | sync 대상 checkout과 manifest 생성 시점을 다시 확인한다. |
+| `upstream Cargo.lock provenance mismatch` | bundled studio/WASM manifest fingerprint와 target upstream checkout root `Cargo.lock`이 다르다. | strict verifier가 manifest 값·실제 값·비교 경로를 출력하고 실패 | sync 대상 checkout과 manifest 생성 시점을 다시 확인한 뒤 후보 asset을 재생성한다. hash를 수동 보정하지 않는다. |
 | `artifact hash mismatch` | 현재 빌드 산출물과 `rhwp-core.lock` artifact hash/size가 다르다. | `./scripts/build-rust-macos.sh --verify-lock` 실패 | 의도한 변경이면 `--update-lock`, 아니면 산출물 재생성/rollback을 검토한다. |
 | `FFI symbol diff` | generated C ABI symbol set이 기대값과 다르다. | `diff -u rhwp-ffi-symbols.txt Frameworks/generated_rhwp_symbols.txt` 실패 | Swift 영향 분석과 ABI 의도성 확인 전 merge 금지. |
 | `render smoke failure` | build는 되지만 native render tree 렌더 결과가 깨진다. | decode 실패, page size 0, 이미지 조회 실패, smoke script 실패 | render tree schema/Swift renderer/core output을 분리 조사한다. |
@@ -417,7 +426,7 @@ Stable release tag 전환:
 - [ ] generated FFI symbol set이 `rhwp-ffi-symbols.txt`와 일치하거나, ABI 변경 계획이 별도로 승인되었다.
 - [ ] render smoke가 앱 저장소 루트 `samples/` 기준으로 통과한다.
 - [ ] `RustBridge/Cargo.lock`과 `rhwp-core.lock`의 repo, release tag, resolved commit 정합성 검증 방법이 준비되어 있다.
-- [ ] bundled `rhwp-studio`를 함께 sync하는 경우 manifest의 `source_cargo_lock_sha256` 검토 방법이 준비되어 있다.
+- [ ] bundled `rhwp-studio`를 함께 sync하는 경우 target checkout을 넘긴 strict verifier가 manifest의 `source_cargo_lock_sha256`과 root `Cargo.lock` 실제 hash 일치를 자동 확인한다.
 - [ ] `rhwp-core.lock`에 release tag, resolved commit, artifact hash/size를 기록할 수 있다.
 - [ ] native render tree 경로가 HostApp, Quick Look, Thumbnail의 기준 경로로 유지된다.
 

--- a/mydocs/working/task_m040_375_stage1.md
+++ b/mydocs/working/task_m040_375_stage1.md
@@ -1,0 +1,106 @@
+# Task #375 Stage 1 완료보고서
+
+## 단계 목적
+
+`source_cargo_lock_sha256`의 생성·검증과 upstream sync workflow 호출 경로를 조사하고, 실제 target root `Cargo.lock` 비교를 추가해도 기존 app/release 검증을 깨뜨리지 않는 strict/compatibility 계약을 확정했다. 이 단계에서는 제품·helper·workflow를 수정하지 않았다.
+
+## 산출물
+
+| 파일 | 변경 | 요약 |
+|------|------|------|
+| `mydocs/plans/task_m040_375_impl.md` | 신규 | 4단계 구현계획, verifier mode, failure taxonomy와 수용 기준 |
+| `mydocs/working/task_m040_375_stage1.md` | 신규 | 현행 provenance 호출 graph와 설계 결정 기록 |
+| `mydocs/orders/20260813.md` | 수정 | #375를 Stage 1 완료, Stage 2 진행 상태로 갱신 |
+
+## 조사 결과
+
+### Manifest 생성과 현재 bundled 기준
+
+- `scripts/sync-rhwp-studio.sh`는 target checkout `HEAD`가 expected commit인지 확인한 뒤 root `Cargo.lock` 존재를 요구한다.
+- 같은 script가 `shasum -a 256 "$UPSTREAM_DIR/Cargo.lock"` 값을 manifest top-level `source_cargo_lock_sha256`으로 기록한다.
+- 기록 후 `scripts/verify-rhwp-studio-assets.sh`를 실행하지만 현재는 `--upstream-dir` 입력이 없어 64자 lowercase 형식만 self-check한다.
+- 현재 bundled manifest는 `v0.8.2`, commit `9b16aa9e...`, fingerprint `64ff4041...`을 기록한다. Task #375에서는 이 production 값과 asset을 변경하지 않는다.
+
+### Verifier 호출 graph
+
+Repository에서 `verify-rhwp-studio-assets.sh` 호출은 workflow/helper/smoke에 걸쳐 10곳 확인됐다.
+
+| 호출 경로 | Upstream checkout | 필요한 mode |
+|----------|-------------------|-------------|
+| `sync-rhwp-studio.sh` 최종 self-check | 있음 | strict actual hash 비교 |
+| `rhwp-upstream-sync-pr.yml` create candidate | 있음 | strict actual hash 비교 |
+| PR CI macOS validation | 없음 | resource-only compatibility |
+| Release/app bundle/public runbook | 없음 | resource-only compatibility |
+| Visual/fallback smoke helper | 없음 | resource-only compatibility |
+
+따라서 upstream 입력을 전역 필수화하면 app bundle과 일반 PR CI가 깨진다. Optional `--upstream-dir`을 strict mode opt-in으로 두는 것이 호출자 책임과 일치한다.
+
+### Workflow checkout lifecycle
+
+현재 `.github/workflows/rhwp-upstream-sync-pr.yml`에는 studio-only PR job이 없고 full sync candidate 경로 하나가 있다.
+
+1. `resolve-target`이 target checkout을 clone해 impact를 조사한다.
+2. `build-studio-assets`가 별도 checkout에서 WASM/studio를 만들고 `pkg`, `rhwp-studio/dist`만 artifact로 올린다.
+3. `create-full-sync-pr`이 target commit을 다시 clone해 checkout 전체를 복원한 뒤 build artifact를 덮어쓴다.
+4. 따라서 create job의 `upstream_dir`에는 root `Cargo.lock`, `.git`, built `pkg/dist`가 모두 존재한다.
+5. 이 job은 `sync-rhwp-studio.sh --upstream-dir`에는 경로를 전달하지만 그 다음 explicit verifier에는 전달하지 않는다.
+
+Strict comparison은 새 checkout이나 artifact 추가 없이 create job과 sync self-check 두 지점에 연결할 수 있다.
+
+### PR body와 CI 경계
+
+- Full/studio PR body helper는 `source_cargo_lock_sha256` 실제 일치를 maintainer 수동 checkbox로 요구한다.
+- Full sync workflow verification file은 resource verifier 성공을 표시하지만 현재 명령 문자열에 target checkout 비교가 드러나지 않는다.
+- General PR CI의 macOS verifier는 candidate branch에 upstream checkout이 없으므로 actual hash 비교의 진실 원천이 될 수 없다.
+- 대신 Ubuntu `script-checks`에서 isolated fixture를 실행하면 helper contract 회귀를 모든 PR에서 조기에 차단할 수 있다.
+- 신규 fixture는 `scripts/ci/**` 분류로 release checks는 켜지지만 macOS/Rust gate는 자동으로 켜지지 않으므로 core provenance explicit path에 추가해야 한다.
+
+### 선행 작업과 후속 경계
+
+- Task #370/PR #374는 fingerprint 기록과 optional 형식 검증까지만 소유했다.
+- Task #439/PR #464는 core build-info canonical gate를 먼저 merge했다.
+- 열린 PR #463은 두 gate 완료 전 생성된 v0.8.4 candidate이며 Task #375에서 수정·close하지 않는다. Task #375 merge 후 별도 승인으로 정리하고 workflow를 재실행한다.
+
+## 설계 결정
+
+1. `verify-rhwp-studio-assets.sh`에 optional `--upstream-dir DIR`을 추가한다.
+2. Upstream 입력이 없으면 fingerprint field 부재를 허용하고, 있으면 형식만 검증하는 기존 mode를 유지한다.
+3. Upstream 입력이 있으면 directory, root `Cargo.lock`, manifest field 존재, 형식, actual hash 일치를 모두 요구한다.
+4. Checkout HEAD/tag 검증은 sync script가 계속 소유하며 asset verifier는 Cargo.lock file provenance에 집중한다.
+5. Mismatch는 manifest value, actual value, Cargo.lock path를 구분해 출력한다.
+6. Sync writer 최종 verifier와 full sync explicit verifier 모두 같은 target directory를 넘긴다.
+7. Full/studio PR body는 수동 hash 재계산 대신 automatic verifier result 확인을 요구한다.
+8. Minimal temporary resource/upstream fixture를 신규 CI test로 두고 production resource의 전후 byte 무손실을 확인한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Stage 1에서는 계획서·보고서·오늘할일만 변경했다. `scripts/**`, `.github/workflows/**`, `Sources/**`, `RustBridge/**`, `rhwp-core.lock`, bundled `rhwp-studio` manifest/asset은 변경하지 않았다.
+
+## 검증 결과
+
+```text
+$ rg -n "source_cargo_lock_sha256|verify-rhwp-studio-assets|sync-rhwp-studio|upstream_dir" ...
+73 matching lines recorded
+
+$ rg -n "scripts/verify-rhwp-studio-assets.sh" .github/workflows scripts | wc -l
+10
+
+$ git diff --check
+통과
+```
+
+구현계획서는 Stage 1~4, strict/compatibility mode 표, failure taxonomy, 단계별 수용 기준과 최종 PR 절차를 포함한다.
+
+## 잔여 위험
+
+- Writer와 verifier가 같은 `shasum` 계약을 사용하더라도 비교 대상 path가 달라지면 잘못된 mismatch가 발생할 수 있어 fixture에서 실제 path를 고정해야 한다.
+- Strict mode에서 field 부재를 호환 성공으로 처리하면 candidate provenance 누락이 계속 통과하므로 upstream 입력 시 field를 필수화해야 한다.
+- `write-rhwp-studio-sync-pr-body.sh`는 현재 workflow에서 직접 호출되지 않지만 재사용 가능한 helper 계약이므로 full helper와 함께 문구를 정렬해야 한다.
+
+## 다음 단계 영향
+
+Stage 2에서는 verifier interface와 strict 비교, sync self-check 전달, isolated fixture만 구현한다. Workflow, PR body, classification은 Stage 3까지 변경하지 않는다.
+
+## 승인 요청
+
+작업지시자가 PR 생성까지 진행하도록 승인한 범위에 따라 Stage 2 — verifier 실제 비교와 isolated fixture 구현으로 진행한다.

--- a/mydocs/working/task_m040_375_stage2.md
+++ b/mydocs/working/task_m040_375_stage2.md
@@ -1,0 +1,122 @@
+# Task #375 Stage 2 완료보고서
+
+## 단계 목적
+
+`scripts/verify-rhwp-studio-assets.sh`에 optional target upstream checkout 검증 mode를 추가해 manifest `source_cargo_lock_sha256`과 root `Cargo.lock` 실제 SHA-256을 비교하고, sync writer가 생성 직후 같은 계약으로 self-check하도록 구현했다. Temporary resource/upstream fixture로 compatibility와 strict 오류 분기를 고정했다.
+
+## 산출물
+
+| 파일 | 변경 | 규모/요약 |
+|------|------|-----------|
+| `scripts/verify-rhwp-studio-assets.sh` | 수정 | 208줄, `--upstream-dir`, actual hash 비교와 구분된 진단 |
+| `scripts/sync-rhwp-studio.sh` | 수정 | 286줄, writer 최종 verifier에 `UPSTREAM_DIR` 전달 |
+| `scripts/ci/test-rhwp-studio-cargo-lock-verification.sh` | 신규 | 216줄, compatibility/strict/sync/no-mutation fixture |
+| `mydocs/working/task_m040_375_stage2.md` | 신규 | 구현과 검증 결과 기록 |
+| `mydocs/orders/20260813.md` | 수정 | #375를 Stage 2 완료, Stage 3 진행 상태로 갱신 |
+
+## 변경 내용
+
+### Optional strict verifier interface
+
+기존 positional resource path와 `--resource-dir`, `--tag`, `--commit` interface를 유지하고 다음 option을 추가했다.
+
+```text
+--upstream-dir DIR  Compare manifest source_cargo_lock_sha256 with DIR/Cargo.lock.
+                    When set, the manifest fingerprint and upstream Cargo.lock are required.
+```
+
+Upstream 입력이 없으면 기존과 같이 fingerprint field가 없는 legacy resource를 허용하고, field가 있으면 lowercase 64자 SHA-256 형식을 검사한다.
+
+Upstream 입력이 있으면 다음 조건을 blocking gate로 적용한다.
+
+1. Manifest fingerprint field 존재
+2. Fingerprint lowercase 64자 형식
+3. Upstream directory 존재
+4. Root `Cargo.lock` file 존재
+5. Manifest value와 `shasum -a 256` actual value 일치
+
+### Mismatch 진단
+
+Actual hash mismatch는 format 오류와 다른 메시지로 실패하며 세 값을 표시한다.
+
+```text
+FAIL: manifest source_cargo_lock_sha256 does not match upstream root Cargo.lock
+Manifest value: <manifest sha256>
+Actual value:   <computed sha256>
+Cargo.lock:     <target checkout path>/Cargo.lock
+```
+
+Manifest field 누락, upstream directory 누락, root `Cargo.lock` 누락, `--upstream-dir` option 값 누락도 각각 별도 메시지로 실패한다.
+
+### Sync writer self-check
+
+`scripts/sync-rhwp-studio.sh`는 이미 upstream root `Cargo.lock`을 읽어 manifest에 기록한다. 최종 verifier 호출에 같은 `UPSTREAM_DIR`을 전달해 기록된 값이 실제 source file과 일치하는지 즉시 확인한다.
+
+```text
+scripts/verify-rhwp-studio-assets.sh \
+  --resource-dir <target> \
+  --tag <tag> \
+  --commit <commit> \
+  --upstream-dir <target checkout>
+```
+
+### Isolated fixture
+
+신규 fixture는 `mktemp -d` 아래에 최소 resource와 git upstream checkout을 만들고 다음 case를 확인한다.
+
+| Case | 기대 결과 |
+|------|-----------|
+| Legacy manifest, resource-only | 성공 |
+| Valid fingerprint + matching upstream | 성공, actual compared path 출력 |
+| Malformed fingerprint | 형식 오류 실패 |
+| Valid fingerprint mismatch | provenance mismatch + expected/actual/path 진단 |
+| Strict mode + missing manifest field | field 누락 실패 |
+| Missing upstream directory | directory 누락 실패 |
+| Missing upstream root Cargo.lock | file 누락 실패 |
+| `--upstream-dir` missing value | interface 오류 실패 |
+| `sync-rhwp-studio.sh --check` | generated fingerprint actual self-check와 sync check 성공 |
+| Production default verifier | 성공, production manifest byte 무변경 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+`Sources/HostApp/Resources/rhwp-studio/**`, `rhwp-core.lock`, `RustBridge/**`, `Frameworks/**`는 변경하지 않았다. Fixture는 production manifest를 snapshot한 뒤 기본 verifier를 실행하고 `cmp`로 byte 무변경을 확인한다. Sync 검증도 fixture target에서 `--check` mode로 실행했다.
+
+## 검증 결과
+
+```text
+$ bash -n scripts/verify-rhwp-studio-assets.sh \
+    scripts/sync-rhwp-studio.sh \
+    scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+통과
+
+$ shellcheck scripts/verify-rhwp-studio-assets.sh \
+    scripts/sync-rhwp-studio.sh \
+    scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+통과
+
+$ scripts/verify-rhwp-studio-assets.sh --help
+--upstream-dir DIR interface 확인
+
+$ scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+OK: rhwp-studio Cargo.lock fingerprint verification fixtures passed
+
+$ scripts/verify-rhwp-studio-assets.sh
+OK: rhwp-studio assets verified at .../Sources/HostApp/Resources/rhwp-studio
+
+$ git diff --check
+통과
+```
+
+## 잔여 위험
+
+- Stage 2 시점에는 신규 fixture가 PR CI와 upstream sync preflight에서 아직 호출되지 않는다. Stage 3에서 연결해야 지속 gate가 된다.
+- Full sync workflow의 sync self-check는 새 interface 덕분에 strict하지만, 이어지는 explicit verifier 호출과 verification summary는 아직 resource-only 명령을 표시한다.
+- `shasum`은 기존 manifest writer와 같은 계산 계약이다. Ubuntu fixture runner 가용성은 Stage 3 PR CI 연결과 GitHub-hosted check에서 최종 확인한다.
+
+## 다음 단계 영향
+
+Stage 3에서는 신규 fixture를 Ubuntu PR CI와 upstream preflight에 연결하고, full sync explicit verifier에 `--upstream-dir`을 전달한다. PR body checklist는 actual hash 수동 계산 대신 자동 verifier 결과 확인 문구로 정렬한다.
+
+## 승인 요청
+
+작업지시자가 PR 생성까지 진행하도록 승인한 범위에 따라 Stage 3 — sync workflow와 generated PR body 연결로 진행한다.

--- a/mydocs/working/task_m040_375_stage3.md
+++ b/mydocs/working/task_m040_375_stage3.md
@@ -1,0 +1,129 @@
+# Task #375 Stage 3 완료보고서
+
+## 단계 목적
+
+Stage 2의 upstream `Cargo.lock` actual hash 비교를 PR CI와 upstream full sync candidate 생성 경로에 연결하고, generated full/studio PR body와 path classification을 automatic provenance gate 기준으로 정렬했다.
+
+## 산출물
+
+| 파일 | 변경 | 요약 |
+|------|------|------|
+| `.github/workflows/pr-ci.yml` | 수정 | Ubuntu script-checks에서 studio Cargo.lock fixture 실행 |
+| `.github/workflows/rhwp-upstream-sync-pr.yml` | 수정 | Preflight fixture, candidate strict verifier와 verification summary 연결 |
+| `scripts/ci/classify-pr-changes.sh` | 수정 | 신규 fixture에 macOS/Rust/release gate 활성화 |
+| `scripts/ci/write-rhwp-full-sync-pr-body.sh` | 수정 | Automatic fingerprint comparison scope/checklist 반영 |
+| `scripts/ci/write-rhwp-studio-sync-pr-body.sh` | 수정 | 수동 hash 대조를 automatic verifier 결과 확인으로 변경 |
+| `mydocs/working/task_m040_375_stage3.md` | 신규 | Workflow/body/classification 검증 기록 |
+| `mydocs/orders/20260813.md` | 수정 | #375를 Stage 3 완료, Stage 4 진행 상태로 갱신 |
+
+## 변경 내용
+
+### PR CI 조기 fixture gate
+
+Ubuntu `script-checks`는 core build-info fixture 뒤에 다음 단계를 실행한다.
+
+```yaml
+- name: Check studio Cargo.lock verification fixtures
+  run: scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+```
+
+순수 shell/minimal fixture이므로 macOS Rust build 전 수 초 내에 compatibility/strict contract 회귀를 차단한다. 기존 macOS bundled resource verifier는 checkout 없는 resource-only integrity gate로 유지한다.
+
+### Upstream sync preflight와 candidate strict verification
+
+`resolve-target` helper preflight에 신규 fixture의 `bash -n`과 실제 실행을 추가했다. 따라서 workflow가 target build를 시작하기 전에 verifier contract 자체를 확인한다.
+
+`create-full-sync-pr` job은 restored target checkout의 `upstream_dir`을 explicit verifier에 전달한다.
+
+```text
+scripts/verify-rhwp-studio-assets.sh \
+  --tag <target-tag> \
+  --commit <target-commit> \
+  --upstream-dir <restored-target-checkout>
+```
+
+Sync writer self-check와 candidate explicit verifier가 모두 strict comparison을 수행한다. Verification file과 Actions summary에는 다음 의미를 고정했다.
+
+```text
+Cargo.lock fingerprint match OK
+```
+
+Mismatch가 발생하면 `git diff --check`, stage, commit, branch push와 PR 생성 전에 job이 중단된다.
+
+### Generated PR body
+
+Full sync scope는 manifest가 fingerprint를 기록할 뿐 아니라 workflow verifier가 target checkout과 자동 비교한다고 설명한다. Maintainer checklist는 다음 automatic result 확인으로 바뀌었다.
+
+```text
+automatic bundled studio verifier reports that source_cargo_lock_sha256
+matches the target upstream root Cargo.lock
+```
+
+Studio helper의 한국어 checklist도 같은 책임으로 정렬했다. 작업자가 SHA-256을 수동 재계산하는 것은 필수 checklist가 아니며, target release/source identity와 자동 check 결과를 검토한다.
+
+### Path classification
+
+신규 fixture는 `scripts/ci/**` 공통 release 분류에 더해 별도 provenance case를 갖는다.
+
+```text
+run_macos_build=true
+run_rust_verify=true
+run_release_checks=true
+```
+
+분류 사유는 build-info가 아니라 `bundled studio Cargo.lock provenance verification`, `bundled studio/core provenance verification`으로 표시해 진단 의미를 맞췄다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Workflow, classifier와 generated PR body 문구만 변경했다. `Sources/**`, `RustBridge/**`, `Frameworks/**`, `rhwp-core.lock`, production bundled `rhwp-studio` asset/manifest는 변경하지 않았다. Generated body fixture는 `build.noindex/`에만 만들었다.
+
+## 검증 결과
+
+```text
+$ bash -n <classifier/full body/studio body/verifier/sync/fixture>
+통과
+
+$ shellcheck -e SC2129 <Stage 2~3 관련 helper>
+통과
+SC2129는 기존 body writer의 반복 append style에 대한 기존 제외다.
+
+$ ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path) }'
+전체 6개 workflow parse 통과
+
+$ actionlint .github/workflows/pr-ci.yml .github/workflows/rhwp-upstream-sync-pr.yml
+통과
+
+$ scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+OK: rhwp-studio Cargo.lock fingerprint verification fixtures passed
+
+$ scripts/ci/classify-pr-changes.sh HEAD^ HEAD
+run_macos_build=true
+run_rust_verify=true
+run_release_checks=true
+
+$ scripts/validate-github-body.sh build.noindex/task375-stage3-full-body.md
+통과
+
+$ scripts/validate-github-body.sh build.noindex/task375-stage3-studio-body.md
+통과
+
+$ rg -n "automatic bundled studio verifier|자동 bundled studio verifier|Cargo.lock fingerprint match OK" <generated bodies>
+Full/studio verification과 automatic checklist 문구 확인
+
+$ git diff --check
+통과
+```
+
+## 잔여 위험
+
+- Actual remote upstream release와 GitHub-hosted workflow execution은 Task #375 PR merge 뒤 default branch workflow에서 최종 확인해야 한다.
+- PR CI는 target checkout을 보유하지 않으므로 candidate manifest의 actual hash를 재계산하지 않는다. Candidate 생성 workflow의 strict verifier와 isolated fixture가 이 계약의 진실 원천이다.
+- Studio body helper는 현재 full sync workflow에서 직접 사용되지 않지만 별도 studio sync 재사용을 위해 동일 automatic gate 문구를 유지한다.
+
+## 다음 단계 영향
+
+Stage 4에서는 build/core/CI/compatibility 문서를 strict/compatibility mode와 automatic gate 기준으로 갱신한다. 그 뒤 전체 shell, fixture, production verifier, workflow, body, classification no-mutation 통합 검증을 실행한다.
+
+## 승인 요청
+
+작업지시자가 PR 생성까지 진행하도록 승인한 범위에 따라 Stage 4 — 운영 문서 정렬과 통합 검증으로 진행한다.

--- a/mydocs/working/task_m040_375_stage4.md
+++ b/mydocs/working/task_m040_375_stage4.md
@@ -1,0 +1,142 @@
+# Task #375 Stage 4 완료보고서
+
+## 단계 목적
+
+`source_cargo_lock_sha256` 자동 비교의 resource-only 하위 호환과 upstream sync strict gate 경계를 운영 문서에 반영하고, 실제 upstream `v0.8.2` checkout을 포함한 shell·fixture·workflow·본문 통합 검증으로 Issue #375 수용 기준을 확인했다.
+
+## 산출물
+
+| 파일 | 변경 | 요약 |
+|------|------|------|
+| `mydocs/manual/build_run_guide.md` | 수정 | Resource-only/strict verifier 명령과 오류 진단 문서화 |
+| `mydocs/manual/core_dependency_operation_guide.md` | 수정 | Full sync 자동 fingerprint gate와 점검 항목 반영 |
+| `mydocs/manual/ci_workflow_guide.md` | 수정 | PR CI fixture, upstream sync 차단 조건, 로컬 재현과 실패 해석 반영 |
+| `mydocs/tech/core_release_compatibility.md` | 수정 | RustBridge lock과 upstream studio provenance 실패 책임 분리 |
+| `mydocs/working/task_m040_375_stage4.md` | 신규 | 운영 문서 변경과 통합 검증 기록 |
+| `mydocs/orders/20260813.md` | 수정 | #375를 Stage 4 완료, 최종 보고 진행 상태로 갱신 |
+
+## 변경 내용
+
+### Resource-only와 strict 검증 경계
+
+일반 앱 build·PR CI·release 검증은 upstream checkout이 없으므로 기존 resource-only verifier를 유지한다. 이 경로에서는 legacy manifest의 `source_cargo_lock_sha256` 누락을 허용하고, field가 있으면 lowercase SHA-256 형식을 확인한다.
+
+Upstream sync candidate는 target checkout을 함께 넘겨 다음 명령을 blocking gate로 사용한다.
+
+```bash
+scripts/verify-rhwp-studio-assets.sh \
+  --upstream-dir /absolute/path/to/target-rhwp-checkout \
+  --tag <release-tag> \
+  --commit <resolved-commit>
+```
+
+Strict mode에서는 manifest field, upstream root `Cargo.lock`과 실제 hash 일치가 모두 필수다. Field 누락, malformed SHA-256, upstream directory/file 누락, 값 mismatch를 서로 다른 오류로 진단한다.
+
+### 자동 gate와 maintainer 검토 책임
+
+Full sync workflow는 bundled studio sync 직후 writer self-check와 explicit verifier에서 같은 target checkout을 사용한다. Fingerprint 오류가 있으면 candidate stage·commit·push·PR 생성 전에 중단된다.
+
+Generated PR body와 Actions summary는 `Cargo.lock fingerprint match OK` 결과를 기록한다. Maintainer는 SHA-256을 수동 재계산하는 대신 target tag/commit, 자동 verifier 결과와 app-facing impact를 검토한다.
+
+### Lock 실패 유형 분리
+
+`RustBridge/Cargo.lock`과 `rhwp-core.lock` resolved commit 불일치는 기존 `Cargo.lock mismatch`다. Bundled studio manifest와 target upstream root `Cargo.lock` 실제 hash 불일치는 `upstream Cargo.lock provenance mismatch`로 별도 분류한다. 후자는 manifest 값을 수동 보정하지 않고 target checkout과 asset 생성 시점을 확인한 뒤 candidate를 재생성한다.
+
+## 실제 upstream 검증
+
+Production manifest가 가리키는 upstream release를 shallow checkout해 tracked file과 worktree file을 독립 확인했다.
+
+```text
+release tag: v0.8.2
+resolved commit: 9b16aa9e23f476e2b335d7c029fc9f24a199d63c
+manifest source_cargo_lock_sha256:
+64ff4041c1874c01c7a901b28df2639082836ced44df392cd37b3227d4772279
+
+$ shasum -a 256 <upstream>/Cargo.lock
+64ff4041c1874c01c7a901b28df2639082836ced44df392cd37b3227d4772279
+
+$ git -C <upstream> show HEAD:Cargo.lock | shasum -a 256
+64ff4041c1874c01c7a901b28df2639082836ced44df392cd37b3227d4772279
+
+$ scripts/verify-rhwp-studio-assets.sh \
+    --upstream-dir <upstream> \
+    --tag v0.8.2 \
+    --commit 9b16aa9e23f476e2b335d7c029fc9f24a199d63c
+OK: manifest source_cargo_lock_sha256 matches <upstream>/Cargo.lock
+OK: rhwp-studio assets verified
+```
+
+Checkout은 ignored `build.noindex/`에만 두었고 production manifest와 asset을 수정하지 않았다.
+
+## 요구사항별 완료 증거
+
+| Issue #375 요구사항 | 완료 증거 |
+|------|------|
+| Manifest fingerprint와 target upstream root `Cargo.lock` 실제 SHA-256 비교 | Verifier `--upstream-dir` 구현, isolated match/mismatch fixture, 실제 `v0.8.2` strict 통과 |
+| Field 누락 하위 호환 | Resource-only legacy fixture 성공, strict mode field 누락 fixture 실패 |
+| Full/studio sync target checkout 사용 | `sync-rhwp-studio.sh` writer self-check와 full sync workflow explicit verifier에 `upstream_dir` 전달 |
+| Malformed field와 실제 mismatch 구분 | Format 오류와 manifest/actual/path mismatch 진단을 fixture로 고정 |
+| 운영 문서와 PR body/checklist 갱신 | Build/core/CI/compatibility 문서 4종과 full/studio generated PR body helper 반영 |
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Stage 4는 문서와 보고서만 변경했다. Task 전체 기준으로 `Sources/HostApp/Resources/rhwp-studio/**`, `RustBridge/**`, `Frameworks/**`, `rhwp-core.lock`, `RhwpCoreBuildInfo.swift`를 변경하지 않았다. Existing PR #463, automation branch, workflow run과 release 상태도 변경하지 않았다.
+
+## 통합 검증 결과
+
+```text
+$ for script in scripts/*.sh scripts/ci/*.sh; do bash -n "$script"; done
+통과
+
+$ shellcheck -e SC2129 <Task #375 관련 6개 helper>
+통과
+SC2129는 기존 body writer의 반복 append style에 대한 기존 제외다.
+
+$ scripts/ci/test-rhwp-core-build-info.sh
+OK: RhwpCoreBuildInfo writer and verifier fixtures passed
+
+$ scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+OK: rhwp-studio Cargo.lock fingerprint verification fixtures passed
+
+$ ./scripts/verify-rhwp-core-build-info.sh
+OK
+
+$ ./scripts/verify-rhwp-studio-assets.sh
+OK: rhwp-studio assets verified
+
+$ ./scripts/check-no-appkit.sh
+OK: shared Swift code has no AppKit/UIKit dependencies
+
+$ ruby Psych.parse_file <전체 workflow>
+전체 6개 workflow parse 통과
+
+$ actionlint .github/workflows/pr-ci.yml .github/workflows/rhwp-upstream-sync-pr.yml
+통과
+
+$ scripts/ci/classify-pr-changes.sh origin/devel HEAD
+docs_only=false
+run_macos_build=true
+run_rust_verify=true
+run_render_smoke=false
+run_release_checks=true
+
+$ scripts/validate-github-body.sh <generated full/studio body>
+두 본문 통과, automatic verifier checklist와 verification 문구 확인
+
+$ git diff --check
+통과
+```
+
+## 잔여 위험
+
+- GitHub-hosted PR CI의 macOS build와 Rust lock verify는 PR 생성 뒤 원격 check에서 최종 확인한다.
+- 실제 automation workflow의 candidate 차단 동작은 Task #375가 `devel`에 merge된 뒤 기존 #463을 정리하고 workflow를 재실행할 때 확인한다.
+- Task #375는 기존 #463 또는 bundled studio/core version을 갱신하지 않는다.
+
+## 다음 단계 영향
+
+`task-final-report` 절차로 Task 전체 통합 검증과 최종 보고서를 작성하고, 오늘할일을 완료 처리한 뒤 `publish/task375` push와 `devel` 대상 Open PR을 생성한다.
+
+## 승인 근거
+
+작업지시자가 Issue #375 작업과 PR 생성까지 명시했으므로 최종 보고와 PR 게시까지 진행한다.

--- a/scripts/ci/classify-pr-changes.sh
+++ b/scripts/ci/classify-pr-changes.sh
@@ -154,6 +154,14 @@ classify_path() {
   esac
 
   case "$path" in
+    scripts/ci/test-rhwp-studio-cargo-lock-verification.sh)
+      enable_macos_build "$path affects bundled studio Cargo.lock provenance verification"
+      enable_rust_verify "$path affects bundled studio/core provenance verification"
+      matched=1
+      ;;
+  esac
+
+  case "$path" in
     RustBridge/examples/*)
       ;;
     RustBridge/*|rhwp-core.lock|Frameworks/*|Vendor/rhwp/*|rust-toolchain.toml|scripts/build-rust-macos.sh|scripts/update-rhwp-core.sh|scripts/sync-rhwp-studio.sh|scripts/verify-rhwp-studio-assets.sh)

--- a/scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+++ b/scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+VERIFIER="$ROOT/scripts/verify-rhwp-studio-assets.sh"
+SYNC="$ROOT/scripts/sync-rhwp-studio.sh"
+PRODUCTION_RESOURCE="$ROOT/Sources/HostApp/Resources/rhwp-studio"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/rhwp-studio-cargo-lock-test.XXXXXX")"
+COMMAND_STDOUT="$TMP_ROOT/command.stdout"
+COMMAND_STDERR="$TMP_ROOT/command.stderr"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local path="$1"
+  local expected="$2"
+  local description="$3"
+  if ! grep -Fq -- "$expected" "$path"; then
+    echo "ERROR: $description" >&2
+    echo "Expected to contain: $expected" >&2
+    echo "Actual content:" >&2
+    sed 's/^/  /' "$path" >&2
+    exit 1
+  fi
+}
+
+assert_files_equal() {
+  local expected="$1"
+  local actual="$2"
+  local description="$3"
+  if ! cmp -s "$expected" "$actual"; then
+    echo "ERROR: $description" >&2
+    diff -u "$expected" "$actual" >&2 || true
+    exit 1
+  fi
+}
+
+expect_failure() {
+  local description="$1"
+  local expected_stderr="$2"
+  shift 2
+  if "$@" > "$COMMAND_STDOUT" 2> "$COMMAND_STDERR"; then
+    fail "$description unexpectedly succeeded"
+  fi
+  assert_contains "$COMMAND_STDERR" "$expected_stderr" \
+    "$description returned an unexpected error"
+}
+
+write_resource() {
+  local resource_dir="$1"
+  local fingerprint="${2:-}"
+  local fingerprint_line=""
+
+  mkdir -p "$resource_dir/assets"
+  cat > "$resource_dir/index.html" <<'EOF'
+<!doctype html>
+<link rel="stylesheet" href="./assets/index-fixture.css">
+<link rel="stylesheet" href="./alhangeul-wkwebview-overrides.css">
+<script type="module" src="./assets/index-fixture.js"></script>
+EOF
+  cat > "$resource_dir/alhangeul-wkwebview-overrides.css" <<'EOF'
+select.sb-combo,
+select.sb-ls-select {
+  appearance: none;
+}
+EOF
+  printf '%s\n' 'console.log("fixture");' > "$resource_dir/assets/index-fixture.js"
+  printf '%s\n' 'body { color: black; }' > "$resource_dir/assets/index-fixture.css"
+  printf '%s\n' 'fixture-wasm' > "$resource_dir/assets/rhwp_bg-fixture.wasm"
+  printf '%s\n' 'fixture-service-worker' > "$resource_dir/registerSW.js"
+  printf '%s\n' '{}' > "$resource_dir/manifest.webmanifest"
+
+  if [ -n "$fingerprint" ]; then
+    fingerprint_line="  \"source_cargo_lock_sha256\": \"$fingerprint\","
+  fi
+
+  cat > "$resource_dir/manifest.json" <<EOF
+{
+  "name": "rhwp-studio",
+  "source_release_tag": "v9.9.9",
+  "source_resolved_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+$fingerprint_line
+  "wasm_build_command": "fixture wasm build",
+  "recommended_wasm_build_command": "fixture recommended wasm build",
+  "actual_wasm_build_command": "fixture wasm build",
+  "studio_build_command": "npx tsc && npx vite build --base ./"
+}
+EOF
+}
+
+write_upstream_checkout() {
+  local upstream_dir="$1"
+  mkdir -p "$upstream_dir/pkg" "$upstream_dir/rhwp-studio/dist/assets"
+  printf '%s\n' 'fixture Cargo lock contents' > "$upstream_dir/Cargo.lock"
+  printf '%s\n' 'fixture-rhwp-js' > "$upstream_dir/pkg/rhwp.js"
+  printf '%s\n' 'fixture-rhwp-wasm' > "$upstream_dir/pkg/rhwp_bg.wasm"
+  cat > "$upstream_dir/rhwp-studio/dist/index.html" <<'EOF'
+<!doctype html>
+<link rel="stylesheet" href="./assets/index-sync.css">
+<script type="module" crossorigin src="./assets/index-sync.js"></script>
+EOF
+  printf '%s\n' 'console.log("sync fixture");' \
+    > "$upstream_dir/rhwp-studio/dist/assets/index-sync.js"
+  printf '%s\n' 'body { color: blue; }' \
+    > "$upstream_dir/rhwp-studio/dist/assets/index-sync.css"
+  printf '%s\n' 'sync-fixture-wasm' \
+    > "$upstream_dir/rhwp-studio/dist/assets/rhwp_bg-sync.wasm"
+  printf '%s\n' 'sync-service-worker' \
+    > "$upstream_dir/rhwp-studio/dist/registerSW.js"
+  printf '%s\n' '{}' \
+    > "$upstream_dir/rhwp-studio/dist/manifest.webmanifest"
+
+  git -C "$upstream_dir" init -q
+  git -C "$upstream_dir" config user.name fixture
+  git -C "$upstream_dir" config user.email fixture@example.invalid
+  git -C "$upstream_dir" add Cargo.lock pkg rhwp-studio/dist
+  git -C "$upstream_dir" commit -qm "fixture upstream"
+}
+
+for required_script in "$VERIFIER" "$SYNC"; do
+  [ -x "$required_script" ] || fail "missing executable helper: $required_script"
+done
+
+production_manifest_before="$TMP_ROOT/production-manifest.before.json"
+cp "$PRODUCTION_RESOURCE/manifest.json" "$production_manifest_before"
+
+legacy_resource="$TMP_ROOT/legacy-resource"
+write_resource "$legacy_resource"
+"$VERIFIER" --resource-dir "$legacy_resource" > "$COMMAND_STDOUT"
+assert_contains "$COMMAND_STDOUT" "rhwp-studio assets verified" \
+  "legacy resource-only verification did not succeed"
+
+upstream_dir="$TMP_ROOT/upstream"
+write_upstream_checkout "$upstream_dir"
+expected_fingerprint="$(shasum -a 256 "$upstream_dir/Cargo.lock" | awk '{print $1}')"
+
+strict_resource="$TMP_ROOT/strict-resource"
+write_resource "$strict_resource" "$expected_fingerprint"
+"$VERIFIER" \
+  --resource-dir "$strict_resource" \
+  --upstream-dir "$upstream_dir" \
+  > "$COMMAND_STDOUT"
+assert_contains "$COMMAND_STDOUT" \
+  "manifest source_cargo_lock_sha256 matches $upstream_dir/Cargo.lock" \
+  "strict fingerprint verification did not report the compared Cargo.lock"
+
+malformed_resource="$TMP_ROOT/malformed-resource"
+write_resource "$malformed_resource" "not-a-sha256"
+expect_failure "malformed manifest fingerprint" \
+  "manifest source_cargo_lock_sha256 must be a lowercase sha256 hex string" \
+  "$VERIFIER" --resource-dir "$malformed_resource"
+
+mismatch_resource="$TMP_ROOT/mismatch-resource"
+write_resource "$mismatch_resource" \
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+expect_failure "upstream fingerprint mismatch" \
+  "manifest source_cargo_lock_sha256 does not match upstream root Cargo.lock" \
+  "$VERIFIER" --resource-dir "$mismatch_resource" --upstream-dir "$upstream_dir"
+assert_contains "$COMMAND_STDERR" "Manifest value:" \
+  "fingerprint mismatch omitted the manifest value"
+assert_contains "$COMMAND_STDERR" "Actual value:" \
+  "fingerprint mismatch omitted the actual value"
+assert_contains "$COMMAND_STDERR" "$upstream_dir/Cargo.lock" \
+  "fingerprint mismatch omitted the Cargo.lock path"
+
+expect_failure "strict verification without manifest fingerprint" \
+  "manifest missing source_cargo_lock_sha256 required for upstream comparison" \
+  "$VERIFIER" --resource-dir "$legacy_resource" --upstream-dir "$upstream_dir"
+
+missing_lock_upstream="$TMP_ROOT/missing-lock-upstream"
+mkdir -p "$missing_lock_upstream"
+expect_failure "strict verification without upstream Cargo.lock" \
+  "missing upstream root Cargo.lock: $missing_lock_upstream/Cargo.lock" \
+  "$VERIFIER" --resource-dir "$strict_resource" --upstream-dir "$missing_lock_upstream"
+
+expect_failure "strict verification without upstream directory" \
+  "missing upstream directory: $TMP_ROOT/missing-upstream" \
+  "$VERIFIER" \
+    --resource-dir "$strict_resource" \
+    --upstream-dir "$TMP_ROOT/missing-upstream"
+
+expect_failure "upstream option without value" \
+  "missing value for --upstream-dir" \
+  "$VERIFIER" --upstream-dir
+
+sync_target="$TMP_ROOT/sync-target"
+write_resource "$sync_target"
+upstream_commit="$(git -C "$upstream_dir" rev-parse HEAD)"
+"$SYNC" \
+  --check \
+  --upstream-dir "$upstream_dir" \
+  --target-dir "$sync_target" \
+  --tag v9.9.9 \
+  --commit "$upstream_commit" \
+  --actual-wasm-build-command "fixture wasm build" \
+  > "$COMMAND_STDOUT"
+assert_contains "$COMMAND_STDOUT" \
+  "manifest source_cargo_lock_sha256 matches $upstream_dir/Cargo.lock" \
+  "sync self-check did not compare the generated fingerprint"
+assert_contains "$COMMAND_STDOUT" "rhwp-studio sync check passed" \
+  "sync check did not complete"
+
+"$VERIFIER" > "$COMMAND_STDOUT"
+assert_files_equal "$production_manifest_before" "$PRODUCTION_RESOURCE/manifest.json" \
+  "fixture verification changed the production rhwp-studio manifest"
+
+echo "OK: rhwp-studio Cargo.lock fingerprint verification fixtures passed"

--- a/scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+++ b/scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
@@ -58,6 +58,7 @@ expect_failure() {
 write_resource() {
   local resource_dir="$1"
   local fingerprint="${2:-}"
+  local resolved_commit="${3:-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}"
   local fingerprint_line=""
 
   mkdir -p "$resource_dir/assets"
@@ -87,7 +88,7 @@ EOF
 {
   "name": "rhwp-studio",
   "source_release_tag": "v9.9.9",
-  "source_resolved_commit": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "source_resolved_commit": "$resolved_commit",
 $fingerprint_line
   "wasm_build_command": "fixture wasm build",
   "recommended_wasm_build_command": "fixture recommended wasm build",
@@ -141,17 +142,28 @@ assert_contains "$COMMAND_STDOUT" "rhwp-studio assets verified" \
 
 upstream_dir="$TMP_ROOT/upstream"
 write_upstream_checkout "$upstream_dir"
+upstream_commit="$(git -C "$upstream_dir" rev-parse HEAD)"
 expected_fingerprint="$(shasum -a 256 "$upstream_dir/Cargo.lock" | awk '{print $1}')"
 
 strict_resource="$TMP_ROOT/strict-resource"
-write_resource "$strict_resource" "$expected_fingerprint"
+write_resource "$strict_resource" "$expected_fingerprint" "$upstream_commit"
 "$VERIFIER" \
   --resource-dir "$strict_resource" \
   --upstream-dir "$upstream_dir" \
   > "$COMMAND_STDOUT"
 assert_contains "$COMMAND_STDOUT" \
+  "upstream checkout HEAD matches $upstream_commit" \
+  "strict fingerprint verification did not bind the checkout commit"
+assert_contains "$COMMAND_STDOUT" \
   "manifest source_cargo_lock_sha256 matches $upstream_dir/Cargo.lock" \
   "strict fingerprint verification did not report the compared Cargo.lock"
+
+unknown_commit_resource="$TMP_ROOT/unknown-commit-resource"
+write_resource "$unknown_commit_resource" "$expected_fingerprint" \
+  "cccccccccccccccccccccccccccccccccccccccc"
+expect_failure "strict verification with unavailable expected commit" \
+  "expected upstream commit is not available in checkout: cccccccccccccccccccccccccccccccccccccccc" \
+  "$VERIFIER" --resource-dir "$unknown_commit_resource" --upstream-dir "$upstream_dir"
 
 malformed_resource="$TMP_ROOT/malformed-resource"
 write_resource "$malformed_resource" "not-a-sha256"
@@ -161,7 +173,8 @@ expect_failure "malformed manifest fingerprint" \
 
 mismatch_resource="$TMP_ROOT/mismatch-resource"
 write_resource "$mismatch_resource" \
-  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" \
+  "$upstream_commit"
 expect_failure "upstream fingerprint mismatch" \
   "manifest source_cargo_lock_sha256 does not match upstream root Cargo.lock" \
   "$VERIFIER" --resource-dir "$mismatch_resource" --upstream-dir "$upstream_dir"
@@ -188,13 +201,34 @@ expect_failure "strict verification without upstream directory" \
     --resource-dir "$strict_resource" \
     --upstream-dir "$TMP_ROOT/missing-upstream"
 
+non_checkout_upstream="$TMP_ROOT/non-checkout-upstream"
+mkdir -p "$non_checkout_upstream"
+cp "$upstream_dir/Cargo.lock" "$non_checkout_upstream/Cargo.lock"
+expect_failure "strict verification without Git checkout" \
+  "upstream directory is not a git checkout: $non_checkout_upstream" \
+  "$VERIFIER" --resource-dir "$strict_resource" --upstream-dir "$non_checkout_upstream"
+
 expect_failure "upstream option without value" \
   "missing value for --upstream-dir" \
   "$VERIFIER" --upstream-dir
 
+printf '%s\n' 'stale checkout marker' > "$upstream_dir/stale-checkout-marker.txt"
+git -C "$upstream_dir" add stale-checkout-marker.txt
+git -C "$upstream_dir" commit -qm "advance fixture checkout without changing Cargo.lock"
+stale_upstream_head="$(git -C "$upstream_dir" rev-parse HEAD)"
+expect_failure "strict verification with stale checkout" \
+  "upstream checkout HEAD does not match expected commit" \
+  "$VERIFIER" --resource-dir "$strict_resource" --upstream-dir "$upstream_dir"
+assert_contains "$COMMAND_STDERR" "Expected commit: $upstream_commit" \
+  "stale checkout diagnostic omitted the expected commit"
+assert_contains "$COMMAND_STDERR" "Actual HEAD:     $stale_upstream_head" \
+  "stale checkout diagnostic omitted the actual HEAD"
+assert_contains "$COMMAND_STDERR" "Checkout:        $upstream_dir" \
+  "stale checkout diagnostic omitted the checkout path"
+
 sync_target="$TMP_ROOT/sync-target"
 write_resource "$sync_target"
-upstream_commit="$(git -C "$upstream_dir" rev-parse HEAD)"
+upstream_commit="$stale_upstream_head"
 "$SYNC" \
   --check \
   --upstream-dir "$upstream_dir" \

--- a/scripts/ci/write-rhwp-full-sync-pr-body.sh
+++ b/scripts/ci/write-rhwp-full-sync-pr-body.sh
@@ -279,7 +279,7 @@ $MENTION upstream \`edwardkim/rhwp\` release 감지 결과 full upstream sync �
 - \`rhwp-core.lock\`, \`RustBridge/Cargo.toml\`, \`RustBridge/Cargo.lock\` are updated to the target upstream release provenance.
 - \`Sources/RhwpCoreBridge/RhwpCoreBuildInfo.swift\` is regenerated from the completed \`rhwp-core.lock\`.
 - Bundled \`rhwp-studio\` and WASM assets are rebuilt from the same target commit.
-- Bundled \`rhwp-studio\` manifest records the target upstream root \`Cargo.lock\` fingerprint.
+- Bundled \`rhwp-studio\` manifest records the target upstream root \`Cargo.lock\` fingerprint, and the sync verifier compares it with the target checkout automatically.
 - Generated \`Frameworks/\` artifacts are not committed; their reference metadata is recorded in \`rhwp-core.lock\`.
 
 ## Upstream impact detection
@@ -319,7 +319,7 @@ EOF
 - [ ] \`rhwp-core.lock\` tag/commit and \`RustBridge/Cargo.lock\` resolved commit match the upstream release.
 - [ ] \`RhwpCoreBuildInfo.swift\` release tag, commit, and enabled features match \`rhwp-core.lock\`.
 - [ ] bundled \`rhwp-studio\` manifest tag/commit matches the upstream release.
-- [ ] bundled \`rhwp-studio\` manifest \`source_cargo_lock_sha256\` matches the target upstream root \`Cargo.lock\`.
+- [ ] automatic bundled studio verifier reports that \`source_cargo_lock_sha256\` matches the target upstream root \`Cargo.lock\`.
 - [ ] PR CI macOS build, Rust/core verify, bundled studio verify, and release helper checks pass.
 - [ ] upstream \`rhwp\` release notes and source changes are reviewed for app-facing impact.
 - [ ] viewer/editor smoke need is decided before merge.

--- a/scripts/ci/write-rhwp-studio-sync-pr-body.sh
+++ b/scripts/ci/write-rhwp-studio-sync-pr-body.sh
@@ -285,7 +285,7 @@ EOF
 ## Maintainer checklist
 
 - [ ] bundled \`rhwp-studio\` manifest의 tag/commit과 upstream release가 맞는지 확인
-- [ ] bundled \`rhwp-studio\` manifest의 \`source_cargo_lock_sha256\`이 target upstream root \`Cargo.lock\`과 맞는지 확인
+- [ ] 자동 bundled studio verifier가 \`source_cargo_lock_sha256\`과 target upstream root \`Cargo.lock\` 일치를 보고하는지 확인
 - [ ] PR CI의 macOS build, Rust/core verify, release helper checks 결과 확인
 - [ ] viewer/editor smoke 필요 여부 판단
 - [ ] release note에 upstream \`rhwp\` 반영을 표시할지 판단

--- a/scripts/ci/write-rhwp-studio-sync-pr-body.sh
+++ b/scripts/ci/write-rhwp-studio-sync-pr-body.sh
@@ -285,7 +285,7 @@ EOF
 ## Maintainer checklist
 
 - [ ] bundled \`rhwp-studio\` manifest의 tag/commit과 upstream release가 맞는지 확인
-- [ ] 자동 bundled studio verifier가 \`source_cargo_lock_sha256\`과 target upstream root \`Cargo.lock\` 일치를 보고하는지 확인
+- [ ] Verification 결과에 \`source_cargo_lock_sha256\`과 target upstream root \`Cargo.lock\` 일치가 기록되었는지 확인
 - [ ] PR CI의 macOS build, Rust/core verify, release helper checks 결과 확인
 - [ ] viewer/editor smoke 필요 여부 판단
 - [ ] release note에 upstream \`rhwp\` 반영을 표시할지 판단

--- a/scripts/sync-rhwp-studio.sh
+++ b/scripts/sync-rhwp-studio.sh
@@ -273,6 +273,8 @@ cat > "$TARGET/manifest.json" <<JSON
 }
 JSON
 
+# Re-read the generated manifest and source file to catch writer, quoting, and copy drift.
+# Upstream HEAD was already resolved above; the verifier independently enforces it again.
 "$ROOT/scripts/verify-rhwp-studio-assets.sh" \
   --resource-dir "$TARGET" \
   --tag "$EXPECTED_RELEASE_TAG" \

--- a/scripts/sync-rhwp-studio.sh
+++ b/scripts/sync-rhwp-studio.sh
@@ -276,7 +276,8 @@ JSON
 "$ROOT/scripts/verify-rhwp-studio-assets.sh" \
   --resource-dir "$TARGET" \
   --tag "$EXPECTED_RELEASE_TAG" \
-  --commit "$expected_commit_resolved"
+  --commit "$expected_commit_resolved" \
+  --upstream-dir "$UPSTREAM_DIR"
 
 if [ "$CHECK_MODE" = "true" ]; then
   echo "OK: rhwp-studio sync check passed for $EXPECTED_RELEASE_TAG at $expected_commit_resolved"

--- a/scripts/verify-rhwp-studio-assets.sh
+++ b/scripts/verify-rhwp-studio-assets.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RESOURCE_DIR="$ROOT/Sources/HostApp/Resources/rhwp-studio"
 EXPECTED_RELEASE_TAG=""
 EXPECTED_COMMIT=""
+UPSTREAM_DIR=""
 
 fail() {
   echo "FAIL: $*" >&2
@@ -14,12 +15,14 @@ fail() {
 usage() {
   cat >&2 <<EOF
 Usage: $0 [RESOURCE_DIR] [options]
-       $0 [--resource-dir DIR] [--tag TAG] [--commit COMMIT]
+       $0 [--resource-dir DIR] [--tag TAG] [--commit COMMIT] [--upstream-dir DIR]
 
 Options:
   --resource-dir DIR  rhwp-studio resource directory. Defaults to bundled HostApp resource.
   --tag TAG           Expected rhwp release tag. Defaults to manifest source_release_tag.
   --commit COMMIT     Expected rhwp resolved commit. Defaults to manifest source_resolved_commit.
+  --upstream-dir DIR  Compare manifest source_cargo_lock_sha256 with DIR/Cargo.lock.
+                      When set, the manifest fingerprint and upstream Cargo.lock are required.
   -h, --help          Show this help.
 EOF
 }
@@ -97,6 +100,13 @@ parse_args() {
         EXPECTED_COMMIT="$2"
         shift
         ;;
+      --upstream-dir)
+        if [ "$#" -lt 2 ] || [ -z "$2" ]; then
+          fail "missing value for --upstream-dir"
+        fi
+        UPSTREAM_DIR="$2"
+        shift
+        ;;
       -h|--help)
         usage
         exit 0
@@ -163,8 +173,26 @@ fi
 
 grep -Fq "\"source_release_tag\": \"$EXPECTED_RELEASE_TAG\"" "$RESOURCE_DIR/manifest.json" || fail "manifest release tag does not match $EXPECTED_RELEASE_TAG"
 grep -Fq "\"source_resolved_commit\": \"$EXPECTED_COMMIT\"" "$RESOURCE_DIR/manifest.json" || fail "manifest commit does not match expected commit $EXPECTED_COMMIT"
+source_cargo_lock_sha256=""
 if source_cargo_lock_sha256="$(manifest_field "$RESOURCE_DIR/manifest.json" source_cargo_lock_sha256)"; then
   validate_sha256 source_cargo_lock_sha256 "$source_cargo_lock_sha256"
+elif [ -n "$UPSTREAM_DIR" ]; then
+  fail "manifest missing source_cargo_lock_sha256 required for upstream comparison"
+fi
+
+if [ -n "$UPSTREAM_DIR" ]; then
+  [ -d "$UPSTREAM_DIR" ] || fail "missing upstream directory: $UPSTREAM_DIR"
+  upstream_cargo_lock="$UPSTREAM_DIR/Cargo.lock"
+  [ -f "$upstream_cargo_lock" ] || fail "missing upstream root Cargo.lock: $upstream_cargo_lock"
+  actual_cargo_lock_sha256="$(shasum -a 256 "$upstream_cargo_lock" | awk '{print $1}')"
+  if [ "$source_cargo_lock_sha256" != "$actual_cargo_lock_sha256" ]; then
+    echo "FAIL: manifest source_cargo_lock_sha256 does not match upstream root Cargo.lock" >&2
+    echo "Manifest value: $source_cargo_lock_sha256" >&2
+    echo "Actual value:   $actual_cargo_lock_sha256" >&2
+    echo "Cargo.lock:     $upstream_cargo_lock" >&2
+    exit 1
+  fi
+  echo "OK: manifest source_cargo_lock_sha256 matches $upstream_cargo_lock"
 fi
 wasm_build_command="$(manifest_field "$RESOURCE_DIR/manifest.json" wasm_build_command)" \
   || fail "manifest missing wasm_build_command"

--- a/scripts/verify-rhwp-studio-assets.sh
+++ b/scripts/verify-rhwp-studio-assets.sh
@@ -22,7 +22,8 @@ Options:
   --tag TAG           Expected rhwp release tag. Defaults to manifest source_release_tag.
   --commit COMMIT     Expected rhwp resolved commit. Defaults to manifest source_resolved_commit.
   --upstream-dir DIR  Compare manifest source_cargo_lock_sha256 with DIR/Cargo.lock.
-                      When set, the manifest fingerprint and upstream Cargo.lock are required.
+                      When set, DIR must be a Git checkout at the expected commit;
+                      the manifest fingerprint and upstream Cargo.lock are required.
   -h, --help          Show this help.
 EOF
 }
@@ -184,6 +185,20 @@ if [ -n "$UPSTREAM_DIR" ]; then
   [ -d "$UPSTREAM_DIR" ] || fail "missing upstream directory: $UPSTREAM_DIR"
   upstream_cargo_lock="$UPSTREAM_DIR/Cargo.lock"
   [ -f "$upstream_cargo_lock" ] || fail "missing upstream root Cargo.lock: $upstream_cargo_lock"
+  if ! upstream_head="$(git -C "$UPSTREAM_DIR" rev-parse --verify 'HEAD^{commit}' 2>/dev/null)"; then
+    fail "upstream directory is not a git checkout: $UPSTREAM_DIR"
+  fi
+  if ! expected_upstream_commit="$(git -C "$UPSTREAM_DIR" rev-parse --verify "$EXPECTED_COMMIT^{commit}" 2>/dev/null)"; then
+    fail "expected upstream commit is not available in checkout: $EXPECTED_COMMIT"
+  fi
+  if [ "$upstream_head" != "$expected_upstream_commit" ]; then
+    echo "FAIL: upstream checkout HEAD does not match expected commit" >&2
+    echo "Expected commit: $expected_upstream_commit" >&2
+    echo "Actual HEAD:     $upstream_head" >&2
+    echo "Checkout:        $UPSTREAM_DIR" >&2
+    exit 1
+  fi
+  echo "OK: upstream checkout HEAD matches $expected_upstream_commit"
   actual_cargo_lock_sha256="$(shasum -a 256 "$upstream_cargo_lock" | awk '{print $1}')"
   if [ "$source_cargo_lock_sha256" != "$actual_cargo_lock_sha256" ]; then
     echo "FAIL: manifest source_cargo_lock_sha256 does not match upstream root Cargo.lock" >&2


### PR DESCRIPTION
## 요약

- Bundled `rhwp-studio` manifest의 resolved commit과 `source_cargo_lock_sha256`을 target upstream Git checkout HEAD와 root `Cargo.lock` 실제 SHA-256에 결합하는 strict verifier를 추가했습니다.
- Checkout 없는 resource-only 검증은 기존 missing-field asset 호환을 유지하고, sync candidate는 stale/non-Git checkout·field 누락·malformed·actual mismatch를 PR 생성 전 차단합니다.
- Sync writer self-check, upstream workflow, Ubuntu fixture, change classification과 generated full/studio PR body를 provenance verification 계약에 연결했습니다.
- 실제 upstream `v0.8.2` checkout/blob과 production manifest의 fingerprint 일치 및 전체 shell·workflow·body 통합 검증을 완료했습니다.

Closes #375

## 주요 변경

- `scripts/verify-rhwp-studio-assets.sh`
  - optional `--upstream-dir DIR` 추가
  - Git checkout HEAD와 manifest/`--commit` resolved commit 결합 검증
  - manifest fingerprint와 `DIR/Cargo.lock` actual SHA-256 비교
  - stale/non-Git checkout, malformed field, field/file 누락, mismatch 진단 분리
- `scripts/sync-rhwp-studio.sh`
  - manifest 기록 직후 같은 upstream checkout으로 strict self-check
  - self-check의 writer quoting/copy drift 방어 의도 명시
- `.github/workflows/pr-ci.yml`, `.github/workflows/rhwp-upstream-sync-pr.yml`
  - isolated fixture 조기 실행
  - restored target checkout을 candidate verifier에 전달
  - `Cargo.lock fingerprint match OK` 결과를 summary/body에 기록
- CI/helper/문서
  - 신규 fixture가 macOS/Rust/release gate를 활성화하도록 분류
  - generated full PR은 automatic verifier, studio helper는 전달된 verification result 기준으로 갱신
  - build/core/CI/compatibility 운영 문서를 resource-only/strict 책임으로 정렬

## 검증

- [x] 전체 `scripts/*.sh`, `scripts/ci/*.sh` `bash -n`
- [x] Task 관련 6개 helper `shellcheck -e SC2129`
- [x] `scripts/ci/test-rhwp-core-build-info.sh`
- [x] `scripts/ci/test-rhwp-studio-cargo-lock-verification.sh`
- [x] Cargo.lock이 같은 stale checkout과 non-Git directory negative fixture
- [x] `./scripts/verify-rhwp-core-build-info.sh`
- [x] `./scripts/verify-rhwp-studio-assets.sh`
- [x] `./scripts/check-no-appkit.sh`
- [x] 전체 workflow 6개 Psych parse
- [x] 수정 workflow 2개 `actionlint`
- [x] Generated full/studio PR body validator
- [x] 실제 upstream `v0.8.2` strict verifier
- [x] `git diff --check`
- [x] `origin/devel` 대비 behind 0 / ahead 8

Actual upstream fingerprint evidence:

```text
manifest:                     64ff4041c1874c01c7a901b28df2639082836ced44df392cd37b3227d4772279
v0.8.2 checkout Cargo.lock:   64ff4041c1874c01c7a901b28df2639082836ced44df392cd37b3227d4772279
git show HEAD:Cargo.lock:     64ff4041c1874c01c7a901b28df2639082836ced44df392cd37b3227d4772279
strict verifier:              OK
checkout HEAD binding:        OK
```

## 작업 기록

- [수행 계획서](https://github.com/postmelee/alhangeul-macos/blob/db97b677536464cc76dff527f8bac58d5a909e77/mydocs/plans/task_m040_375.md)
- [구현 계획서](https://github.com/postmelee/alhangeul-macos/blob/db97b677536464cc76dff527f8bac58d5a909e77/mydocs/plans/task_m040_375_impl.md)
- [Stage 1 보고서](https://github.com/postmelee/alhangeul-macos/blob/db97b677536464cc76dff527f8bac58d5a909e77/mydocs/working/task_m040_375_stage1.md)
- [Stage 2 보고서](https://github.com/postmelee/alhangeul-macos/blob/db97b677536464cc76dff527f8bac58d5a909e77/mydocs/working/task_m040_375_stage2.md)
- [Stage 3 보고서](https://github.com/postmelee/alhangeul-macos/blob/db97b677536464cc76dff527f8bac58d5a909e77/mydocs/working/task_m040_375_stage3.md)
- [Stage 4 보고서](https://github.com/postmelee/alhangeul-macos/blob/db97b677536464cc76dff527f8bac58d5a909e77/mydocs/working/task_m040_375_stage4.md)
- [최종 보고서](https://github.com/postmelee/alhangeul-macos/blob/db97b677536464cc76dff527f8bac58d5a909e77/mydocs/report/task_m040_375_report.md)

## 단계 커밋

- [`4b4abf9`](https://github.com/postmelee/alhangeul-macos/commit/4b4abf9) 수행 계획서 작성과 오늘할일 갱신
- [`48b7545`](https://github.com/postmelee/alhangeul-macos/commit/48b7545) 구현 계획서 작성
- [`e9b95f8`](https://github.com/postmelee/alhangeul-macos/commit/e9b95f8) Stage 1 검증 경로 조사
- [`fd989f5`](https://github.com/postmelee/alhangeul-macos/commit/fd989f5) Stage 2 actual fingerprint 비교 구현
- [`1b529c0`](https://github.com/postmelee/alhangeul-macos/commit/1b529c0) Stage 3 workflow provenance gate 연결
- [`e5378ba`](https://github.com/postmelee/alhangeul-macos/commit/e5378ba) Stage 4 운영 문서와 통합 검증
- [`0f8d51e`](https://github.com/postmelee/alhangeul-macos/commit/0f8d51e) 최종 보고서와 오늘할일 완료 처리
- [`db97b67`](https://github.com/postmelee/alhangeul-macos/commit/db97b67) PR 리뷰 피드백 보정

## 제외 범위와 후속 순서

- Upstream `edwardkim/rhwp`, core pin, bundled studio asset/manifest, RustBridge/artifact는 변경하지 않았습니다.
- 기존 PR #463, automation branch, workflow run과 public release 상태는 변경하지 않았습니다.
- 이 PR merge 후 별도 승인으로 #463/기존 automation branch를 정리하고 upstream sync workflow를 재실행해 새 candidate의 build-info/Cargo.lock gate를 확인합니다.
- 새 sync PR merge 뒤 별도 release runbook으로 signing/notarization, GitHub Release, Sparkle/Pages와 Homebrew 작업을 진행합니다.
