### PR TITLE
Task #472 Stage 4.1: history-only back-merge 생략 판정

### DIFF
--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -17,4 +17,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #472 | v0.1.10 public release 준비와 배포 실행 | 진행중 | M900, Stage 3 완료 · source PR 생성 승인 대기 |
+| #472 | v0.1.10 public release 준비와 배포 실행 | 진행중 | M900, source PR #473 merge 완료 · Stage 4 release PR 준비 |

--- a/mydocs/plans/task_m900_472.md
+++ b/mydocs/plans/task_m900_472.md
@@ -297,7 +297,7 @@ Homebrew는 official public DMG URL과 SHA256이 확정되고 별도 승인을 �
 ## 리스크
 
 - Stage 1 전후로 `devel`에 다른 PR이 merge되면 candidate commit과 포함 PR 분석 범위가 달라진다. candidate 이동을 조용히 흡수하지 않고 release owner에게 재확정받는다.
-- `origin/main` 전용 commit의 ancestry만 보고 history-only back-merge를 만들면 content 변화 없이 이력과 검토 비용만 늘어난다. release merge의 두 번째 parent와 tree를 비교하고, 실제 content drift가 있을 때만 별도 승인으로 back-merge한다.
+- `origin/main` 전용 commit의 ancestry만 보고 history-only back-merge를 만들면 content 변화 없이 이력과 검토 비용만 늘어난다. release merge의 두 번째 parent와 tree를 비교하고, 실제 content drift가 있을 때만 별도 승인으로 back-merge한다. history-only back-merge를 생략하면 좌측 ancestry count는 release merge마다 단조 증가하므로 그 수 자체를 drift 신호로 사용하지 않는다.
 - local toolchain의 strict `librhwp.a` byte hash/size가 reference와 다르다. portable source/header/FFI 통과만으로 strict 통과라고 기록하거나 lock을 임의 갱신하지 않는다.
 - upstream latest가 `v0.8.4` 이후로 이동하면 `require_latest_rhwp=true`가 publish를 차단한다. guard를 임의로 해제하지 않고 새 sync 또는 명시적 예외 판단으로 분리한다.
 - v0.8.3 누적 변경에는 암호 문서, 중첩 표, 선택·복사와 렌더링 보정이 포함된다. v0.8.4 자체의 배포 채널 복원 설명만 보고 app-facing smoke를 축소하지 않는다.

--- a/mydocs/plans/task_m900_472.md
+++ b/mydocs/plans/task_m900_472.md
@@ -45,7 +45,7 @@ PR #471 merge로 현재 `devel`의 native core, RustBridge dependency와 bundled
 
 현재 HostApp, Quick Look과 Thumbnail extension source version/build는 모두 `0.1.9 (15)`다. Release Rehearsal/Publish workflow 기본 입력도 `version=0.1.9`, `previous_release_ref=v0.1.8`, `expected_rhwp_tag=v0.8.2`에 머물러 있어 새 release identity와 정렬해야 한다.
 
-현재 `origin/main`은 `26f3104469135c5e80b3a19dddb9d0baebfbfb0a`, `origin/devel`은 `4abdc30746edcd25be3d11fa3d5c1e09f600c6c3`이며 `origin/main...origin/devel` 좌우 차이는 `3 68`이다. Stage 1에서 main 전용 3개 커밋의 성격과 이미 devel에 반영됐는지를 확인하고, release PR 전에 필요한 back-merge를 별도 승인·PR로 분리해야 한다.
+현재 `origin/main`은 `26f3104469135c5e80b3a19dddb9d0baebfbfb0a`, Stage 1 시작 시점의 `origin/devel`은 `4abdc30746edcd25be3d11fa3d5c1e09f600c6c3`이며 당시 `origin/main...origin/devel` 좌우 차이는 `3 68`이었다. Stage 1~3 source PR #473 merge 뒤 다시 확인한 `main` 전용 3개 commit은 모두 PR #446, #450과 #452의 release transport merge다. 각 merge tree는 두 번째 parent인 당시 `devel` head와 같고 `main` 전용 non-merge commit이나 누락 content가 없으므로 Task #472에서는 history-only `main -> devel` back-merge를 생략한다. 실제 content drift를 차단하는 장기 운영 규칙과 자동 gate는 후속 Issue #474로 분리한다.
 
 로컬 v0.8.4 strict `librhwp.a` byte hash는 workflow가 기록한 reference와 달랐지만 source tag/commit, Cargo resolution, generated header와 FFI symbol 검증은 portable 정책으로 통과했다. strict mismatch를 lock 갱신으로 숨기지 않고 release source preflight에서 strict와 portable 결과를 분리해 기록해야 한다.
 
