### PR TITLE
Task #467: rhwp v0.8.4 RenderNode decoder 호환 보정

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -82,6 +82,7 @@ jobs:
           bash scripts/ci/detect-rhwp-studio-impact.sh --help
           bash scripts/ci/prepare-pages-artifact.sh --help
           bash scripts/ci/read-rhwp-core-lock.sh --help
+          bash scripts/ci/test-render-tree-decoder.sh --help
           bash scripts/ci/update-release-version-notices.sh --help
           bash scripts/ci/write-rhwp-full-sync-pr-body.sh --help
           bash scripts/ci/write-rhwp-studio-sync-pr-body.sh --help
@@ -144,6 +145,12 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+
+      - name: Verify render tree decoder compatibility
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/ci/test-render-tree-decoder.sh
 
       - name: Install build dependencies
         shell: bash

--- a/Sources/RhwpCoreBridge/RenderTree.swift
+++ b/Sources/RhwpCoreBridge/RenderTree.swift
@@ -8,12 +8,13 @@ import Foundation
 
 // MARK: - 렌더 노드
 
+// Upstream에서 제거된 필드는 모델에 남기지 않는다. JSONDecoder는 구버전 JSON의
+// 알 수 없는 추가 키(예: dirty)를 무시하므로 이전 core 출력도 계속 수용한다.
 struct RenderNode: Decodable {
     let id: UInt32
     let nodeType: RenderNodeType
     let bbox: BBox
     let children: [RenderNode]
-    let dirty: Bool
     let visible: Bool
 
     enum CodingKeys: String, CodingKey {
@@ -21,7 +22,6 @@ struct RenderNode: Decodable {
         case nodeType = "node_type"
         case bbox
         case children
-        case dirty
         case visible
     }
 }

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -5,6 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #439 | rhwp Upstream Sync PR에 RhwpCoreBuildInfo 갱신과 검증 gate 추가 | 완료 | M020, Stage 1~4 및 통합 검증 완료, 완료: 05:02 |
+| #467 | rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정 | 진행 중 | M020, 수행계획 작성 및 구현계획 준비 |
 
 ## M040 — v0.4
 

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #439 | rhwp Upstream Sync PR에 RhwpCoreBuildInfo 갱신과 검증 gate 추가 | 완료 | M020, Stage 1~4 및 통합 검증 완료, 완료: 05:02 |
-| #467 | rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정 | 진행 중 | M020, Stage 1~3 및 v0.8.4 통합 smoke 완료, 최종 보고 준비 |
+| #467 | rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정 | 완료 | M020, Stage 1~3 및 통합 검증 완료, 완료: 14:23 |
 
 ## M040 — v0.4
 

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #439 | rhwp Upstream Sync PR에 RhwpCoreBuildInfo 갱신과 검증 gate 추가 | 완료 | M020, Stage 1~4 및 통합 검증 완료, 완료: 05:02 |
-| #467 | rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정 | 진행 중 | M020, Stage 2 decoder/fixture/CI 구현 완료 및 Stage 3 진행 |
+| #467 | rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정 | 진행 중 | M020, Stage 1~3 및 v0.8.4 통합 smoke 완료, 최종 보고 준비 |
 
 ## M040 — v0.4
 

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #439 | rhwp Upstream Sync PR에 RhwpCoreBuildInfo 갱신과 검증 gate 추가 | 완료 | M020, Stage 1~4 및 통합 검증 완료, 완료: 05:02 |
-| #467 | rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정 | 진행 중 | M020, 수행계획 작성 및 구현계획 준비 |
+| #467 | rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정 | 진행 중 | M020, 수행계획 완료 및 3단계 구현계획 수립 |
 
 ## M040 — v0.4
 

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #439 | rhwp Upstream Sync PR에 RhwpCoreBuildInfo 갱신과 검증 gate 추가 | 완료 | M020, Stage 1~4 및 통합 검증 완료, 완료: 05:02 |
-| #467 | rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정 | 진행 중 | M020, 수행계획 완료 및 3단계 구현계획 수립 |
+| #467 | rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정 | 진행 중 | M020, Stage 1 호환 계약 확정 및 Stage 2 진행 |
 
 ## M040 — v0.4
 

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #439 | rhwp Upstream Sync PR에 RhwpCoreBuildInfo 갱신과 검증 gate 추가 | 완료 | M020, Stage 1~4 및 통합 검증 완료, 완료: 05:02 |
-| #467 | rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정 | 진행 중 | M020, Stage 1 호환 계약 확정 및 Stage 2 진행 |
+| #467 | rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정 | 진행 중 | M020, Stage 2 decoder/fixture/CI 구현 완료 및 Stage 3 진행 |
 
 ## M040 — v0.4
 

--- a/mydocs/plans/task_m020_467.md
+++ b/mydocs/plans/task_m020_467.md
@@ -1,0 +1,100 @@
+# Task M020 #467 수행계획서
+
+## 목적
+
+rhwp v0.8.4에서 제거된 `RenderNode.dirty`를 Swift decoder가 계속 필수 키로 요구해 native render tree 전체 decode가 실패하는 호환성 회귀를 보정한다.
+
+현재 Swift renderer가 실제로 사용하지 않는 `dirty` 저장 속성과 coding key를 제거하고, `dirty` 포함/미포함 JSON을 모두 검증하는 작은 fixture를 PR CI에 연결한다. 이를 통해 새 upstream schema는 정상 수용하면서 기존 v0.8.2 계열 JSON의 추가 필드도 계속 허용한다.
+
+## 배경
+
+PR #466 후보는 upstream sync 자체 검증을 통과했지만 macOS native renderer smoke에서 기본 샘플 3종 모두 `render tree is nil`로 실패했다. 같은 후보를 로컬에서 재현하고 decode 오류를 노출한 결과 첫 자식 노드의 `dirty` 키가 없다는 `DecodingError.keyNotFound`가 확인됐다.
+
+Upstream rhwp v0.8.4의 `RenderNode` 정의에서는 `dirty` 필드가 제거됐다. 반면 `Sources/RhwpCoreBridge/RenderTree.swift`는 `let dirty: Bool`과 `case dirty`를 유지하고 있다. 저장소 전체 검색 결과 Swift renderer는 이 속성을 소비하지 않는다. 임시 worktree에서 두 선언만 제거했을 때 기존 v0.8.4 후보의 native renderer smoke 3종이 모두 통과했다.
+
+PR #463 당시에는 render smoke 분류가 누락돼 회귀가 드러나지 않았고, #439 변경에서 분류 경계를 보강한 뒤 PR #466 검증이 이를 차단했다. 따라서 PR #466 자체를 우회하기보다 호환 보정을 `devel`에 먼저 반영한 뒤 upstream sync 후보를 갱신해야 한다.
+
+## 범위
+
+포함:
+
+- Swift `RenderNode` 모델에서 사용하지 않는 `dirty` 저장 속성과 coding key를 제거한다.
+- 중첩 노드에서 `dirty`가 없는 v0.8.4 형식과 `dirty`가 있는 기존 형식을 각각 decode하는 독립 fixture를 추가한다.
+- fixture를 실행하는 shell helper와 macOS PR CI 조기 gate를 추가한다.
+- fixture/helper만 바뀌는 후속 PR도 macOS·render 검증을 건너뛰지 않도록 path classification을 보강한다.
+- rhwp v0.8.4 bridge artifact를 사용한 native renderer smoke 3종과 관련 정적 검증을 수행한다.
+- 단계 보고서, 최종 보고서와 오늘할일을 갱신한다.
+
+제외:
+
+- upstream rhwp 소스 또는 v0.8.4 release tag 변경
+- 다른 render tree schema의 선제적 optional 처리나 decoder 대규모 리팩터링
+- `RhwpDocument.renderPageTree`의 오류 반환 계약 변경
+- PR #466 branch 직접 수정, merge 또는 close
+- 공개 릴리스, 서명, 공증, GitHub Release와 배포 작업
+
+## 설계 방향
+
+1. 제품 코드가 소비하지 않는 retired field는 optional 상태로 보존하지 않고 Swift 모델에서 제거한다.
+2. Swift `JSONDecoder`가 알 수 없는 추가 키를 기본적으로 무시하는 동작을 이용해 기존 `dirty` 포함 JSON 호환성을 유지한다.
+3. Fixture는 Rust bridge나 sample 문서 없이 `RenderTree.swift`와 Foundation만 compile해 schema 계약을 빠르게 확인한다.
+4. Fixture는 root와 child를 모두 포함해 실제 실패 지점이었던 중첩 노드 누락도 검증한다.
+5. Fixture helper는 임시 디렉터리에 binary와 module cache를 만들고 종료 시 정리하며 tracked file을 변경하지 않는다.
+6. PR CI는 비싼 Rust artifact build보다 먼저 fixture를 실행해 동일 회귀를 빠르게 진단한다.
+7. 실제 v0.8.4 통합 검증은 PR #466 후보 commit의 core pin/artifact 조건을 격리된 worktree 또는 동등한 안전한 경로에서 재현한다. Task #467 branch의 production core pin은 변경하지 않는다.
+
+## 예상 변경 파일
+
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+- 신규 `scripts/ci/render_tree_decoder_fixture.swift`
+- 신규 `scripts/ci/test-render-tree-decoder.sh`
+- `scripts/ci/classify-pr-changes.sh`
+- `.github/workflows/pr-ci.yml`
+- `mydocs/orders/20260813.md`
+- `mydocs/plans/task_m020_467.md`
+- `mydocs/plans/task_m020_467_impl.md`
+- `mydocs/working/task_m020_467_stage1.md`
+- `mydocs/working/task_m020_467_stage2.md`
+- `mydocs/working/task_m020_467_stage3.md`
+- `mydocs/report/task_m020_467_report.md`
+
+## 잠정 단계
+
+1. Stage 1: upstream/Swift schema 차이, 소비 지점, decoder 기본 동작과 CI 호출 경계를 확정한다.
+2. Stage 2: `dirty` 제거, 양방향 fixture/helper와 PR CI/path classification을 구현하고 독립 검증한다.
+3. Stage 3: current branch 전체 정적 검증과 v0.8.4 native renderer smoke 3종을 수행하고 후속 PR #466 갱신 조건을 정리한다.
+
+## 검증 계획
+
+```bash
+bash -n scripts/ci/test-render-tree-decoder.sh scripts/ci/classify-pr-changes.sh
+scripts/ci/test-render-tree-decoder.sh
+./scripts/check-no-appkit.sh
+ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path) }'
+scripts/ci/classify-pr-changes.sh origin/devel HEAD
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+git diff --check
+```
+
+v0.8.4 통합 후보에서는 다음을 추가 수행한다.
+
+```bash
+ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/build-rust-macos.sh --verify-lock
+./scripts/validate-stage3-render.sh build.noindex/task467-v084-smoke
+```
+
+## 리스크
+
+- `dirty`가 다른 Swift 소비 지점에서 암묵적으로 필요하다면 제거가 동작 변경을 만들 수 있다. 구현 전 저장소 전체 참조와 renderer 경로를 재확인한다.
+- JSONDecoder의 unknown-key 허용만 믿고 실제 fixture를 두지 않으면 decoder customization 시 기존 호환성이 다시 깨질 수 있다. `dirty` 포함 형식을 별도 case로 고정한다.
+- Fixture가 top-level node만 검사하면 실제 실패한 child 경로를 놓칠 수 있다. 두 형식 모두 중첩 노드를 포함한다.
+- `scripts/ci/*` 일반 분류만 적용하면 release check만 실행되고 macOS decoder fixture가 skip될 수 있다. 신규 helper와 Swift fixture를 renderer trigger로 명시한다.
+- Task #467의 core pin을 v0.8.4로 바꾸면 PR #466과 범위가 섞인다. 통합 검증은 별도 worktree에서 수행하고 제품 diff에는 포함하지 않는다.
+- Workflow YAML 정적 parse는 GitHub-hosted runner 동작을 완전히 보장하지 않는다. PR 생성 후 필수 CI를 확인하고 merge는 별도 승인으로 남긴다.
+
+## 승인 반영
+
+작업지시자는 같은 스레드에서 이슈 정리와 필수 작업을 순차 진행했고, PR #466 CI 실패 원인 진단 뒤 Task #467을 새 이슈로 등록해 PR 생성까지 진행하도록 명시했다. 이에 따라 이 수행계획, 3단계 구현·검증, 최종 보고와 `devel` 대상 Open PR 생성까지 승인된 범위로 진행한다.
+
+PR #467 merge, Issue #467 close, PR #466 갱신·재생성 및 공개 릴리스는 이번 승인에 포함하지 않는다.

--- a/mydocs/plans/task_m020_467_impl.md
+++ b/mydocs/plans/task_m020_467_impl.md
@@ -1,0 +1,232 @@
+# Task M020 #467 구현계획서
+
+수행계획서: `mydocs/plans/task_m020_467.md`
+
+## 작업 개요
+
+- 이슈: #467 `rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정`
+- 마일스톤: M020 `v0.2.x Skia Quick Look/Thumbnail Backend`
+- 기준 브랜치: `devel`
+- 작업 브랜치: `local/task467`
+- 게시 브랜치: `publish/task467`
+- 차단 대상: PR #466 `Sync rhwp upstream v0.8.4`
+- 직접 원인: upstream `RenderNode.dirty` 제거와 Swift 필수 decode key 잔존
+
+작업지시자가 PR 생성까지 진행하도록 승인했으므로 각 Stage의 완료 조건과 검증을 충족한 뒤 다음 Stage로 연속 진행한다. 각 Stage source와 보고서는 분리된 커밋으로 남긴다.
+
+## 구현 전 확인 결과
+
+| 항목 | 현재 상태 | 구현 반영 |
+|------|-----------|-----------|
+| upstream schema | rhwp v0.8.4 `RenderNode`에 `dirty` 없음 | 제거된 field를 Swift 모델에서도 삭제한다. |
+| Swift schema | `dirty: Bool`과 `case dirty`가 자동 `Decodable`의 필수 key | 두 선언을 함께 제거한다. |
+| 소비 지점 | 저장소에서 `RenderNode.dirty` 참조 없음 | optional/default 보존 없이 모델을 축소한다. |
+| 오류 경로 | 첫 child에서 `keyNotFound(dirty)`, `renderPageTree`는 `try?`로 nil 반환 | `renderPageTree` 오류 계약은 변경하지 않고 schema를 맞춘다. |
+| 임시 검증 | 두 선언 제거 시 v0.8.4 native smoke 3종 통과 | 같은 최소 patch를 tracked source에 적용한다. |
+| 기존 JSON | JSONDecoder는 선언하지 않은 추가 key를 무시 | `dirty` 포함 fixture로 동작을 고정한다. |
+| PR CI | `RenderTree.swift` 변경은 macOS build/render smoke를 실행 | 독립 fixture를 Rust build 전 조기 실행한다. |
+| helper 분류 | 일반 `scripts/ci/*`는 release check 대상이지만 render smoke를 보장하지 않음 | 신규 helper/fixture exact path를 renderer trigger로 추가한다. |
+
+## 공통 구현 원칙
+
+1. `Sources/RhwpCoreBridge`에는 Foundation 외 AppKit/UIKit 직접 의존을 추가하지 않는다.
+2. Upstream v0.8.4에 없는 속성을 별도 compatibility property로 만들지 않는다.
+3. `dirty` 외 schema, renderer, FFI ABI와 `project.yml`은 변경하지 않는다.
+4. Fixture는 root와 child의 id, node type, visibility와 child count를 확인한다.
+5. Current 형식은 root/child 모두 `dirty`가 없고 legacy 형식은 root/child 모두 `dirty`가 있다.
+6. Fixture helper는 `--help`를 지원하고 인자를 받지 않으며 repository 밖 임시 directory만 사용한다.
+7. PR CI는 macOS runner에서 Foundation-only fixture를 먼저 실행한다. Ubuntu script job은 shell syntax만 검증한다.
+8. Path classification은 source와 신규 fixture/helper 변경에서 `run_macos_build=true`, `run_render_smoke=true`를 보장한다.
+9. v0.8.4 smoke 검증은 Task #467 branch의 core pin/artifact를 변경하지 않는 격리 worktree에서 수행한다.
+10. PR #466이나 automation branch의 remote 상태는 Task #467에서 변경하지 않는다.
+
+## 판정 규칙
+
+| 결과 | 판정 |
+|------|------|
+| `dirty` 없는 root/child decode 성공 | 통과 |
+| `dirty` 있는 root/child decode 성공 | 통과 |
+| Fixture가 legacy `dirty` 존재를 모델 속성으로 요구 | 범위 위반 |
+| `RenderNode.dirty` 참조 잔존 | blocking |
+| `Sources/RhwpCoreBridge` AppKit/UIKit 검증 실패 | blocking |
+| 신규 helper/fixture-only 분류에서 macOS 또는 render gate false | blocking |
+| Workflow YAML parse 또는 shell syntax 실패 | blocking |
+| v0.8.4 sample 3종 중 render tree nil/비한글/blank bitmap | blocking |
+| Task #467 diff에 v0.8.4 core pin이나 bundled asset 포함 | 범위 위반 |
+| PR #466 merge/close 또는 공개 release 실행 | 범위 위반 |
+
+## Stage 1. 호환 계약과 CI 경계 확정
+
+### 목표
+
+재현 결과를 tracked source와 upstream schema에 대조하고, retired field 제거가 안전한지와 독립 fixture/CI의 exact contract를 확정한다.
+
+### 대상
+
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+- `Sources/RhwpCoreBridge/RhwpDocument.swift`
+- `scripts/validate-stage3-render.sh`
+- `scripts/ci/classify-pr-changes.sh`
+- `.github/workflows/pr-ci.yml`
+- upstream v0.8.4 `RenderNode` 정의
+- `mydocs/working/task_m020_467_stage1.md`
+- `mydocs/orders/20260813.md`
+
+### 작업
+
+1. Swift `dirty` 선언과 전체 소비 지점을 재검색한다.
+2. Upstream v0.8.2와 v0.8.4 `RenderNode` field 차이를 기록한다.
+3. 실제 decode 오류 path와 `try?`에 의한 nil 전환 경로를 기록한다.
+4. JSONDecoder unknown-key 허용이 legacy compatibility를 제공하는지 작은 compile/run probe로 확인한다.
+5. Fixture JSON, assertion, shell helper output과 failure contract를 확정한다.
+6. PR CI 조기 실행 위치와 path classification exact trigger를 확정한다.
+7. 제품 source/helper/workflow를 변경하지 않고 조사 보고서를 작성한다.
+
+### 검증
+
+```bash
+rg -n "dirty" Sources scripts .github mydocs/manual
+rg -n "RenderNode|renderPageTree|validate-stage3-render" Sources scripts .github/workflows/pr-ci.yml
+./scripts/check-no-appkit.sh
+git diff --check
+```
+
+### 완료 조건
+
+- Retired field 제거가 renderer 소비를 바꾸지 않는 근거가 기록돼 있다.
+- Current/legacy fixture와 child assertion이 확정돼 있다.
+- CI 실행 위치와 classification trigger가 실제 workflow 기준으로 확정돼 있다.
+- 제품 source/helper/workflow tracked file은 변경되지 않았다.
+
+### 커밋
+
+```text
+Task #467 Stage 1: render tree decoder 호환 계약 확정
+```
+
+## Stage 2. Decoder 보정과 회귀 fixture/CI 구현
+
+### 목표
+
+Swift 모델에서 retired `dirty`를 제거하고, current/legacy JSON 양방향 호환을 독립 fixture로 고정해 PR CI에서 조기 검출한다.
+
+### 대상
+
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+- 신규 `scripts/ci/render_tree_decoder_fixture.swift`
+- 신규 `scripts/ci/test-render-tree-decoder.sh`
+- `scripts/ci/classify-pr-changes.sh`
+- `.github/workflows/pr-ci.yml`
+- `mydocs/working/task_m020_467_stage2.md`
+- `mydocs/orders/20260813.md`
+
+### 작업
+
+1. `RenderNode.dirty`와 해당 coding key를 제거하고 legacy extra key 허용 의도를 주석으로 남긴다.
+2. Current/legacy 중첩 JSON을 decode하고 root/child 구조를 검증하는 Swift fixture를 추가한다.
+3. Foundation-only fixture를 격리 compile/run하는 shell helper를 추가한다.
+4. Helper `--help`, unexpected argument와 정상 output contract를 검증한다.
+5. PR CI macOS validation의 dependency/Rust build 전에 helper를 실행한다.
+6. 신규 helper/fixture를 macOS build와 render smoke trigger로 분류한다.
+7. Source와 Stage 2 보고서를 함께 검증·커밋한다.
+
+### 검증
+
+```bash
+bash -n scripts/ci/test-render-tree-decoder.sh scripts/ci/classify-pr-changes.sh
+bash scripts/ci/test-render-tree-decoder.sh --help
+scripts/ci/test-render-tree-decoder.sh
+./scripts/check-no-appkit.sh
+ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path) }'
+scripts/ci/classify-pr-changes.sh origin/devel HEAD
+git diff --check
+```
+
+Fixture-only 임시 ref 또는 동등한 입력에서도 `run_macos_build=true`와 `run_render_smoke=true`를 확인한다.
+
+### 완료 조건
+
+- Current/legacy fixture가 모두 성공하고 root/child assertion이 동작한다.
+- Swift 모델에 `dirty` 선언이 남지 않는다.
+- Helper가 tracked file을 만들거나 변경하지 않는다.
+- PR CI가 Rust build 전에 fixture를 실행한다.
+- Source와 helper/fixture 변경 모두 필요한 renderer gate를 활성화한다.
+
+### 커밋
+
+```text
+Task #467 Stage 2: RenderNode 호환 보정과 decoder fixture 추가
+```
+
+## Stage 3. 통합 회귀 검증과 upstream sync handoff
+
+### 목표
+
+Current `devel` 기준 정적·helper 검증과 v0.8.4 candidate 기준 native renderer smoke를 완료해 Task #467 수용 조건과 PR #466 후속 순서를 확정한다.
+
+### 대상
+
+- Task #467 전체 변경
+- PR #466 head 또는 동일 v0.8.4 candidate를 사용한 격리 worktree
+- `mydocs/working/task_m020_467_stage3.md`
+- `mydocs/orders/20260813.md`
+
+### 작업
+
+1. 전체 shell syntax, workflow YAML, shared Swift boundary, build-info/studio verifier를 실행한다.
+2. `origin/devel..HEAD` classification에서 macOS·render·release flag를 확인한다.
+3. PR #466 v0.8.4 candidate에 Task #467 source patch를 격리 적용한다.
+4. v0.8.4 Rust bridge lock verification을 static archive hash skip 범위로 실행한다.
+5. 기본 sample 3종 native renderer smoke와 non-blank bitmap 결과를 확인한다.
+6. 격리 worktree와 build output을 정리하고 Task #467 working tree 무손실을 확인한다.
+7. PR #466을 Task #467 merge 뒤 갱신/재생성해야 한다는 handoff를 기록한다.
+
+### 검증
+
+```bash
+for script in scripts/*.sh scripts/ci/*.sh; do bash -n "$script"; done
+scripts/ci/test-render-tree-decoder.sh
+scripts/ci/test-rhwp-core-build-info.sh
+scripts/ci/test-rhwp-studio-cargo-lock-verification.sh
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path) }'
+scripts/ci/classify-pr-changes.sh origin/devel HEAD
+git diff --check
+```
+
+격리 v0.8.4 후보:
+
+```bash
+ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/build-rust-macos.sh --verify-lock
+./scripts/validate-stage3-render.sh build.noindex/task467-v084-smoke
+```
+
+### 완료 조건
+
+- 전체 local/static 검증이 통과한다.
+- v0.8.4 sample 3종이 render tree, Hangul text/glyph와 non-blank PNG 검증을 통과한다.
+- Task #467 diff에 core pin/artifact/bundled asset 변경이 없다.
+- 격리 worktree와 임시 output이 정리돼 있다.
+- PR #466 후속 재실행 조건과 공개 release 제외 경계가 기록돼 있다.
+
+### 커밋
+
+```text
+Task #467 Stage 3: v0.8.4 native renderer 통합 검증 완료
+```
+
+## 최종 보고와 PR
+
+Stage 1~3 완료 후 `mydocs/report/task_m020_467_report.md`를 작성하고 오늘할일을 완료 처리한다. 최종 커밋 뒤 `publish/task467`에 push하고 `devel` 대상 Open PR을 생성한다.
+
+PR 본문에는 다음을 포함한다.
+
+- `Closes #467`
+- PR #466 실패 재현과 직접 원인
+- current/legacy fixture 계약
+- v0.8.4 sample 3종 smoke 결과
+- path classification과 CI 영향
+- Task #467 merge 뒤 PR #466 갱신/재생성 handoff
+- 공개 release가 범위 밖이라는 명시

--- a/mydocs/plans/task_m020_467_impl.md
+++ b/mydocs/plans/task_m020_467_impl.md
@@ -230,3 +230,34 @@ PR 본문에는 다음을 포함한다.
 - path classification과 CI 영향
 - Task #467 merge 뒤 PR #466 갱신/재생성 handoff
 - 공개 release가 범위 밖이라는 명시
+
+## PR #468 리뷰 반영 계획
+
+리뷰: `https://github.com/postmelee/alhangeul-macos/pull/468#issuecomment-5276420011`
+
+초기 PR은 merge 가능 판정을 받았고 current/legacy envelope fixture, CI 위치, helper mode와 하이퍼-워터폴 문서/커밋 규칙이 유효하다고 확인됐다. 작업지시자 승인에 따라 다음 소규모 보완을 같은 PR에 반영한다.
+
+1. `TextRunNode`와 모든 non-optional `TextStyle` field를 포함하는 payload JSON을 fixture에 추가하고 `.textRun` case, text/style 대표 값과 field marker를 assert한다.
+2. Fixture의 thrown error를 `do`/`catch`에서 stderr로 출력하고 `EXIT_FAILURE`로 종료해 CI 실패를 exit 1로 정규화한다.
+3. `rhwp-core.lock`과 `Frameworks/*` 변경을 renderer path로 명시해 `run_render_smoke=true`를 직접 보장한다.
+4. 초기 계획과 최종 보고서에 리뷰 반영 범위, 검증 결과와 follow-up 이슈를 기록한다.
+
+다음 구조 개선은 Task #467 범위를 확장하지 않고 별도 이슈로 분리한다.
+
+- #469: pin된 core producer의 render tree golden 자동 갱신과 Swift decoder 계약 검증
+- #470: known `RenderNodeType` payload decode 실패와 unknown future variant 구분·진단
+
+리뷰 보정 검증:
+
+```bash
+scripts/ci/test-render-tree-decoder.sh
+# 의도적 assertion 실패 probe에서 stderr prefix와 exit 1 확인
+bash -n scripts/ci/test-render-tree-decoder.sh scripts/ci/classify-pr-changes.sh
+shellcheck -e SC2129 scripts/ci/test-render-tree-decoder.sh scripts/ci/classify-pr-changes.sh
+scripts/ci/classify-pr-changes.sh origin/devel origin/automation/rhwp-v0.8.4-full-sync
+./scripts/check-no-appkit.sh
+ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path) }'
+git diff --check
+```
+
+Producer-backed golden과 runtime decode 오류 정책은 각각 #469, #470 수용 조건에서 구현하며 이 PR에서는 수동 payload fixture와 classification 경계만 보강한다.

--- a/mydocs/report/task_m020_467_report.md
+++ b/mydocs/report/task_m020_467_report.md
@@ -1,0 +1,217 @@
+# Task #467 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#467 rhwp v0.8.4 RenderNode dirty 제거에 Swift decoder 호환 보정](https://github.com/postmelee/alhangeul-macos/issues/467) |
+| 마일스톤 | M020 `v0.2.x Skia Quick Look/Thumbnail Backend` |
+| 기준 통합 브랜치 | `devel` |
+| 작업 브랜치 | `local/task467` |
+| 게시 브랜치 | `publish/task467` |
+| 단계 | Stage 1~3 |
+| 차단 대상 | [PR #466 Sync rhwp upstream v0.8.4](https://github.com/postmelee/alhangeul-macos/pull/466) |
+
+Rhwp v0.8.4에서 제거된 `RenderNode.dirty`를 Swift decoder가 계속 필수 key로 요구해 native render tree 전체가 `nil`이 되는 호환성 회귀를 보정했다.
+
+사용하지 않는 Swift property와 coding key를 제거해 v0.8.4 JSON을 수용하고, JSONDecoder의 unknown-key 허용으로 `dirty`가 남은 v0.8.2 JSON도 계속 수용한다. 두 형식을 중첩 node fixture로 고정하고 PR CI에서 Rust build 전에 실행하도록 연결했다. 신규 fixture/helper만 바뀌는 후속 PR도 macOS build와 native render smoke를 건너뛰지 않게 path classification을 보강했다.
+
+PR #466 v0.8.4 candidate에 같은 보정을 격리 적용한 결과 기본 sample 3종의 render tree, Hangul text/glyph와 non-blank PNG smoke가 모두 통과했다. Task #467은 PR #466, upstream automation branch, core pin과 공개 release 상태를 변경하지 않았다.
+
+## 직접 원인과 해결
+
+### 변경 전
+
+Swift 모델은 다음 member를 합성 `Decodable`의 필수 대상으로 포함했다.
+
+```swift
+let dirty: Bool
+case dirty
+```
+
+Upstream v0.8.4 `RenderNode`에서는 `dirty` field와 관련 observer helper가 제거돼 JSON에 key가 존재하지 않는다. 실제 오류는 첫 child에서 발생했다.
+
+```text
+DecodingError.keyNotFound: Key 'dirty' not found
+Path: children[0]
+```
+
+`RhwpDocument.renderPageTree(at:)`가 decode를 `try?`로 실행하므로 이 오류는 전체 tree `nil`로 변환되고, PR #466 native smoke는 sample 3종 모두 `render tree is nil`로 실패했다.
+
+### 변경 후
+
+Swift `RenderNode`에서 사용하지 않는 `dirty` property와 coding key를 제거했다. 다른 field, node type, custom decoder, renderer와 `renderPageTree` 오류 반환 계약은 변경하지 않았다.
+
+합성 `Decodable` 동작은 다음과 같다.
+
+| Producer | JSON 상태 | Swift 결과 |
+|----------|-----------|------------|
+| rhwp v0.8.4 | `dirty` 없음 | 필수 decode 대상이 아니므로 성공 |
+| rhwp v0.8.2 계열 | `dirty` 있음 | unknown extra key로 무시해 성공 |
+
+이 의도를 `RenderTree.swift` 주석과 current/legacy fixture로 함께 고정했다.
+
+## 변경 파일과 영향 범위
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `Sources/RhwpCoreBridge/RenderTree.swift` | `dirty` property/CodingKey 제거, retired/legacy field 호환 의도 주석 |
+| `scripts/ci/render_tree_decoder_fixture.swift` | Current/legacy root-child JSON decode와 구조 assertion |
+| `scripts/ci/test-render-tree-decoder.sh` | Foundation-only 격리 compile/run, help/argument/cleanup contract |
+| `scripts/ci/classify-pr-changes.sh` | 신규 fixture/helper를 macOS build와 render smoke trigger로 분류 |
+| `.github/workflows/pr-ci.yml` | Helper interface 확인, macOS checkout 직후 조기 decoder fixture 실행 |
+| `mydocs/plans/task_m020_467.md` | 목적, 범위, 설계 방향, 3단계와 위험 |
+| `mydocs/plans/task_m020_467_impl.md` | Stage별 exact contract, 판정 규칙과 검증 명령 |
+| `mydocs/working/task_m020_467_stage1.md` | Upstream schema/소비/CI 경계 조사 |
+| `mydocs/working/task_m020_467_stage2.md` | Decoder/fixture/CI 구현과 독립 검증 |
+| `mydocs/working/task_m020_467_stage3.md` | Current 회귀와 v0.8.4 통합 smoke, 임시 산출물 정리 |
+| `mydocs/report/task_m020_467_report.md` | 최종 수용 결과와 upstream sync handoff |
+| `mydocs/orders/20260813.md` | #467 등록, 단계 진행과 완료 시각 |
+
+변경하지 않은 범위:
+
+- `project.yml`, `Alhangeul.xcodeproj`
+- `RhwpDocument.renderPageTree`와 Rust FFI ABI
+- `rhwp-core.lock`, `Frameworks/`, `RhwpCoreBuildInfo.swift`
+- Bundled rhwp-studio asset
+- Renderer layout/drawing 동작
+- PR #466과 upstream automation remote state
+- Signing, notarization, GitHub Release와 배포
+
+## 단계별 결과
+
+| 단계 | 커밋 | 결과 |
+|------|------|------|
+| 수행 계획 | `6bc435e` | Issue #467 범위, branch, 오늘할일과 3단계 검증 경계 등록 |
+| 구현 계획 | `d4fe663` | Retired field, fixture, CI와 통합 판정 규칙 확정 |
+| Stage 1 | `f60d79f` | Upstream v0.8.2→v0.8.4 schema 차이, 무소비 근거와 CI 경계 확정 |
+| Stage 2 | `1b49a87` | `dirty` 제거, current/legacy fixture/helper와 PR CI/classification 구현 |
+| Stage 3 | `56497f7` | 전체 회귀, v0.8.4 bridge provenance와 sample 3종 smoke 완료 |
+| 최종 보고 | 현재 커밋 | 최종 수용 결과, 오늘할일 완료와 PR #466 handoff 정리 |
+
+## 변경 전·후 정량 비교
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| Swift 필수 `dirty` decode member | property 1개 + CodingKey 1개 | 0개 |
+| Decoder compatibility fixture | 없음 | current/legacy 2 case, root/child assertion |
+| Fixture helper | 없음 | Foundation-only shell helper 1개 |
+| PR CI decoder gate | 실제 native smoke에서 간접 검출 | Rust build 전 독립 fixture + 이후 native smoke |
+| Helper-only macOS/render 분류 | 보장 안 됨 | exact path 2개 모두 true |
+| Stage 2 source diff | 없음 | 5 files, `+138 / -3` |
+| 단계 보고서 | 없음 | Stage 1~3 보고서 3개 |
+| 최종 보고 전 전체 diff | 없음 | 11 files, `+928 / -3` |
+
+## Fixture와 CI 계약
+
+### Swift fixture
+
+두 case 모두 `MasterPage` root와 `Header` child를 가진다.
+
+- `current-without-dirty`: root/child 모두 `dirty` 없음
+- `legacy-with-dirty`: root/child 모두 `dirty` 있음
+
+각 case에서 root/child id, node type, visible, child count와 empty descendants를 확인한다. 실제 실패 지점이었던 `children[0]`을 포함하므로 top-level-only 검증으로 회귀가 빠져나가지 않는다.
+
+### Shell helper
+
+- Argument 없는 production 실행
+- `--help`/`-h` 성공
+- Unexpected argument exit 2
+- `mktemp -d`의 binary/module cache만 사용
+- `trap`으로 exact temp root 정리
+- Tracked source와 repository build output 무변경
+
+### PR CI
+
+MacOS validation의 순서는 다음과 같다.
+
+1. Checkout
+2. Render tree decoder compatibility fixture
+3. Build dependency 설치
+4. Rust bridge artifact 준비
+5. Shared boundary/build-info/studio asset 검증
+6. Xcode project 생성과 HostApp build
+7. Native renderer smoke
+
+Schema-only 오류는 비싼 Rust universal build 전에 직접적인 fixture failure로 종료된다. Source/helper/workflow 전체 Task #467 diff의 classification은 `macOS=true`, `render=true`, `release=true`, `Rust verify=false`다. Core provenance 입력이 바뀌지 않았으므로 Rust verify false는 의도한 값이다.
+
+## 검증 결과
+
+### Current branch
+
+```text
+전체 shell syntax: 통과
+render tree decoder current/legacy fixture: 통과
+helper help와 unexpected argument: 통과
+shellcheck -e SC2129: 통과
+core build-info isolated fixture: 통과
+studio Cargo.lock isolated fixture: 통과
+shared Swift AppKit/UIKit boundary: 통과
+production RhwpCoreBuildInfo verifier: 통과
+bundled rhwp-studio asset verifier: 통과
+전체 workflow Psych parse: 6개 통과
+committed ref PR classification: 기대 flag/reason 통과
+git diff --check: 통과
+```
+
+### v0.8.4 candidate bridge
+
+| 항목 | 값 |
+|------|----|
+| release tag | `v0.8.4` |
+| resolved commit | `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
+| feature | `native-skia` |
+| PR #466 head | `0672f1b5f9e963ba9198cd3000ba9bce80ae3ae0` |
+| universal architectures | `x86_64 arm64` |
+
+`ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1` 정책으로 static archive byte hash/size만 skip하고 source provenance, Cargo.lock, generated header와 FFI symbols를 검증했다. 전체 build와 lock verification이 통과했다.
+
+### v0.8.4 native renderer
+
+| 샘플 | text runs | Hangul runs | Hangul scalars | non-white pixels | 결과 |
+|------|-----------|-------------|----------------|------------------|------|
+| `KTX.hwp` | 410 | 76 | 209 | 455,342 | 통과 |
+| `request.hwp` | 102 | 36 | 309 | 70,619 | 통과 |
+| `exam_kor.hwp` | 133 | 86 | 1,368 | 173,827 | 통과 |
+
+세 sample 모두 render tree non-nil, Hangul text/glyph와 non-blank PNG 조건을 통과했다. 기존 layout overlap diagnostic은 failure가 아니며 Task #467에서 layout을 변경하지 않았다.
+
+## 임시 검증 자원 정리
+
+PR #466 detached worktree, 두 architecture의 Cargo target, 209MB universal static library, 209MB XCFramework, sample PNG/module cache와 Stage 1 module cache를 제거했다. 모두 재생성 가능한 임시 산출물이며 원격 상태와 tracked source에는 영향이 없다.
+
+정리 후 주 worktree 하나만 남았고 `local/task467` working tree는 clean이다.
+
+## 잔여 위험과 후속 작업
+
+### Task #467 PR
+
+- Open PR 생성 후 GitHub-hosted `Classify changed files`, `Script syntax checks`, `macOS validation`, `Release helper checks`를 확인한다.
+- 모든 필수 check 통과 뒤에만 `devel` merge한다.
+- Merge 후 Issue #467 close와 local/publish branch 정리는 `pr-merge-cleanup` 절차로 수행한다.
+
+### PR #466과 upstream sync
+
+Task #467은 [PR #466](https://github.com/postmelee/alhangeul-macos/pull/466)을 수정하거나 merge하지 않았다. 권장 후속 순서는 다음과 같다.
+
+1. Task #467 PR merge
+2. 최신 `devel` 기준 upstream sync workflow 재실행 또는 운영 정책에 따른 PR #466 갱신/재생성
+3. 새 candidate에서 decoder fixture와 native smoke 성공 확인
+4. Build-info와 Cargo.lock provenance gate 확인
+5. Upstream sync PR merge
+6. 별도 승인으로 release runbook 진행
+
+### 공개 release
+
+Task #467은 signing/notarization, GitHub Release, Pages/Sparkle, Homebrew Cask 작업을 실행하지 않았다. Upstream sync PR merge와 전체 CI 확인 뒤 작업지시자의 별도 release 승인을 받아야 한다.
+
+## 작업지시자 검토 요청
+
+Task #467 PR에서 다음을 중점 확인해 달라.
+
+1. 사용하지 않는 retired `dirty` member를 optional로 남기지 않고 제거한 최소 보정
+2. Current/legacy JSON 모두 root/child까지 검증하는 fixture 계약
+3. Rust build 전 조기 fixture와 이후 native smoke의 2단계 검출 경계
+4. Fixture/helper-only 변경도 macOS/render gate를 활성화하는 path classification
+5. PR #466을 직접 수정하지 않고 Task #467 merge 뒤 최신 `devel`에서 갱신하는 handoff

--- a/mydocs/report/task_m020_467_report.md
+++ b/mydocs/report/task_m020_467_report.md
@@ -14,7 +14,7 @@
 
 Rhwp v0.8.4에서 제거된 `RenderNode.dirty`를 Swift decoder가 계속 필수 key로 요구해 native render tree 전체가 `nil`이 되는 호환성 회귀를 보정했다.
 
-사용하지 않는 Swift property와 coding key를 제거해 v0.8.4 JSON을 수용하고, JSONDecoder의 unknown-key 허용으로 `dirty`가 남은 v0.8.2 JSON도 계속 수용한다. 두 형식을 중첩 node fixture로 고정하고 PR CI에서 Rust build 전에 실행하도록 연결했다. 신규 fixture/helper만 바뀌는 후속 PR도 macOS build와 native render smoke를 건너뛰지 않게 path classification을 보강했다.
+사용하지 않는 Swift property와 coding key를 제거해 v0.8.4 JSON을 수용하고, JSONDecoder의 unknown-key 허용으로 `dirty`가 남은 v0.8.2 JSON도 계속 수용한다. 두 형식을 중첩 node fixture로 고정하고 PR CI에서 Rust build 전에 실행하도록 연결했다. PR 리뷰 후에는 전체 `TextRunNode`/`TextStyle` payload decode와 `.textRun` case를 추가하고, 실패를 stderr와 exit 1로 정규화했다. 신규 fixture/helper뿐 아니라 `rhwp-core.lock`/`Frameworks/*` 변경도 native render smoke를 직접 활성화하도록 path classification을 보강했다.
 
 PR #466 v0.8.4 candidate에 같은 보정을 격리 적용한 결과 기본 sample 3종의 render tree, Hangul text/glyph와 non-blank PNG smoke가 모두 통과했다. Task #467은 PR #466, upstream automation branch, core pin과 공개 release 상태를 변경하지 않았다.
 
@@ -56,9 +56,9 @@ Swift `RenderNode`에서 사용하지 않는 `dirty` property와 coding key를 �
 | 파일 | 변경 내용 |
 |------|-----------|
 | `Sources/RhwpCoreBridge/RenderTree.swift` | `dirty` property/CodingKey 제거, retired/legacy field 호환 의도 주석 |
-| `scripts/ci/render_tree_decoder_fixture.swift` | Current/legacy root-child JSON decode와 구조 assertion |
+| `scripts/ci/render_tree_decoder_fixture.swift` | Current/legacy root-child JSON, 전체 TextRun/TextStyle payload decode와 구조/case assertion, stderr/exit 1 failure |
 | `scripts/ci/test-render-tree-decoder.sh` | Foundation-only 격리 compile/run, help/argument/cleanup contract |
-| `scripts/ci/classify-pr-changes.sh` | 신규 fixture/helper를 macOS build와 render smoke trigger로 분류 |
+| `scripts/ci/classify-pr-changes.sh` | 신규 fixture/helper와 core lock/artifact를 macOS build와 render smoke trigger로 분류 |
 | `.github/workflows/pr-ci.yml` | Helper interface 확인, macOS checkout 직후 조기 decoder fixture 실행 |
 | `mydocs/plans/task_m020_467.md` | 목적, 범위, 설계 방향, 3단계와 위험 |
 | `mydocs/plans/task_m020_467_impl.md` | Stage별 exact contract, 판정 규칙과 검증 명령 |
@@ -88,16 +88,18 @@ Swift `RenderNode`에서 사용하지 않는 `dirty` property와 coding key를 �
 | Stage 2 | `1b49a87` | `dirty` 제거, current/legacy fixture/helper와 PR CI/classification 구현 |
 | Stage 3 | `56497f7` | 전체 회귀, v0.8.4 bridge provenance와 sample 3종 smoke 완료 |
 | 최종 보고 | 현재 커밋 | 최종 수용 결과, 오늘할일 완료와 PR #466 handoff 정리 |
+| PR 리뷰 반영 | 후속 커밋 | TextRun payload, 명시적 exit 1, core lock/artifact render 분류와 #469/#470 등록 |
 
 ## 변경 전·후 정량 비교
 
 | 항목 | 변경 전 | 변경 후 |
 |------|---------|---------|
 | Swift 필수 `dirty` decode member | property 1개 + CodingKey 1개 | 0개 |
-| Decoder compatibility fixture | 없음 | current/legacy 2 case, root/child assertion |
+| Decoder compatibility fixture | 없음 | current/legacy envelope 2 case + TextRun/TextStyle payload 1 case |
 | Fixture helper | 없음 | Foundation-only shell helper 1개 |
 | PR CI decoder gate | 실제 native smoke에서 간접 검출 | Rust build 전 독립 fixture + 이후 native smoke |
 | Helper-only macOS/render 분류 | 보장 안 됨 | exact path 2개 모두 true |
+| Core lock/artifact render 분류 | BuildInfo source 변경의 부수 효과 | `rhwp-core.lock`, `Frameworks/*` direct renderer trigger |
 | Stage 2 source diff | 없음 | 5 files, `+138 / -3` |
 | 단계 보고서 | 없음 | Stage 1~3 보고서 3개 |
 | 최종 보고 전 전체 diff | 없음 | 11 files, `+928 / -3` |
@@ -106,18 +108,23 @@ Swift `RenderNode`에서 사용하지 않는 `dirty` property와 coding key를 �
 
 ### Swift fixture
 
-두 case 모두 `MasterPage` root와 `Header` child를 가진다.
+Envelope 두 case는 `MasterPage` root와 `Header` child를 가진다.
 
 - `current-without-dirty`: root/child 모두 `dirty` 없음
 - `legacy-with-dirty`: root/child 모두 `dirty` 있음
 
 각 case에서 root/child id, node type, visible, child count와 empty descendants를 확인한다. 실제 실패 지점이었던 `children[0]`을 포함하므로 top-level-only 검증으로 회귀가 빠져나가지 않는다.
 
+PR 리뷰 반영으로 세 번째 `text-run-payload` case를 추가했다. 이 JSON은 `TextRunNode`의 필수 field와 `TextStyle`의 모든 non-optional field를 포함한다. Decode 뒤 `.textRun` case인지 확인해 known payload 실패가 조용히 `.unknown`으로 바뀌는 회귀를 막고, text/font/tab stop/border fill/field marker 대표 값을 assert한다.
+
+수동 payload snapshot은 local Swift decoder 변경을 검출하지만 future upstream producer drift를 자동 반영하지는 않는다. 실제 producer-backed golden은 #469 작업으로 분리했다.
+
 ### Shell helper
 
 - Argument 없는 production 실행
 - `--help`/`-h` 성공
 - Unexpected argument exit 2
+- Fixture decode/assertion 실패는 `ERROR: render tree decoder fixture failed:` stderr와 exit 1
 - `mktemp -d`의 binary/module cache만 사용
 - `trap`으로 exact temp root 정리
 - Tracked source와 repository build output 무변경
@@ -134,7 +141,7 @@ MacOS validation의 순서는 다음과 같다.
 6. Xcode project 생성과 HostApp build
 7. Native renderer smoke
 
-Schema-only 오류는 비싼 Rust universal build 전에 직접적인 fixture failure로 종료된다. Source/helper/workflow 전체 Task #467 diff의 classification은 `macOS=true`, `render=true`, `release=true`, `Rust verify=false`다. Core provenance 입력이 바뀌지 않았으므로 Rust verify false는 의도한 값이다.
+Schema-only 오류는 비싼 Rust universal build 전에 직접적인 fixture failure로 종료된다. Source/helper/workflow 전체 Task #467 diff의 classification은 `macOS=true`, `render=true`, `release=true`, `Rust verify=false`다. Core provenance 입력이 바뀌지 않았으므로 Rust verify false는 의도한 값이다. Upstream core candidate에서는 `rhwp-core.lock` 자체가 render reason을 제공하므로 generated `RhwpCoreBuildInfo.swift`가 우연히 renderer pattern에 걸리는 데 의존하지 않는다. `Frameworks/`는 현재 gitignore 대상이지만 향후 tracked artifact 경로가 생겨도 같은 direct gate를 적용한다.
 
 ## 검증 결과
 
@@ -142,7 +149,8 @@ Schema-only 오류는 비싼 Rust universal build 전에 직접적인 fixture fa
 
 ```text
 전체 shell syntax: 통과
-render tree decoder current/legacy fixture: 통과
+render tree decoder current/legacy envelope + TextRun payload fixture: 통과
+의도적 TextRun assertion 실패 probe: stderr prefix와 exit 1 통과
 helper help와 unexpected argument: 통과
 shellcheck -e SC2129: 통과
 core build-info isolated fixture: 통과
@@ -152,6 +160,7 @@ production RhwpCoreBuildInfo verifier: 통과
 bundled rhwp-studio asset verifier: 통과
 전체 workflow Psych parse: 6개 통과
 committed ref PR classification: 기대 flag/reason 통과
+v0.8.4 sync classification: rhwp-core.lock direct render reason 확인
 git diff --check: 통과
 ```
 
@@ -185,6 +194,15 @@ PR #466 detached worktree, 두 architecture의 Cargo target, 209MB universal sta
 
 ## 잔여 위험과 후속 작업
 
+### 등록한 follow-up 이슈
+
+- [#469 Pin된 core render tree golden 자동 갱신 및 Swift decoder 계약 검증](https://github.com/postmelee/alhangeul-macos/issues/469)
+  - 수동 JSON snapshot이 future upstream producer drift를 자동 검출하지 못하는 구조적 갭을 다룬다.
+- [#470 Known RenderNodeType payload decode 실패 진단과 unknown variant 구분](https://github.com/postmelee/alhangeul-macos/issues/470)
+  - Known payload의 malformed decode와 unknown future variant를 구분하고 envelope/payload 오류의 coding path를 노출한다.
+
+Task #467은 두 후속 이슈의 runtime/golden 구조를 선행 구현하지 않고 빠른 수동 fixture와 CI classification만 보강했다.
+
 ### Task #467 PR
 
 - Open PR 생성 후 GitHub-hosted `Classify changed files`, `Script syntax checks`, `macOS validation`, `Release helper checks`를 확인한다.
@@ -211,7 +229,8 @@ Task #467은 signing/notarization, GitHub Release, Pages/Sparkle, Homebrew Cask 
 Task #467 PR에서 다음을 중점 확인해 달라.
 
 1. 사용하지 않는 retired `dirty` member를 optional로 남기지 않고 제거한 최소 보정
-2. Current/legacy JSON 모두 root/child까지 검증하는 fixture 계약
+2. Current/legacy JSON의 root/child와 TextRun/TextStyle payload case를 검증하는 fixture 계약
 3. Rust build 전 조기 fixture와 이후 native smoke의 2단계 검출 경계
-4. Fixture/helper-only 변경도 macOS/render gate를 활성화하는 path classification
-5. PR #466을 직접 수정하지 않고 Task #467 merge 뒤 최신 `devel`에서 갱신하는 handoff
+4. Fixture/helper와 core lock/artifact 변경이 macOS/render gate를 활성화하는 path classification
+5. Producer golden과 runtime decode 진단을 #469/#470 작업으로 분리한 경계
+6. PR #466을 직접 수정하지 않고 Task #467 merge 뒤 최신 `devel`에서 갱신하는 handoff

--- a/mydocs/working/task_m020_467_stage1.md
+++ b/mydocs/working/task_m020_467_stage1.md
@@ -1,0 +1,145 @@
+# Task M020 #467 Stage 1 완료보고서
+
+## 단계 목적
+
+PR #466 macOS validation 실패를 upstream/Swift schema와 실제 소비 경로에 다시 대조하고, retired `dirty` field 제거가 안전한지와 current/legacy fixture 및 PR CI 실행 경계를 확정한다.
+
+이번 단계는 제품 source, helper와 workflow를 변경하지 않고 조사와 계약 확정만 수행했다.
+
+## 산출물
+
+- `mydocs/working/task_m020_467_stage1.md`
+  - upstream schema 차이, Swift decode 실패 경로, fixture와 CI 계약을 기록했다.
+- `mydocs/orders/20260813.md`
+  - #467 상태를 Stage 1 완료 및 Stage 2 진행으로 갱신했다.
+
+## 조사 결과
+
+### 직접 원인과 오류 전파
+
+PR #466 head `0672f1b5f9e963ba9198cd3000ba9bce80ae3ae0`에서 v0.8.4 Rust bridge를 lock 기준으로 빌드한 뒤 native renderer smoke를 실행하면 기본 샘플 3종 모두 `render tree is nil`로 실패했다.
+
+동일 후보에서 `renderPageTree`의 `try?`를 임시 진단 코드로 풀어 실제 오류를 출력한 결과는 다음과 같다.
+
+```text
+DecodingError.keyNotFound: Key 'dirty' not found
+Path: children[0]
+```
+
+`RhwpDocument.renderPageTree(at:)`는 `JSONDecoder().decode(RenderNode.self, from:)`를 `try?`로 실행한다. 따라서 첫 child의 필수 key 누락이 throw되면 전체 tree가 `nil`로 축약되고 smoke에서는 원래 decode 오류 대신 `render tree is nil`이 보인다.
+
+Task #467에서는 이 오류 표시 계약이나 `try?`를 변경하지 않는다. 원인이 된 Swift schema만 upstream serialization과 맞춘다.
+
+### Upstream v0.8.2와 v0.8.4 차이
+
+로컬 Cargo git checkout에서 현재 `devel` 기준 v0.8.2 commit `9b16aa9e23f476e2b335d7c029fc9f24a199d63c`와 PR #466 v0.8.4 commit `496333b27d21ddb9114ba9ae340bcb895870c9a7`의 `src/renderer/render_tree.rs`를 직접 비교했다.
+
+v0.8.4 diff는 `RenderNode`의 다음 항목을 제거한다.
+
+- `pub dirty: bool`
+- constructor의 `dirty: true`
+- `invalidate`, `mark_clean`, `mark_clean_recursive`, `has_dirty_nodes`
+
+Serde JSON에서 `dirty`가 더 이상 생성되지 않는 것은 의도된 upstream schema 변경이다. PR #466의 `rhwp-core.lock`도 위 v0.8.4 commit을 정확히 가리킨다.
+
+### Swift 소비 지점
+
+제품 source, scripts와 workflow에서 `dirty`/`.dirty`를 검색한 결과 실제 항목은 아래 두 선언뿐이다.
+
+```text
+Sources/RhwpCoreBridge/RenderTree.swift:16: let dirty: Bool
+Sources/RhwpCoreBridge/RenderTree.swift:24: case dirty
+```
+
+Renderer, compositor, overlay 처리와 smoke helper 어느 곳도 이 속성을 읽지 않는다. 따라서 optional/default property로 보존할 제품 동작이 없고, upstream에서 제거된 모델 member를 Swift에서도 제거하는 것이 가장 작은 보정이다.
+
+### Legacy JSON 호환성
+
+Swift `JSONDecoder`의 합성 `Decodable`은 `CodingKeys`에 없는 추가 JSON key를 무시한다. Foundation-only probe에서 `id`만 선언한 모델로 `{"id":1,"dirty":true}`를 decode했고 다음 결과를 확인했다.
+
+```text
+unknown-key-compatible id=1
+```
+
+그러므로 Swift 모델에서 `dirty` member와 coding key를 제거하면 다음 두 계약을 동시에 만족한다.
+
+- v0.8.4 current JSON: key가 없어도 필수 decode 대상이 아니므로 성공
+- v0.8.2 legacy JSON: 남아 있는 `dirty`는 unknown extra key로 무시돼 성공
+
+이 기본 동작이 향후 custom decoder 변경으로 깨지지 않게 두 형식을 모두 tracked fixture로 고정한다.
+
+### Fixture exact contract
+
+Stage 2 fixture는 `RenderTree.swift`와 한 개의 Swift main만 Foundation으로 compile한다. Rust library, module map, sample 문서와 Xcode project는 필요하지 않다.
+
+두 case 모두 root와 child를 가진다.
+
+| case | root/child `dirty` | 확인 항목 |
+|------|--------------------|-----------|
+| current | 모두 없음 | root `MasterPage`, child `Header`, id/visible/children |
+| legacy | 모두 있음 | 같은 구조와 값, 추가 key 무시 |
+
+Root만 검사하면 PR #466에서 실제 실패한 `children[0]` 경로를 놓칠 수 있으므로 child node type과 id까지 assert한다. 성공 시 current/legacy 두 case 이름을 포함한 한 줄을 출력하고 decode/assertion 오류는 non-zero로 전파한다.
+
+Shell helper는 다음 계약으로 확정한다.
+
+- `scripts/ci/test-render-tree-decoder.sh`
+- no-argument 실행만 지원하고 `--help`/`-h`는 usage 후 성공
+- unexpected argument는 usage 후 실패
+- `mktemp -d`로 binary와 Swift module cache를 만들고 `trap`으로 정리
+- tracked source와 `build.noindex/`에 결과를 남기지 않음
+
+### PR CI와 path classification
+
+현재 `RenderTree.swift` 변경은 `Sources/*` 및 `Sources/RhwpCoreBridge/*` 규칙으로 macOS build와 render smoke를 이미 활성화한다. 반면 신규 `scripts/ci/*`만 변경하면 일반 CI/release automation 규칙으로 release checks만 활성화되고 macOS fixture 실행이 보장되지 않는다.
+
+Stage 2에서 다음 경계를 적용한다.
+
+1. `.github/workflows/pr-ci.yml`의 macOS validation checkout 직후, dependency 설치와 Rust bridge build 전에 decoder fixture를 실행한다.
+2. `scripts/ci/test-render-tree-decoder.sh`와 `scripts/ci/render_tree_decoder_fixture.swift` exact path에서 macOS build와 render smoke를 활성화한다.
+3. 일반 `scripts/ci/*` release check 분류도 그대로 적용해 CI helper 변경의 기존 검증 범위를 축소하지 않는다.
+
+Fixture만 바뀌는 후속 PR도 macOS fixture와 실제 native smoke를 함께 실행하며, 제품 source 변경 PR은 기존대로 같은 두 gate를 실행한다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+이번 단계는 신규 조사 보고서와 오늘할일 비고만 변경했다. `Sources/`, `scripts/`, `.github/workflows/`의 tracked 본문은 변경하지 않았다.
+
+## 검증 결과
+
+```text
+rg -n "\bdirty\b|\.dirty\b" Sources scripts .github
+결과: RenderTree.swift의 property와 CodingKey 두 곳만 확인
+
+upstream git diff v0.8.2..v0.8.4 -- src/renderer/render_tree.rs
+결과: dirty field, 초기값과 관련 observer helper 제거 확인
+
+Swift Foundation unknown-key probe
+결과: unknown-key-compatible id=1
+
+./scripts/check-no-appkit.sh
+결과: OK: shared Swift code has no AppKit/UIKit dependencies
+
+scripts/ci/classify-pr-changes.sh origin/devel HEAD
+결과: 문서-only 현재 diff에서 모든 실행 flag false, 기존 분류 기준 확인
+
+git diff --check
+결과: 통과
+```
+
+## 잔여 위험
+
+- Fixture compile은 serialization producer 자체를 실행하지 않는다. Stage 3에서 실제 v0.8.4 bridge와 sample 3종 smoke로 producer/consumer 통합을 확인한다.
+- `JSONDecoder` unknown-key 허용은 기본 동작이지만 custom `init(from:)`가 추가되면 달라질 수 있다. Legacy fixture를 CI에 고정해 회귀를 차단한다.
+- 신규 helper가 exact classification에 빠지면 helper-only 변경에서 macOS gate가 skip될 수 있다. Stage 2에서 isolated path classification을 별도로 검증한다.
+- PR CI에 조기 step을 추가해도 GitHub-hosted 실행 전에는 runner 환경을 완전히 보장할 수 없다. PR 생성 후 필수 check 결과를 확인한다.
+
+## 다음 단계 영향
+
+Stage 2는 확정한 최소 표면만 변경한다.
+
+1. Swift `RenderNode`에서 `dirty` property와 coding key를 제거한다.
+2. Current/legacy 중첩 JSON Swift fixture와 격리 shell helper를 추가한다.
+3. PR CI macOS validation의 Rust build 전 조기 fixture step을 추가한다.
+4. 신규 helper/fixture exact path를 macOS build와 render smoke trigger로 추가한다.
+5. 독립 fixture, shared boundary, workflow parse와 classification을 검증한다.

--- a/mydocs/working/task_m020_467_stage2.md
+++ b/mydocs/working/task_m020_467_stage2.md
@@ -1,0 +1,144 @@
+# Task M020 #467 Stage 2 완료보고서
+
+## 단계 목적
+
+Swift `RenderNode`에서 upstream v0.8.4에 더 이상 존재하지 않는 `dirty` 필수 decode 계약을 제거하고, current/legacy 중첩 JSON 양방향 호환을 독립 fixture로 고정한다. Fixture를 PR CI에서 Rust build 전에 실행하고 helper-only 변경도 macOS·render gate를 건너뛰지 않도록 분류한다.
+
+## 산출물
+
+- `Sources/RhwpCoreBridge/RenderTree.swift`
+  - 사용하지 않는 `dirty` property와 coding key를 제거했다.
+  - retired field를 모델에 남기지 않고 legacy unknown key를 허용한다는 의도를 주석으로 기록했다.
+- `scripts/ci/render_tree_decoder_fixture.swift`
+  - `dirty` 없는 current JSON과 `dirty` 포함 legacy JSON의 root/child decode를 검증한다.
+- `scripts/ci/test-render-tree-decoder.sh`
+  - `RenderTree.swift`와 fixture를 임시 directory에서 compile/run하고 결과를 정리한다.
+- `scripts/ci/classify-pr-changes.sh`
+  - 신규 Swift fixture와 shell helper를 macOS build/render smoke trigger에 명시했다.
+- `.github/workflows/pr-ci.yml`
+  - helper interface 확인과 macOS validation 조기 fixture step을 추가했다.
+- `mydocs/working/task_m020_467_stage2.md`
+  - 구현과 독립 검증 결과를 기록했다.
+- `mydocs/orders/20260813.md`
+  - #467 상태를 Stage 2 완료 및 Stage 3 진행으로 갱신했다.
+
+## 구현 결과
+
+### Swift decoder 계약
+
+`RenderNode`에서 아래 두 선언만 제거했다.
+
+```swift
+let dirty: Bool
+case dirty
+```
+
+다른 node field, enum variant, custom decoder와 renderer 코드는 변경하지 않았다. 합성 `Decodable`은 v0.8.4 JSON에서 더 이상 `dirty`를 요구하지 않고, v0.8.2 JSON에 남아 있는 `dirty`는 unknown extra key로 무시한다.
+
+모델 위에는 다음 의도를 남겼다.
+
+- upstream에서 제거된 field를 제품 모델에 호환용 상태로 남기지 않는다.
+- 구버전 core JSON의 알 수 없는 추가 key는 계속 수용한다.
+
+### Current/legacy fixture
+
+두 JSON은 모두 `MasterPage` root 아래 `Header` child를 가진다. 실제 PR #466 오류 path인 `children[0]`을 포함해 root/child 양쪽 schema를 검사한다.
+
+| case | `dirty` | assertion |
+|------|---------|-----------|
+| `current-without-dirty` | root/child 모두 없음 | root id/type/visible, child count, child id/type/visible/empty children |
+| `legacy-with-dirty` | root/child 모두 있음 | current와 같은 구조, 추가 key가 decode를 방해하지 않음 |
+
+Fixture failure는 thrown error로 non-zero 종료하며 성공 output은 다음 한 줄로 고정했다.
+
+```text
+OK: render tree decoder accepts current JSON without dirty and legacy JSON with dirty
+```
+
+### 격리 helper
+
+Shell helper는 argument 없이 실행한다. `--help`/`-h`는 compile 없이 usage를 출력하고, 그 밖의 인자는 exit 2로 거부한다.
+
+실행 시 `mktemp -d`로 binary와 Swift module cache를 만들고 `trap`에서 exact temp root만 제거한다. Repository의 tracked source, `build.noindex/`와 일반 Swift/Clang cache에 산출물을 남기지 않는다.
+
+### PR CI 조기 gate
+
+macOS validation에서 checkout 직후 decoder helper를 실행하도록 배치했다. XcodeGen/cbindgen 설치와 Rust universal artifact build보다 앞서므로 schema-only 회귀는 빠르고 직접적인 fixture 오류로 종료된다.
+
+Ubuntu `Script syntax checks`는 기존 `scripts/ci/*.sh` 반복으로 shell syntax를 검사하고 helper interface 단계에서 `--help`를 확인한다. 실제 Swift compile/run은 Xcode toolchain이 보장된 macOS validation이 담당한다.
+
+### Path classification
+
+다음 exact path를 기존 renderer/extension pattern에 추가했다.
+
+- `scripts/ci/render_tree_decoder_fixture.swift`
+- `scripts/ci/test-render-tree-decoder.sh`
+
+전체 Stage 2 diff를 담은 working tree 무변경 임시 commit object로 classifier를 실행한 결과는 다음과 같다.
+
+| Flag | 결과 |
+|------|------|
+| `docs_only` | `false` |
+| `run_macos_build` | `true` |
+| `run_rust_verify` | `false` |
+| `run_render_smoke` | `true` |
+| `run_release_checks` | `true` |
+
+MacOS/render reasons에 source뿐 아니라 신규 Swift fixture와 shell helper가 각각 출력됐다. 따라서 fixture/helper-only 변경도 두 gate를 활성화한다. Core pin/artifact가 바뀌지 않았으므로 `run_rust_verify=false`는 의도한 결과다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- `RenderTree.swift`: `dirty` 선언 2줄 제거와 호환 의도 주석 2줄 추가
+- `classify-pr-changes.sh`: 기존 renderer pattern에 exact path 2개만 추가
+- `pr-ci.yml`: helper `--help` 1줄과 macOS 조기 실행 step 추가
+- 신규 fixture/helper: 총 128줄
+
+Stage 2 source diff는 5 files, `+138 / -3`이다. `project.yml`, Xcode project, Rust FFI, core pin, artifact와 bundled studio asset은 변경하지 않았다.
+
+## 검증 결과
+
+```text
+bash -n scripts/ci/test-render-tree-decoder.sh scripts/ci/classify-pr-changes.sh
+결과: 통과
+
+bash scripts/ci/test-render-tree-decoder.sh --help
+결과: usage 출력 후 성공
+
+scripts/ci/test-render-tree-decoder.sh unexpected
+결과: 예상대로 실패
+
+scripts/ci/test-render-tree-decoder.sh
+결과: current-without-dirty, legacy-with-dirty 모두 통과
+
+./scripts/check-no-appkit.sh
+결과: OK: shared Swift code has no AppKit/UIKit dependencies
+
+ruby Psych.parse_file 전체 workflow
+결과: 6개 workflow 모두 parse 통과
+
+shellcheck -e SC2129 신규 helper와 classifier
+결과: 통과
+
+scripts/ci/classify-pr-changes.sh origin/devel <stage2-probe-commit>
+결과: macOS=true, render=true, release=true, Rust verify=false
+
+git diff --cached --check
+결과: 통과
+```
+
+## 잔여 위험
+
+- Fixture는 실제 Rust serialization을 호출하지 않는다. Stage 3에서 PR #466 v0.8.4 candidate와 sample 3종으로 통합 확인한다.
+- PR CI workflow step은 local YAML parse만 완료했다. GitHub-hosted runner 실행 결과는 PR 생성 뒤 확인해야 한다.
+- `RenderTree.swift`의 다른 field도 future upstream에서 바뀔 수 있다. 이번 작업은 실제로 검출된 `dirty` 하나만 다루며 선제 optional 처리는 하지 않는다.
+- `run_rust_verify=false`이므로 Task #467 PR은 current v0.8.2 bridge를 재빌드한다. v0.8.4 lock 통합 검증은 Stage 3 격리 worktree에서 별도로 수행한다.
+
+## 다음 단계 영향
+
+Stage 3에서는 source를 확장하지 않고 다음을 검증한다.
+
+1. 전체 shell syntax, helper fixture, workflow YAML과 shared boundary를 다시 실행한다.
+2. Production build-info/studio provenance verifier를 확인한다.
+3. PR #466 v0.8.4 candidate에 Task #467 source 보정을 격리 적용한다.
+4. v0.8.4 Rust bridge lock verification과 native renderer sample 3종 smoke를 실행한다.
+5. Temporary worktree/output을 정리하고 PR #466 갱신 handoff를 기록한다.

--- a/mydocs/working/task_m020_467_stage3.md
+++ b/mydocs/working/task_m020_467_stage3.md
@@ -1,0 +1,168 @@
+# Task M020 #467 Stage 3 완료보고서
+
+## 단계 목적
+
+Task #467 전체 변경의 local/static 회귀를 검증하고, PR #466 v0.8.4 candidate에 Stage 2 decoder 보정을 격리 적용해 실제 Rust producer와 Swift consumer가 native renderer sample 3종에서 다시 연결되는지 확인한다. 검증 뒤 임시 worktree와 build/smoke 산출물을 모두 정리하고 upstream sync 후속 조건을 확정한다.
+
+## 산출물
+
+- `mydocs/working/task_m020_467_stage3.md`
+  - 전체 회귀, v0.8.4 bridge provenance와 native smoke 결과, 임시 산출물 정리와 handoff를 기록했다.
+- `mydocs/orders/20260813.md`
+  - #467 상태를 Stage 1~3와 v0.8.4 통합 smoke 완료로 갱신했다.
+
+Stage 3에서는 제품 source, helper와 workflow를 추가 변경하지 않았다.
+
+## Current branch 전체 검증
+
+`local/task467` HEAD에서 다음 범위를 실행했다.
+
+1. `scripts/*.sh`, `scripts/ci/*.sh` 전체 shell syntax
+2. Current/legacy render tree decoder fixture
+3. Core build-info writer/verifier isolated fixture
+4. Bundled rhwp-studio Cargo.lock provenance isolated fixture
+5. Shared Swift AppKit/UIKit boundary
+6. Production core build-info와 bundled studio asset verifier
+7. 전체 GitHub Actions workflow YAML parse
+8. `origin/devel..HEAD` PR change classification
+9. `git diff --check`와 clean working tree
+
+모든 명령이 성공했다.
+
+Classification 결과:
+
+| Flag | 결과 | 근거 |
+|------|------|------|
+| `docs_only` | `false` | source, helper, workflow 변경 |
+| `run_macos_build` | `true` | `RenderTree.swift`, decoder fixture/helper |
+| `run_rust_verify` | `false` | core pin/artifact/ABI 변경 없음 |
+| `run_render_smoke` | `true` | source와 fixture/helper exact renderer path |
+| `run_release_checks` | `true` | PR CI와 `scripts/ci/*` 변경 |
+
+MacOS와 render reasons에 `RenderTree.swift`, `render_tree_decoder_fixture.swift`, `test-render-tree-decoder.sh`가 각각 나타났다. 따라서 Stage 2에서 의도한 helper-only 분류 경계도 실제 committed ref 기준으로 확인됐다.
+
+## v0.8.4 격리 검증 구성
+
+원격 branch나 PR #466을 수정하지 않고 다음 방식으로 검증했다.
+
+1. PR #466 head `0672f1b5f9e963ba9198cd3000ba9bce80ae3ae0`을 `build.noindex/task467-v084-worktree` detached worktree로 생성했다.
+2. Task #467 Stage 2 commit `1b49a87`을 임시 cherry-pick했다.
+3. 오늘할일 문서 한 곳만 충돌해 candidate 쪽 내용을 유지했다. 제품 source, fixture와 workflow는 자동 적용됐다.
+4. Decoder fixture를 먼저 실행했다.
+5. v0.8.4 bridge를 universal arm64/x86_64로 빌드하고 lock을 검증했다.
+6. 기본 sample 3종 native renderer smoke를 실행했다.
+7. Worktree가 clean임을 확인한 뒤 worktree 전체와 내부 build/smoke output을 제거했다.
+
+Task #467 branch의 `rhwp-core.lock`, `Frameworks/`, bundled asset과 Git refs는 변경하지 않았다.
+
+## v0.8.4 bridge 검증
+
+사용한 candidate identity:
+
+| 항목 | 값 |
+|------|----|
+| release tag | `v0.8.4` |
+| resolved commit | `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
+| enabled features | `native-skia` |
+| PR head | `0672f1b5f9e963ba9198cd3000ba9bce80ae3ae0` |
+
+명령:
+
+```bash
+ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 ./scripts/build-rust-macos.sh --verify-lock
+```
+
+첫 sandbox 실행은 rust-skia prebuilt artifact 다운로드 시 DNS 차단으로 실패했다. 코드/lock 오류가 아니므로 네트워크가 허용된 동일 명령으로 재실행했다.
+
+재실행 결과:
+
+- arm64와 x86_64 release static library build 성공
+- universal binary architecture `x86_64 arm64` 확인
+- cbindgen header check 성공
+- FFI symbol 15개 검증 성공
+- `Rhwp.xcframework` 생성 성공
+- source provenance, Cargo.lock, generated header와 FFI symbols 검증 성공
+- PR CI 정책과 동일하게 `Frameworks/universal/librhwp.a` byte hash/size 비교만 skip
+
+최종 output은 `Verified: .../rhwp-core.lock`으로 종료했다.
+
+## v0.8.4 native renderer smoke
+
+명령:
+
+```bash
+./scripts/validate-stage3-render.sh build.noindex/task467-v084-smoke
+```
+
+결과:
+
+| 샘플 | 크기 | text runs | Hangul runs | Hangul scalars | non-white pixels | 판정 |
+|------|------|-----------|-------------|----------------|------------------|------|
+| `KTX.hwp` | 1123×794 | 410 | 76 | 209 | 455,342 | 통과 |
+| `request.hwp` | 567×794 | 102 | 36 | 309 | 70,619 | 통과 |
+| `exam_kor.hwp` | 1123×1588 | 133 | 86 | 1,368 | 173,827 | 통과 |
+
+세 문서 모두 다음 조건을 통과했다.
+
+- 문서 open과 첫 page size 조회
+- render tree non-nil
+- text run과 Hangul run/scalar 존재
+- native PNG 생성
+- non-blank bitmap
+
+KTX와 exam_kor 실행 중 기존 layout overlap diagnostic이 출력됐지만 smoke failure 조건이 아니며, 세 결과 모두 `OK`로 종료했다. Task #467의 범위는 decode 호환이므로 기존 layout diagnostic은 변경하지 않는다.
+
+## 임시 산출물 정리
+
+검증 뒤 다음을 제거했다.
+
+- `build.noindex/task467-v084-worktree` detached worktree
+- Worktree 내부 arm64/x86_64 Cargo target
+- 209MB universal static library와 209MB XCFramework
+- Sample 3종 smoke PNG와 module cache
+- `build.noindex/task467-stage1-module-cache`
+
+정리 후 `git worktree list`에는 주 작업 경로 `local/task467` 하나만 남았고, `git status --short --branch`는 `## local/task467`로 clean이다. 삭제한 항목은 모두 재생성 가능한 임시 build/검증 산출물이다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+Stage 3의 tracked 변경은 신규 완료보고서와 오늘할일 비고뿐이다. Stage 2 source/helper/workflow는 검증만 수행했고 추가 수정하지 않았다.
+
+## 검증 결과 요약
+
+```text
+전체 shell syntax: 통과
+render tree decoder fixture: 통과
+core build-info fixture: 통과
+studio Cargo.lock fixture: 통과
+shared Swift boundary: 통과
+production build-info verifier: 통과
+bundled studio asset verifier: 통과
+전체 workflow Psych parse: 6개 통과
+PR classification: macOS=true, render=true, release=true, Rust=false
+v0.8.4 bridge build/provenance: 통과
+v0.8.4 native renderer sample 3종: 통과
+git diff --check: 통과
+임시 worktree/cache 정리: 완료
+main working tree: clean
+```
+
+## 잔여 위험
+
+- Local v0.8.4 통합 검증은 성공했지만 Task #467 PR의 GitHub-hosted macOS/release checks는 PR 생성 후 확인해야 한다.
+- PR #466 자체의 기존 실패 check는 Task #467 merge만으로 자동 갱신되지 않는다. 최신 `devel`을 반영하거나 workflow를 다시 실행해 새 candidate check를 만들어야 한다.
+- Fixture는 현재 검출된 `dirty` retired field만 고정한다. Future upstream schema 변화는 같은 방식으로 명시적으로 조사·보정해야 한다.
+- KTX/exam_kor의 layout overlap diagnostic은 기존 renderer 상태이며 Task #467 acceptance를 막지 않는다.
+
+## Upstream sync handoff
+
+Task #467은 PR #466이나 automation branch를 변경하지 않았다. 권장 후속 순서는 다음과 같다.
+
+1. Task #467 PR의 GitHub-hosted CI 확인
+2. Task #467 PR merge
+3. `pr-merge-cleanup`으로 Issue #467과 local/publish branch 정리
+4. 최신 `devel` 기준 upstream sync workflow 재실행 또는 정책에 따른 PR #466 갱신/재생성
+5. 새 candidate에서 decoder fixture, v0.8.4 native smoke와 build-info/Cargo.lock provenance gate 확인
+6. Upstream sync PR merge 뒤 별도 승인으로 release 작업 진행
+
+PR #466 merge와 공개 release는 계속 Task #467 범위 밖이다.

--- a/scripts/ci/classify-pr-changes.sh
+++ b/scripts/ci/classify-pr-changes.sh
@@ -172,7 +172,7 @@ classify_path() {
   esac
 
   case "$path" in
-    Sources/RhwpCoreBridge/*|Sources/Shared/*|Sources/QLExtension/*|Sources/ThumbnailExtension/*|samples/*|scripts/stage3_render_check.swift|scripts/validate-stage3-render.sh|scripts/render-debug-compare.sh|scripts/render_debug_compare.swift)
+    Sources/RhwpCoreBridge/*|Sources/Shared/*|Sources/QLExtension/*|Sources/ThumbnailExtension/*|samples/*|scripts/ci/render_tree_decoder_fixture.swift|scripts/ci/test-render-tree-decoder.sh|scripts/stage3_render_check.swift|scripts/validate-stage3-render.sh|scripts/render-debug-compare.sh|scripts/render_debug_compare.swift)
       enable_macos_build "$path affects renderer or extension paths"
       enable_render_smoke "$path affects renderer smoke coverage"
       matched=1

--- a/scripts/ci/classify-pr-changes.sh
+++ b/scripts/ci/classify-pr-changes.sh
@@ -172,7 +172,7 @@ classify_path() {
   esac
 
   case "$path" in
-    Sources/RhwpCoreBridge/*|Sources/Shared/*|Sources/QLExtension/*|Sources/ThumbnailExtension/*|samples/*|scripts/ci/render_tree_decoder_fixture.swift|scripts/ci/test-render-tree-decoder.sh|scripts/stage3_render_check.swift|scripts/validate-stage3-render.sh|scripts/render-debug-compare.sh|scripts/render_debug_compare.swift)
+    Sources/RhwpCoreBridge/*|Sources/Shared/*|Sources/QLExtension/*|Sources/ThumbnailExtension/*|Frameworks/*|rhwp-core.lock|samples/*|scripts/ci/render_tree_decoder_fixture.swift|scripts/ci/test-render-tree-decoder.sh|scripts/stage3_render_check.swift|scripts/validate-stage3-render.sh|scripts/render-debug-compare.sh|scripts/render_debug_compare.swift)
       enable_macos_build "$path affects renderer or extension paths"
       enable_render_smoke "$path affects renderer smoke coverage"
       matched=1

--- a/scripts/ci/render_tree_decoder_fixture.swift
+++ b/scripts/ci/render_tree_decoder_fixture.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 private enum RenderTreeDecoderFixtureError: Error, CustomStringConvertible {
@@ -49,6 +50,61 @@ private let legacyJSON = #"""
 }
 """#
 
+private let textRunPayloadJSON = #"""
+{
+  "id": 3,
+  "node_type": {
+    "TextRun": {
+      "text": "한글 fixture",
+      "style": {
+        "font_family": "FixtureSans",
+        "font_size": 12,
+        "color": 4278190080,
+        "bold": false,
+        "italic": false,
+        "underline": "None",
+        "strikethrough": false,
+        "letter_spacing": 0,
+        "ratio": 1,
+        "default_tab_width": 40,
+        "tab_stops": [],
+        "auto_tab_right": false,
+        "available_width": 240,
+        "line_x_offset": 0,
+        "tab_leaders": [],
+        "inline_tabs": [],
+        "extra_word_spacing": 0,
+        "extra_char_spacing": 0,
+        "outline_type": 0,
+        "shadow_type": 0,
+        "shadow_color": 0,
+        "shadow_offset_x": 0,
+        "shadow_offset_y": 0,
+        "emboss": false,
+        "engrave": false,
+        "superscript": false,
+        "subscript": false,
+        "emphasis_dot": 0,
+        "underline_shape": 0,
+        "strike_shape": 0,
+        "underline_color": 0,
+        "strike_color": 0,
+        "shade_color": 0
+      },
+      "is_para_end": false,
+      "is_line_break_end": false,
+      "is_vertical": false,
+      "border_fill_id": 0,
+      "baseline": 9,
+      "field_marker": "None"
+    }
+  },
+  "bbox": { "x": 12, "y": 24, "width": 96, "height": 18 },
+  "children": [],
+  "visible": true
+}
+"""#
+
 private func require(_ condition: @autoclosure () -> Bool, _ message: String) throws {
     guard condition() else {
         throw RenderTreeDecoderFixtureError.assertion(message)
@@ -75,11 +131,43 @@ private func verifyFixture(named name: String, json: String) throws {
     }
 }
 
+private func verifyTextRunPayloadFixture() throws {
+    let data = Data(textRunPayloadJSON.utf8)
+    let root = try JSONDecoder().decode(RenderNode.self, from: data)
+
+    try require(root.id == 3, "text-run-payload: unexpected root id")
+    try require(root.visible, "text-run-payload: root must be visible")
+    try require(root.children.isEmpty, "text-run-payload: root must not have children")
+    guard case .textRun(let textRun) = root.nodeType else {
+        throw RenderTreeDecoderFixtureError.assertion(
+            "text-run-payload: expected TextRun instead of unknown node type"
+        )
+    }
+    try require(textRun.text == "한글 fixture", "text-run-payload: unexpected text")
+    try require(textRun.style.fontFamily == "FixtureSans", "text-run-payload: unexpected font")
+    try require(textRun.style.tabStops.isEmpty, "text-run-payload: unexpected tab stops")
+    try require(textRun.borderFillId == 0, "text-run-payload: unexpected border fill")
+    guard case .none = textRun.fieldMarker else {
+        throw RenderTreeDecoderFixtureError.assertion(
+            "text-run-payload: unexpected field marker"
+        )
+    }
+}
+
 @main
 private struct RenderTreeDecoderFixture {
-    static func main() throws {
-        try verifyFixture(named: "current-without-dirty", json: currentJSON)
-        try verifyFixture(named: "legacy-with-dirty", json: legacyJSON)
-        print("OK: render tree decoder accepts current JSON without dirty and legacy JSON with dirty")
+    static func main() {
+        do {
+            try verifyFixture(named: "current-without-dirty", json: currentJSON)
+            try verifyFixture(named: "legacy-with-dirty", json: legacyJSON)
+            try verifyTextRunPayloadFixture()
+            print(
+                "OK: render tree decoder accepts current/legacy envelopes and TextRun payload"
+            )
+        } catch {
+            let message = "ERROR: render tree decoder fixture failed: \(error)\n"
+            FileHandle.standardError.write(Data(message.utf8))
+            exit(EXIT_FAILURE)
+        }
     }
 }

--- a/scripts/ci/render_tree_decoder_fixture.swift
+++ b/scripts/ci/render_tree_decoder_fixture.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+private enum RenderTreeDecoderFixtureError: Error, CustomStringConvertible {
+    case assertion(String)
+
+    var description: String {
+        switch self {
+        case .assertion(let message):
+            return message
+        }
+    }
+}
+
+private let currentJSON = #"""
+{
+  "id": 1,
+  "node_type": "MasterPage",
+  "bbox": { "x": 0, "y": 0, "width": 595, "height": 842 },
+  "children": [
+    {
+      "id": 2,
+      "node_type": "Header",
+      "bbox": { "x": 10, "y": 20, "width": 575, "height": 30 },
+      "children": [],
+      "visible": true
+    }
+  ],
+  "visible": true
+}
+"""#
+
+private let legacyJSON = #"""
+{
+  "id": 1,
+  "node_type": "MasterPage",
+  "bbox": { "x": 0, "y": 0, "width": 595, "height": 842 },
+  "children": [
+    {
+      "id": 2,
+      "node_type": "Header",
+      "bbox": { "x": 10, "y": 20, "width": 575, "height": 30 },
+      "children": [],
+      "dirty": false,
+      "visible": true
+    }
+  ],
+  "dirty": true,
+  "visible": true
+}
+"""#
+
+private func require(_ condition: @autoclosure () -> Bool, _ message: String) throws {
+    guard condition() else {
+        throw RenderTreeDecoderFixtureError.assertion(message)
+    }
+}
+
+private func verifyFixture(named name: String, json: String) throws {
+    let data = Data(json.utf8)
+    let root = try JSONDecoder().decode(RenderNode.self, from: data)
+
+    try require(root.id == 1, "\(name): unexpected root id")
+    try require(root.visible, "\(name): root must be visible")
+    try require(root.children.count == 1, "\(name): expected one child")
+    guard case .masterPage = root.nodeType else {
+        throw RenderTreeDecoderFixtureError.assertion("\(name): unexpected root node type")
+    }
+
+    let child = root.children[0]
+    try require(child.id == 2, "\(name): unexpected child id")
+    try require(child.visible, "\(name): child must be visible")
+    try require(child.children.isEmpty, "\(name): child must not have descendants")
+    guard case .header = child.nodeType else {
+        throw RenderTreeDecoderFixtureError.assertion("\(name): unexpected child node type")
+    }
+}
+
+@main
+private struct RenderTreeDecoderFixture {
+    static func main() throws {
+        try verifyFixture(named: "current-without-dirty", json: currentJSON)
+        try verifyFixture(named: "legacy-with-dirty", json: legacyJSON)
+        print("OK: render tree decoder accepts current JSON without dirty and legacy JSON with dirty")
+    }
+}

--- a/scripts/ci/test-render-tree-decoder.sh
+++ b/scripts/ci/test-render-tree-decoder.sh
@@ -9,7 +9,8 @@ usage() {
 Usage: $0
 
 Compiles RenderTree.swift with an isolated fixture and verifies both current
-JSON without the retired dirty field and legacy JSON that still contains it.
+JSON without the retired dirty field, legacy JSON that still contains it,
+and a complete TextRun/TextStyle payload.
 EOF
 }
 

--- a/scripts/ci/test-render-tree-decoder.sh
+++ b/scripts/ci/test-render-tree-decoder.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+usage() {
+  cat >&2 <<EOF
+Usage: $0
+
+Compiles RenderTree.swift with an isolated fixture and verifies both current
+JSON without the retired dirty field and legacy JSON that still contains it.
+EOF
+}
+
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  usage
+  exit 0
+fi
+
+if [ "$#" -ne 0 ]; then
+  usage
+  exit 2
+fi
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/alhangeul-render-tree-decoder.XXXXXX")"
+
+cleanup() {
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+MODULE_CACHE="$TMP_ROOT/swift-module-cache"
+BIN="$TMP_ROOT/render-tree-decoder-fixture"
+mkdir -p "$MODULE_CACHE"
+
+swiftc -parse-as-library \
+  -module-cache-path "$MODULE_CACHE" \
+  "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \
+  "$ROOT/scripts/ci/render_tree_decoder_fixture.swift" \
+  -o "$BIN"
+
+"$BIN"


### PR DESCRIPTION
## 요약

- rhwp v0.8.4에서 제거된 `RenderNode.dirty`를 Swift decoder가 필수 key로 요구해 native render tree가 `nil`이 되던 호환성 회귀를 보정합니다.
- 사용하지 않는 Swift property/CodingKey를 제거해 v0.8.4 JSON을 수용하고, JSONDecoder의 unknown-key 허용으로 `dirty`가 남은 기존 JSON도 계속 수용합니다.
- Current/legacy envelope와 전체 `TextRunNode`/`TextStyle` payload fixture를 macOS PR CI에서 Rust build 전에 실행합니다.
- Fixture/helper와 core lock/artifact 변경이 native render smoke를 직접 활성화하도록 path classification을 보강합니다.

PR #466 후보에서 재현된 직접 오류는 첫 자식 노드의 `DecodingError.keyNotFound(dirty)`였습니다. 같은 v0.8.4 candidate에 이 보정을 격리 적용한 뒤 기본 sample 3종 native smoke가 모두 통과했습니다.

## 변경 내역

### Decoder 호환 보정

- `Sources/RhwpCoreBridge/RenderTree.swift`
  - `RenderNode.dirty` property 제거
  - `dirty` CodingKey 제거
  - Retired upstream field를 남기지 않고 legacy unknown key를 허용한다는 의도 주석 추가

다른 render node field, enum variant, custom decoder, renderer, Rust FFI ABI와 `RhwpDocument.renderPageTree` 오류 계약은 변경하지 않습니다.

### 회귀 fixture

- `current-without-dirty`: `dirty`가 없는 root/child envelope
- `legacy-with-dirty`: `dirty`가 남은 root/child envelope
- `text-run-payload`: 모든 non-optional `TextStyle` field를 포함한 `TextRunNode`와 `.textRun` assertion
- Fixture decode/assertion 실패: `ERROR: render tree decoder fixture failed:` stderr와 exit 1
- Shell helper: Foundation-only 격리 compile/run, `--help`, unexpected argument와 temp cleanup contract

### PR CI와 분류

- macOS validation checkout 직후 decoder fixture를 실행해 Rust universal build 전에 schema 회귀를 직접 진단합니다.
- Fixture/helper exact path를 macOS build와 render smoke trigger에 추가합니다.
- `rhwp-core.lock`과 `Frameworks/*`도 direct renderer trigger로 분류해 generated BuildInfo 변경의 부수 효과에 의존하지 않습니다.
- Task 전체 classification은 `macOS=true`, `render=true`, `release=true`, `Rust verify=false`입니다. Core pin/artifact/ABI가 이 PR에서 바뀌지 않았으므로 Rust verify false는 의도한 결과입니다.

## PR 리뷰 반영

[리뷰 코멘트](https://github.com/postmelee/alhangeul-macos/pull/468#issuecomment-5276420011)의 권고를 다음과 같이 반영했습니다.

- TextRun/TextStyle payload가 `.unknown`으로 조용히 전환되지 않는 fixture 추가
- Uncaught error/SIGTRAP 대신 명시적 stderr와 exit 1
- `rhwp-core.lock|Frameworks/*`의 direct render-smoke 분류

구조 개선은 별도 follow-up으로 등록했습니다.

- [#469 Pin된 core render tree golden 자동 갱신 및 Swift decoder 계약 검증](https://github.com/postmelee/alhangeul-macos/issues/469)
- [#470 Known RenderNodeType payload decode 실패 진단과 unknown variant 구분](https://github.com/postmelee/alhangeul-macos/issues/470)

## 단계별 결과

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/5d4a8bf349e66293ea9f8723a496ea6b17646fec/mydocs/working/task_m020_467_stage1.md)** ([f60d79f](https://github.com/postmelee/alhangeul-macos/commit/f60d79f)): upstream v0.8.2→v0.8.4 schema 차이, Swift 무소비 근거와 fixture/CI 경계 확정
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/5d4a8bf349e66293ea9f8723a496ea6b17646fec/mydocs/working/task_m020_467_stage2.md)** ([1b49a87](https://github.com/postmelee/alhangeul-macos/commit/1b49a87)): `dirty` 제거, current/legacy fixture/helper와 PR CI/classification 구현
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/5d4a8bf349e66293ea9f8723a496ea6b17646fec/mydocs/working/task_m020_467_stage3.md)** ([56497f7](https://github.com/postmelee/alhangeul-macos/commit/56497f7)): 전체 회귀, v0.8.4 bridge provenance와 sample 3종 native smoke 완료
- **PR 리뷰 반영** ([5d4a8bf](https://github.com/postmelee/alhangeul-macos/commit/5d4a8bf)): TextRun payload, exit 1, core direct render 분류와 follow-up 이슈 등록

## 작업 문서

- 수행 계획서: [task_m020_467.md](https://github.com/postmelee/alhangeul-macos/blob/5d4a8bf349e66293ea9f8723a496ea6b17646fec/mydocs/plans/task_m020_467.md)
- 구현 계획서: [task_m020_467_impl.md](https://github.com/postmelee/alhangeul-macos/blob/5d4a8bf349e66293ea9f8723a496ea6b17646fec/mydocs/plans/task_m020_467_impl.md)
- 최종 보고서: [task_m020_467_report.md](https://github.com/postmelee/alhangeul-macos/blob/5d4a8bf349e66293ea9f8723a496ea6b17646fec/mydocs/report/task_m020_467_report.md)

## 검증

### Current branch

- 전체 `scripts/*.sh`, `scripts/ci/*.sh` shell syntax
- Current/legacy envelope와 TextRun/TextStyle payload fixture
- 의도적 TextRun assertion 실패 probe의 stderr prefix와 exit 1
- Helper interface와 관련 `shellcheck -e SC2129`
- Core build-info와 studio Cargo.lock isolated fixture
- Shared Swift AppKit/UIKit boundary
- Production core build-info와 bundled studio asset verifier
- 전체 GitHub Actions workflow Psych parse 6개
- v0.8.4 sync classification의 `rhwp-core.lock` direct render reason
- `git diff --check`

모두 통과했습니다.

### v0.8.4 candidate

- Release tag: `v0.8.4`
- Resolved commit: `496333b27d21ddb9114ba9ae340bcb895870c9a7`
- Feature: `native-skia`
- PR #466 head: `0672f1b5f9e963ba9198cd3000ba9bce80ae3ae0`
- Universal architectures: `x86_64 arm64`
- Source provenance, Cargo.lock, generated header와 FFI symbols: 통과

PR CI와 동일하게 `Frameworks/universal/librhwp.a` byte hash/size 비교만 skip했습니다.

| 샘플 | text runs | Hangul runs | Hangul scalars | non-white pixels | 결과 |
|------|-----------|-------------|----------------|------------------|------|
| `KTX.hwp` | 410 | 76 | 209 | 455,342 | 통과 |
| `request.hwp` | 102 | 36 | 309 | 70,619 | 통과 |
| `exam_kor.hwp` | 133 | 86 | 1,368 | 173,827 | 통과 |

## 범위 밖과 후속 순서

이 PR은 `rhwp-core.lock`, `Frameworks/`, bundled studio asset, PR #466 remote state와 공개 release 상태를 변경하지 않습니다.

권장 후속 순서:

1. 이 PR의 GitHub-hosted CI 확인과 merge
2. `pr-merge-cleanup`으로 Issue/branch 정리
3. 최신 `devel` 기준 upstream sync workflow 재실행 또는 운영 정책에 따른 PR #466 갱신/재생성
4. 새 candidate의 decoder/native smoke와 build-info/Cargo.lock provenance gate 확인
5. Upstream sync PR merge
6. 별도 승인으로 release runbook 진행

Closes #467