@@ -94,7 +94,7 @@ PR #471 merge로 현재 `devel`의 native core, RustBridge dependency와 bundled
 3. `rhwp-core.lock`, RustBridge lock, `RhwpCoreBuildInfo.swift`와 bundled studio manifest의 tag/commit을 source와 artifact 단계 모두에서 대조한다. sync writer만 identity를 생성하고 release 경로는 verifier로만 차단하는 원칙을 유지한다.
 4. bundled studio manifest의 `source_cargo_lock_sha256`을 target upstream checkout의 root `Cargo.lock`과 비교한 sync 근거를 release record에 연결한다. 일반 release workflow가 writer나 sync를 재실행해 후보를 조용히 바꾸지 않게 한다.
 5. strict `librhwp.a` byte 검증과 portable source/header/FFI 검증을 하나의 성공으로 합치지 않는다. strict mismatch가 재현되면 toolchain·archive 차이와 portable 결과를 보고하고 rehearsal 진입 전 release owner가 허용 경계를 판정한다.
-6. `origin/main` 전용 3개 commit을 first-parent, patch와 이전 release record로 분석한다. 필요한 back-merge는 release source 변경과 섞지 않고 별도 PR/승인 gate로 처리한다.
+6. `origin/main` 전용 3개 commit을 first-parent, patch와 이전 release record로 분석한다. transport-only merge와 실제 content drift를 구분하며, 현재 세 commit에는 history-only back-merge를 만들지 않는다. 이후 실제 `main` 전용 content가 발견되면 release source 변경과 섞지 않고 별도 PR/승인 gate로 back-merge한다. 장기 판정 규칙과 자동화는 Issue #474가 소유한다.
 7. `v0.1.9..candidate`의 merge PR, PR body, 연결 Issue와 최종 보고서를 근거로 포함 PR 분석 표를 만든다. 직전 release 종료 정리와 단순 transport는 신규 사용자-facing 변화에서 제외한다.
 8. 공개 문구는 사용자가 실제로 보는 저장, PDF·인쇄, viewer/editor 호환, Finder preview/thumbnail 변화만 주요 변경으로 설명한다. provenance, workflow default, 분석 telemetry와 단순 version bump는 운영·기술 세부로 분리한다.
 9. rehearsal artifact, pre-public draft DMG와 official public DMG를 서로 다른 계층으로 관리한다. rehearsal/draft URL이나 SHA256을 Sparkle, Pages 또는 Homebrew 입력으로 사용하지 않는다.
@@ -297,7 +297,7 @@ Homebrew는 official public DMG URL과 SHA256이 확정되고 별도 승인을 �
 ## 리스크
 
 - Stage 1 전후로 `devel`에 다른 PR이 merge되면 candidate commit과 포함 PR 분석 범위가 달라진다. candidate 이동을 조용히 흡수하지 않고 release owner에게 재확정받는다.
-- `origin/main`에만 있는 3개 commit을 확인하지 않고 release PR을 만들면 Pages·release 기록 이력이 누락되거나 충돌할 수 있다. patch와 tree 관계를 조사한 뒤 back-merge 필요성을 별도 승인받는다.
+- `origin/main` 전용 commit의 ancestry만 보고 history-only back-merge를 만들면 content 변화 없이 이력과 검토 비용만 늘어난다. release merge의 두 번째 parent와 tree를 비교하고, 실제 content drift가 있을 때만 별도 승인으로 back-merge한다.
 - local toolchain의 strict `librhwp.a` byte hash/size가 reference와 다르다. portable source/header/FFI 통과만으로 strict 통과라고 기록하거나 lock을 임의 갱신하지 않는다.
 - upstream latest가 `v0.8.4` 이후로 이동하면 `require_latest_rhwp=true`가 publish를 차단한다. guard를 임의로 해제하지 않고 새 sync 또는 명시적 예외 판단으로 분리한다.
 - v0.8.3 누적 변경에는 암호 문서, 중첩 표, 선택·복사와 렌더링 보정이 포함된다. v0.8.4 자체의 배포 채널 복원 설명만 보고 app-facing smoke를 축소하지 않는다.
@@ -315,7 +315,7 @@ Homebrew는 official public DMG URL과 SHA256이 확정되고 별도 승인을 �
 2. release title에는 upstream 반영이 주요 변화 중 하나이므로 `(rhwp v0.8.4)`를 포함하고, 실행 시점에도 upstream latest가 같으면 `require_latest_rhwp=true`를 사용한다.
 3. 기준 브랜치는 `devel`, 작업 브랜치는 `local/task472`, 메인 worktree를 사용한다.
 4. 위 6개 잠정 단계와 각 단계 종료 승인 gate를 사용한다.
-5. Stage 1에서 `origin/main` 전용 3개 commit을 조사하고, 필요한 back-merge는 release source 변경과 분리된 별도 PR·승인으로 처리한다.
+5. Stage 1~4 조사 결과 `origin/main` 전용 3개 commit은 tree-identical release transport로 판정해 history-only back-merge를 생략한다. 실제 content drift가 새로 생기면 release source 변경과 분리된 별도 PR·승인으로 처리하고, 장기 자동 gate는 Issue #474로 추적한다.
 6. strict static archive mismatch가 재현되면 rehearsal 전에 strict/portable 결과와 artifact 근거를 다시 보고하고 release owner의 별도 판정을 받는다.
 7. 실제 HWP/HWPX 저장·재열기, PDF 저장·인쇄 시작, Finder Preview/Thumbnail, Sparkle update와 signed/notarized draft 설치 smoke를 official publish 전 차단 gate로 둔다.
 8. stale LaunchServices record 자체는 전역 reset 사유로 삼지 않고, 활성 provider path와 release candidate 설치본 동작을 판정 기준으로 사용한다.

--- a/mydocs/plans/task_m900_472_impl.md
+++ b/mydocs/plans/task_m900_472_impl.md
@@ -22,7 +22,7 @@
 | release title | `Alhangeul v0.1.10 (rhwp v0.8.4)` |
 | workflow 정책 | `require_latest_rhwp=true`, `include_rhwp_in_title=true` |
 
-2026-08-13 구현계획 작성 시점의 `origin/main`은 `26f3104469135c5e80b3a19dddb9d0baebfbfb0a`, `origin/devel`은 `4abdc30746edcd25be3d11fa3d5c1e09f600c6c3`이며 `origin/main...origin/devel` 좌우 차이는 `3 68`이다. Stage 1에서 `main` 전용 3개 commit의 patch와 tree가 `devel`에 이미 등가 반영됐는지 확인하고, 필요한 경우 Stage 4 전에 reviewed `main -> devel` back-merge PR로 이력을 보존한다.
+2026-08-13 구현계획 작성 시점의 `origin/main`은 `26f3104469135c5e80b3a19dddb9d0baebfbfb0a`, `origin/devel`은 `4abdc30746edcd25be3d11fa3d5c1e09f600c6c3`이며 `origin/main...origin/devel` 좌우 차이는 `3 68`이었다. PR #473 merge 뒤 Stage 4 재검증에서는 좌우 차이가 `3 75`이고 `main` 전용 non-merge commit은 없다. PR #446, #450과 #452 merge tree가 각각 두 번째 parent와 동일하고 current `main` tree도 merge base와 같으므로 실제 content drift가 아닌 transport-only ancestry divergence로 판정한다. Task #472에서는 history-only back-merge를 생략하고 장기 정책·자동 gate는 Issue #474로 분리한다.
 
 ## 공통 작업 원칙
 
@@ -30,7 +30,7 @@
 2. release identity의 진실 원천은 세 app target plist, `rhwp-core.lock`, `RustBridge/Cargo.lock`, `RhwpCoreBuildInfo`, bundled studio manifest와 final tag commit의 교집합이다.
 3. candidate SHA가 이동하면 이전 검증을 자동 승계하지 않는다. 새 merge PR, changed path와 재실행해야 할 gate를 먼저 보고한다.
 4. Stage 1~3 source와 release communication 변경은 intermediate source PR로 `devel`에 먼저 반영한다. 이 PR merge 전에는 `devel -> main` release PR을 만들지 않는다.
-5. `main` 전용 변경을 보존할 필요가 있으면 squash/cherry-pick으로 이력을 다시 쓰지 않고 reviewed `main -> devel` back-merge PR을 사용한다.
+5. `main` 전용 실제 content를 보존할 필요가 있으면 squash/cherry-pick으로 이력을 다시 쓰지 않고 reviewed `main -> devel` back-merge PR을 사용한다. source parent와 tree가 같은 release transport merge만 남은 경우에는 history-only back-merge를 만들지 않는다.
 6. release PR은 updated `devel` head에서 `main` base로 만들고 merge commit을 유지한다. tag는 merge된 `main` release commit에만 생성한다.
 7. sync writer는 release 단계에서 실행하지 않는다. `RhwpCoreBuildInfo`와 bundled studio provenance는 verifier로만 검사하며, 후보를 맞추기 위한 자동 rewrite를 허용하지 않는다.
 8. strict static archive byte 검증과 portable source/header/FFI 검증을 별개 결과로 기록한다. local strict mismatch만을 이유로 `rhwp-core.lock` artifact hash를 갱신하지 않는다.
@@ -49,8 +49,8 @@
 | Rehearsal workflow 실행 | Stage 3 local source preflight 통과 후 | 실행하지 않음 |
 | `publish/task472` push와 intermediate source PR 생성 | Stage 3 완료보고 승인 후 | local branch만 유지 |
 | source PR merge | source PR CI와 review 통과 후 | Open 상태 유지 |
-| `main -> devel` back-merge PR 생성·merge | source PR merge와 branch divergence 확인 후 | 생성·merge하지 않음 |
-| `devel -> main` release PR 생성·merge | source와 back-merge gate 통과 후 | 생성·merge하지 않음 |
+| 실제 content drift용 `main -> devel` back-merge PR 생성·merge | source PR merge와 branch content 판정 후 | transport-only면 생성하지 않음 |
+| `devel -> main` release PR 생성·merge | source merge와 branch content 판정 후 | 생성·merge하지 않음 |
 | annotated `v0.1.10` tag 생성·push | release PR merge commit 확정 후 | tag 없음 |
 | draft Publish workflow | tag와 pre-public 입력 재확인 후 | 실행하지 않음 |
 | official Publish workflow | signed/notarized draft smoke 통과 후 | draft/public surface 유지 |
@@ -382,19 +382,20 @@ Stage 3 진행 중·완료보고에서 다음 mutation을 분리해 승인 요�
 2. Rehearsal workflow 실행
 3. `publish/task472` source PR 생성
 4. source PR CI 통과 뒤 merge
-5. Stage 4의 `main` back-merge/release PR 준비 진입
+5. Stage 4의 `main` content 판정과 release PR 준비 진입
 
 ## Stage 4. Source 반영, main/tag와 pre-public signed candidate
 
 ### 목표
 
-승인된 Stage 1~3 source와 communication을 `devel`에 반영하고, main-only 변경을 보존한 final release candidate를 `main`과 annotated tag로 확정한 뒤 signed/notarized draft DMG의 차단 smoke를 수행한다.
+승인된 Stage 1~3 source와 communication이 `devel`에 반영됐음을 확인하고, main-only ancestry와 실제 content drift를 구분해 final release candidate를 `main`과 annotated tag로 확정한 뒤 signed/notarized draft DMG의 차단 smoke를 수행한다.
 
 ### 대상
 
 - `publish/task472` intermediate source PR
 - `origin/main`, `origin/devel`과 양쪽 전용 commit/tree
-- tree 변경 없는 release 이력 정리용 `main -> devel` back-merge PR
+- branch content 판정 근거와 후속 Issue #474
+- 실제 content drift가 있을 때만 만드는 `main -> devel` back-merge PR
 - `devel -> main` release PR
 - annotated `v0.1.10` tag
 - draft `Release Publish DMG` run과 artifact
@@ -407,8 +408,8 @@ Stage 3 진행 중·완료보고에서 다음 mutation을 분리해 승인 요�
 2. source PR의 exact head SHA, PR CI gate와 release helper 결과를 확인하고 별도 승인 후 merge commit 방식으로 merge한다.
 3. source PR merge 뒤 local task branch를 새 `origin/devel`에 정렬하고 remote publish branch를 다음 게시 전까지 정리한다.
 4. `origin/main...origin/devel` left/right commit, file diff와 merge tree를 다시 계산한다. 현재 기준 `main` 전용 PR #446, #450, #452 merge는 각각 `devel` 쪽 부모와 tree-identical이고 `main` 전용 non-merge content와 `docs/` 차이는 없다.
-5. source PR merge 뒤에도 같은 판정이면 content 복구가 아니라 release transport 이력 정리를 목적으로 tree 변경 없는 reviewed `main -> devel` back-merge PR을 별도 승인으로 진행한다. `main`이 이동해 실제 content 차이가 생기면 이 판정을 중단하고 대상 파일과 소유 branch를 다시 확인한다.
-6. back-merge 뒤 local task branch를 새 `origin/devel`에 정렬하고 core/studio provenance, source identity, release communication과 CI를 다시 확인한다.
+5. source PR merge 뒤에도 같은 판정이면 transport-only ancestry divergence를 허용하고 history-only `main -> devel` back-merge를 생략한다. 이 invariant의 문서화와 자동 gate는 Issue #474로 추적한다. `main`이 이동해 실제 content 차이가 생기면 이 판정을 중단하고 대상 파일과 소유 branch를 다시 확인한 뒤 별도 승인으로 back-merge한다.
+6. branch content 판정 뒤 local task branch가 최신 `origin/devel`과 일치하는지 확인하고 core/studio provenance, source identity, release communication과 CI를 다시 확인한다.
 7. 정확한 updated `devel` head에서 `main` 대상 release PR을 만들고 title/body, included commits, tree와 branch protection check를 검증한다.
 8. 별도 승인 후 release PR을 merge commit 방식으로 merge한다.
 9. merge된 `main` release commit과 tree를 확인하고 별도 승인 후 annotated `v0.1.10` tag를 생성·push한다.
@@ -425,7 +426,7 @@ Stage 3 진행 중·완료보고에서 다음 mutation을 분리해 승인 요�
 
 ### 검증
 
-생성 결과의 exact 번호를 `TASK472_SOURCE_PR`, `TASK472_BACKMERGE_PR`, `TASK472_RELEASE_PR`에 넣어 다음 검증을 실행한다. back-merge 전후 tree가 동일한지 확인하고 history-only 목적을 Stage 보고서에 기록한다.
+생성 결과의 exact 번호를 `TASK472_SOURCE_PR`, `TASK472_RELEASE_PR`에 넣어 다음 검증을 실행한다. `TASK472_BACKMERGE_PR`은 실제 content drift로 back-merge가 필요할 때만 사용한다. transport-only 판정이면 source parent/tree 동일성, `main` 전용 non-merge commit 부재와 Issue #474를 Stage 보고서에 기록한다.
 
 ```bash
 gh pr view "$TASK472_SOURCE_PR" --repo postmelee/alhangeul-macos \
@@ -434,8 +435,10 @@ git fetch origin --prune
 git rev-list --left-right --count origin/main...origin/devel
 git log --left-right --cherry-pick --oneline origin/main...origin/devel
 git diff --stat origin/main...origin/devel
-gh pr view "$TASK472_BACKMERGE_PR" --repo postmelee/alhangeul-macos \
-  --json number,state,mergeable,mergeStateStatus,mergeCommit,statusCheckRollup,url
+if test -n "${TASK472_BACKMERGE_PR:-}"; then
+  gh pr view "$TASK472_BACKMERGE_PR" --repo postmelee/alhangeul-macos \
+    --json number,state,mergeable,mergeStateStatus,mergeCommit,statusCheckRollup,url
+fi
 gh pr view "$TASK472_RELEASE_PR" --repo postmelee/alhangeul-macos \
   --json number,state,mergeable,mergeStateStatus,mergeCommit,statusCheckRollup,url
 git rev-parse origin/main
@@ -477,7 +480,7 @@ scripts/smoke-finder-integration.sh --version 0.1.10
 ### 완료 조건
 
 - Stage 1~3 source PR이 `devel`에 merge되고 source branch와 merge commit이 기록돼 있다.
-- main-only 변경 보존 여부가 명시돼 있고 필요한 back-merge가 CI/review 후 완료됐다.
+- main-only ancestry와 실제 content drift 판정이 명시돼 있고, transport-only면 history-only back-merge를 생략한 근거가 기록돼 있다. 실제 content drift가 있으면 필요한 back-merge가 CI/review 후 완료됐다.
 - release PR merge commit, annotated tag와 checked-out release tree가 같은 candidate다.
 - draft workflow가 exact tag에서 성공하고 stable appcast/Pages는 갱신되지 않았다.
 - draft DMG가 signing/notarization/staple/Gatekeeper/universal/layout gate를 통과한다.
@@ -488,7 +491,7 @@ scripts/smoke-finder-integration.sh --version 0.1.10
 
 ### 산출물과 커밋
 
-- source/back-merge/release PR과 merge commit URL
+- source/release PR과 merge commit URL, 필요 시 실제 content drift back-merge PR
 - annotated `v0.1.10` tag와 release commit
 - draft workflow run, DMG URL/SHA256와 수동 smoke 기록
 - 보정된 `mydocs/release/v0.1.10.md`
@@ -619,7 +622,7 @@ Stage 5 완료보고서 기준으로 Stage 6 release record·최종 보고와 �
 
 ### 작업
 
-1. release identity, final tag/commit, source/back-merge/release PR, workflow run과 모든 public URL을 확정한다.
+1. release identity, final tag/commit, source/release PR, 필요 시 content back-merge PR, workflow run과 모든 public URL을 확정한다.
 2. public DMG filename, URL, SHA256, size, signing/notarization, appcast와 Homebrew 결과 또는 미실행 사유를 release record에 반영한다.
 3. draft/official install, 저장·재열기, PDF·인쇄, Finder/Preview, Sparkle와 Intel Mac smoke의 실제 실행 여부를 구분한다.
 4. 최종 보고서에 Stage 1~5 결과, 승인 이력, blocking/non-blocking 결과, known limitations와 후속 이슈를 정리한다.
@@ -679,7 +682,7 @@ Stage 6 완료보고서와 최종 보고서 승인을 받은 뒤 필요한 close
 - upstream root `Cargo.lock` fingerprint가 bundled manifest와 일치하지 않는다.
 - strict artifact mismatch가 남았는데 portable 결과와 release owner 허용 판정 없이 Rehearsal로 넘어가야 한다.
 - generated header/FFI, Rust/Swift tests, decoder fixture, app target, renderer, 저장/PDF/인쇄 회귀, release helper, universal slice 또는 release note 검증이 실패한다.
-- source PR이 merge되지 않았거나 main-only 변경 보존 판단 없이 release PR로 넘어가야 한다.
+- source PR이 merge되지 않았거나 main-only ancestry/content 판정 없이 release PR로 넘어가야 한다.
 - release PR/tag/tree가 서로 다른 candidate를 가리킨다.
 - tag 생성, draft/official Publish, Pages/Sparkle, Homebrew 또는 PR merge를 별도 승인 없이 실행해야 한다.
 - signed draft의 notarization, staple, Gatekeeper, 저장·PDF·인쇄, app/Finder/provider 또는 crash gate가 실패한다.
@@ -694,10 +697,10 @@ Stage 6 완료보고서와 최종 보고서 승인을 받은 뒤 필요한 close
 
 1. 이 구현계획의 6개 Stage와 각 Stage 완료보고 승인 순서를 사용한다.
 2. Stage 1~3 source/communication은 intermediate `devel` PR로 먼저 반영한다.
-3. current `main` 전용 변경은 Stage 1에서 분석하고, 필요한 경우 Stage 4에서 reviewed `main -> devel` back-merge로 보존한 뒤 `devel -> main` release PR을 진행한다.
+3. current `main` 전용 commit은 Stage 4에서 transport-only로 재확인해 history-only back-merge를 생략한다. 실제 content drift가 있으면 reviewed `main -> devel` back-merge로 보존한 뒤 `devel -> main` release PR을 진행하며, 장기 자동 판정은 Issue #474로 추적한다.
 4. `RhwpCoreBuildInfo` writer나 studio sync를 release 경로에서 실행하지 않고 verifier-only gate를 사용한다.
 5. strict static archive mismatch가 남으면 Rehearsal 전에 strict/portable 근거와 release artifact 허용 여부를 별도로 승인받는다.
-6. Rehearsal, source PR merge, back-merge, release PR merge, tag, draft Publish, official Publish, Homebrew와 main closeout은 외부 mutation 승인표대로 각각 별도 승인받는다.
+6. Rehearsal, source PR merge, 실제 content drift가 있을 때의 back-merge, release PR merge, tag, draft Publish, official Publish, Homebrew와 main closeout은 외부 mutation 승인표대로 각각 별도 승인받는다.
 7. signed draft에서 실제 HWP/HWPX 저장·재열기, PDF 저장·인쇄 시작, WebKit trust boundary, app/Finder provider와 crash를 official publish 전 차단 gate로 검증한다.
 8. clean official v0.1.9 baseline에서 Sparkle update를 검증하고, baseline이 invalid하면 재설치 또는 대체 경로를 먼저 승인받는다.
 9. stale LaunchServices record 자체는 전역 reset 사유로 삼지 않고 활성 provider root와 signed candidate 동작을 판정 기준으로 사용한다.

--- a/mydocs/plans/task_m900_472_impl.md
+++ b/mydocs/plans/task_m900_472_impl.md
@@ -426,7 +426,7 @@ Stage 3 진행 중·완료보고에서 다음 mutation을 분리해 승인 요�
 
 ### 검증
 
-생성 결과의 exact 번호를 `TASK472_SOURCE_PR`, `TASK472_RELEASE_PR`에 넣어 다음 검증을 실행한다. `TASK472_BACKMERGE_PR`은 실제 content drift로 back-merge가 필요할 때만 사용한다. transport-only 판정이면 source parent/tree 동일성, `main` 전용 non-merge commit 부재와 Issue #474를 Stage 보고서에 기록한다.
+생성 결과의 exact 번호를 `TASK472_SOURCE_PR`, `TASK472_RELEASE_PR`에 넣어 다음 검증을 실행한다. `TASK472_BACKMERGE_PR`은 실제 content drift로 back-merge가 필요할 때만 사용한다. transport-only 판정이면 source parent/tree 동일성, `main` 전용 non-merge commit 부재와 Issue #474를 Stage 보고서에 기록한다. 좌측 ancestry count는 release transport merge마다 증가하는 진단값이며 content drift 판정값으로 사용하지 않는다.
 
 ```bash
 gh pr view "$TASK472_SOURCE_PR" --repo postmelee/alhangeul-macos \
@@ -435,6 +435,12 @@ git fetch origin --prune
 git rev-list --left-right --count origin/main...origin/devel
 git log --left-right --cherry-pick --oneline origin/main...origin/devel
 git diff --stat origin/main...origin/devel
+git rev-list --left-only --no-merges origin/main...origin/devel
+git diff --name-status \
+  origin/main "$(git merge-base origin/main origin/devel)"
+for commit in $(git rev-list --left-only --merges origin/main...origin/devel); do
+  git diff --name-status "$commit^2" "$commit"
+done
 if test -n "${TASK472_BACKMERGE_PR:-}"; then
   gh pr view "$TASK472_BACKMERGE_PR" --repo postmelee/alhangeul-macos \
     --json number,state,mergeable,mergeStateStatus,mergeCommit,statusCheckRollup,url
@@ -481,6 +487,7 @@ scripts/smoke-finder-integration.sh --version 0.1.10
 
 - Stage 1~3 source PR이 `devel`에 merge되고 source branch와 merge commit이 기록돼 있다.
 - main-only ancestry와 실제 content drift 판정이 명시돼 있고, transport-only면 history-only back-merge를 생략한 근거가 기록돼 있다. 실제 content drift가 있으면 필요한 back-merge가 CI/review 후 완료됐다.
+- Stage 4 보고서에는 Stage 1의 history-only back-merge 필요 권고를 번복한 사실과 non-merge commit 부재, source parent/tree 동일성 근거가 기록돼 있다.
 - release PR merge commit, annotated tag와 checked-out release tree가 같은 candidate다.
 - draft workflow가 exact tag에서 성공하고 stable appcast/Pages는 갱신되지 않았다.
 - draft DMG가 signing/notarization/staple/Gatekeeper/universal/layout gate를 통과한다.

--- a/mydocs/release/v0.1.10.md
+++ b/mydocs/release/v0.1.10.md
@@ -15,7 +15,7 @@
 | Stage 2 분석 HEAD | `58424de31051007c2f185410f47ef090680c4ad9` |
 | Stage 2 범위 | `v0.1.9..58424de31051007c2f185410f47ef090680c4ad9` |
 | Stage 3 exact candidate | `95800eed4b2a631d2615203c3bed6cc1f7fa5d4e` |
-| current `origin/devel` | `447b31bcd1cb235980387df2a679fe243f161943` |
+| Stage 4.1 판정 시점 `origin/devel` | `447b31bcd1cb235980387df2a679fe243f161943` |
 | `origin/main` | `26f3104469135c5e80b3a19dddb9d0baebfbfb0a` |
 | merge base | `9e564ff79410bd06c36b36d3dd3cd6fa2b6e4c49` |
 | source PR | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), merge commit `447b31bcd1cb235980387df2a679fe243f161943` |
@@ -37,7 +37,7 @@
 
 Stage 1에서 HostApp, Quick Look과 Thumbnail extension을 모두 `0.1.10 (16)`으로 갱신했다. Release Rehearsal/Publish workflow default는 `0.1.10`, `v0.1.9`, `v0.8.4`로 정렬했고 `require_latest_rhwp=true`, `include_rhwp_in_title=true`, `draft=false`, `prerelease=false` 보호 기본값을 유지했다.
 
-현재 `origin/main` 전용 3개 commit은 PR #446, #450과 #452의 v0.1.9 release transport다. 각 merge tree는 대응 `devel` head와 같고 current `main` tree도 merge base `9e564ff...` tree와 같으며 `main` 전용 non-merge commit도 없으므로 누락된 content는 없다. Task #472에서는 content 변화가 없는 history-only `main -> devel` back-merge를 생략하고 updated `devel`에서 release PR을 준비한다. ancestry/content 판정 규칙의 문서화와 자동 gate는 [#474](https://github.com/postmelee/alhangeul-macos/issues/474)로 분리했다.
+현재 `origin/main` 전용 3개 commit은 PR #446, #450과 #452의 v0.1.9 release transport다. 각 merge tree는 대응 `devel` head와 같고 current `main` tree도 merge base `9e564ff...` tree와 같으며 `main` 전용 non-merge commit도 없으므로 누락된 content는 없다. Task #472에서는 content 변화가 없는 history-only `main -> devel` back-merge를 생략하고 updated `devel`에서 release PR을 준비한다. 이 선택으로 좌측 ancestry count는 release merge마다 증가하므로 count 자체를 content drift 신호로 사용하지 않는다. ancestry/content 판정 규칙의 문서화와 자동 gate는 [#474](https://github.com/postmelee/alhangeul-macos/issues/474)로 분리했다.
 
 Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable artifact 경계를 승인받아 strict static archive byte mismatch와 분리했다. exact candidate `95800ee...`의 source preflight, Rust/Swift test, 세 target Release build, renderer와 local universal package가 통과했다. 이어 같은 SHA를 `publish/task472`에 push해 실행한 Rehearsal run `31681525166`에서 unsigned universal DMG의 checksum, `hdiutil` integrity와 layout을 확인했다. rehearsal 뒤에도 GitHub latest Release, Pages와 stable appcast는 public `v0.1.9 (15)`를 유지했다. 상세 근거는 `mydocs/working/task_m900_472_stage3.md`에 기록한다.
 

--- a/mydocs/release/v0.1.10.md
+++ b/mydocs/release/v0.1.10.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.10` build `16` candidate, Stage 3 source preflight와 Rehearsal 완료 · source PR 생성 승인 대기 |
+| 상태 | `v0.1.10` build `16` candidate, source PR #473 merge 완료 · Stage 4 release PR 준비 |
 | 목표 Git tag | `v0.1.10` |
 | 목표 app version | `0.1.10` |
 | 목표 build | `16` |
@@ -15,9 +15,12 @@
 | Stage 2 분석 HEAD | `58424de31051007c2f185410f47ef090680c4ad9` |
 | Stage 2 범위 | `v0.1.9..58424de31051007c2f185410f47ef090680c4ad9` |
 | Stage 3 exact candidate | `95800eed4b2a631d2615203c3bed6cc1f7fa5d4e` |
+| current `origin/devel` | `447b31bcd1cb235980387df2a679fe243f161943` |
 | `origin/main` | `26f3104469135c5e80b3a19dddb9d0baebfbfb0a` |
 | merge base | `9e564ff79410bd06c36b36d3dd3cd6fa2b6e4c49` |
-| source PR / back-merge / release PR | 미생성, Stage 3~4 별도 승인 gate |
+| source PR | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), merge commit `447b31bcd1cb235980387df2a679fe243f161943` |
+| back-merge | transport-only ancestry로 판정, history-only PR 생략 |
+| release PR | 미생성, Stage 4 별도 승인 gate |
 | annotated tag | 미생성 |
 | Rehearsal | [run `31681525166`](https://github.com/postmelee/alhangeul-macos/actions/runs/31681525166) 성공, unsigned artifact |
 | signed draft Publish | 미실행 |
@@ -34,7 +37,7 @@
 
 Stage 1에서 HostApp, Quick Look과 Thumbnail extension을 모두 `0.1.10 (16)`으로 갱신했다. Release Rehearsal/Publish workflow default는 `0.1.10`, `v0.1.9`, `v0.8.4`로 정렬했고 `require_latest_rhwp=true`, `include_rhwp_in_title=true`, `draft=false`, `prerelease=false` 보호 기본값을 유지했다.
 
-현재 `origin/main` 전용 3개 commit은 PR #446, #450과 #452의 v0.1.9 release transport다. 각 merge tree는 대응 `devel` head와 같고 current `main` tree도 merge base `9e564ff...` tree와 같으므로 누락된 content는 없다. Stage 4에서는 v0.1.10 release PR의 이력을 명확히 하기 위해 tree 변경 없는 reviewed `main -> devel` back-merge PR을 별도 승인 대상으로 둔다.
+현재 `origin/main` 전용 3개 commit은 PR #446, #450과 #452의 v0.1.9 release transport다. 각 merge tree는 대응 `devel` head와 같고 current `main` tree도 merge base `9e564ff...` tree와 같으며 `main` 전용 non-merge commit도 없으므로 누락된 content는 없다. Task #472에서는 content 변화가 없는 history-only `main -> devel` back-merge를 생략하고 updated `devel`에서 release PR을 준비한다. ancestry/content 판정 규칙의 문서화와 자동 gate는 [#474](https://github.com/postmelee/alhangeul-macos/issues/474)로 분리했다.
 
 Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable artifact 경계를 승인받아 strict static archive byte mismatch와 분리했다. exact candidate `95800ee...`의 source preflight, Rust/Swift test, 세 target Release build, renderer와 local universal package가 통과했다. 이어 같은 SHA를 `publish/task472`에 push해 실행한 Rehearsal run `31681525166`에서 unsigned universal DMG의 checksum, `hdiutil` integrity와 layout을 확인했다. rehearsal 뒤에도 GitHub latest Release, Pages와 stable appcast는 public `v0.1.9 (15)`를 유지했다. 상세 근거는 `mydocs/working/task_m900_472_stage3.md`에 기록한다.
 
@@ -211,8 +214,8 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 - [x] 포함 PR 자동 분석과 release owner 판정 작성
 - [x] source preflight, strict/portable artifact와 universal package 검증
 - [x] 별도 승인 후 Rehearsal workflow 실행과 artifact 검증
-- [ ] Task #472 intermediate source PR을 `devel`에 merge
-- [ ] `main` 전용 이력을 reviewed history-only PR로 `devel`에 back-merge
+- [x] Task #472 intermediate source PR #473을 `devel`에 merge
+- [x] `main` 전용 commit을 transport-only로 판정하고 history-only back-merge 생략
 - [ ] `devel -> main` release PR merge와 annotated `v0.1.10` tag 생성
 - [ ] `draft=true`, `prerelease=false` signed Publish 실행
 - [ ] signed/notarized draft DMG의 저장, PDF·인쇄, 앱/Finder 차단 gate 통과
@@ -234,6 +237,7 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 - deployment target macOS 12 실장과 Intel Mac 실제 설치·실행은 실행하지 않으면 통과로 기록하지 않는다.
 - [#459](https://github.com/postmelee/alhangeul-macos/issues/459)는 PDF·인쇄 lifecycle의 중복/stale callback 후속이다.
 - [#469](https://github.com/postmelee/alhangeul-macos/issues/469)는 producer-backed render-tree golden, [#470](https://github.com/postmelee/alhangeul-macos/issues/470)는 decoder 실패 진단 후속이다.
+- [#474](https://github.com/postmelee/alhangeul-macos/issues/474)는 release transport ancestry와 실제 `main` content drift를 구분하는 운영 규칙·자동 gate 후속이다.
 
 ## Release communication checklist
 


### PR DESCRIPTION
## 변경 내용

- source PR #473 merge 상태와 현재 `devel` head를 Task #472 계획·릴리스 기록에 반영했습니다.
- `main` 전용 PR #446, #450, #452 merge commit을 release transport로 분류하고 history-only `main -> devel` back-merge를 생략하도록 Stage 4 절차를 보정했습니다.
- 실제 `main` content drift가 있을 때만 별도 back-merge를 요구하도록 mutation gate, 검증 명령과 완료 조건을 조건부로 정리했습니다.
- 장기 운영 규칙과 자동 검증 gate는 후속 Issue #474 이슈로 분리했습니다.
- 오늘할일의 Task #472 상태를 source PR merge 완료·Stage 4 release PR 준비로 갱신했습니다.

## 이유

현재 `main` 전용 commit 3개는 모두 merge tree가 두 번째 parent인 당시 `devel` head와 같습니다. `main` 전용 non-merge commit도 없고 current `main` tree와 merge base 사이의 파일 차이도 없어 누락된 content가 없습니다. 따라서 tree 변경 없는 back-merge는 content를 복구하지 않고 이력과 검토 비용만 늘립니다.

## 영향

- 앱 source, release workflow와 배포 artifact는 변경하지 않습니다.
- tag 생성, release PR 생성·merge, Publish workflow와 public surface는 실행하지 않습니다.
- 이 PR merge 뒤 updated `devel`에서 별도 승인으로 `devel -> main` v0.1.10 release PR을 준비할 수 있습니다.

## 검증

- `git diff --check`
- `git rev-list --left-right --count origin/main...devel` → `3 75`
- `git rev-list --left-only --no-merges origin/main...devel` → 결과 없음
- PR #446, #450, #452 merge commit과 각 두 번째 parent의 `git diff --name-status` → 결과 없음
- `git diff --name-status origin/main 9e564ff79410bd06c36b36d3dd3cd6fa2b6e4c49` → 결과 없음

## 관련

- Task #472
- source PR #473
- follow-up Issue #474
