### PR TITLE
Task #472: v0.1.10 release 종료 정리

### DIFF
--- a/Casks/alhangeul.rb
+++ b/Casks/alhangeul.rb
@@ -1,6 +1,6 @@
 cask "alhangeul" do
-  version "0.1.9"
-  sha256 "8110dc4cc2d965b4fe4d0a8cd6b285488a1fb5443f5bda606a35207c5bccc6ca"
+  version "0.1.10"
+  sha256 "800ea0df2aee7ef380fb6af316f34d5a3c6bbbe60ef9b96054defac1e5dafd0e"
 
   url "https://github.com/postmelee/alhangeul-macos/releases/download/v#{version}/alhangeul-macos-#{version}.dmg"
   name "알한글"

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Maintained with support from **OpenAI’s [Codex for Open Source](https://develo
 
 - GitHub Release: [Alhangeul v0.1.10](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10)
 - 업데이트 페이지: [알한글 v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html)
-- Homebrew Cask: public DMG SHA256 확정 후 별도 배포 단계에서 반영
+- Homebrew Cask: `brew install --cask postmelee/tap/alhangeul`로 같은 signed/notarized universal DMG 설치
 - 포함된 `rhwp`: [`v0.8.4`](https://github.com/edwardkim/rhwp/releases/tag/v0.8.4) (`rhwp-core.lock`, bundled `rhwp-studio` manifest 기준)
 - Sparkle update 기준: short version은 `0.1.10`, build는 `16`입니다.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -209,7 +209,7 @@
           <p>상단 다운로드 버튼은 최신 공식 릴리즈의 DMG 파일을 바로 내려받도록 연결됩니다. v0.1.10 공식 DMG도 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다. 파일이 준비되지 않았거나 이전 버전이
             필요하면 <a href="https://github.com/postmelee/alhangeul-macos/releases/latest" target="_blank"
               rel="noreferrer">GitHub Releases</a>에서 배포 상태를 확인할 수 있습니다.</p>
-          <p>Homebrew Cask는 public DMG URL과 SHA256을 확인한 뒤 별도 배포 단계에서 갱신합니다. 반영 전에는 GitHub Release DMG를 사용하고, 반영 뒤에는 <code>brew install --cask postmelee/tap/alhangeul</code>로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
+          <p>Homebrew Cask로도 v0.1.10을 설치할 수 있습니다. <code>brew install --cask postmelee/tap/alhangeul</code>을 실행하면 GitHub Release와 같은 signed/notarized universal DMG를 사용합니다.</p>
         </details>
         <details>
           <summary>앱 업데이트는 어떻게 확인하나요?</summary>

--- a/docs/updates/index.html
+++ b/docs/updates/index.html
@@ -69,8 +69,8 @@
 
       <section class="updates-section" aria-labelledby="homebrew-title">
         <h2 id="homebrew-title">Homebrew Cask</h2>
-        <p>Homebrew Cask는 GitHub Release DMG 공개 뒤 별도 배포 단계에서 반영합니다. 반영 전에는 위 DMG 다운로드를 사용하고, 반영 뒤에는
-          <code>brew install --cask postmelee/tap/alhangeul</code>로 같은 signed/notarized universal DMG를 설치할 수 있습니다.</p>
+        <p>Homebrew Cask로도 v0.1.10을 설치할 수 있습니다.
+          <code>brew install --cask postmelee/tap/alhangeul</code>을 실행하면 GitHub Release와 같은 signed/notarized universal DMG를 사용합니다.</p>
       </section>
 
       <section class="updates-section" aria-labelledby="release-notes-title">

--- a/docs/updates/v0.1.10.html
+++ b/docs/updates/v0.1.10.html
@@ -113,7 +113,7 @@
       <section class="updates-section" aria-labelledby="release-install-title">
         <h2 id="release-install-title">설치와 업데이트</h2>
         <p>DMG 파일을 내려받아 앱을 Applications 폴더로 옮긴 뒤, 앱을 한 번 실행합니다. v0.1.10 공식 DMG는 Intel Mac과 Apple Silicon Mac에서 같은 파일을 사용합니다.</p>
-        <p>Homebrew Cask는 public DMG URL과 SHA256이 확정된 뒤 별도 배포 단계에서 반영합니다.</p>
+        <p>Homebrew Cask로도 같은 signed/notarized universal DMG를 설치할 수 있습니다. <code>brew install --cask postmelee/tap/alhangeul</code>을 실행하세요.</p>
         <p>설치한 앱에서는 메뉴 막대의 <code>알한글 &gt; 업데이트 확인...</code>을 선택해 새 버전을 확인할 수 있습니다.</p>
       </section>
     </div>

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -17,4 +17,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #472 | v0.1.10 public release 준비와 배포 실행 | 진행중 | M900, Stage 4 signed draft 차단 gate 완료 · Stage 5 official 승인 대기 |
+| #472 | v0.1.10 public release 준비와 배포 실행 | 진행중 | M900, Stage 5 official publish·public update 검증 완료 · Homebrew 별도 승인 대기 |

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -17,4 +17,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #472 | v0.1.10 public release 준비와 배포 실행 | 진행중 | M900, source PR #473 merge 완료 · Stage 4 release PR 준비 |
+| #472 | v0.1.10 public release 준비와 배포 실행 | 진행중 | M900, Stage 4 signed draft 차단 gate 완료 · Stage 5 official 승인 대기 |

--- a/mydocs/orders/20260813.md
+++ b/mydocs/orders/20260813.md
@@ -17,4 +17,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #472 | v0.1.10 public release 준비와 배포 실행 | 진행중 | M900, Stage 5 official publish·public update 검증 완료 · Homebrew 별도 승인 대기 |
+| #472 | v0.1.10 public release 준비와 배포 실행 | 진행중 | M900, Stage 5 Homebrew Cask 배포·smoke 완료 · Stage 6 closeout 승인 대기 |

--- a/mydocs/orders/20260816.md
+++ b/mydocs/orders/20260816.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 8월 16일
+
+## M900 — Release Operations
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #472 | v0.1.10 release closeout과 최종 보고 | 완료 | closeout source·Release body 후보·최종 보고 준비, 게시·merge·Pages 별도 승인 대기 · 완료: 10:04 |

--- a/mydocs/orders/20260817.md
+++ b/mydocs/orders/20260817.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 8월 17일
+
+## M900 — Release Operations
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #472 | v0.1.10 devel 최종 보고와 종료 정리 | 완료 | PR #477 merge·Pages 재검증, devel 최종 PR·merge·cleanup 승인 · 완료: 07:12 |

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.10` | 후보 · signed draft 차단 gate 완료 · official 승인 대기 | [draft](https://github.com/postmelee/alhangeul-macos/releases/tag/untagged-91bda2ed93cfa0d3ca56) · [tag `v0.1.10`](https://github.com/postmelee/alhangeul-macos/tree/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
+| `v0.1.10` | 공개 완료 · Homebrew 별도 승인 대기 | [Alhangeul v0.1.10 (rhwp v0.8.4)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
 | `v0.1.9` | 공개 완료 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
 | `v0.1.8` | 공개 완료 | [Alhangeul v0.1.8](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) | [v0.1.8](https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html) | [`v0.1.8.md`](v0.1.8.md) |
 | `v0.1.7` | 공개 완료 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.10` | 공개·Homebrew 완료 · 문구 closeout 대기 | [Alhangeul v0.1.10 (rhwp v0.8.4)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
+| `v0.1.10` | 공개·Homebrew·문구 closeout 완료 | [Alhangeul v0.1.10 (rhwp v0.8.4)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
 | `v0.1.9` | 공개 완료 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
 | `v0.1.8` | 공개 완료 | [Alhangeul v0.1.8](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) | [v0.1.8](https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html) | [`v0.1.8.md`](v0.1.8.md) |
 | `v0.1.7` | 공개 완료 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.10` | 공개 완료 · Homebrew Cask 배포 완료 | [Alhangeul v0.1.10 (rhwp v0.8.4)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
+| `v0.1.10` | 공개·Homebrew 완료 · 문구 closeout 대기 | [Alhangeul v0.1.10 (rhwp v0.8.4)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
 | `v0.1.9` | 공개 완료 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
 | `v0.1.8` | 공개 완료 | [Alhangeul v0.1.8](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) | [v0.1.8](https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html) | [`v0.1.8.md`](v0.1.8.md) |
 | `v0.1.7` | 공개 완료 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.10` | 후보 · Stage 3 완료 | [Alhangeul v0.1.10](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
+| `v0.1.10` | 후보 · release tag 완료 · signed draft 대기 | 미생성 · [tag `v0.1.10`](https://github.com/postmelee/alhangeul-macos/tree/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
 | `v0.1.9` | 공개 완료 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
 | `v0.1.8` | 공개 완료 | [Alhangeul v0.1.8](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) | [v0.1.8](https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html) | [`v0.1.8.md`](v0.1.8.md) |
 | `v0.1.7` | 공개 완료 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.10` | 후보 · release tag 완료 · signed draft 대기 | 미생성 · [tag `v0.1.10`](https://github.com/postmelee/alhangeul-macos/tree/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
+| `v0.1.10` | 후보 · signed draft 차단 gate 완료 · official 승인 대기 | [draft](https://github.com/postmelee/alhangeul-macos/releases/tag/untagged-91bda2ed93cfa0d3ca56) · [tag `v0.1.10`](https://github.com/postmelee/alhangeul-macos/tree/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
 | `v0.1.9` | 공개 완료 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
 | `v0.1.8` | 공개 완료 | [Alhangeul v0.1.8](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) | [v0.1.8](https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html) | [`v0.1.8.md`](v0.1.8.md) |
 | `v0.1.7` | 공개 완료 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |

--- a/mydocs/release/index.md
+++ b/mydocs/release/index.md
@@ -17,7 +17,7 @@
 
 | 버전 | 상태 | GitHub Release | Pages 릴리즈 노트 | 내부 기록 |
 |------|------|----------------|-------------------|-----------|
-| `v0.1.10` | 공개 완료 · Homebrew 별도 승인 대기 | [Alhangeul v0.1.10 (rhwp v0.8.4)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
+| `v0.1.10` | 공개 완료 · Homebrew Cask 배포 완료 | [Alhangeul v0.1.10 (rhwp v0.8.4)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10) | [v0.1.10](https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html) | [`v0.1.10.md`](v0.1.10.md) |
 | `v0.1.9` | 공개 완료 | [Alhangeul v0.1.9](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.9) | [v0.1.9](https://postmelee.github.io/alhangeul-macos/updates/v0.1.9.html) | [`v0.1.9.md`](v0.1.9.md) |
 | `v0.1.8` | 공개 완료 | [Alhangeul v0.1.8](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.8) | [v0.1.8](https://postmelee.github.io/alhangeul-macos/updates/v0.1.8.html) | [`v0.1.8.md`](v0.1.8.md) |
 | `v0.1.7` | 공개 완료 | [Alhangeul v0.1.7](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.7) | [v0.1.7](https://postmelee.github.io/alhangeul-macos/updates/v0.1.7.html) | [`v0.1.7.md`](v0.1.7.md) |

--- a/mydocs/release/v0.1.10.md
+++ b/mydocs/release/v0.1.10.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.10` build `16`, public stable · Pages/Sparkle · 실제 v0.1.9 update · Homebrew Cask 배포 검증 완료 · Stage 6 closeout source 준비 |
+| 상태 | `v0.1.10` build `16`, public stable · Pages/Sparkle · 실제 v0.1.9 update · Homebrew Cask 배포 검증 완료 · GitHub Release 문구 보정 · Stage 6 main closeout 대기 |
 | 목표 Git tag | `v0.1.10` |
 | 목표 app version | `0.1.10` |
 | 목표 build | `16` |
@@ -35,7 +35,7 @@
 | Pages / stable appcast | public `v0.1.10 (16)`, same DMG URL/size와 EdDSA signature 확인 |
 | Stage 6 public appcast SHA256 | `36b5d62bc9477bf6b586c19888071ba8610be0ac42a116b2a8be7bf5cee3af5a` |
 | Homebrew Cask | public `v0.1.10`, SHA256 `800ea0df...e5dafd0e`, tap commit `f712c88...` |
-| Stage 6 communication closeout | repository source와 GitHub Release body 후보 준비 · main PR, Release 본문 수정과 Pages 재배포 승인 대기 |
+| Stage 6 communication closeout | GitHub Release Homebrew 문구 보정 완료 · repository source 준비 · main PR과 Pages 재배포 대기 |
 | Release 실행 이슈 | [#472](https://github.com/postmelee/alhangeul-macos/issues/472) |
 | expected rhwp | `v0.8.4` / `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
 | upstream latest | `v0.8.4`, candidate lock과 일치 |
@@ -53,7 +53,7 @@ Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 s
 
 Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG SHA256 `800ea0df...e5dafd0e`, size 169,177,234 bytes를 확정하고 GitHub latest Release, Pages와 EdDSA stable appcast를 `0.1.10 (16)`으로 배포했다. clean `/Applications` v0.1.9 기준선에서 실제 Sparkle download·install·relaunch를 완료했고 v0.1.10 Preview/Thumbnail이 registration repair 없이 자연 갱신됐다. public 설치본에서 HWP/HWPX app open, Quick Look와 Thumbnail의 실제 `/Applications` provider process를 확인했으며 신규 crash는 없었다. 이후 별도 승인으로 repository Cask와 `postmelee/homebrew-tap`을 public DMG의 exact SHA256으로 갱신하고 tap commit `f712c88...`을 게시했다. style/audit와 fully-qualified install/uninstall smoke가 통과했으며 기존 Sparkle 설치본과 provider 등록을 복원했다. public 문구 closeout은 Stage 6의 별도 `main` 대상 PR 전까지 대기한다. 상세 근거는 `mydocs/working/task_m900_472_stage5.md`에 기록한다.
 
-2026-08-16 Stage 6 live 재확인에서 GitHub Release, DMG asset, appcast와 public tap identity는 변하지 않았다. public appcast SHA256은 `36b5d62b...af5a`이고 `0.1.10 (16)`, public DMG URL, 169,177,234 bytes와 EdDSA signature를 유지한다. 반면 `origin/main`의 repository Cask는 아직 v0.1.9이고 README, Pages home/update index/v0.1.10 note와 GitHub Release body에는 Homebrew 배포 전 문구가 남아 있다. `local/task472`에서 Cask와 네 source 문서를 현재 설치 명령으로 보정하고, public appcast를 byte 단위로 보존한 Pages artifact와 GitHub Release body 한 줄 보정 후보를 검증했다. main closeout PR, Release 본문 직접 수정과 docs-only Pages 재배포는 Stage 6 완료보고 승인 전에는 게시하지 않는다.
+2026-08-16 Stage 6 live 재확인에서 GitHub Release, DMG asset, appcast와 public tap identity는 변하지 않았다. public appcast SHA256은 `36b5d62b...af5a`이고 `0.1.10 (16)`, public DMG URL, 169,177,234 bytes와 EdDSA signature를 유지한다. `origin/main`의 repository Cask는 아직 v0.1.9이고 README와 Pages home/update index/v0.1.10 note에는 Homebrew 배포 전 문구가 남아 있었다. `local/task472`에서 Cask와 네 source 문서를 현재 설치 명령으로 보정하고 public appcast를 byte 단위로 보존한 Pages artifact를 검증했다. 작업지시자 승인 뒤 GitHub Release body는 검증된 후보 파일로 직접 보정했으며, 공개 본문이 후보와 일치하고 이전 문구가 제거됐음을 재확인했다. main closeout PR과 docs-only Pages 재배포는 아직 대기한다.
 
 ## 개인정보 정책 승인
 
@@ -178,7 +178,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 | [#375](https://github.com/postmelee/alhangeul-macos/issues/375) | [#465](https://github.com/postmelee/alhangeul-macos/pull/465) | merge·close 완료 | upstream Cargo.lock fingerprint gate |
 | [#467](https://github.com/postmelee/alhangeul-macos/issues/467) | [#468](https://github.com/postmelee/alhangeul-macos/pull/468) | merge·close 완료 | v0.8.4 decoder compatibility |
 | 없음 | [#471](https://github.com/postmelee/alhangeul-macos/pull/471) | merge 완료 | `rhwp v0.8.4` full sync |
-| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | release와 Homebrew 완료 · Stage 6 closeout source/최종 보고 준비 · 게시·merge·Pages 확인 대기 |
+| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | release와 Homebrew 완료 · GitHub Release 문구 보정 완료 · main closeout PR·merge·Pages 확인 대기 |
 
 ## 검증 기준
 
@@ -191,7 +191,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 | Upstream Cargo.lock | target checkout root hash와 manifest fingerprint 일치 | Stage 3 통과 |
 | Workflow default | `0.1.10`, `v0.1.9`, `v0.8.4` | Stage 1 통과 |
 | Release PR analysis | `v0.1.9..34ba512...` 포함 PR과 release transport 분리 | final candidate owner 보정 완료 |
-| Release communication | README, Pages home/update, release index/record | Stage 2 release 문구와 Stage 6 Homebrew closeout source 준비 |
+| Release communication | README, Pages home/update, release index/record | GitHub Release 보정 완료 · Stage 6 Homebrew closeout source 준비 |
 | Static archive | strict byte reference와 portable source/header/FFI 분리 | strict mismatch 기록 · portable 승인/통과 |
 | Rust/Swift tests | RustBridge, decoder fixture, HostAppTests, ExternalImageTests | Stage 3 통과 |
 | Release build/render | 세 target build와 representative renderer | Stage 3 통과 |
@@ -285,5 +285,5 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 - [x] Sparkle/Pages와 실제 update 결과 반영
 - [x] 별도 승인된 Homebrew 결과 반영
 - [x] Stage 6 repository Cask, public 문서와 GitHub Release body closeout 후보 검증
-- [ ] GitHub Release Homebrew 문구 직접 보정
+- [x] GitHub Release Homebrew 문구 직접 보정과 공개 본문 재검증
 - [ ] main closeout PR merge와 docs-only Pages 재배포 확인

--- a/mydocs/release/v0.1.10.md
+++ b/mydocs/release/v0.1.10.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.10` build `16`, release PR #476 merge · annotated tag · signed draft 차단 gate 완료 · official 승인 대기 |
+| 상태 | `v0.1.10` build `16`, public stable · Pages/Sparkle · 실제 v0.1.9 update 검증 완료 · Homebrew 승인 대기 |
 | 목표 Git tag | `v0.1.10` |
 | 목표 app version | `0.1.10` |
 | 목표 build | `16` |
@@ -27,16 +27,16 @@
 | Rehearsal | [run `31681525166`](https://github.com/postmelee/alhangeul-macos/actions/runs/31681525166) 성공, unsigned artifact |
 | signed draft Publish | [run `31806721517`](https://github.com/postmelee/alhangeul-macos/actions/runs/31806721517) 성공, exact tag target `fafed425...` |
 | Draft DMG / SHA256 | [`alhangeul-macos-0.1.10.dmg`](https://github.com/postmelee/alhangeul-macos/releases/tag/untagged-91bda2ed93cfa0d3ca56), `e54d5a1d2c4875f96ff704d61e0a8567146e00fca0cfc55cd51c04875457a7af` |
-| official stable Publish | 미실행 |
-| Public DMG / SHA256 | 미생성 |
-| Pages / stable appcast | draft run에서도 deploy skip, 현재 public `v0.1.9 (15)` 유지 |
-| Homebrew Cask | 현재 public `v0.1.9` 유지 |
+| official stable Publish | [run `31812500336`](https://github.com/postmelee/alhangeul-macos/actions/runs/31812500336) 성공, release job `94806246847`, Pages job `94810917280` |
+| Public DMG / SHA256 | [`alhangeul-macos-0.1.10.dmg`](https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.10/alhangeul-macos-0.1.10.dmg), `800ea0df2aee7ef380fb6af316f34d5a3c6bbbe60ef9b96054defac1e5dafd0e`, 169,177,234 bytes |
+| Pages / stable appcast | public `v0.1.10 (16)`, same DMG URL/size와 EdDSA signature 확인 |
+| Homebrew Cask | public `v0.1.9` 유지, 별도 승인 대기 |
 | Release 실행 이슈 | [#472](https://github.com/postmelee/alhangeul-macos/issues/472) |
 | expected rhwp | `v0.8.4` / `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
 | upstream latest | `v0.8.4`, candidate lock과 일치 |
 | latest guard | `require_latest_rhwp=true`, 예외 계획 없음 |
 
-2026-08-14 tag 생성 직전 live 조회에서 최신 공개 알한글은 non-draft/non-prerelease `v0.1.9`, upstream latest는 `rhwp v0.8.4`였다. remote `v0.1.10` tag와 GitHub Release가 없음을 확인한 뒤 annotated tag를 생성·push했다. 별도 승인으로 signed draft Publish를 실행해 `isDraft=true`, `prerelease=false` Release와 notarized DMG를 생성·검증했으며 공개 채널은 변경하지 않았다.
+2026-08-14 tag 생성 직전 live 조회에서 최신 공개 알한글은 non-draft/non-prerelease `v0.1.9`, upstream latest는 `rhwp v0.8.4`였다. remote `v0.1.10` tag와 GitHub Release가 없음을 확인한 뒤 annotated tag를 생성·push했다. 별도 승인으로 signed draft Publish를 실행해 `isDraft=true`, `prerelease=false` Release와 notarized DMG를 생성·검증했으며 공개 채널은 변경하지 않았다. 이어 2026-08-15 KST 별도 승인으로 official Publish를 실행해 `v0.1.10`을 non-draft/non-prerelease latest로 게시하고 Pages와 stable appcast를 배포했다.
 
 Stage 1에서 HostApp, Quick Look과 Thumbnail extension을 모두 `0.1.10 (16)`으로 갱신했다. Release Rehearsal/Publish workflow default는 `0.1.10`, `v0.1.9`, `v0.8.4`로 정렬했고 `require_latest_rhwp=true`, `include_rhwp_in_title=true`, `draft=false`, `prerelease=false` 보호 기본값을 유지했다.
 
@@ -45,6 +45,8 @@ release PR 직전 `origin/main` 전용 3개 commit은 PR #446, #450과 #452의 v
 Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable artifact 경계를 승인받아 strict static archive byte mismatch와 분리했다. exact candidate `95800ee...`의 source preflight, Rust/Swift test, 세 target Release build, renderer와 local universal package가 통과했다. 이어 같은 SHA를 `publish/task472`에 push해 실행한 Rehearsal run `31681525166`에서 unsigned universal DMG의 checksum, `hdiutil` integrity와 layout을 확인했다. rehearsal 뒤에도 GitHub latest Release, Pages와 stable appcast는 public `v0.1.9 (15)`를 유지했다. 상세 근거는 `mydocs/working/task_m900_472_stage3.md`에 기록한다.
 
 Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 signing, notarization, staple, Gatekeeper와 draft asset upload를 통과했다. DMG actual SHA256은 `e54d5a1...a7af`다. signed 앱에서 HWP/HWPX 열기·형식별 저장·재열기, 전체 페이지 PDF와 native 인쇄 panel을 확인했다. 후보 Preview/Thumbnail만 단독 등록한 격리 smoke에서 HWP/HWPX 결과와 실제 executable 경로를 확인한 뒤 기존 `/Applications` v0.1.9 및 사용자 v0.1.8 등록을 복원했다. 신규 crash는 없고 draft DMG도 detach했다. GitHub latest Release, Pages와 stable appcast는 계속 public `v0.1.9 (15)`를 유지한다. 상세 근거는 `mydocs/working/task_m900_472_stage4.md`에 기록한다.
+
+Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG SHA256 `800ea0df...e5dafd0e`, size 169,177,234 bytes를 확정하고 GitHub latest Release, Pages와 EdDSA stable appcast를 `0.1.10 (16)`으로 배포했다. clean `/Applications` v0.1.9 기준선에서 실제 Sparkle download·install·relaunch를 완료했고 v0.1.10 Preview/Thumbnail이 registration repair 없이 자연 갱신됐다. public 설치본에서 HWP/HWPX app open, Quick Look와 Thumbnail의 실제 `/Applications` provider process를 확인했으며 신규 crash는 없었다. Homebrew는 별도 승인 전이므로 기존 public v0.1.9 상태와 대기 문구를 유지한다. 상세 근거는 `mydocs/working/task_m900_472_stage5.md`에 기록한다.
 
 ## 개인정보 정책 승인
 
@@ -169,7 +171,7 @@ Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 s
 | [#375](https://github.com/postmelee/alhangeul-macos/issues/375) | [#465](https://github.com/postmelee/alhangeul-macos/pull/465) | merge·close 완료 | upstream Cargo.lock fingerprint gate |
 | [#467](https://github.com/postmelee/alhangeul-macos/issues/467) | [#468](https://github.com/postmelee/alhangeul-macos/pull/468) | merge·close 완료 | v0.8.4 decoder compatibility |
 | 없음 | [#471](https://github.com/postmelee/alhangeul-macos/pull/471) | merge 완료 | `rhwp v0.8.4` full sync |
-| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | source, branch 판정, release transport와 signed draft gate 완료 · official 승인 대기 |
+| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | source, release transport, signed draft와 official public surface 완료 · Homebrew 승인 대기 |
 
 ## 검증 기준
 
@@ -191,9 +193,10 @@ Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 s
 | Rehearsal DMG | unsigned checksum/integrity/universal/layout | run `31681525166` 통과 |
 | Signed draft DMG | signing/notarization/staple/Gatekeeper | run `31806721517`, DMG SHA256 `e54d5a1...a7af` 통과 |
 | Signed Finder/Preview | 실제 provider path와 HWP/HWPX | 후보 단독 등록에서 Preview/Thumbnail executable과 non-blank 결과 확인, 복원 완료 |
-| Public release | GitHub Release, public DMG/checksum, Pages/appcast | 별도 승인 후 실행 예정 |
-| Public update | v0.1.9 -> v0.1.10 Sparkle와 extension refresh | 별도 승인 후 실행 예정 |
-| Homebrew | official public DMG URL/SHA256과 install/uninstall | 별도 승인 후 실행 예정 |
+| Public release | GitHub Release, public DMG/checksum, Pages/appcast | run `31812500336`, public DMG `800ea0df...e5dafd0e`, Pages/appcast 통과 |
+| Public update | v0.1.9 -> v0.1.10 Sparkle와 extension refresh | 실제 download/install/relaunch, repair 없는 Preview/Thumbnail refresh 통과 |
+| Public app/Finder | HWP/HWPX open, Quick Look/Thumbnail provider | `/Applications` v0.1.10 process provenance와 non-blank 결과 통과 |
+| Homebrew | official public DMG URL/SHA256과 install/uninstall | public 입력 확정, 별도 승인 대기 |
 
 ## Release metadata
 
@@ -215,6 +218,12 @@ Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 s
 | `include_rhwp_in_title` | `true` |
 | Stage 4 draft gate | `draft=true`, `prerelease=false` |
 | Stage 5 official gate | `draft=false`, `prerelease=false` |
+| official workflow | https://github.com/postmelee/alhangeul-macos/actions/runs/31812500336 |
+| GitHub Release | https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10 |
+| public DMG | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.10/alhangeul-macos-0.1.10.dmg |
+| public DMG SHA256 / size | `800ea0df2aee7ef380fb6af316f34d5a3c6bbbe60ef9b96054defac1e5dafd0e` / 169,177,234 bytes |
+| Pages release note | https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html |
+| stable appcast | https://postmelee.github.io/alhangeul-macos/appcast.xml, `0.1.10 (16)` |
 | core lock | `rhwp-core.lock` |
 | studio manifest | `Sources/HostApp/Resources/rhwp-studio/manifest.json` |
 
@@ -232,9 +241,10 @@ Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 s
 - [x] `draft=true`, `prerelease=false` signed Publish 실행
 - [x] signed/notarized draft DMG의 저장, PDF·인쇄, 앱/Finder 차단 gate 통과
 - [x] draft 실행에서 stable appcast와 Pages 배포 skip 및 public `v0.1.9` 유지 확인
-- [ ] official stable Publish workflow 실행
-- [ ] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
-- [ ] v0.1.9에서 v0.1.10 Sparkle update와 extension refresh 확인
+- [x] official stable Publish workflow 실행
+- [x] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
+- [x] v0.1.9에서 v0.1.10 Sparkle update와 extension refresh 확인
+- [x] public 설치본 HWP/HWPX app open과 Preview/Thumbnail provider provenance 확인
 - [ ] 별도 승인 후 Homebrew Cask 반영과 install/uninstall smoke
 
 ## 알려진 제한 사항과 후속 이슈
@@ -263,5 +273,6 @@ Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 s
 - [x] README, Pages와 release record의 version/build/rhwp identity 일치
 - [x] final source candidate `34ba512...`에서 release note helper 재생성
 - [x] signed draft 결과와 실제 미실행 항목 반영
-- [ ] official public DMG URL/SHA256 반영
-- [ ] Sparkle/Pages와 Homebrew 결과 반영
+- [x] official public DMG URL/SHA256 반영
+- [x] Sparkle/Pages와 실제 update 결과 반영
+- [ ] 별도 승인된 Homebrew 결과와 public 문서 closeout 반영

--- a/mydocs/release/v0.1.10.md
+++ b/mydocs/release/v0.1.10.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.10` build `16`, public stable · Pages/Sparkle · 실제 v0.1.9 update 검증 완료 · Homebrew 승인 대기 |
+| 상태 | `v0.1.10` build `16`, public stable · Pages/Sparkle · 실제 v0.1.9 update · Homebrew Cask 배포 검증 완료 |
 | 목표 Git tag | `v0.1.10` |
 | 목표 app version | `0.1.10` |
 | 목표 build | `16` |
@@ -30,7 +30,7 @@
 | official stable Publish | [run `31812500336`](https://github.com/postmelee/alhangeul-macos/actions/runs/31812500336) 성공, release job `94806246847`, Pages job `94810917280` |
 | Public DMG / SHA256 | [`alhangeul-macos-0.1.10.dmg`](https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.10/alhangeul-macos-0.1.10.dmg), `800ea0df2aee7ef380fb6af316f34d5a3c6bbbe60ef9b96054defac1e5dafd0e`, 169,177,234 bytes |
 | Pages / stable appcast | public `v0.1.10 (16)`, same DMG URL/size와 EdDSA signature 확인 |
-| Homebrew Cask | public `v0.1.9` 유지, 별도 승인 대기 |
+| Homebrew Cask | public `v0.1.10`, SHA256 `800ea0df...e5dafd0e`, tap commit `f712c88...` |
 | Release 실행 이슈 | [#472](https://github.com/postmelee/alhangeul-macos/issues/472) |
 | expected rhwp | `v0.8.4` / `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
 | upstream latest | `v0.8.4`, candidate lock과 일치 |
@@ -46,7 +46,7 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 
 Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 signing, notarization, staple, Gatekeeper와 draft asset upload를 통과했다. DMG actual SHA256은 `e54d5a1...a7af`다. signed 앱에서 HWP/HWPX 열기·형식별 저장·재열기, 전체 페이지 PDF와 native 인쇄 panel을 확인했다. 후보 Preview/Thumbnail만 단독 등록한 격리 smoke에서 HWP/HWPX 결과와 실제 executable 경로를 확인한 뒤 기존 `/Applications` v0.1.9 및 사용자 v0.1.8 등록을 복원했다. 신규 crash는 없고 draft DMG도 detach했다. GitHub latest Release, Pages와 stable appcast는 계속 public `v0.1.9 (15)`를 유지한다. 상세 근거는 `mydocs/working/task_m900_472_stage4.md`에 기록한다.
 
-Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG SHA256 `800ea0df...e5dafd0e`, size 169,177,234 bytes를 확정하고 GitHub latest Release, Pages와 EdDSA stable appcast를 `0.1.10 (16)`으로 배포했다. clean `/Applications` v0.1.9 기준선에서 실제 Sparkle download·install·relaunch를 완료했고 v0.1.10 Preview/Thumbnail이 registration repair 없이 자연 갱신됐다. public 설치본에서 HWP/HWPX app open, Quick Look와 Thumbnail의 실제 `/Applications` provider process를 확인했으며 신규 crash는 없었다. Homebrew는 별도 승인 전이므로 기존 public v0.1.9 상태와 대기 문구를 유지한다. 상세 근거는 `mydocs/working/task_m900_472_stage5.md`에 기록한다.
+Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG SHA256 `800ea0df...e5dafd0e`, size 169,177,234 bytes를 확정하고 GitHub latest Release, Pages와 EdDSA stable appcast를 `0.1.10 (16)`으로 배포했다. clean `/Applications` v0.1.9 기준선에서 실제 Sparkle download·install·relaunch를 완료했고 v0.1.10 Preview/Thumbnail이 registration repair 없이 자연 갱신됐다. public 설치본에서 HWP/HWPX app open, Quick Look와 Thumbnail의 실제 `/Applications` provider process를 확인했으며 신규 crash는 없었다. 이후 별도 승인으로 repository Cask와 `postmelee/homebrew-tap`을 public DMG의 exact SHA256으로 갱신하고 tap commit `f712c88...`을 게시했다. style/audit와 fully-qualified install/uninstall smoke가 통과했으며 기존 Sparkle 설치본과 provider 등록을 복원했다. public 문구 closeout은 Stage 6의 별도 `main` 대상 PR 전까지 대기한다. 상세 근거는 `mydocs/working/task_m900_472_stage5.md`에 기록한다.
 
 ## 개인정보 정책 승인
 
@@ -171,7 +171,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 | [#375](https://github.com/postmelee/alhangeul-macos/issues/375) | [#465](https://github.com/postmelee/alhangeul-macos/pull/465) | merge·close 완료 | upstream Cargo.lock fingerprint gate |
 | [#467](https://github.com/postmelee/alhangeul-macos/issues/467) | [#468](https://github.com/postmelee/alhangeul-macos/pull/468) | merge·close 완료 | v0.8.4 decoder compatibility |
 | 없음 | [#471](https://github.com/postmelee/alhangeul-macos/pull/471) | merge 완료 | `rhwp v0.8.4` full sync |
-| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | source, release transport, signed draft와 official public surface 완료 · Homebrew 승인 대기 |
+| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | source, release transport, signed draft, official public surface와 Homebrew 완료 · Stage 6 closeout 대기 |
 
 ## 검증 기준
 
@@ -196,7 +196,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 | Public release | GitHub Release, public DMG/checksum, Pages/appcast | run `31812500336`, public DMG `800ea0df...e5dafd0e`, Pages/appcast 통과 |
 | Public update | v0.1.9 -> v0.1.10 Sparkle와 extension refresh | 실제 download/install/relaunch, repair 없는 Preview/Thumbnail refresh 통과 |
 | Public app/Finder | HWP/HWPX open, Quick Look/Thumbnail provider | `/Applications` v0.1.10 process provenance와 non-blank 결과 통과 |
-| Homebrew | official public DMG URL/SHA256과 install/uninstall | public 입력 확정, 별도 승인 대기 |
+| Homebrew | official public DMG URL/SHA256과 install/uninstall | Cask `0.1.10`, tap `f712c88...`, style/audit와 install/uninstall 통과 |
 
 ## Release metadata
 
@@ -224,6 +224,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 | public DMG SHA256 / size | `800ea0df2aee7ef380fb6af316f34d5a3c6bbbe60ef9b96054defac1e5dafd0e` / 169,177,234 bytes |
 | Pages release note | https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html |
 | stable appcast | https://postmelee.github.io/alhangeul-macos/appcast.xml, `0.1.10 (16)` |
+| Homebrew tap | https://github.com/postmelee/homebrew-tap, commit `f712c88e7e468395aeb09210cb6e24503dfb7d4f` |
 | core lock | `rhwp-core.lock` |
 | studio manifest | `Sources/HostApp/Resources/rhwp-studio/manifest.json` |
 
@@ -245,7 +246,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 - [x] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
 - [x] v0.1.9에서 v0.1.10 Sparkle update와 extension refresh 확인
 - [x] public 설치본 HWP/HWPX app open과 Preview/Thumbnail provider provenance 확인
-- [ ] 별도 승인 후 Homebrew Cask 반영과 install/uninstall smoke
+- [x] 별도 승인 후 Homebrew Cask 반영과 install/uninstall smoke
 
 ## 알려진 제한 사항과 후속 이슈
 
@@ -275,4 +276,5 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 - [x] signed draft 결과와 실제 미실행 항목 반영
 - [x] official public DMG URL/SHA256 반영
 - [x] Sparkle/Pages와 실제 update 결과 반영
-- [ ] 별도 승인된 Homebrew 결과와 public 문서 closeout 반영
+- [x] 별도 승인된 Homebrew 결과 반영
+- [ ] Stage 6 public 문서 closeout과 Pages 재배포 반영

--- a/mydocs/release/v0.1.10.md
+++ b/mydocs/release/v0.1.10.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.10` build `16`, release PR #476 merge · annotated tag 완료 · signed draft 승인 대기 |
+| 상태 | `v0.1.10` build `16`, release PR #476 merge · annotated tag · signed draft 차단 gate 완료 · official 승인 대기 |
 | 목표 Git tag | `v0.1.10` |
 | 목표 app version | `0.1.10` |
 | 목표 build | `16` |
@@ -25,23 +25,26 @@
 | release PR | [#476](https://github.com/postmelee/alhangeul-macos/pull/476), merge commit `fafed425d4b87162c2188d1384d618adc2211eb6` |
 | annotated tag | `v0.1.10`, tag object `cd74a7ec8f3bc5bcc5862931b1eda9bbfeecc1b3`, target `fafed425d4b87162c2188d1384d618adc2211eb6` |
 | Rehearsal | [run `31681525166`](https://github.com/postmelee/alhangeul-macos/actions/runs/31681525166) 성공, unsigned artifact |
-| signed draft Publish | 미실행 |
+| signed draft Publish | [run `31806721517`](https://github.com/postmelee/alhangeul-macos/actions/runs/31806721517) 성공, exact tag target `fafed425...` |
+| Draft DMG / SHA256 | [`alhangeul-macos-0.1.10.dmg`](https://github.com/postmelee/alhangeul-macos/releases/tag/untagged-91bda2ed93cfa0d3ca56), `e54d5a1d2c4875f96ff704d61e0a8567146e00fca0cfc55cd51c04875457a7af` |
 | official stable Publish | 미실행 |
 | Public DMG / SHA256 | 미생성 |
-| Pages / stable appcast | merge-time [run `31696542384`](https://github.com/postmelee/alhangeul-macos/actions/runs/31696542384)에서 deploy skip, 현재 public `v0.1.9 (15)` 유지 |
+| Pages / stable appcast | draft run에서도 deploy skip, 현재 public `v0.1.9 (15)` 유지 |
 | Homebrew Cask | 현재 public `v0.1.9` 유지 |
 | Release 실행 이슈 | [#472](https://github.com/postmelee/alhangeul-macos/issues/472) |
 | expected rhwp | `v0.8.4` / `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
 | upstream latest | `v0.8.4`, candidate lock과 일치 |
 | latest guard | `require_latest_rhwp=true`, 예외 계획 없음 |
 
-2026-08-14 tag 생성 직전 live 조회에서 최신 공개 알한글은 non-draft/non-prerelease `v0.1.9`, upstream latest는 `rhwp v0.8.4`였다. remote `v0.1.10` tag와 GitHub Release가 없음을 확인한 뒤 annotated tag를 생성·push했다. GitHub Release는 tag push만으로 생성되지 않았고 signed draft Publish 승인 전 상태다.
+2026-08-14 tag 생성 직전 live 조회에서 최신 공개 알한글은 non-draft/non-prerelease `v0.1.9`, upstream latest는 `rhwp v0.8.4`였다. remote `v0.1.10` tag와 GitHub Release가 없음을 확인한 뒤 annotated tag를 생성·push했다. 별도 승인으로 signed draft Publish를 실행해 `isDraft=true`, `prerelease=false` Release와 notarized DMG를 생성·검증했으며 공개 채널은 변경하지 않았다.
 
 Stage 1에서 HostApp, Quick Look과 Thumbnail extension을 모두 `0.1.10 (16)`으로 갱신했다. Release Rehearsal/Publish workflow default는 `0.1.10`, `v0.1.9`, `v0.8.4`로 정렬했고 `require_latest_rhwp=true`, `include_rhwp_in_title=true`, `draft=false`, `prerelease=false` 보호 기본값을 유지했다.
 
 release PR 직전 `origin/main` 전용 3개 commit은 PR #446, #450과 #452의 v0.1.9 release transport였다. 각 merge tree는 대응 `devel` head와 같고 당시 `main` tree도 merge base `9e564ff...` tree와 같으며 `main` 전용 non-merge commit도 없으므로 누락된 content가 없었다. Task #472에서는 content 변화가 없는 history-only `main -> devel` back-merge를 생략했고, 장기 ancestry/content 판정 규칙과 자동 gate는 [#474](https://github.com/postmelee/alhangeul-macos/issues/474)로 분리했다. 이후 PR #476 merge로 `main` release commit `fafed425...`의 tree가 final `devel` candidate `34ba512...`의 tree와 정확히 같음을 재확인했다.
 
 Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable artifact 경계를 승인받아 strict static archive byte mismatch와 분리했다. exact candidate `95800ee...`의 source preflight, Rust/Swift test, 세 target Release build, renderer와 local universal package가 통과했다. 이어 같은 SHA를 `publish/task472`에 push해 실행한 Rehearsal run `31681525166`에서 unsigned universal DMG의 checksum, `hdiutil` integrity와 layout을 확인했다. rehearsal 뒤에도 GitHub latest Release, Pages와 stable appcast는 public `v0.1.9 (15)`를 유지했다. 상세 근거는 `mydocs/working/task_m900_472_stage3.md`에 기록한다.
+
+Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 signing, notarization, staple, Gatekeeper와 draft asset upload를 통과했다. DMG actual SHA256은 `e54d5a1...a7af`다. signed 앱에서 HWP/HWPX 열기·형식별 저장·재열기, 전체 페이지 PDF와 native 인쇄 panel을 확인했다. 후보 Preview/Thumbnail만 단독 등록한 격리 smoke에서 HWP/HWPX 결과와 실제 executable 경로를 확인한 뒤 기존 `/Applications` v0.1.9 및 사용자 v0.1.8 등록을 복원했다. 신규 crash는 없고 draft DMG도 detach했다. GitHub latest Release, Pages와 stable appcast는 계속 public `v0.1.9 (15)`를 유지한다. 상세 근거는 `mydocs/working/task_m900_472_stage4.md`에 기록한다.
 
 ## 개인정보 정책 승인
 
@@ -166,7 +169,7 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 | [#375](https://github.com/postmelee/alhangeul-macos/issues/375) | [#465](https://github.com/postmelee/alhangeul-macos/pull/465) | merge·close 완료 | upstream Cargo.lock fingerprint gate |
 | [#467](https://github.com/postmelee/alhangeul-macos/issues/467) | [#468](https://github.com/postmelee/alhangeul-macos/pull/468) | merge·close 완료 | v0.8.4 decoder compatibility |
 | 없음 | [#471](https://github.com/postmelee/alhangeul-macos/pull/471) | merge 완료 | `rhwp v0.8.4` full sync |
-| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | source, branch 판정과 release transport 완료 · signed draft 대기 |
+| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | source, branch 판정, release transport와 signed draft gate 완료 · official 승인 대기 |
 
 ## 검증 기준
 
@@ -183,11 +186,11 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 | Static archive | strict byte reference와 portable source/header/FFI 분리 | strict mismatch 기록 · portable 승인/통과 |
 | Rust/Swift tests | RustBridge, decoder fixture, HostAppTests, ExternalImageTests | Stage 3 통과 |
 | Release build/render | 세 target build와 representative renderer | Stage 3 통과 |
-| HWP/HWPX 저장 | 네 format 조합, 후속 저장, 재열기와 원본 무손실 | 기존 PR 근거 확인, signed draft 재검증 예정 |
-| PDF/인쇄 | page count/geometry/text/raster와 trust boundary | 기존 PR 근거 확인, signed draft 재검증 예정 |
+| HWP/HWPX 저장 | 네 format 조합, 후속 저장, 재열기와 원본 무손실 | signed draft HWP/HWPX 저장·재열기와 원본 SHA 유지 확인 |
+| PDF/인쇄 | page count/geometry/text/raster와 trust boundary | signed draft HWP 1쪽·HWPX 9쪽 PDF와 인쇄 panel, 자동 trust boundary 통과 |
 | Rehearsal DMG | unsigned checksum/integrity/universal/layout | run `31681525166` 통과 |
-| Signed draft DMG | signing/notarization/staple/Gatekeeper | 별도 승인 후 실행 예정 |
-| Signed Finder/Preview | 실제 provider path와 HWP/HWPX | 별도 승인 후 실행 예정 |
+| Signed draft DMG | signing/notarization/staple/Gatekeeper | run `31806721517`, DMG SHA256 `e54d5a1...a7af` 통과 |
+| Signed Finder/Preview | 실제 provider path와 HWP/HWPX | 후보 단독 등록에서 Preview/Thumbnail executable과 non-blank 결과 확인, 복원 완료 |
 | Public release | GitHub Release, public DMG/checksum, Pages/appcast | 별도 승인 후 실행 예정 |
 | Public update | v0.1.9 -> v0.1.10 Sparkle와 extension refresh | 별도 승인 후 실행 예정 |
 | Homebrew | official public DMG URL/SHA256과 install/uninstall | 별도 승인 후 실행 예정 |
@@ -226,9 +229,9 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 - [x] Task #472 intermediate source PR #473을 `devel`에 merge
 - [x] `main` 전용 commit을 transport-only로 판정하고 history-only back-merge 생략
 - [x] `devel -> main` release PR #476 merge와 annotated `v0.1.10` tag 생성
-- [ ] `draft=true`, `prerelease=false` signed Publish 실행
-- [ ] signed/notarized draft DMG의 저장, PDF·인쇄, 앱/Finder 차단 gate 통과
-- [ ] draft 실행에서 stable appcast와 Pages 배포 skip 및 public `v0.1.9` 유지 확인
+- [x] `draft=true`, `prerelease=false` signed Publish 실행
+- [x] signed/notarized draft DMG의 저장, PDF·인쇄, 앱/Finder 차단 gate 통과
+- [x] draft 실행에서 stable appcast와 Pages 배포 skip 및 public `v0.1.9` 유지 확인
 - [ ] official stable Publish workflow 실행
 - [ ] public DMG SHA256, GitHub Release, Pages와 stable appcast 확인
 - [ ] v0.1.9에서 v0.1.10 Sparkle update와 extension refresh 확인
@@ -259,6 +262,6 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 - [x] 해결된 Issue와 open 참고 Issue를 구분
 - [x] README, Pages와 release record의 version/build/rhwp identity 일치
 - [x] final source candidate `34ba512...`에서 release note helper 재생성
-- [ ] signed draft 결과와 실제 미실행 항목 반영
+- [x] signed draft 결과와 실제 미실행 항목 반영
 - [ ] official public DMG URL/SHA256 반영
 - [ ] Sparkle/Pages와 Homebrew 결과 반영

--- a/mydocs/release/v0.1.10.md
+++ b/mydocs/release/v0.1.10.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.10` build `16`, public stable · Pages/Sparkle · 실제 v0.1.9 update · Homebrew Cask 배포 검증 완료 |
+| 상태 | `v0.1.10` build `16`, public stable · Pages/Sparkle · 실제 v0.1.9 update · Homebrew Cask 배포 검증 완료 · Stage 6 closeout source 준비 |
 | 목표 Git tag | `v0.1.10` |
 | 목표 app version | `0.1.10` |
 | 목표 build | `16` |
@@ -19,6 +19,9 @@
 | final source candidate | `34ba5127b9cd6614cffac6f0091201d3c3b1c13f` |
 | release merge commit / tree | `fafed425d4b87162c2188d1384d618adc2211eb6` / `7320f3a7e68a7a8926a40a041f44fc612d02db27` |
 | `origin/main` | `fafed425d4b87162c2188d1384d618adc2211eb6` |
+| Stage 6 기준 `origin/devel` | `34ba5127b9cd6614cffac6f0091201d3c3b1c13f` |
+| Stage 6 branch divergence | `origin/main...origin/devel` = `4 0`, main 전용 release transport merge만 존재 |
+| Stage 6 closeout tree diff | main/devel 각 동일한 release closeout 12파일, 제품 source/project/workflow 변경 없음 |
 | Stage 4.1 판정 시점 merge base | `9e564ff79410bd06c36b36d3dd3cd6fa2b6e4c49` |
 | source PR | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), merge commit `447b31bcd1cb235980387df2a679fe243f161943` |
 | back-merge | transport-only ancestry로 판정, history-only PR 생략 |
@@ -30,7 +33,9 @@
 | official stable Publish | [run `31812500336`](https://github.com/postmelee/alhangeul-macos/actions/runs/31812500336) 성공, release job `94806246847`, Pages job `94810917280` |
 | Public DMG / SHA256 | [`alhangeul-macos-0.1.10.dmg`](https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.10/alhangeul-macos-0.1.10.dmg), `800ea0df2aee7ef380fb6af316f34d5a3c6bbbe60ef9b96054defac1e5dafd0e`, 169,177,234 bytes |
 | Pages / stable appcast | public `v0.1.10 (16)`, same DMG URL/size와 EdDSA signature 확인 |
+| Stage 6 public appcast SHA256 | `36b5d62bc9477bf6b586c19888071ba8610be0ac42a116b2a8be7bf5cee3af5a` |
 | Homebrew Cask | public `v0.1.10`, SHA256 `800ea0df...e5dafd0e`, tap commit `f712c88...` |
+| Stage 6 communication closeout | repository source와 GitHub Release body 후보 준비 · main PR, Release 본문 수정과 Pages 재배포 승인 대기 |
 | Release 실행 이슈 | [#472](https://github.com/postmelee/alhangeul-macos/issues/472) |
 | expected rhwp | `v0.8.4` / `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
 | upstream latest | `v0.8.4`, candidate lock과 일치 |
@@ -47,6 +52,8 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 signing, notarization, staple, Gatekeeper와 draft asset upload를 통과했다. DMG actual SHA256은 `e54d5a1...a7af`다. signed 앱에서 HWP/HWPX 열기·형식별 저장·재열기, 전체 페이지 PDF와 native 인쇄 panel을 확인했다. 후보 Preview/Thumbnail만 단독 등록한 격리 smoke에서 HWP/HWPX 결과와 실제 executable 경로를 확인한 뒤 기존 `/Applications` v0.1.9 및 사용자 v0.1.8 등록을 복원했다. 신규 crash는 없고 draft DMG도 detach했다. GitHub latest Release, Pages와 stable appcast는 계속 public `v0.1.9 (15)`를 유지한다. 상세 근거는 `mydocs/working/task_m900_472_stage4.md`에 기록한다.
 
 Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG SHA256 `800ea0df...e5dafd0e`, size 169,177,234 bytes를 확정하고 GitHub latest Release, Pages와 EdDSA stable appcast를 `0.1.10 (16)`으로 배포했다. clean `/Applications` v0.1.9 기준선에서 실제 Sparkle download·install·relaunch를 완료했고 v0.1.10 Preview/Thumbnail이 registration repair 없이 자연 갱신됐다. public 설치본에서 HWP/HWPX app open, Quick Look와 Thumbnail의 실제 `/Applications` provider process를 확인했으며 신규 crash는 없었다. 이후 별도 승인으로 repository Cask와 `postmelee/homebrew-tap`을 public DMG의 exact SHA256으로 갱신하고 tap commit `f712c88...`을 게시했다. style/audit와 fully-qualified install/uninstall smoke가 통과했으며 기존 Sparkle 설치본과 provider 등록을 복원했다. public 문구 closeout은 Stage 6의 별도 `main` 대상 PR 전까지 대기한다. 상세 근거는 `mydocs/working/task_m900_472_stage5.md`에 기록한다.
+
+2026-08-16 Stage 6 live 재확인에서 GitHub Release, DMG asset, appcast와 public tap identity는 변하지 않았다. public appcast SHA256은 `36b5d62b...af5a`이고 `0.1.10 (16)`, public DMG URL, 169,177,234 bytes와 EdDSA signature를 유지한다. 반면 `origin/main`의 repository Cask는 아직 v0.1.9이고 README, Pages home/update index/v0.1.10 note와 GitHub Release body에는 Homebrew 배포 전 문구가 남아 있다. `local/task472`에서 Cask와 네 source 문서를 현재 설치 명령으로 보정하고, public appcast를 byte 단위로 보존한 Pages artifact와 GitHub Release body 한 줄 보정 후보를 검증했다. main closeout PR, Release 본문 직접 수정과 docs-only Pages 재배포는 Stage 6 완료보고 승인 전에는 게시하지 않는다.
 
 ## 개인정보 정책 승인
 
@@ -171,7 +178,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 | [#375](https://github.com/postmelee/alhangeul-macos/issues/375) | [#465](https://github.com/postmelee/alhangeul-macos/pull/465) | merge·close 완료 | upstream Cargo.lock fingerprint gate |
 | [#467](https://github.com/postmelee/alhangeul-macos/issues/467) | [#468](https://github.com/postmelee/alhangeul-macos/pull/468) | merge·close 완료 | v0.8.4 decoder compatibility |
 | 없음 | [#471](https://github.com/postmelee/alhangeul-macos/pull/471) | merge 완료 | `rhwp v0.8.4` full sync |
-| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | source, release transport, signed draft, official public surface와 Homebrew 완료 · Stage 6 closeout 대기 |
+| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | release와 Homebrew 완료 · Stage 6 closeout source/최종 보고 준비 · 게시·merge·Pages 확인 대기 |
 
 ## 검증 기준
 
@@ -184,7 +191,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 | Upstream Cargo.lock | target checkout root hash와 manifest fingerprint 일치 | Stage 3 통과 |
 | Workflow default | `0.1.10`, `v0.1.9`, `v0.8.4` | Stage 1 통과 |
 | Release PR analysis | `v0.1.9..34ba512...` 포함 PR과 release transport 분리 | final candidate owner 보정 완료 |
-| Release communication | README, Pages home/update, release index/record | Stage 2 작성 완료 |
+| Release communication | README, Pages home/update, release index/record | Stage 2 release 문구와 Stage 6 Homebrew closeout source 준비 |
 | Static archive | strict byte reference와 portable source/header/FFI 분리 | strict mismatch 기록 · portable 승인/통과 |
 | Rust/Swift tests | RustBridge, decoder fixture, HostAppTests, ExternalImageTests | Stage 3 통과 |
 | Release build/render | 세 target build와 representative renderer | Stage 3 통과 |
@@ -223,7 +230,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 | public DMG | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.10/alhangeul-macos-0.1.10.dmg |
 | public DMG SHA256 / size | `800ea0df2aee7ef380fb6af316f34d5a3c6bbbe60ef9b96054defac1e5dafd0e` / 169,177,234 bytes |
 | Pages release note | https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html |
-| stable appcast | https://postmelee.github.io/alhangeul-macos/appcast.xml, `0.1.10 (16)` |
+| stable appcast | https://postmelee.github.io/alhangeul-macos/appcast.xml, `0.1.10 (16)`, SHA256 `36b5d62b...af5a` |
 | Homebrew tap | https://github.com/postmelee/homebrew-tap, commit `f712c88e7e468395aeb09210cb6e24503dfb7d4f` |
 | core lock | `rhwp-core.lock` |
 | studio manifest | `Sources/HostApp/Resources/rhwp-studio/manifest.json` |
@@ -277,4 +284,6 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 - [x] official public DMG URL/SHA256 반영
 - [x] Sparkle/Pages와 실제 update 결과 반영
 - [x] 별도 승인된 Homebrew 결과 반영
-- [ ] Stage 6 public 문서 closeout과 Pages 재배포 반영
+- [x] Stage 6 repository Cask, public 문서와 GitHub Release body closeout 후보 검증
+- [ ] GitHub Release Homebrew 문구 직접 보정
+- [ ] main closeout PR merge와 docs-only Pages 재배포 확인

--- a/mydocs/release/v0.1.10.md
+++ b/mydocs/release/v0.1.10.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.10` build `16`, public stable · Pages/Sparkle · 실제 v0.1.9 update · Homebrew Cask 배포 검증 완료 · GitHub Release 문구 보정 · main closeout draft PR #477 게시 |
+| 상태 | `v0.1.10` build `16`, public stable · Pages/Sparkle · 실제 v0.1.9 update · Homebrew Cask · GitHub Release/Pages 문구 closeout 완료 |
 | 목표 Git tag | `v0.1.10` |
 | 목표 app version | `0.1.10` |
 | 목표 build | `16` |
@@ -18,13 +18,14 @@
 | Stage 4.1 판정 시점 `origin/devel` | `447b31bcd1cb235980387df2a679fe243f161943` |
 | final source candidate | `34ba5127b9cd6614cffac6f0091201d3c3b1c13f` |
 | release merge commit / tree | `fafed425d4b87162c2188d1384d618adc2211eb6` / `7320f3a7e68a7a8926a40a041f44fc612d02db27` |
-| `origin/main` | `fafed425d4b87162c2188d1384d618adc2211eb6` |
+| `origin/main` | closeout merge `7162a80fdadf4e121623be1da9c1a7d933ef0fac` |
 | Stage 6 기준 `origin/devel` | `34ba5127b9cd6614cffac6f0091201d3c3b1c13f` |
-| Stage 6 branch divergence | `origin/main...origin/devel` = `4 0`, main 전용 release transport merge만 존재 |
-| Stage 6 closeout tree diff | main/devel 각 동일한 release closeout 12파일, 제품 source/project/workflow 변경 없음 |
+| Stage 6 branch divergence | PR #477 merge 뒤 `origin/main...origin/devel` = `12 0`, 기존 release transport 4 + closeout head 7 + merge commit 1 |
+| Stage 6 closeout tree diff | main closeout 12파일 반영 완료 · devel 최종 후보는 오늘할일 포함 13파일, 제품 source/project/workflow 변경 없음 |
 | Stage 4.1 판정 시점 merge base | `9e564ff79410bd06c36b36d3dd3cd6fa2b6e4c49` |
 | source PR | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), merge commit `447b31bcd1cb235980387df2a679fe243f161943` |
 | back-merge | transport-only ancestry로 판정, history-only PR 생략 |
+| main closeout PR | [#477](https://github.com/postmelee/alhangeul-macos/pull/477), merge commit `7162a80fdadf4e121623be1da9c1a7d933ef0fac` |
 | release PR | [#476](https://github.com/postmelee/alhangeul-macos/pull/476), merge commit `fafed425d4b87162c2188d1384d618adc2211eb6` |
 | annotated tag | `v0.1.10`, tag object `cd74a7ec8f3bc5bcc5862931b1eda9bbfeecc1b3`, target `fafed425d4b87162c2188d1384d618adc2211eb6` |
 | Rehearsal | [run `31681525166`](https://github.com/postmelee/alhangeul-macos/actions/runs/31681525166) 성공, unsigned artifact |
@@ -35,7 +36,7 @@
 | Pages / stable appcast | public `v0.1.10 (16)`, same DMG URL/size와 EdDSA signature 확인 |
 | Stage 6 public appcast SHA256 | `36b5d62bc9477bf6b586c19888071ba8610be0ac42a116b2a8be7bf5cee3af5a` |
 | Homebrew Cask | public `v0.1.10`, SHA256 `800ea0df...e5dafd0e`, tap commit `f712c88...` |
-| Stage 6 communication closeout | GitHub Release Homebrew 문구 보정 완료 · main draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477) 게시 · CI/merge와 Pages 재배포 대기 |
+| Stage 6 communication closeout | GitHub Release Homebrew 문구 보정 · PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477) merge · [Pages run `31975531842`](https://github.com/postmelee/alhangeul-macos/actions/runs/31975531842)와 public 화면 검증 완료 |
 | Release 실행 이슈 | [#472](https://github.com/postmelee/alhangeul-macos/issues/472) |
 | expected rhwp | `v0.8.4` / `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
 | upstream latest | `v0.8.4`, candidate lock과 일치 |
@@ -53,7 +54,7 @@ Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 s
 
 Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG SHA256 `800ea0df...e5dafd0e`, size 169,177,234 bytes를 확정하고 GitHub latest Release, Pages와 EdDSA stable appcast를 `0.1.10 (16)`으로 배포했다. clean `/Applications` v0.1.9 기준선에서 실제 Sparkle download·install·relaunch를 완료했고 v0.1.10 Preview/Thumbnail이 registration repair 없이 자연 갱신됐다. public 설치본에서 HWP/HWPX app open, Quick Look와 Thumbnail의 실제 `/Applications` provider process를 확인했으며 신규 crash는 없었다. 이후 별도 승인으로 repository Cask와 `postmelee/homebrew-tap`을 public DMG의 exact SHA256으로 갱신하고 tap commit `f712c88...`을 게시했다. style/audit와 fully-qualified install/uninstall smoke가 통과했으며 기존 Sparkle 설치본과 provider 등록을 복원했다. public 문구 closeout은 Stage 6의 별도 `main` 대상 PR 전까지 대기한다. 상세 근거는 `mydocs/working/task_m900_472_stage5.md`에 기록한다.
 
-2026-08-16 Stage 6 live 재확인에서 GitHub Release, DMG asset, appcast와 public tap identity는 변하지 않았다. public appcast SHA256은 `36b5d62b...af5a`이고 `0.1.10 (16)`, public DMG URL, 169,177,234 bytes와 EdDSA signature를 유지한다. `origin/main`의 repository Cask는 아직 v0.1.9이고 README와 Pages home/update index/v0.1.10 note에는 Homebrew 배포 전 문구가 남아 있었다. `local/task472`에서 Cask와 네 source 문서를 현재 설치 명령으로 보정하고 public appcast를 byte 단위로 보존한 Pages artifact를 검증했다. 작업지시자 승인 뒤 GitHub Release body는 검증된 후보 파일로 직접 보정했으며, 공개 본문이 후보와 일치하고 이전 문구가 제거됐음을 재확인했다. 같은 승인 범위에서 main closeout draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477)을 게시했으며 CI/merge와 docs-only Pages 재배포는 아직 대기한다.
+2026-08-16 Stage 6 live 재확인에서 GitHub Release, DMG asset, appcast와 public tap identity는 변하지 않았다. public appcast SHA256은 `36b5d62b...af5a`이고 `0.1.10 (16)`, public DMG URL, 169,177,234 bytes와 EdDSA signature를 유지한다. `local/task472`에서 repository Cask와 네 public source 문서를 현재 Homebrew 설치 명령으로 보정하고 public appcast를 byte 단위로 보존한 Pages artifact를 검증했다. 작업지시자 승인 뒤 GitHub Release body를 검증된 후보와 일치하도록 수정했고, main closeout PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477)을 merge commit `7162a80...`으로 반영했다. 2026-08-17 docs-only Pages run `31975531842` 성공 뒤 홈, 업데이트 목록과 v0.1.10 note의 현재 명령을 확인했으며 stable appcast가 기존 SHA256 및 byte content를 유지함을 재검증했다.
 
 ## 개인정보 정책 승인
 
@@ -178,7 +179,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 | [#375](https://github.com/postmelee/alhangeul-macos/issues/375) | [#465](https://github.com/postmelee/alhangeul-macos/pull/465) | merge·close 완료 | upstream Cargo.lock fingerprint gate |
 | [#467](https://github.com/postmelee/alhangeul-macos/issues/467) | [#468](https://github.com/postmelee/alhangeul-macos/pull/468) | merge·close 완료 | v0.8.4 decoder compatibility |
 | 없음 | [#471](https://github.com/postmelee/alhangeul-macos/pull/471) | merge 완료 | `rhwp v0.8.4` full sync |
-| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476), [#477](https://github.com/postmelee/alhangeul-macos/pull/477) | 진행중 | release와 Homebrew 완료 · GitHub Release 문구 보정 완료 · main closeout draft 게시 · CI/merge·Pages 확인 대기 |
+| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476), [#477](https://github.com/postmelee/alhangeul-macos/pull/477) | 종료 정리중 | release·Homebrew·GitHub Release/Pages closeout 완료 · devel 최종 보고 PR과 Issue close 대기 |
 
 ## 검증 기준
 
@@ -191,7 +192,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 | Upstream Cargo.lock | target checkout root hash와 manifest fingerprint 일치 | Stage 3 통과 |
 | Workflow default | `0.1.10`, `v0.1.9`, `v0.8.4` | Stage 1 통과 |
 | Release PR analysis | `v0.1.9..34ba512...` 포함 PR과 release transport 분리 | final candidate owner 보정 완료 |
-| Release communication | README, Pages home/update, release index/record | GitHub Release 보정 완료 · Stage 6 Homebrew closeout source 준비 |
+| Release communication | README, Pages home/update, release index/record | GitHub Release와 public Pages Homebrew closeout 검증 완료 |
 | Static archive | strict byte reference와 portable source/header/FFI 분리 | strict mismatch 기록 · portable 승인/통과 |
 | Rust/Swift tests | RustBridge, decoder fixture, HostAppTests, ExternalImageTests | Stage 3 통과 |
 | Release build/render | 세 target build와 representative renderer | Stage 3 통과 |
@@ -287,4 +288,4 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 - [x] Stage 6 repository Cask, public 문서와 GitHub Release body closeout 후보 검증
 - [x] GitHub Release Homebrew 문구 직접 보정과 공개 본문 재검증
 - [x] main closeout draft PR #477 게시와 exact 12파일 범위 확인
-- [ ] main closeout PR merge와 docs-only Pages 재배포 확인
+- [x] main closeout PR #477 merge와 docs-only Pages 재배포 확인

--- a/mydocs/release/v0.1.10.md
+++ b/mydocs/release/v0.1.10.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.10` build `16` candidate, source PR #473 merge 완료 · Stage 4 release PR 준비 |
+| 상태 | `v0.1.10` build `16`, release PR #476 merge · annotated tag 완료 · signed draft 승인 대기 |
 | 목표 Git tag | `v0.1.10` |
 | 목표 app version | `0.1.10` |
 | 목표 build | `16` |
@@ -16,30 +16,36 @@
 | Stage 2 범위 | `v0.1.9..58424de31051007c2f185410f47ef090680c4ad9` |
 | Stage 3 exact candidate | `95800eed4b2a631d2615203c3bed6cc1f7fa5d4e` |
 | Stage 4.1 판정 시점 `origin/devel` | `447b31bcd1cb235980387df2a679fe243f161943` |
-| `origin/main` | `26f3104469135c5e80b3a19dddb9d0baebfbfb0a` |
-| merge base | `9e564ff79410bd06c36b36d3dd3cd6fa2b6e4c49` |
+| final source candidate | `34ba5127b9cd6614cffac6f0091201d3c3b1c13f` |
+| release merge commit / tree | `fafed425d4b87162c2188d1384d618adc2211eb6` / `7320f3a7e68a7a8926a40a041f44fc612d02db27` |
+| `origin/main` | `fafed425d4b87162c2188d1384d618adc2211eb6` |
+| Stage 4.1 판정 시점 merge base | `9e564ff79410bd06c36b36d3dd3cd6fa2b6e4c49` |
 | source PR | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), merge commit `447b31bcd1cb235980387df2a679fe243f161943` |
 | back-merge | transport-only ancestry로 판정, history-only PR 생략 |
-| release PR | 미생성, Stage 4 별도 승인 gate |
-| annotated tag | 미생성 |
+| release PR | [#476](https://github.com/postmelee/alhangeul-macos/pull/476), merge commit `fafed425d4b87162c2188d1384d618adc2211eb6` |
+| annotated tag | `v0.1.10`, tag object `cd74a7ec8f3bc5bcc5862931b1eda9bbfeecc1b3`, target `fafed425d4b87162c2188d1384d618adc2211eb6` |
 | Rehearsal | [run `31681525166`](https://github.com/postmelee/alhangeul-macos/actions/runs/31681525166) 성공, unsigned artifact |
 | signed draft Publish | 미실행 |
 | official stable Publish | 미실행 |
 | Public DMG / SHA256 | 미생성 |
-| Pages / stable appcast | 현재 public `v0.1.9 (15)` 유지 |
+| Pages / stable appcast | merge-time [run `31696542384`](https://github.com/postmelee/alhangeul-macos/actions/runs/31696542384)에서 deploy skip, 현재 public `v0.1.9 (15)` 유지 |
 | Homebrew Cask | 현재 public `v0.1.9` 유지 |
 | Release 실행 이슈 | [#472](https://github.com/postmelee/alhangeul-macos/issues/472) |
 | expected rhwp | `v0.8.4` / `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
 | upstream latest | `v0.8.4`, candidate lock과 일치 |
 | latest guard | `require_latest_rhwp=true`, 예외 계획 없음 |
 
-2026-08-13 live 조회에서 최신 공개 알한글은 non-draft/non-prerelease `v0.1.9`, upstream latest는 `rhwp v0.8.4`다. Stage 1 시작 candidate `4abdc30...`은 수행·구현계획 승인 시점에서 이동하지 않았고 `v0.1.10` local/remote tag는 없다.
+2026-08-14 tag 생성 직전 live 조회에서 최신 공개 알한글은 non-draft/non-prerelease `v0.1.9`, upstream latest는 `rhwp v0.8.4`였다. remote `v0.1.10` tag와 GitHub Release가 없음을 확인한 뒤 annotated tag를 생성·push했다. GitHub Release는 tag push만으로 생성되지 않았고 signed draft Publish 승인 전 상태다.
 
 Stage 1에서 HostApp, Quick Look과 Thumbnail extension을 모두 `0.1.10 (16)`으로 갱신했다. Release Rehearsal/Publish workflow default는 `0.1.10`, `v0.1.9`, `v0.8.4`로 정렬했고 `require_latest_rhwp=true`, `include_rhwp_in_title=true`, `draft=false`, `prerelease=false` 보호 기본값을 유지했다.
 
-현재 `origin/main` 전용 3개 commit은 PR #446, #450과 #452의 v0.1.9 release transport다. 각 merge tree는 대응 `devel` head와 같고 current `main` tree도 merge base `9e564ff...` tree와 같으며 `main` 전용 non-merge commit도 없으므로 누락된 content는 없다. Task #472에서는 content 변화가 없는 history-only `main -> devel` back-merge를 생략하고 updated `devel`에서 release PR을 준비한다. 이 선택으로 좌측 ancestry count는 release merge마다 증가하므로 count 자체를 content drift 신호로 사용하지 않는다. ancestry/content 판정 규칙의 문서화와 자동 gate는 [#474](https://github.com/postmelee/alhangeul-macos/issues/474)로 분리했다.
+release PR 직전 `origin/main` 전용 3개 commit은 PR #446, #450과 #452의 v0.1.9 release transport였다. 각 merge tree는 대응 `devel` head와 같고 당시 `main` tree도 merge base `9e564ff...` tree와 같으며 `main` 전용 non-merge commit도 없으므로 누락된 content가 없었다. Task #472에서는 content 변화가 없는 history-only `main -> devel` back-merge를 생략했고, 장기 ancestry/content 판정 규칙과 자동 gate는 [#474](https://github.com/postmelee/alhangeul-macos/issues/474)로 분리했다. 이후 PR #476 merge로 `main` release commit `fafed425...`의 tree가 final `devel` candidate `34ba512...`의 tree와 정확히 같음을 재확인했다.
 
 Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable artifact 경계를 승인받아 strict static archive byte mismatch와 분리했다. exact candidate `95800ee...`의 source preflight, Rust/Swift test, 세 target Release build, renderer와 local universal package가 통과했다. 이어 같은 SHA를 `publish/task472`에 push해 실행한 Rehearsal run `31681525166`에서 unsigned universal DMG의 checksum, `hdiutil` integrity와 layout을 확인했다. rehearsal 뒤에도 GitHub latest Release, Pages와 stable appcast는 public `v0.1.9 (15)`를 유지했다. 상세 근거는 `mydocs/working/task_m900_472_stage3.md`에 기록한다.
+
+## 개인정보 정책 승인
+
+2026-08-14 작업지시자는 익명 실행·version transition 이벤트의 기본 활성화와 최초 실행 timing을 인지한 상태에서 현재 동작을 `v0.1.10`의 의도된 정책으로 승인했다. `prepareForLaunch`가 앱 시작 초기에 실행되므로 최초 실행 이벤트는 사용자가 개인정보 설정에서 opt-out하기 전에 전송될 수 있다. 이벤트에는 문서 내용·파일명·경로와 영구 사용자·기기·설치 식별자를 넣지 않고, opt-out하면 보관 중인 이벤트를 삭제하고 이후 수집·전송을 중단한다. 이 결정으로 final source candidate 코드는 변경하지 않았다. 공개 review 후속과 tag gate 범위는 [Issue #472 승인 기록](https://github.com/postmelee/alhangeul-macos/issues/472#issuecomment-5294038739)에 남겼다.
 
 ## 사용자용 요약
 
@@ -79,9 +85,12 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 | [#458](https://github.com/postmelee/alhangeul-macos/pull/458) | Task #455: rhwp-studio PDF 저장 메뉴를 SVG 기반 native PDF 내보내기로 통합 | 사용자-facing 기능 | 예 | 예 | [#455](https://github.com/postmelee/alhangeul-macos/issues/455) | 없음 | PR body, `mydocs/report/task_m010_455_report.md` | 전체 page, 최신 편집, searchable text |
 | [#457](https://github.com/postmelee/alhangeul-macos/pull/457) | Task #456: HostApp HWP/HWPX native 저장 경로 연결 | 사용자-facing 기능 | 예 | 예 | [#456](https://github.com/postmelee/alhangeul-macos/issues/456) | 없음 | PR body, `mydocs/report/task_m010_456_report.md` | HWP/HWPX 형식별 저장·재열기 |
 | [#454](https://github.com/postmelee/alhangeul-macos/pull/454) | Task #453: 최초 실행·버전 전환 익명 이벤트 수집 | 사용자-facing 개인정보·운영 | 예 | 예 | [#453](https://github.com/postmelee/alhangeul-macos/issues/453) | 없음 | PR body, `mydocs/report/task_m040_453_report.md` | 식별자 없는 payload와 opt-out을 공개 |
+| [#473](https://github.com/postmelee/alhangeul-macos/pull/473) | Task #472: v0.1.10 release candidate source 준비 | 운영/배포 | 아니오 | 아니오 | 없음 | [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | PR body, Stage 1~3 기록 | version, communication과 source gate 반영 |
+| [#475](https://github.com/postmelee/alhangeul-macos/pull/475) | Task #472: main/devel history-only back-merge 생략 판정 | 운영/배포 | 아니오 | 아니오 | 없음 | [#472](https://github.com/postmelee/alhangeul-macos/issues/472), [#474](https://github.com/postmelee/alhangeul-macos/issues/474) | PR body, Stage 4.1 기록 | transport ancestry와 content drift 분리 |
+| [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | Release: Alhangeul v0.1.10 (rhwp v0.8.4) | release transport | 아니오 | 아니오 | 없음 | [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | PR body, review와 merge-time Pages gate | exact `devel` candidate를 `main`에 반영 |
 | [#451](https://github.com/postmelee/alhangeul-macos/pull/451) | Task #441: v0.1.9 릴리즈 종료 정리와 Homebrew 배포 기록 | 이전 release closeout | 아니오 | 아니오 | 이전 release [#441](https://github.com/postmelee/alhangeul-macos/issues/441) | 없음 | PR body, `mydocs/report/task_m900_441_report.md` | v0.1.10 신규 변화에서 제외 |
 
-자동 helper는 위 9개 first-parent merge를 모두 후보로 모았다. release owner 보정 결과 PR #451은 직전 release closeout으로 제외하고, PR #464와 #465는 public 주요 변화가 아니라 provenance gate로 분류한다.
+자동 helper의 initial 후보와 final candidate까지의 운영 PR을 함께 보정했다. release owner 판정 결과 PR #451은 직전 release closeout으로 제외하고, PR #464와 #465는 public 주요 변화가 아니라 provenance gate로 분류하며, PR #473, #475와 #476은 release 운영·transport로 분류한다.
 
 ## GitHub Release 본문 구조 후보
 
@@ -157,7 +166,7 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 | [#375](https://github.com/postmelee/alhangeul-macos/issues/375) | [#465](https://github.com/postmelee/alhangeul-macos/pull/465) | merge·close 완료 | upstream Cargo.lock fingerprint gate |
 | [#467](https://github.com/postmelee/alhangeul-macos/issues/467) | [#468](https://github.com/postmelee/alhangeul-macos/pull/468) | merge·close 완료 | v0.8.4 decoder compatibility |
 | 없음 | [#471](https://github.com/postmelee/alhangeul-macos/pull/471) | merge 완료 | `rhwp v0.8.4` full sync |
-| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | 미생성 | 진행중 | release execution |
+| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | source, branch 판정과 release transport 완료 · signed draft 대기 |
 
 ## 검증 기준
 
@@ -169,7 +178,7 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 | Studio asset | bundled manifest가 `v0.8.4` / `496333b...` | Stage 1 resource verifier 통과 |
 | Upstream Cargo.lock | target checkout root hash와 manifest fingerprint 일치 | Stage 3 통과 |
 | Workflow default | `0.1.10`, `v0.1.9`, `v0.8.4` | Stage 1 통과 |
-| Release PR analysis | `v0.1.9..58424de...` merge PR과 transport 분리 | Stage 2 owner 보정 완료 |
+| Release PR analysis | `v0.1.9..34ba512...` 포함 PR과 release transport 분리 | final candidate owner 보정 완료 |
 | Release communication | README, Pages home/update, release index/record | Stage 2 작성 완료 |
 | Static archive | strict byte reference와 portable source/header/FFI 분리 | strict mismatch 기록 · portable 승인/통과 |
 | Rust/Swift tests | RustBridge, decoder fixture, HostAppTests, ExternalImageTests | Stage 3 통과 |
@@ -216,7 +225,7 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 - [x] 별도 승인 후 Rehearsal workflow 실행과 artifact 검증
 - [x] Task #472 intermediate source PR #473을 `devel`에 merge
 - [x] `main` 전용 commit을 transport-only로 판정하고 history-only back-merge 생략
-- [ ] `devel -> main` release PR merge와 annotated `v0.1.10` tag 생성
+- [x] `devel -> main` release PR #476 merge와 annotated `v0.1.10` tag 생성
 - [ ] `draft=true`, `prerelease=false` signed Publish 실행
 - [ ] signed/notarized draft DMG의 저장, PDF·인쇄, 앱/Finder 차단 gate 통과
 - [ ] draft 실행에서 stable appcast와 Pages 배포 skip 및 public `v0.1.9` 유지 확인
@@ -234,6 +243,7 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 - 실제 가로·세로 혼합 HWP/HWPX fixture는 없다. 혼합 geometry와 print orientation 미강제는 합성 SVG 자동 테스트로 검증했다.
 - PDF/인쇄 renderer의 `style-src 'unsafe-inline'`과 `img-src data:`는 현재 upstream SVG 충실도에 필요한 최소 예외다.
 - 익명 실행 추이는 전체 설치 수나 고유 사용자 수가 아니라 network를 통해 endpoint에 도달한 event 수다. 영구 폐쇄망과 보관기간 내 재연결되지 않은 실행은 관측하지 않는다.
+- 익명 event는 기본 활성화이며 최초 실행 이벤트가 설정 화면에서 opt-out하기 전에 전송될 수 있다. `v0.1.10`에서는 payload 비식별 경계와 즉시 opt-out을 유지하는 의도된 정책으로 승인했다.
 - deployment target macOS 12 실장과 Intel Mac 실제 설치·실행은 실행하지 않으면 통과로 기록하지 않는다.
 - [#459](https://github.com/postmelee/alhangeul-macos/issues/459)는 PDF·인쇄 lifecycle의 중복/stale callback 후속이다.
 - [#469](https://github.com/postmelee/alhangeul-macos/issues/469)는 producer-backed render-tree golden, [#470](https://github.com/postmelee/alhangeul-macos/issues/470)는 decoder 실패 진단 후속이다.
@@ -248,7 +258,7 @@ Stage 3에서는 source/Cargo/header/FFI/XCFramework를 유지하는 portable ar
 - [x] PR #464/#465 provenance gate를 사용자 주요 기능에서 분리
 - [x] 해결된 Issue와 open 참고 Issue를 구분
 - [x] README, Pages와 release record의 version/build/rhwp identity 일치
-- [x] Stage 3 exact candidate에서 release note helper 재생성
+- [x] final source candidate `34ba512...`에서 release note helper 재생성
 - [ ] signed draft 결과와 실제 미실행 항목 반영
 - [ ] official public DMG URL/SHA256 반영
 - [ ] Sparkle/Pages와 Homebrew 결과 반영

--- a/mydocs/release/v0.1.10.md
+++ b/mydocs/release/v0.1.10.md
@@ -4,7 +4,7 @@
 
 | 항목 | 값 |
 |------|----|
-| 상태 | `v0.1.10` build `16`, public stable · Pages/Sparkle · 실제 v0.1.9 update · Homebrew Cask 배포 검증 완료 · GitHub Release 문구 보정 · Stage 6 main closeout 대기 |
+| 상태 | `v0.1.10` build `16`, public stable · Pages/Sparkle · 실제 v0.1.9 update · Homebrew Cask 배포 검증 완료 · GitHub Release 문구 보정 · main closeout draft PR #477 게시 |
 | 목표 Git tag | `v0.1.10` |
 | 목표 app version | `0.1.10` |
 | 목표 build | `16` |
@@ -35,7 +35,7 @@
 | Pages / stable appcast | public `v0.1.10 (16)`, same DMG URL/size와 EdDSA signature 확인 |
 | Stage 6 public appcast SHA256 | `36b5d62bc9477bf6b586c19888071ba8610be0ac42a116b2a8be7bf5cee3af5a` |
 | Homebrew Cask | public `v0.1.10`, SHA256 `800ea0df...e5dafd0e`, tap commit `f712c88...` |
-| Stage 6 communication closeout | GitHub Release Homebrew 문구 보정 완료 · repository source 준비 · main PR과 Pages 재배포 대기 |
+| Stage 6 communication closeout | GitHub Release Homebrew 문구 보정 완료 · main draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477) 게시 · CI/merge와 Pages 재배포 대기 |
 | Release 실행 이슈 | [#472](https://github.com/postmelee/alhangeul-macos/issues/472) |
 | expected rhwp | `v0.8.4` / `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
 | upstream latest | `v0.8.4`, candidate lock과 일치 |
@@ -53,7 +53,7 @@ Stage 4 signed draft run `31806721517`은 exact tag target `fafed425...`에서 s
 
 Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG SHA256 `800ea0df...e5dafd0e`, size 169,177,234 bytes를 확정하고 GitHub latest Release, Pages와 EdDSA stable appcast를 `0.1.10 (16)`으로 배포했다. clean `/Applications` v0.1.9 기준선에서 실제 Sparkle download·install·relaunch를 완료했고 v0.1.10 Preview/Thumbnail이 registration repair 없이 자연 갱신됐다. public 설치본에서 HWP/HWPX app open, Quick Look와 Thumbnail의 실제 `/Applications` provider process를 확인했으며 신규 crash는 없었다. 이후 별도 승인으로 repository Cask와 `postmelee/homebrew-tap`을 public DMG의 exact SHA256으로 갱신하고 tap commit `f712c88...`을 게시했다. style/audit와 fully-qualified install/uninstall smoke가 통과했으며 기존 Sparkle 설치본과 provider 등록을 복원했다. public 문구 closeout은 Stage 6의 별도 `main` 대상 PR 전까지 대기한다. 상세 근거는 `mydocs/working/task_m900_472_stage5.md`에 기록한다.
 
-2026-08-16 Stage 6 live 재확인에서 GitHub Release, DMG asset, appcast와 public tap identity는 변하지 않았다. public appcast SHA256은 `36b5d62b...af5a`이고 `0.1.10 (16)`, public DMG URL, 169,177,234 bytes와 EdDSA signature를 유지한다. `origin/main`의 repository Cask는 아직 v0.1.9이고 README와 Pages home/update index/v0.1.10 note에는 Homebrew 배포 전 문구가 남아 있었다. `local/task472`에서 Cask와 네 source 문서를 현재 설치 명령으로 보정하고 public appcast를 byte 단위로 보존한 Pages artifact를 검증했다. 작업지시자 승인 뒤 GitHub Release body는 검증된 후보 파일로 직접 보정했으며, 공개 본문이 후보와 일치하고 이전 문구가 제거됐음을 재확인했다. main closeout PR과 docs-only Pages 재배포는 아직 대기한다.
+2026-08-16 Stage 6 live 재확인에서 GitHub Release, DMG asset, appcast와 public tap identity는 변하지 않았다. public appcast SHA256은 `36b5d62b...af5a`이고 `0.1.10 (16)`, public DMG URL, 169,177,234 bytes와 EdDSA signature를 유지한다. `origin/main`의 repository Cask는 아직 v0.1.9이고 README와 Pages home/update index/v0.1.10 note에는 Homebrew 배포 전 문구가 남아 있었다. `local/task472`에서 Cask와 네 source 문서를 현재 설치 명령으로 보정하고 public appcast를 byte 단위로 보존한 Pages artifact를 검증했다. 작업지시자 승인 뒤 GitHub Release body는 검증된 후보 파일로 직접 보정했으며, 공개 본문이 후보와 일치하고 이전 문구가 제거됐음을 재확인했다. 같은 승인 범위에서 main closeout draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477)을 게시했으며 CI/merge와 docs-only Pages 재배포는 아직 대기한다.
 
 ## 개인정보 정책 승인
 
@@ -178,7 +178,7 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 | [#375](https://github.com/postmelee/alhangeul-macos/issues/375) | [#465](https://github.com/postmelee/alhangeul-macos/pull/465) | merge·close 완료 | upstream Cargo.lock fingerprint gate |
 | [#467](https://github.com/postmelee/alhangeul-macos/issues/467) | [#468](https://github.com/postmelee/alhangeul-macos/pull/468) | merge·close 완료 | v0.8.4 decoder compatibility |
 | 없음 | [#471](https://github.com/postmelee/alhangeul-macos/pull/471) | merge 완료 | `rhwp v0.8.4` full sync |
-| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476) | 진행중 | release와 Homebrew 완료 · GitHub Release 문구 보정 완료 · main closeout PR·merge·Pages 확인 대기 |
+| [#472](https://github.com/postmelee/alhangeul-macos/issues/472) | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), [#475](https://github.com/postmelee/alhangeul-macos/pull/475), [#476](https://github.com/postmelee/alhangeul-macos/pull/476), [#477](https://github.com/postmelee/alhangeul-macos/pull/477) | 진행중 | release와 Homebrew 완료 · GitHub Release 문구 보정 완료 · main closeout draft 게시 · CI/merge·Pages 확인 대기 |
 
 ## 검증 기준
 
@@ -286,4 +286,5 @@ Stage 5 official run `31812500336`은 같은 exact tag target에서 public DMG S
 - [x] 별도 승인된 Homebrew 결과 반영
 - [x] Stage 6 repository Cask, public 문서와 GitHub Release body closeout 후보 검증
 - [x] GitHub Release Homebrew 문구 직접 보정과 공개 본문 재검증
+- [x] main closeout draft PR #477 게시와 exact 12파일 범위 확인
 - [ ] main closeout PR merge와 docs-only Pages 재배포 확인

--- a/mydocs/report/task_m900_472_report.md
+++ b/mydocs/report/task_m900_472_report.md
@@ -17,12 +17,42 @@
 | signed draft | [run `31806721517`](https://github.com/postmelee/alhangeul-macos/actions/runs/31806721517) |
 | official Publish | [run `31812500336`](https://github.com/postmelee/alhangeul-macos/actions/runs/31812500336) |
 | Homebrew tap | [`postmelee/homebrew-tap` commit `f712c88`](https://github.com/postmelee/homebrew-tap/commit/f712c88e7e468395aeb09210cb6e24503dfb7d4f) |
-| main closeout | draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477) |
+| main closeout | PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477) merge `7162a80`, [Pages run `31975531842`](https://github.com/postmelee/alhangeul-macos/actions/runs/31975531842) 성공 |
 | 단계 | 수행계획, 구현계획, Stage 1~6 |
 
 `v0.1.10` release source와 communication을 upstream `rhwp v0.8.4` 기준으로 정렬하고 source preflight, unsigned Rehearsal, signed/notarized draft 차단 gate를 거쳐 official stable release를 게시했다. public DMG, Pages, stable Sparkle appcast, 실제 `v0.1.9 -> v0.1.10` 업데이트와 app/Finder provider를 확인한 뒤 같은 official DMG를 maintainer Homebrew tap에도 배포했다.
 
-Stage 6에서는 release identity와 public surface를 다시 조회하고 repository Cask, README, Pages source와 GitHub Release body의 Homebrew 대기 문구를 closeout 대상으로 확정했다. source 변경, appcast 보존 Pages artifact와 Release body 후보를 검증했고, 작업지시자 승인 뒤 공개 GitHub Release 본문을 후보와 일치하도록 보정하고 main closeout draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477)을 게시했다. CI/merge와 Pages 재배포는 아직 대기한다.
+Stage 6에서는 release identity와 public surface를 다시 조회하고 repository Cask, README, Pages source와 GitHub Release body의 Homebrew 대기 문구를 closeout 대상으로 확정했다. source 변경, appcast 보존 Pages artifact와 Release body 후보를 검증했고, 작업지시자 승인 뒤 공개 GitHub Release 본문을 후보와 일치하도록 보정했다. main closeout PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477)은 merge commit `7162a80...`으로 반영됐고 docs-only Pages run `31975531842` 성공 뒤 public Homebrew 문구와 stable appcast byte 보존을 재확인했다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `Casks/alhangeul.rb` | public v0.1.10 DMG version/SHA256과 repository Cask 정렬 |
+| `README.md` | 현재 Homebrew 설치 명령 반영 |
+| `docs/index.html` | public 홈의 v0.1.10 Homebrew 안내 반영 |
+| `docs/updates/index.html` | 업데이트 목록의 v0.1.10 및 Homebrew 안내 반영 |
+| `docs/updates/v0.1.10.html` | 버전별 설치 안내 반영 |
+| `mydocs/orders/20260813.md` | Stage 5/6 이력 상태 반영 |
+| `mydocs/orders/20260816.md` | closeout source와 최종 보고 준비 완료 기록 |
+| `mydocs/orders/20260817.md` | PR #477 merge·Pages 확인과 devel 최종 handoff 완료 기록 |
+| `mydocs/release/index.md` | v0.1.10 closeout 완료 상태 반영 |
+| `mydocs/release/v0.1.10.md` | release, Homebrew, main closeout과 public 재검증 장기 기록 |
+| `mydocs/report/task_m900_472_report.md` | Task #472 최종 결과와 종료 조건 기록 |
+| `mydocs/working/task_m900_472_stage4.md` | signed candidate 차단 gate 결과 기록 |
+| `mydocs/working/task_m900_472_stage5.md` | official publish와 Homebrew 검증 결과 기록 |
+
+최종 `devel` PR은 위 release/public 문서와 운영 기록 13파일만 변경하며 제품 `Sources/`, Xcode project, workflow와 이미 게시된 v0.1.10 release tag tree에는 영향을 주지 않는다.
+
+## 변경 전·후 정량 비교
+
+| 항목 | closeout 전 | closeout 후 |
+|------|-------------|-------------|
+| repository Cask | `0.1.9`, 이전 SHA256 | `0.1.10`, public DMG SHA256 `800ea0df...e5dafd0e` |
+| public Homebrew 안내 | Release/Pages에 배포 전 문구 잔존 | GitHub Release와 Pages 3화면에 현재 설치 명령 반영 |
+| stable appcast | `0.1.10 (16)`, SHA256 `36b5d62b...af5a` | 동일 version/SHA256 및 byte content 보존 |
+| main closeout | 미반영 12파일 | PR #477 merge commit `7162a80...`, Pages run `31975531842` 성공 |
+| devel 최종 PR 범위 | closeout 미반영 | 운영/문서 13파일, 제품 source/project/workflow 0파일 |
 
 ## 단계별 결과
 
@@ -39,6 +69,7 @@ Stage 6에서는 release identity와 public surface를 다시 조회하고 repos
 | Stage 5.1 | `870fa90` | repository/tap Cask 게시, audit/install/uninstall과 설치본 복구 |
 | Stage 6 | `43390f2` | public communication closeout source, 최종 release record와 최종 보고 준비 |
 | Stage 6.1 | `2f62314` | GitHub Release body 보정, 공개 본문 재검증과 closeout 기록 갱신 |
+| Stage 6.2 | `12234b6` | main closeout PR #477 게시 결과와 exact diff 기록 |
 
 Stage 1~3 변경은 PR [#473](https://github.com/postmelee/alhangeul-macos/pull/473)으로 `devel` merge commit `447b31b...`에 반영했다. PR [#475](https://github.com/postmelee/alhangeul-macos/pull/475)는 history-only back-merge 생략 판정을 `devel` merge commit `34ba512...`에 반영했고, PR [#476](https://github.com/postmelee/alhangeul-macos/pull/476)은 같은 tree를 `main` release commit `fafed425...`으로 승격했다.
 
@@ -54,6 +85,8 @@ Stage 1~3 변경은 PR [#473](https://github.com/postmelee/alhangeul-macos/pull/
 | tag peeled commit | `fafed425d4b87162c2188d1384d618adc2211eb6` |
 | Stage 6 `origin/main` / `origin/devel` | `fafed425...` / `34ba512...` |
 | Stage 6 left/right | `origin/main...origin/devel` = `4 0` |
+| closeout `origin/main` / `origin/devel` | `7162a80...` / `34ba512...` |
+| closeout left/right | `origin/main...origin/devel` = `12 0`, 기존 transport 4 + closeout head 7 + merge commit 1 |
 
 `main` 전용 네 commit은 이전 release transport PR #446, #450, #452와 현재 release PR #476 merge다. 각 release merge tree는 대응 `devel` source parent tree와 같고 main 전용 non-merge 제품 content가 없으므로 history-only back-merge를 만들지 않았다. 이 판정을 반복 가능한 정책과 자동 gate로 만드는 후속은 Issue [#474](https://github.com/postmelee/alhangeul-macos/issues/474)로 분리했다.
 
@@ -128,25 +161,25 @@ public 설치본에서 HWP/HWPX 앱 열기, Quick Look와 Thumbnail을 다시 �
 
 tap의 기존 `Untrusted` 상태를 바꾸지 않았고 `brew trust` 같은 전역 신뢰 변경도 하지 않았다. smoke 중 Homebrew 자체는 `6.0.15`에서 `6.0.17`로 자동 갱신됐지만 다른 formula/cask는 변경하지 않았다. 종료 시 Homebrew Cask는 미설치 상태이며 기존 Sparkle 설치본 `/Applications/Alhangeul.app` `0.1.10 (16)`과 사용자 경로 v0.1.8 provider 등록을 복원했다.
 
-## Stage 6 Closeout 준비
+## Stage 6 Closeout 완료
 
-2026-08-16 live 재확인 결과는 다음과 같다.
+2026-08-16~17 live 재확인 결과는 다음과 같다.
 
-| surface | 현재 live 상태 | closeout 준비 |
-|---------|----------------|---------------|
-| GitHub Release/DMG | v0.1.10 stable/latest와 exact asset 유지, Homebrew 설치 명령 반영 | 검증된 후보와 공개 본문 일치 확인 |
-| Homebrew tap | public v0.1.10 Cask 제공 | repository `Casks/alhangeul.rb`를 같은 version/SHA256으로 정렬 |
-| Pages home/update | 다운로드와 appcast는 v0.1.10, Homebrew 대기 문구 잔존 | 세 화면과 v0.1.10 note를 현재 설치 명령으로 보정 |
-| stable appcast | `0.1.10 (16)`, SHA256 `36b5d62b...af5a` | docs-only artifact에서 byte-identical 보존 |
-| release record | `main`에는 publish 직전 상태 | public/Homebrew/closeout 실제 결과로 보정 |
+| surface | 최종 live 상태 | 검증 결과 |
+|---------|----------------|-----------|
+| GitHub Release/DMG | v0.1.10 stable/latest와 exact asset 유지, Homebrew 설치 명령 반영 | 검증된 후보와 공개 본문 일치 |
+| Homebrew tap | public v0.1.10 Cask 제공 | repository Cask와 같은 version/SHA256 |
+| Pages home/update | v0.1.10 다운로드, 릴리즈 노트와 Homebrew 설치 명령 제공 | run `31975531842` 성공 뒤 세 화면 직접 확인 |
+| stable appcast | `0.1.10 (16)`, SHA256 `36b5d62b...af5a` | closeout 전 public appcast와 byte-identical |
+| release record | public/Homebrew/closeout 실제 결과 반영 | devel 최종 보고 handoff 준비 |
 
 준비한 public source diff는 `README.md`, `docs/index.html`, `docs/updates/index.html`, `docs/updates/v0.1.10.html`의 Homebrew 문구다. repository Cask, release index/record, Stage 4~5 기록과 이 최종 보고서를 함께 release closeout 기록으로 유지한다.
 
-`scripts/ci/update-release-version-notices.sh --check`, release note template check, GitHub body validator와 prepared Pages artifact가 통과했다. prepared artifact의 `appcast.xml`은 현재 public appcast와 byte-identical하다. GitHub Release body는 검증된 후보 파일로 수정한 뒤 후보와의 전체 본문 일치, 현재 Homebrew 명령 포함과 이전 대기 문구 제거를 재확인했다.
+`scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check`, release note template check, GitHub body validator와 prepared Pages artifact가 통과했다. prepared artifact와 closeout 뒤 public `appcast.xml`은 기존 public appcast와 byte-identical하다. GitHub Release body는 검증된 후보 파일과 전체 본문이 일치하고 현재 Homebrew 명령을 포함하며 이전 대기 문구가 제거됐다.
 
-Stage 6 head를 `origin/main`과 `origin/devel`에 각각 비교한 tree diff는 같은 12파일이다. Cask, README, 네 Pages/공개 문서, 두 작업일 기록, release index/record, Stage 4~5 보고서와 최종 보고서만 포함하며 `Sources/`, project, workflow와 release tag 제품 tree는 바꾸지 않는다. 따라서 main closeout과 devel 운영 기록 PR을 분리해도 불필요한 제품 diff는 생기지 않는다.
+PR #477 게시 시점의 Stage 6 head를 당시 `origin/main`과 `origin/devel`에 각각 비교한 tree diff는 같은 12파일이었다. main closeout merge 뒤 devel 최종 후보에는 2026-08-17 오늘할일 기록을 더한 13파일만 남으며 `Sources/`, project, workflow와 release tag 제품 tree는 바꾸지 않는다.
 
-main closeout draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477)은 `main` 대상 exact 12파일로 게시했다. PR merge와 docs-only Pages workflow는 후속 외부 mutation이므로 별도 지시 전에는 실행하지 않고, 그 전에는 public Pages의 대기 문구를 완료 상태로 기록하지 않는다.
+main closeout PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477)은 `main` 대상 exact 12파일로 merge됐다. merge commit `7162a80...`에서 실행된 docs-only Pages workflow도 성공했고 public 홈, 업데이트 목록, v0.1.10 note와 stable appcast를 직접 재검증했다.
 
 ## 승인 이력과 주요 결정
 
@@ -159,6 +192,18 @@ main closeout draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/
 - Stage 6 closeout source와 최종 보고 작성은 2026-08-16 별도 승인으로 진행했다.
 - 검증된 body file을 사용한 GitHub Release Homebrew 문구 보정과 공개 본문 재검증은 2026-08-16 후속 승인으로 진행했다.
 - main closeout branch push와 draft PR #477 게시도 같은 후속 승인 범위에서 진행했다.
+- PR #477 merge, public Pages 재검증, devel 최종 PR 게시·merge와 cleanup은 2026-08-17 작업지시자가 승인했다.
+
+## 최종 수용 기준 검증
+
+| 수용 기준 | 결과 | 상태 |
+|-----------|------|------|
+| release record/최종 보고 실제 값 | public DMG, run, commit, appcast와 Homebrew 값을 placeholder 없이 기록 | OK |
+| public/repository communication 일치 | GitHub Release, Pages 3화면, Cask와 설치 명령 일치 | OK |
+| main closeout 단일 PR | PR #477 exact 12파일 merge와 Pages 성공 | OK |
+| devel 최종 PR exact diff | 오늘할일 포함 문서/운영 13파일, 제품 변경 없음 | OK |
+| 오늘할일 완료 | `mydocs/orders/20260817.md`, 완료 시각 `07:12` | OK |
+| cleanup 대상 확정 | Issue #472, `publish/task472`, `local/task472`, 분리 worktree 없음 | OK |
 
 ## 미실행 항목과 잔여 위험
 
@@ -173,7 +218,6 @@ main closeout draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/
 | known payload decode 진단 | 미구현 | Issue #470 |
 | main/devel content gate | 규칙·자동화 미구현 | Issue #474 |
 | 비활성 개발 LaunchServices record | 일부 잔존 | 활성 provider와 무관, 전역 reset 미사용 |
-| public Homebrew 문구 | GitHub Release 반영, Pages source 준비 | main closeout merge·Pages 성공 뒤 화면 확인 |
 
 ## 최종 결론
 
@@ -181,12 +225,12 @@ main closeout draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/
 
 strict local static archive, Intel Mac/macOS 12 실기기, 일부 renderer/lifecycle 후속과 비활성 LaunchServices record는 실제 결과와 분리해 잔여 위험으로 기록했다. 어느 항목도 public v0.1.10 identity, signing/notarization, 실제 Apple Silicon 설치·업데이트·Finder 또는 Homebrew smoke를 실패시키는 blocker로 재현되지 않았다.
 
-Task #472의 release 준비, official publish, Homebrew 배포 실행과 GitHub Release 본문 보정 목표는 달성했다. 다만 repository `main`과 public Pages의 Homebrew closeout은 아직 source 후보 상태이므로 Issue #472는 자동으로 닫지 않는다.
+Task #472의 release 준비, official publish, Homebrew 배포 실행, GitHub Release 본문 보정과 repository `main`/public Pages closeout 목표를 모두 달성했다. 남은 절차는 이 최종 기록을 `devel`에 merge하고 Issue #472와 작업 브랜치를 정리하는 운영 종료뿐이다.
 
-## 게시와 종료 조건
+## 작업지시자 승인 및 종료 조건
 
-1. draft PR #477의 review/CI를 확인한다.
-2. 별도 승인으로 main closeout PR을 merge한다.
-3. docs-only Pages workflow 성공, public Homebrew 문구와 stable appcast byte 보존을 확인한다.
-4. 명시적인 `task-final-report` 절차로 Task #472 `devel` 최종 PR을 게시한다.
-5. 위 공개 반영과 필요한 PR merge 뒤 Issue #472를 close하고 `publish/task472`, closeout branch, `local/task472`과 임시 worktree를 `pr-merge-cleanup` 절차로 정리한다.
+2026-08-17 작업지시자가 `devel` 최종 PR 생성·merge와 `pr-merge-cleanup`까지 명시 승인했다.
+
+1. Task #472 최종 기록 PR을 `devel` 대상으로 게시하고 CI를 확인한다.
+2. merge commit 방식으로 PR을 merge해 단계별 커밋 의미를 보존한다.
+3. Issue #472를 close하고 `publish/task472`, `local/task472`과 임시 worktree를 정리한다.

--- a/mydocs/report/task_m900_472_report.md
+++ b/mydocs/report/task_m900_472_report.md
@@ -1,0 +1,189 @@
+# Task M900 #472 최종 보고서
+
+## 작업 요약
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | [#472 `v0.1.10 public release 준비와 배포 실행`](https://github.com/postmelee/alhangeul-macos/issues/472) |
+| 마일스톤 | Release Operations |
+| 기준 브랜치 | `devel` |
+| 작업 브랜치 | `local/task472` |
+| 공개 릴리즈 | [Alhangeul v0.1.10 (rhwp v0.8.4)](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10) |
+| release commit | `fafed425d4b87162c2188d1384d618adc2211eb6` |
+| release tag | annotated `v0.1.10` |
+| app / extension | `0.1.10 (16)` |
+| rhwp core / studio | `v0.8.4` / `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
+| Rehearsal | [run `31681525166`](https://github.com/postmelee/alhangeul-macos/actions/runs/31681525166) |
+| signed draft | [run `31806721517`](https://github.com/postmelee/alhangeul-macos/actions/runs/31806721517) |
+| official Publish | [run `31812500336`](https://github.com/postmelee/alhangeul-macos/actions/runs/31812500336) |
+| Homebrew tap | [`postmelee/homebrew-tap` commit `f712c88`](https://github.com/postmelee/homebrew-tap/commit/f712c88e7e468395aeb09210cb6e24503dfb7d4f) |
+| 단계 | 수행계획, 구현계획, Stage 1~6 |
+
+`v0.1.10` release source와 communication을 upstream `rhwp v0.8.4` 기준으로 정렬하고 source preflight, unsigned Rehearsal, signed/notarized draft 차단 gate를 거쳐 official stable release를 게시했다. public DMG, Pages, stable Sparkle appcast, 실제 `v0.1.9 -> v0.1.10` 업데이트와 app/Finder provider를 확인한 뒤 같은 official DMG를 maintainer Homebrew tap에도 배포했다.
+
+Stage 6에서는 release identity와 public surface를 다시 조회하고 repository Cask, README, Pages source와 GitHub Release body의 Homebrew 대기 문구를 closeout 대상으로 확정했다. source 변경, appcast 보존 Pages artifact와 Release body 후보는 검증했지만 main PR, Release 본문 직접 수정과 Pages 재배포는 이번 완료보고 승인 전에는 게시하지 않았다.
+
+## 단계별 결과
+
+| 단계 | 커밋 | 결과 |
+|------|------|------|
+| 수행계획 | `8f6134f` | `v0.1.10 (16)`, `rhwp v0.8.4`, 6단계 release gate와 외부 mutation 승인 경계 확정 |
+| 구현계획 | `b57d0bd` | source, Rehearsal, signed draft, official publish, Homebrew와 main closeout 절차 구체화 |
+| Stage 1 | `58424de` | 세 app target과 release workflow 입력을 `0.1.10 (16)`, `v0.1.9`, `v0.8.4`로 정렬 |
+| Stage 2 | `95800ee` | 포함 PR 분석, README, Pages, GitHub Release body 후보와 release record 작성 |
+| Stage 3 | `aa1610f`, `4613106` | source/preflight, portable artifact, local package와 Rehearsal 통과, source PR handoff 보정 |
+| Stage 4.1 | `8a59ce9`, `462944d` | release transport ancestry와 실제 content drift를 분리하고 history-only back-merge 생략 |
+| Stage 4.2 / 4 | `868b119`, `8292782` | release PR/tag identity, signed draft와 저장·PDF·인쇄·Finder 차단 gate 통과 |
+| Stage 5 | `2c6ba3a` | official stable Publish, public artifact/Pages/appcast와 실제 Sparkle update 검증 |
+| Stage 5.1 | `870fa90` | repository/tap Cask 게시, audit/install/uninstall과 설치본 복구 |
+| Stage 6 | 이번 커밋 | public communication closeout source, 최종 release record와 최종 보고 준비 |
+
+Stage 1~3 변경은 PR [#473](https://github.com/postmelee/alhangeul-macos/pull/473)으로 `devel` merge commit `447b31b...`에 반영했다. PR [#475](https://github.com/postmelee/alhangeul-macos/pull/475)는 history-only back-merge 생략 판정을 `devel` merge commit `34ba512...`에 반영했고, PR [#476](https://github.com/postmelee/alhangeul-macos/pull/476)은 같은 tree를 `main` release commit `fafed425...`으로 승격했다.
+
+## Release Identity와 브랜치 판정
+
+| 항목 | 값 |
+|------|----|
+| previous release | `v0.1.9`, `ab7a74b5fc35dcdb56b121a8b74d00460a967e7b` |
+| final source candidate | `34ba5127b9cd6614cffac6f0091201d3c3b1c13f` |
+| release merge commit | `fafed425d4b87162c2188d1384d618adc2211eb6` |
+| release tree | `7320f3a7e68a7a8926a40a041f44fc612d02db27` |
+| tag object | `cd74a7ec8f3bc5bcc5862931b1eda9bbfeecc1b3` |
+| tag peeled commit | `fafed425d4b87162c2188d1384d618adc2211eb6` |
+| Stage 6 `origin/main` / `origin/devel` | `fafed425...` / `34ba512...` |
+| Stage 6 left/right | `origin/main...origin/devel` = `4 0` |
+
+`main` 전용 네 commit은 이전 release transport PR #446, #450, #452와 현재 release PR #476 merge다. 각 release merge tree는 대응 `devel` source parent tree와 같고 main 전용 non-merge 제품 content가 없으므로 history-only back-merge를 만들지 않았다. 이 판정을 반복 가능한 정책과 자동 gate로 만드는 후속은 Issue [#474](https://github.com/postmelee/alhangeul-macos/issues/474)로 분리했다.
+
+Stage 5 이후에는 repository Cask, release record와 public Homebrew 문구라는 실제 closeout content가 생겼다. 이는 transport-only ancestry와 다르므로 Stage 6의 단일 `main` 대상 closeout PR과 `devel` 운영 기록 반영 대상으로 유지한다.
+
+## Source, Provenance와 Rehearsal
+
+| 검증 | 결과 |
+|------|------|
+| core/studio provenance | `v0.8.4` / `496333b...` 일치 |
+| upstream root `Cargo.lock` | SHA256 `217783dc...`, bundled manifest fingerprint와 일치 |
+| RustBridge tests | `7/7` 통과 |
+| HostAppTests | `128/128` 통과 |
+| ExternalImageTests | `27/27` 통과 |
+| build-info/Cargo/decoder fixture | 모두 통과 |
+| 세 target Release build | HostApp, Preview, Thumbnail 모두 성공 |
+| renderer | HWP 4개와 HWPX 1개 page 1 PNG `5/5` |
+| local universal package | 앱과 두 extension 모두 `x86_64 + arm64` |
+
+local Rust/Cargo `1.94.1`, Xcode `26.6` 환경에서 strict static archive는 lock reference와 byte hash/size가 달랐다. reference `8c8b831f...` / 219,489,584 bytes에 대해 local 결과는 `65ee0ff3...` / 219,502,168 bytes였다. 이를 성공으로 바꾸거나 lock을 갱신하지 않았고, 작업지시자 승인에 따라 source, Cargo, generated header, FFI symbol과 XCFramework를 유지하는 portable 경계만 release artifact 허용 기준으로 사용했다.
+
+Rehearsal run `31681525166`은 exact candidate `95800ee...`에서 성공했다. unsigned DMG는 167,711,221 bytes, SHA256 `ee9a25bf...dfdc`이며 checksum, `hdiutil verify`, mounted layout과 세 universal target이 통과했다. unsigned Rehearsal은 signing/notarization이나 public 배포 근거로 사용하지 않았다.
+
+## Signed Candidate 차단 Gate
+
+signed draft run `31806721517`은 exact release tag target `fafed425...`에서 성공했다. draft DMG는 169,177,242 bytes, SHA256 `e54d5a1d...a7af`이며 앱/extension 서명, notarization, staple, Gatekeeper, universal architecture, Legal resource와 mounted layout이 통과했다.
+
+| Gate | 결과 |
+|------|------|
+| HWP/HWPX open | 1쪽 HWP와 9쪽 HWPX non-blank render |
+| HWP 저장·재열기 | CFB signature, 별도 결과 파일과 1쪽 render 확인 |
+| HWPX 저장·재열기 | ZIP integrity, 별도 결과 파일과 9쪽 render 확인 |
+| 원본 보존 | 두 원본 SHA256 유지 |
+| PDF | HWP 1쪽, HWPX 9쪽, geometry/searchable text/non-blank 확인 |
+| 인쇄 | native panel HWP `1/1`, HWPX `9페이지 모두`, 취소 후 복귀 |
+| WebKit 경계 | 자동 script/resource/navigation 차단 회귀와 signed 앱 정상 경로 통과 |
+| Finder | 후보만 단독 등록해 Preview/Thumbnail executable path와 HWP/HWPX 결과 확인 |
+| crash | 신규 DiagnosticReport 없음 |
+
+첫 Finder smoke가 기존 `/Applications` v0.1.9 Thumbnail provider를 선택한 결과는 정상 이미지여도 v0.1.10 provenance 근거에서 제외했다. 기존 provider 등록을 잠시 격리한 뒤 signed candidate만 단독 등록해 다시 통과시켰고 검증 후 사용자 설치와 등록 상태를 복원했다.
+
+## Official Public Artifact와 업데이트
+
+| 항목 | 결과 |
+|------|------|
+| workflow | [run `31812500336`](https://github.com/postmelee/alhangeul-macos/actions/runs/31812500336), success |
+| release job / Pages job | `94806246847` / `94810917280`, 모두 success |
+| GitHub Release | non-draft, non-prerelease, latest |
+| DMG | `alhangeul-macos-0.1.10.dmg`, 169,177,234 bytes |
+| SHA256 | `800ea0df2aee7ef380fb6af316f34d5a3c6bbbe60ef9b96054defac1e5dafd0e` |
+| artifact trust | checksum, integrity, deep/strict signature, notarization, staple, Gatekeeper 통과 |
+| version / architecture | 앱과 extension 모두 `0.1.10 (16)`, `x86_64 + arm64` |
+| stable appcast | `0.1.10 (16)`, public DMG URL/size, EdDSA signature |
+| Stage 6 appcast SHA256 | `36b5d62bc9477bf6b586c19888071ba8610be0ac42a116b2a8be7bf5cee3af5a` |
+
+clean official `/Applications/Alhangeul.app` `v0.1.9 (15)`에서 Sparkle UI로 `v0.1.10 (16)`을 download/install/relaunch했다. Preview와 Thumbnail provider가 registration repair 없이 같은 `/Applications` 설치본으로 자연 갱신됐고 `Registration repair used: 0`이었다.
+
+public 설치본에서 HWP/HWPX 앱 열기, Quick Look와 Thumbnail을 다시 확인했다. 실제 Preview/Thumbnail process는 `/Applications/Alhangeul.app` 아래 executable이었고 신규 crash가 없었다. 사용자 경로 v0.1.8 앱 파일과 registration은 검증 뒤 복원했다.
+
+## Homebrew
+
+| 항목 | 결과 |
+|------|------|
+| 설치 명령 | `brew install --cask postmelee/tap/alhangeul` |
+| Cask version | `0.1.10` |
+| Cask SHA256 | official public DMG와 같은 `800ea0df...e5dafd0e` |
+| tap commit | `f712c88e7e468395aeb09210cb6e24503dfb7d4f` |
+| lint | `brew style`, 일반 `brew audit`, 참고용 `brew audit --new` 통과 |
+| install | fully-qualified untrusted tap에서 `0.1.10 (16)` 설치 성공 |
+| trust | deep/strict signature, staple과 Gatekeeper 통과 |
+| uninstall | Caskroom과 Homebrew 설치 앱 제거 확인 |
+
+tap의 기존 `Untrusted` 상태를 바꾸지 않았고 `brew trust` 같은 전역 신뢰 변경도 하지 않았다. smoke 중 Homebrew 자체는 `6.0.15`에서 `6.0.17`로 자동 갱신됐지만 다른 formula/cask는 변경하지 않았다. 종료 시 Homebrew Cask는 미설치 상태이며 기존 Sparkle 설치본 `/Applications/Alhangeul.app` `0.1.10 (16)`과 사용자 경로 v0.1.8 provider 등록을 복원했다.
+
+## Stage 6 Closeout 준비
+
+2026-08-16 live 재확인 결과는 다음과 같다.
+
+| surface | 현재 live 상태 | closeout 준비 |
+|---------|----------------|---------------|
+| GitHub Release/DMG | v0.1.10 stable/latest와 exact asset 유지 | Homebrew 문단 한 줄 보정 후보 검증 |
+| Homebrew tap | public v0.1.10 Cask 제공 | repository `Casks/alhangeul.rb`를 같은 version/SHA256으로 정렬 |
+| Pages home/update | 다운로드와 appcast는 v0.1.10, Homebrew 대기 문구 잔존 | 세 화면과 v0.1.10 note를 현재 설치 명령으로 보정 |
+| stable appcast | `0.1.10 (16)`, SHA256 `36b5d62b...af5a` | docs-only artifact에서 byte-identical 보존 |
+| release record | `main`에는 publish 직전 상태 | public/Homebrew/closeout 실제 결과로 보정 |
+
+준비한 public source diff는 `README.md`, `docs/index.html`, `docs/updates/index.html`, `docs/updates/v0.1.10.html`의 Homebrew 문구다. repository Cask, release index/record, Stage 4~5 기록과 이 최종 보고서를 함께 release closeout 기록으로 유지한다.
+
+`scripts/ci/update-release-version-notices.sh --check`, release note template check, GitHub body validator와 prepared Pages artifact가 통과했다. prepared artifact의 `appcast.xml`은 현재 public appcast와 byte-identical하다. GitHub Release body 후보도 현재 public body에서 Homebrew 한 줄만 의미상 변경한다.
+
+Stage 6 head를 `origin/main`과 `origin/devel`에 각각 비교한 tree diff는 같은 12파일이다. Cask, README, 네 Pages/공개 문서, 두 작업일 기록, release index/record, Stage 4~5 보고서와 최종 보고서만 포함하며 `Sources/`, project, workflow와 release tag 제품 tree는 바꾸지 않는다. 따라서 main closeout과 devel 운영 기록 PR을 분리해도 불필요한 제품 diff는 생기지 않는다.
+
+main closeout branch push/PR, GitHub Release body 직접 수정, PR merge와 docs-only Pages workflow는 외부 mutation이다. 이번 보고 승인 뒤 별도 명시 지시로 실행하며, 그 전에는 public Pages의 대기 문구를 완료 상태로 기록하지 않는다.
+
+## 승인 이력과 주요 결정
+
+- release version/build, `rhwp v0.8.4`, 6단계 실행 계획과 단계별 승인 gate를 확정했다.
+- strict static archive mismatch를 숨기지 않고 portable source/Cargo/header/FFI/XCFramework 경계를 release artifact 기준으로 별도 승인했다.
+- source PR #473, branch 판정 PR #475, release PR #476 merge와 annotated tag 생성은 각각 검토 뒤 진행했다.
+- signed draft, official stable Publish와 Homebrew tap 배포를 각각 별도 승인받았다.
+- 익명 최초 실행·version transition event의 기본 활성화와 opt-out 전 첫 event 가능성을 인지한 상태에서 v0.1.10 정책으로 승인했다.
+- stale LaunchServices record만 없애기 위한 전역 reset은 수행하지 않고 실제 provider path와 process provenance로 판정했다.
+- Stage 6 closeout source와 최종 보고 작성은 2026-08-16 별도 승인으로 진행했다.
+
+## 미실행 항목과 잔여 위험
+
+| 항목 | 상태 | 후속 |
+|------|------|------|
+| Intel Mac 실기기 | 미실행 | universal `x86_64 + arm64` 자동 검증과 별도로 가능한 환경에서 runtime smoke |
+| deployment target macOS 12 실장 | 미실행 | 지원 OS 실기기 검증 기회에 확인 |
+| strict local static archive | byte mismatch | portable 승인 경계와 분리 유지, lock을 로컬 결과로 갱신하지 않음 |
+| 실제 가로·세로 혼합 fixture | 없음 | 합성 SVG geometry와 orientation 미강제 자동 테스트로 보완 |
+| PDF 전체 문서 progress/deadline | 미구현 | Issue #459 lifecycle 후속과 함께 검토 |
+| render-tree producer golden | 미구현 | Issue #469 |
+| known payload decode 진단 | 미구현 | Issue #470 |
+| main/devel content gate | 규칙·자동화 미구현 | Issue #474 |
+| 비활성 개발 LaunchServices record | 일부 잔존 | 활성 provider와 무관, 전역 reset 미사용 |
+| public Homebrew 문구 | source 준비, live 반영 전 | main closeout·Release body·Pages 성공 뒤 확인 |
+
+## 최종 결론
+
+`v0.1.10 (16)`은 release commit `fafed425...`, upstream `rhwp v0.8.4`와 일치하는 signed/notarized universal app으로 public 배포됐다. source preflight, Rehearsal, signed 저장·PDF·인쇄·Finder 차단 gate, official GitHub Release, public DMG, Pages/appcast, 실제 Sparkle update와 maintainer Homebrew tap 배포에서 미해결 release blocker가 없다.
+
+strict local static archive, Intel Mac/macOS 12 실기기, 일부 renderer/lifecycle 후속과 비활성 LaunchServices record는 실제 결과와 분리해 잔여 위험으로 기록했다. 어느 항목도 public v0.1.10 identity, signing/notarization, 실제 Apple Silicon 설치·업데이트·Finder 또는 Homebrew smoke를 실패시키는 blocker로 재현되지 않았다.
+
+Task #472의 release 준비, official publish와 Homebrew 배포 실행 목표는 달성했다. 다만 repository `main`, GitHub Release 본문과 public Pages의 Homebrew closeout은 아직 승인된 source 후보 상태이므로 Issue #472는 자동으로 닫지 않는다.
+
+## 게시와 종료 조건
+
+1. 이 Stage 6 최종 보고와 closeout 범위를 승인한다.
+2. GitHub Release body의 Homebrew 한 줄을 검증된 설치 명령으로 보정한다.
+3. 단일 `main` 대상 closeout PR과 Task #472 `devel` 최종 PR을 exact diff로 게시한다.
+4. review/CI 뒤 별도 승인으로 필요한 PR을 merge한다.
+5. docs-only Pages workflow 성공, public Homebrew 문구와 stable appcast byte 보존을 확인한다.
+6. 위 공개 반영 뒤 Issue #472를 close하고 `publish/task472`, closeout branch, `local/task472`과 임시 worktree를 `pr-merge-cleanup` 절차로 정리한다.

--- a/mydocs/report/task_m900_472_report.md
+++ b/mydocs/report/task_m900_472_report.md
@@ -21,7 +21,7 @@
 
 `v0.1.10` release source와 communication을 upstream `rhwp v0.8.4` 기준으로 정렬하고 source preflight, unsigned Rehearsal, signed/notarized draft 차단 gate를 거쳐 official stable release를 게시했다. public DMG, Pages, stable Sparkle appcast, 실제 `v0.1.9 -> v0.1.10` 업데이트와 app/Finder provider를 확인한 뒤 같은 official DMG를 maintainer Homebrew tap에도 배포했다.
 
-Stage 6에서는 release identity와 public surface를 다시 조회하고 repository Cask, README, Pages source와 GitHub Release body의 Homebrew 대기 문구를 closeout 대상으로 확정했다. source 변경, appcast 보존 Pages artifact와 Release body 후보는 검증했지만 main PR, Release 본문 직접 수정과 Pages 재배포는 이번 완료보고 승인 전에는 게시하지 않았다.
+Stage 6에서는 release identity와 public surface를 다시 조회하고 repository Cask, README, Pages source와 GitHub Release body의 Homebrew 대기 문구를 closeout 대상으로 확정했다. source 변경, appcast 보존 Pages artifact와 Release body 후보를 검증했고, 작업지시자 승인 뒤 공개 GitHub Release 본문을 후보와 일치하도록 보정했다. main PR과 Pages 재배포는 아직 대기한다.
 
 ## 단계별 결과
 
@@ -36,7 +36,7 @@ Stage 6에서는 release identity와 public surface를 다시 조회하고 repos
 | Stage 4.2 / 4 | `868b119`, `8292782` | release PR/tag identity, signed draft와 저장·PDF·인쇄·Finder 차단 gate 통과 |
 | Stage 5 | `2c6ba3a` | official stable Publish, public artifact/Pages/appcast와 실제 Sparkle update 검증 |
 | Stage 5.1 | `870fa90` | repository/tap Cask 게시, audit/install/uninstall과 설치본 복구 |
-| Stage 6 | 이번 커밋 | public communication closeout source, 최종 release record와 최종 보고 준비 |
+| Stage 6 | `43390f2` | public communication closeout source, 최종 release record와 최종 보고 준비 |
 
 Stage 1~3 변경은 PR [#473](https://github.com/postmelee/alhangeul-macos/pull/473)으로 `devel` merge commit `447b31b...`에 반영했다. PR [#475](https://github.com/postmelee/alhangeul-macos/pull/475)는 history-only back-merge 생략 판정을 `devel` merge commit `34ba512...`에 반영했고, PR [#476](https://github.com/postmelee/alhangeul-macos/pull/476)은 같은 tree를 `main` release commit `fafed425...`으로 승격했다.
 
@@ -132,7 +132,7 @@ tap의 기존 `Untrusted` 상태를 바꾸지 않았고 `brew trust` 같은 전�
 
 | surface | 현재 live 상태 | closeout 준비 |
 |---------|----------------|---------------|
-| GitHub Release/DMG | v0.1.10 stable/latest와 exact asset 유지 | Homebrew 문단 한 줄 보정 후보 검증 |
+| GitHub Release/DMG | v0.1.10 stable/latest와 exact asset 유지, Homebrew 설치 명령 반영 | 검증된 후보와 공개 본문 일치 확인 |
 | Homebrew tap | public v0.1.10 Cask 제공 | repository `Casks/alhangeul.rb`를 같은 version/SHA256으로 정렬 |
 | Pages home/update | 다운로드와 appcast는 v0.1.10, Homebrew 대기 문구 잔존 | 세 화면과 v0.1.10 note를 현재 설치 명령으로 보정 |
 | stable appcast | `0.1.10 (16)`, SHA256 `36b5d62b...af5a` | docs-only artifact에서 byte-identical 보존 |
@@ -140,11 +140,11 @@ tap의 기존 `Untrusted` 상태를 바꾸지 않았고 `brew trust` 같은 전�
 
 준비한 public source diff는 `README.md`, `docs/index.html`, `docs/updates/index.html`, `docs/updates/v0.1.10.html`의 Homebrew 문구다. repository Cask, release index/record, Stage 4~5 기록과 이 최종 보고서를 함께 release closeout 기록으로 유지한다.
 
-`scripts/ci/update-release-version-notices.sh --check`, release note template check, GitHub body validator와 prepared Pages artifact가 통과했다. prepared artifact의 `appcast.xml`은 현재 public appcast와 byte-identical하다. GitHub Release body 후보도 현재 public body에서 Homebrew 한 줄만 의미상 변경한다.
+`scripts/ci/update-release-version-notices.sh --check`, release note template check, GitHub body validator와 prepared Pages artifact가 통과했다. prepared artifact의 `appcast.xml`은 현재 public appcast와 byte-identical하다. GitHub Release body는 검증된 후보 파일로 수정한 뒤 후보와의 전체 본문 일치, 현재 Homebrew 명령 포함과 이전 대기 문구 제거를 재확인했다.
 
 Stage 6 head를 `origin/main`과 `origin/devel`에 각각 비교한 tree diff는 같은 12파일이다. Cask, README, 네 Pages/공개 문서, 두 작업일 기록, release index/record, Stage 4~5 보고서와 최종 보고서만 포함하며 `Sources/`, project, workflow와 release tag 제품 tree는 바꾸지 않는다. 따라서 main closeout과 devel 운영 기록 PR을 분리해도 불필요한 제품 diff는 생기지 않는다.
 
-main closeout branch push/PR, GitHub Release body 직접 수정, PR merge와 docs-only Pages workflow는 외부 mutation이다. 이번 보고 승인 뒤 별도 명시 지시로 실행하며, 그 전에는 public Pages의 대기 문구를 완료 상태로 기록하지 않는다.
+main closeout branch push/PR도 이번 작업지시자 승인 범위에 포함해 진행한다. PR merge와 docs-only Pages workflow는 후속 외부 mutation이므로 별도 지시 전에는 실행하지 않고, 그 전에는 public Pages의 대기 문구를 완료 상태로 기록하지 않는다.
 
 ## 승인 이력과 주요 결정
 
@@ -155,6 +155,7 @@ main closeout branch push/PR, GitHub Release body 직접 수정, PR merge와 doc
 - 익명 최초 실행·version transition event의 기본 활성화와 opt-out 전 첫 event 가능성을 인지한 상태에서 v0.1.10 정책으로 승인했다.
 - stale LaunchServices record만 없애기 위한 전역 reset은 수행하지 않고 실제 provider path와 process provenance로 판정했다.
 - Stage 6 closeout source와 최종 보고 작성은 2026-08-16 별도 승인으로 진행했다.
+- 검증된 body file을 사용한 GitHub Release Homebrew 문구 보정과 공개 본문 재검증은 2026-08-16 후속 승인으로 진행했다.
 
 ## 미실행 항목과 잔여 위험
 
@@ -169,7 +170,7 @@ main closeout branch push/PR, GitHub Release body 직접 수정, PR merge와 doc
 | known payload decode 진단 | 미구현 | Issue #470 |
 | main/devel content gate | 규칙·자동화 미구현 | Issue #474 |
 | 비활성 개발 LaunchServices record | 일부 잔존 | 활성 provider와 무관, 전역 reset 미사용 |
-| public Homebrew 문구 | source 준비, live 반영 전 | main closeout·Release body·Pages 성공 뒤 확인 |
+| public Homebrew 문구 | GitHub Release 반영, Pages source 준비 | main closeout merge·Pages 성공 뒤 화면 확인 |
 
 ## 최종 결론
 
@@ -177,13 +178,12 @@ main closeout branch push/PR, GitHub Release body 직접 수정, PR merge와 doc
 
 strict local static archive, Intel Mac/macOS 12 실기기, 일부 renderer/lifecycle 후속과 비활성 LaunchServices record는 실제 결과와 분리해 잔여 위험으로 기록했다. 어느 항목도 public v0.1.10 identity, signing/notarization, 실제 Apple Silicon 설치·업데이트·Finder 또는 Homebrew smoke를 실패시키는 blocker로 재현되지 않았다.
 
-Task #472의 release 준비, official publish와 Homebrew 배포 실행 목표는 달성했다. 다만 repository `main`, GitHub Release 본문과 public Pages의 Homebrew closeout은 아직 승인된 source 후보 상태이므로 Issue #472는 자동으로 닫지 않는다.
+Task #472의 release 준비, official publish, Homebrew 배포 실행과 GitHub Release 본문 보정 목표는 달성했다. 다만 repository `main`과 public Pages의 Homebrew closeout은 아직 source 후보 상태이므로 Issue #472는 자동으로 닫지 않는다.
 
 ## 게시와 종료 조건
 
-1. 이 Stage 6 최종 보고와 closeout 범위를 승인한다.
-2. GitHub Release body의 Homebrew 한 줄을 검증된 설치 명령으로 보정한다.
-3. 단일 `main` 대상 closeout PR과 Task #472 `devel` 최종 PR을 exact diff로 게시한다.
-4. review/CI 뒤 별도 승인으로 필요한 PR을 merge한다.
-5. docs-only Pages workflow 성공, public Homebrew 문구와 stable appcast byte 보존을 확인한다.
-6. 위 공개 반영 뒤 Issue #472를 close하고 `publish/task472`, closeout branch, `local/task472`과 임시 worktree를 `pr-merge-cleanup` 절차로 정리한다.
+1. 단일 `main` 대상 closeout PR을 exact diff로 게시한다.
+2. review/CI 뒤 별도 승인으로 main closeout PR을 merge한다.
+3. docs-only Pages workflow 성공, public Homebrew 문구와 stable appcast byte 보존을 확인한다.
+4. 명시적인 `task-final-report` 절차로 Task #472 `devel` 최종 PR을 게시한다.
+5. 위 공개 반영과 필요한 PR merge 뒤 Issue #472를 close하고 `publish/task472`, closeout branch, `local/task472`과 임시 worktree를 `pr-merge-cleanup` 절차로 정리한다.

--- a/mydocs/report/task_m900_472_report.md
+++ b/mydocs/report/task_m900_472_report.md
@@ -17,11 +17,12 @@
 | signed draft | [run `31806721517`](https://github.com/postmelee/alhangeul-macos/actions/runs/31806721517) |
 | official Publish | [run `31812500336`](https://github.com/postmelee/alhangeul-macos/actions/runs/31812500336) |
 | Homebrew tap | [`postmelee/homebrew-tap` commit `f712c88`](https://github.com/postmelee/homebrew-tap/commit/f712c88e7e468395aeb09210cb6e24503dfb7d4f) |
+| main closeout | draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477) |
 | 단계 | 수행계획, 구현계획, Stage 1~6 |
 
 `v0.1.10` release source와 communication을 upstream `rhwp v0.8.4` 기준으로 정렬하고 source preflight, unsigned Rehearsal, signed/notarized draft 차단 gate를 거쳐 official stable release를 게시했다. public DMG, Pages, stable Sparkle appcast, 실제 `v0.1.9 -> v0.1.10` 업데이트와 app/Finder provider를 확인한 뒤 같은 official DMG를 maintainer Homebrew tap에도 배포했다.
 
-Stage 6에서는 release identity와 public surface를 다시 조회하고 repository Cask, README, Pages source와 GitHub Release body의 Homebrew 대기 문구를 closeout 대상으로 확정했다. source 변경, appcast 보존 Pages artifact와 Release body 후보를 검증했고, 작업지시자 승인 뒤 공개 GitHub Release 본문을 후보와 일치하도록 보정했다. main PR과 Pages 재배포는 아직 대기한다.
+Stage 6에서는 release identity와 public surface를 다시 조회하고 repository Cask, README, Pages source와 GitHub Release body의 Homebrew 대기 문구를 closeout 대상으로 확정했다. source 변경, appcast 보존 Pages artifact와 Release body 후보를 검증했고, 작업지시자 승인 뒤 공개 GitHub Release 본문을 후보와 일치하도록 보정하고 main closeout draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477)을 게시했다. CI/merge와 Pages 재배포는 아직 대기한다.
 
 ## 단계별 결과
 
@@ -37,6 +38,7 @@ Stage 6에서는 release identity와 public surface를 다시 조회하고 repos
 | Stage 5 | `2c6ba3a` | official stable Publish, public artifact/Pages/appcast와 실제 Sparkle update 검증 |
 | Stage 5.1 | `870fa90` | repository/tap Cask 게시, audit/install/uninstall과 설치본 복구 |
 | Stage 6 | `43390f2` | public communication closeout source, 최종 release record와 최종 보고 준비 |
+| Stage 6.1 | `2f62314` | GitHub Release body 보정, 공개 본문 재검증과 closeout 기록 갱신 |
 
 Stage 1~3 변경은 PR [#473](https://github.com/postmelee/alhangeul-macos/pull/473)으로 `devel` merge commit `447b31b...`에 반영했다. PR [#475](https://github.com/postmelee/alhangeul-macos/pull/475)는 history-only back-merge 생략 판정을 `devel` merge commit `34ba512...`에 반영했고, PR [#476](https://github.com/postmelee/alhangeul-macos/pull/476)은 같은 tree를 `main` release commit `fafed425...`으로 승격했다.
 
@@ -144,7 +146,7 @@ tap의 기존 `Untrusted` 상태를 바꾸지 않았고 `brew trust` 같은 전�
 
 Stage 6 head를 `origin/main`과 `origin/devel`에 각각 비교한 tree diff는 같은 12파일이다. Cask, README, 네 Pages/공개 문서, 두 작업일 기록, release index/record, Stage 4~5 보고서와 최종 보고서만 포함하며 `Sources/`, project, workflow와 release tag 제품 tree는 바꾸지 않는다. 따라서 main closeout과 devel 운영 기록 PR을 분리해도 불필요한 제품 diff는 생기지 않는다.
 
-main closeout branch push/PR도 이번 작업지시자 승인 범위에 포함해 진행한다. PR merge와 docs-only Pages workflow는 후속 외부 mutation이므로 별도 지시 전에는 실행하지 않고, 그 전에는 public Pages의 대기 문구를 완료 상태로 기록하지 않는다.
+main closeout draft PR [#477](https://github.com/postmelee/alhangeul-macos/pull/477)은 `main` 대상 exact 12파일로 게시했다. PR merge와 docs-only Pages workflow는 후속 외부 mutation이므로 별도 지시 전에는 실행하지 않고, 그 전에는 public Pages의 대기 문구를 완료 상태로 기록하지 않는다.
 
 ## 승인 이력과 주요 결정
 
@@ -156,6 +158,7 @@ main closeout branch push/PR도 이번 작업지시자 승인 범위에 포함�
 - stale LaunchServices record만 없애기 위한 전역 reset은 수행하지 않고 실제 provider path와 process provenance로 판정했다.
 - Stage 6 closeout source와 최종 보고 작성은 2026-08-16 별도 승인으로 진행했다.
 - 검증된 body file을 사용한 GitHub Release Homebrew 문구 보정과 공개 본문 재검증은 2026-08-16 후속 승인으로 진행했다.
+- main closeout branch push와 draft PR #477 게시도 같은 후속 승인 범위에서 진행했다.
 
 ## 미실행 항목과 잔여 위험
 
@@ -182,8 +185,8 @@ Task #472의 release 준비, official publish, Homebrew 배포 실행과 GitHub 
 
 ## 게시와 종료 조건
 
-1. 단일 `main` 대상 closeout PR을 exact diff로 게시한다.
-2. review/CI 뒤 별도 승인으로 main closeout PR을 merge한다.
+1. draft PR #477의 review/CI를 확인한다.
+2. 별도 승인으로 main closeout PR을 merge한다.
 3. docs-only Pages workflow 성공, public Homebrew 문구와 stable appcast byte 보존을 확인한다.
 4. 명시적인 `task-final-report` 절차로 Task #472 `devel` 최종 PR을 게시한다.
 5. 위 공개 반영과 필요한 PR merge 뒤 Issue #472를 close하고 `publish/task472`, closeout branch, `local/task472`과 임시 worktree를 `pr-merge-cleanup` 절차로 정리한다.

--- a/mydocs/working/task_m900_472_stage4.md
+++ b/mydocs/working/task_m900_472_stage4.md
@@ -1,0 +1,153 @@
+# Task M900 #472 Stage 4 완료보고서
+
+## 단계 목적
+
+`v0.1.10 (16)` final source candidate를 `main`과 annotated tag로 확정하고, 별도 승인된 pre-public draft Publish workflow가 만든 signed/notarized DMG에서 공개 전 차단 gate를 수행한다.
+
+## 확정 기준점
+
+| 항목 | 값 |
+|------|----|
+| source PR | [#473](https://github.com/postmelee/alhangeul-macos/pull/473), `devel` merge commit `447b31bcd1cb235980387df2a679fe243f161943` |
+| main/devel 판정 PR | [#475](https://github.com/postmelee/alhangeul-macos/pull/475), history-only back-merge 생략 근거 반영 |
+| release PR | [#476](https://github.com/postmelee/alhangeul-macos/pull/476), `devel -> main` merge 완료 |
+| final source candidate | `34ba5127b9cd6614cffac6f0091201d3c3b1c13f` |
+| release commit / tree | `fafed425d4b87162c2188d1384d618adc2211eb6` / `7320f3a7e68a7a8926a40a041f44fc612d02db27` |
+| tag | annotated `v0.1.10`, tag object `cd74a7ec8f3bc5bcc5862931b1eda9bbfeecc1b3`, peeled commit `fafed425...` |
+| app / extension | 모두 `0.1.10 (16)` |
+| rhwp core / studio | `v0.8.4` / `496333b27d21ddb9114ba9ae340bcb895870c9a7` |
+| draft workflow | [run `31806721517`](https://github.com/postmelee/alhangeul-macos/actions/runs/31806721517) |
+| draft release | [`Alhangeul v0.1.10 (rhwp v0.8.4)`](https://github.com/postmelee/alhangeul-macos/releases/tag/untagged-91bda2ed93cfa0d3ca56) |
+
+Stage 1에서 제안했던 history-only `main -> devel` back-merge는 Stage 4.1에서 번복해 생략했다. 당시 `main` 전용 PR #446, #450과 #452의 merge tree는 각각 대응 `devel` 부모와 동일했고 `main` 전용 non-merge commit과 실제 content drift가 없었다. PR #475 review를 거쳐 release transport ancestry와 제품 content를 분리했으며, 장기 규칙화와 자동 gate는 Issue #474에서 추적한다.
+
+PR #476 merge 뒤 `main` release commit tree와 final `devel` candidate tree가 동일함을 확인했다. annotated tag는 이 merge commit을 가리킨다. Stage 3 exact candidate `95800ee...`와 release tag 사이의 제품 source, tests, project, lock, workflow와 scripts diff는 없고 release communication 문서만 이동했다.
+
+## Signed draft Publish
+
+별도 승인을 받아 tag `v0.1.10`에서 다음 입력으로 `Release Publish DMG` workflow를 실행했다.
+
+| 입력 | 값 |
+|------|----|
+| `version` | `0.1.10` |
+| `previous_release_ref` | `v0.1.9` |
+| `expected_rhwp_tag` | `v0.8.4` |
+| `require_latest_rhwp` | `true` |
+| `include_rhwp_in_title` | `true` |
+| `draft` / `prerelease` | `true` / `false` |
+
+workflow는 exact tag target `fafed425d4b87162c2188d1384d618adc2211eb6`에서 15분 25초 만에 성공했다. main job `94787323146`의 certificate와 notary credential 준비, 앱·DMG 서명, notarization, staple, Gatekeeper와 draft asset upload가 모두 통과했다. stable Sparkle appcast와 Pages 관련 step은 draft 정책에 따라 skip됐고 deployment job `94791418149`도 실행되지 않았다.
+
+## Draft DMG와 trust 검증
+
+| 항목 | 결과 |
+|------|------|
+| DMG | `alhangeul-macos-0.1.10.dmg`, 169,177,242 bytes |
+| DMG SHA256 | `e54d5a1d2c4875f96ff704d61e0a8567146e00fca0cfc55cd51c04875457a7af` |
+| GitHub asset digest | DMG actual SHA256와 일치 |
+| code signature | 앱, Preview와 Thumbnail 모두 Developer ID 서명 검증 통과 |
+| notarization / staple | 앱과 DMG 모두 통과 |
+| Gatekeeper | 앱과 DMG 모두 `Notarized Developer ID` accepted |
+| architecture | 앱, Preview와 Thumbnail 모두 `arm64 + x86_64` |
+| version | 앱과 extension 모두 `0.1.10 (16)` |
+| Legal | canonical resource 일치 |
+| mounted layout | visible root는 앱과 `Applications`, background `720x460`, 별도 설치 안내 파일 없음 |
+
+다운로드한 asset의 actual SHA256을 GitHub asset digest와 독립 대조했다. DMG를 mount해 앱을 `build.noindex/task472-stage4-draft/Alhangeul.app`에 복사한 뒤 signed app과 DMG를 로컬에서도 검증했다.
+
+샌드박스 안의 `codesign --verify`는 동일 대조군인 TextEdit에도 `CSSMERR_TP_NOT_TRUSTED`를 반환했다. 샌드박스 밖에서는 TextEdit, 기존 public 앱과 draft 앱이 모두 정상 검증됐고 draft 앱과 DMG의 staple/Gatekeeper도 통과했다. 따라서 이 결과는 artifact defect가 아니라 샌드박스의 trustd 접근 제약으로 판정했다.
+
+## Signed 앱 UI와 저장 smoke
+
+기존 `/Applications/Alhangeul.app` `0.1.9 (15)`를 덮어쓰지 않고 signed candidate를 `/Users/melee/Applications/Alhangeul.app`에 설치했다. 기존 사용자 경로의 `0.1.8 (14)`는 smoke 전에 별도 백업했다.
+
+| 경로 | 결과 |
+|------|------|
+| 최초 실행 | 성공, `rhwp v0.8.4 (496333b)`와 HOP `v0.7.13` 충돌 안내 표시 |
+| HWP 열기 | `samples/basic/KTX.hwp`, 1페이지 non-blank render |
+| HWPX 열기 | `samples/hwpx/hwpx-01.hwpx`, 9페이지 non-blank render |
+| 로컬 글꼴 감지 | 현재 문서 필요 글꼴만 확인한다는 개인정보 안내 뒤 HWP 1개, HWPX 8개 저장 |
+| HWP 저장·재열기 | `roundtrip-hwp.hwp`, CFB signature, 26,112 bytes, 1페이지 render |
+| HWPX 저장·재열기 | `roundtrip-hwpx.hwpx`, ZIP integrity 통과, 399,194 bytes, 9페이지 render |
+| 원본 무손실 | KTX SHA256 `6c1a027d...03cf1`, HWPX SHA256 `e17464a1...0f20` 유지 |
+
+저장 결과 SHA256은 HWP `ef24cef71c83186479f79c12e7879b4150565ad88a36b776c01c8f2d3effae90`, HWPX `c00570ead34ee053b25f12e16258bd0927793a05c03282612aeaf30bf9472e10`이다. 결과는 원본과 다른 별도 파일에 저장했고 재열기 뒤 문서 page count와 non-blank render를 확인했다.
+
+## PDF·인쇄와 WebKit 경계
+
+| 샘플 | PDF 결과 | 인쇄 결과 |
+|------|----------|-----------|
+| HWP | 261,569 bytes, 1페이지, `1123 x 794` pts 가로, searchable text, non-blank | native panel `1/1페이지`, 취소 후 앱 복귀 |
+| HWPX | 932,723 bytes, 9페이지, `794 x 1123` pts 세로, searchable text, 전 페이지 non-blank | native panel `9페이지 모두`, 취소 후 앱 복귀 |
+
+HWP PDF SHA256은 `c6c98c2050da2392d9ae8d878f0f89f681dcfa576a2b0871a29e86e7f7272606`, HWPX PDF SHA256은 `84a251ab74dd91c0eeb790bfbf53002d768a06e91d74ac8e3cec383eecac3021`이다. `pdfinfo`에서 JavaScript 없음, 암호화 없음과 page geometry를 확인하고 Poppler로 HWP 1페이지와 HWPX 9페이지 전부를 rasterize해 clipping, overlap과 blank page가 없음을 시각 확인했다.
+
+Stage 3 HostAppTests `128/128`에는 문서 유래 SVG의 script, 외부 resource, navigation 차단과 정상 page SVG 렌더가 포함돼 있다. Stage 3 candidate 이후 release tag까지 제품 source 차이가 없고, signed app에서 정상 HWP/HWPX PDF·인쇄 시작 경로가 모두 통과했다. 이번 단계에서는 malicious SVG를 signed 앱에 새로 주입하지 않고 자동 trust-boundary 회귀와 실제 정상 경로를 결합해 판정했다.
+
+## Finder, Preview와 Thumbnail provenance
+
+첫 `scripts/smoke-finder-integration.sh` 실행은 HWP/HWPX Thumbnail 생성과 시각 검증을 통과했지만 진단 로그에서 macOS가 같은 bundle ID의 `/Applications` v0.1.9 Thumbnail provider를 선택한 사실을 확인했다. 결과는 정상이어도 signed v0.1.10 provenance 근거로 사용하지 않았다.
+
+기존 v0.1.9와 v0.1.8 Preview/Thumbnail 등록만 잠시 해제하고 signed v0.1.10 후보를 단독 등록해 다시 검증했다.
+
+| 경로 | 결과 |
+|------|------|
+| 단독 Preview provider | `.../post-smoke-v0.1.10.app/.../AlhangeulPreview`, `0.1.10`, 유일한 등록 |
+| 단독 Thumbnail provider | `.../post-smoke-v0.1.10.app/.../AlhangeulThumbnail`, `0.1.10`, 유일한 등록 |
+| HWP Thumbnail | 512x363 PNG, SHA256 `4a1fc522...353b`, non-blank |
+| HWPX Thumbnail | 362x512 PNG, SHA256 `3ef08ff5...6b0`, non-blank |
+| HWP Finder Quick Look | KTX 1페이지 non-blank, selectable text 확인 |
+| HWPX Finder Quick Look | 9페이지 sidebar와 1페이지 non-blank render 확인 |
+| 실행 provenance | `ps`에서 Preview와 Thumbnail executable 모두 단독 등록된 signed 후보 경로 확인 |
+| crash | smoke baseline 이후 Alhangeul/Preview/Thumbnail 신규 DiagnosticReport 없음 |
+
+격리 산출물은 `build.noindex/task472-stage4-draft/finder-provenance/`에 보관한다. 검증 후 후보 helper가 남지 않았음을 확인했다.
+
+## Public surface 보호와 등록 복원
+
+draft release는 `isDraft=true`, `isPrerelease=false`, `publishedAt=null`을 유지한다. 검증 종료 시점의 공개 상태는 다음과 같다.
+
+| 표면 | 결과 |
+|------|------|
+| GitHub latest Release | `v0.1.9`, non-draft / non-prerelease |
+| Pages 업데이트 화면 | 다운로드, Homebrew와 최신 릴리즈 노트 모두 `v0.1.9` |
+| stable appcast | `sparkle:shortVersionString=0.1.9`, build `15` |
+| Homebrew | public `v0.1.9` 유지, 이번 단계 미변경 |
+
+검증 종료 시 사용자 설치 상태를 smoke 전과 같게 복원했다.
+
+| 경로 | smoke 전 | 복원 결과 |
+|------|----------|-----------|
+| `/Applications/Alhangeul.app` | `0.1.9 (15)` | 파일 미변경, registration 복원 |
+| `/Users/melee/Applications/Alhangeul.app` | `0.1.8 (14)` | 백업에서 복원, signature valid |
+
+최종 PlugInKit에는 v0.1.9과 v0.1.8의 public/user Preview·Thumbnail 두 항목만 남고 v0.1.10 후보 경로는 없다. 후보 앱은 ignored 검증 산출물로만 보관하며 등록하지 않았다. Quick Look cache를 갱신했고 후보 helper process와 신규 crash가 없으며 draft DMG도 정상 detach했다.
+
+표준 `scripts/check-extension-registration-hygiene.sh --cleanup-dev-registrations`도 다시 실행했다. 과거 `build.noindex` LaunchServices 레코드는 각 exact path의 `lsregister -u`가 `-10814`를 반환해 Stage 3과 같이 비활성 레코드로 남았다. 이어 실행한 `--check-only`는 이 레코드와 smoke 전부터 존재한 v0.1.9/v0.1.8 두 설치 root를 보고해 exit 1이었다. PlugInKit에는 개발/후보 provider가 없고 허용된 두 설치 root만 있으며, 사용자 설치 상태 복원 원칙에 따라 전역 LaunchServices reset이나 기존 앱 삭제는 수행하지 않았다. Stage 5 실제 update smoke 전에는 public v0.1.9 baseline을 다시 격리해 provenance를 확인한다.
+
+## 미실행 항목
+
+Stage 4에서는 다음 public side effect와 별도 환경 검증을 실행하지 않았다.
+
+- draft release의 official publish 전환
+- stable Sparkle appcast와 Pages `v0.1.10` 배포
+- public DMG URL/SHA256 확정
+- 실제 `v0.1.9 -> v0.1.10` Sparkle update와 extension refresh
+- Homebrew Cask 반영과 install/uninstall smoke
+- Intel Mac 실기기 설치·실행
+
+## 판정
+
+- release PR merge commit, tree와 annotated tag가 같은 candidate를 가리킨다.
+- draft Publish workflow의 Developer ID signing, notarization, staple, Gatekeeper, universal slice와 layout이 통과했다.
+- signed candidate에서 HWP/HWPX 열기, 형식별 저장·재열기와 원본 무손실이 통과했다.
+- HWP/HWPX PDF의 page count, geometry, searchable/non-blank 결과와 native 인쇄 panel 시작·취소가 통과했다.
+- 자동 WebKit trust boundary 회귀와 signed app 정상 PDF·인쇄 경로가 함께 통과했다.
+- 후보만 단독 등록한 격리 smoke에서 실제 Preview/Thumbnail executable provenance와 HWP/HWPX 결과를 확인했다.
+- 신규 crash가 없고 검증 등록, 사용자 설치 상태와 DMG mount를 원상 복구했다.
+- GitHub latest Release, Pages와 stable appcast는 계속 public `v0.1.9 (15)`를 유지한다.
+- Stage 4 pre-public signed candidate 차단 gate를 통과로 판정한다.
+
+## 승인 요청
+
+Stage 4 완료보고서와 단계 커밋을 검토한 뒤 Stage 5 official stable Publish workflow 실행 승인을 별도로 요청한다. 이 승인 전에는 draft 공개 전환, stable appcast/Pages 배포, 실제 Sparkle update와 Homebrew 반영을 실행하지 않는다. Homebrew는 Stage 5에서도 별도 승인 gate를 유지한다.

--- a/mydocs/working/task_m900_472_stage5.md
+++ b/mydocs/working/task_m900_472_stage5.md
@@ -2,7 +2,7 @@
 
 ## 단계 목적
 
-Stage 4 signed draft 차단 gate를 통과한 exact `v0.1.10` tag를 official stable release로 게시하고, public DMG, GitHub Pages, stable Sparkle appcast와 실제 `v0.1.9 -> v0.1.10` 업데이트·Finder provider를 공개 산출물 기준으로 검증한다. Homebrew는 이 단계 안에서도 별도 승인 gate로 유지한다.
+Stage 4 signed draft 차단 gate를 통과한 exact `v0.1.10` tag를 official stable release로 게시하고, public DMG, GitHub Pages, stable Sparkle appcast와 실제 `v0.1.9 -> v0.1.10` 업데이트·Finder provider를 공개 산출물 기준으로 검증한다. Homebrew는 이 단계 안에서도 별도 승인 gate로 유지했고, official publish 검증 뒤 추가 승인을 받아 실행했다.
 
 ## Official stable Publish
 
@@ -63,7 +63,7 @@ official run은 draft asset을 새로 생성한 public 산출물로 교체했다
 | enclosure | public tag 고정 DMG URL, length `169177234` |
 | signature | `sparkle:edSignature` 존재 |
 
-Pages deployment 직후 공개 URL을 cache-busting query로 다시 내려받았다. home과 v0.1.10 note의 다운로드 링크, v0.1.9 최신 버전 안내와 stable appcast가 같은 public release를 가리켰고 appcast XML validity도 통과했다. Homebrew가 아직 별도 승인 전이므로 v0.1.10 Pages의 “별도 배포 단계에서 반영” 문구는 의도대로 유지한다.
+Pages deployment 직후 공개 URL을 cache-busting query로 다시 내려받았다. home과 v0.1.10 note의 다운로드 링크, v0.1.9 최신 버전 안내와 stable appcast가 같은 public release를 가리켰고 appcast XML validity도 통과했다. 당시 Homebrew가 별도 승인 전이었으므로 v0.1.10 Pages의 “별도 배포 단계에서 반영” 문구를 유지했다. 이후 Cask 배포가 완료됐지만 public 문구는 Stage 6의 별도 `main` 대상 closeout PR과 Pages 재배포 전까지 그대로 둔다.
 
 ## 실제 Sparkle 업데이트
 
@@ -103,9 +103,36 @@ actual update 결과인 `/Applications/Alhangeul.app` `0.1.10 (16)`은 public �
 
 과거 `build.noindex`의 비활성 LaunchServices record는 Stage 4와 같이 exact unregister가 `-10814`를 반환하는 상태다. 활성 provider provenance를 흐리지 않고 전역 reset은 다른 앱 등록까지 변경하므로 이번에도 수행하지 않았다. 실제 public smoke는 사용자 v0.1.8을 격리한 단일 v0.1.10 provider 상태에서 완료했다. 검증 앱과 provider process를 종료하고 DMG를 detach했으며 새 crash가 없음을 확인했다.
 
-## Homebrew와 미실행 항목
+## Homebrew Cask 배포와 미실행 항목
 
-Homebrew Cask는 별도 승인 전이므로 repository Cask, `postmelee/homebrew-tap`, install/uninstall smoke를 변경하거나 실행하지 않았다. public DMG URL과 SHA256은 확정됐지만 README, Pages home과 update index의 Homebrew 완료 문구도 아직 바꾸지 않는다. 승인되면 이 public SHA256만 사용해 tap-context style/audit/install/uninstall을 검증하고, 결과에 따라 Stage 6 main closeout PR의 exact public 문서 diff를 확정한다.
+official public DMG 검증 뒤 작업지시자의 별도 승인을 받아 repository와 public tap의 Cask를 같은 입력으로 갱신했다.
+
+| 항목 | 결과 |
+|------|------|
+| Cask version | `0.1.10` |
+| Cask SHA256 | `800ea0df2aee7ef380fb6af316f34d5a3c6bbbe60ef9b96054defac1e5dafd0e` |
+| repository source | `Casks/alhangeul.rb`, public DMG checksum helper의 exact 결과 |
+| public tap | [`postmelee/homebrew-tap` commit `f712c88`](https://github.com/postmelee/homebrew-tap/commit/f712c88e7e468395aeb09210cb6e24503dfb7d4f) |
+| public raw Cask | `main`에서 version과 SHA256 일치 확인 |
+| style | `brew style --cask alhangeul` 통과 |
+| audit | `brew audit --cask alhangeul` 통과 |
+| new-cask 참고 audit | `brew audit --cask --new alhangeul` 통과 |
+| install | `brew install --cask postmelee/tap/alhangeul` 통과, `0.1.10 (16)` 설치 |
+| installed trust | deep/strict signature, staple과 Gatekeeper 통과 |
+| uninstall | `brew uninstall --cask alhangeul` 통과, Caskroom과 설치 앱 제거 확인 |
+
+tap은 기존 `Untrusted` 상태를 유지했지만 fully-qualified install이 성공해 `brew trust` 같은 전역 신뢰 변경은 하지 않았다. smoke 과정에서 Homebrew 자체는 `6.0.15`에서 `6.0.17`로 자동 갱신됐고 다른 formula/cask는 변경하지 않았다.
+
+기존 Sparkle 업데이트 결과인 `/Applications/Alhangeul.app` `0.1.10 (16)`을 `build.noindex/task472-stage5-public/pre-homebrew/`에 백업하고 등록을 해제한 뒤 `/private/tmp/alhangeul-task472-pre-homebrew-v0.1.10.app`로 옮겨 Homebrew 설치본과 격리했다. uninstall 후 이 원본을 exact path로 복원하고 LaunchServices/PlugInKit에 다시 등록했다. 최종 상태는 Homebrew cask 미설치, `/Applications` public v0.1.10과 기존 사용자 v0.1.8 provider 등록이며 앱 signature와 Gatekeeper가 유효하고 신규 crash가 없다.
+
+Stage 6 closeout의 exact public 문서 범위는 다음과 같다. 아직 source나 public Pages는 변경하지 않았다.
+
+- `README.md`: 최신 릴리즈 Homebrew 항목을 v0.1.10 제공 완료와 설치 명령으로 보정
+- `docs/index.html`: FAQ의 배포 전/후 조건문을 현재 설치 가능 문구로 보정
+- `docs/updates/index.html`: Homebrew 섹션을 현재 v0.1.10 설치 가능 문구로 보정
+- `docs/updates/v0.1.10.html`: “별도 배포 단계에서 반영” 문구를 현재 설치 명령으로 보정
+
+Stage 5 계획은 앞의 세 문서를 closeout 대상으로 열거했지만 실제 공개 release note에도 같은 대기 문구가 남아 있음을 재확인했다. Stage 6 대상 파일에는 `docs/updates/v0.1.10.html`이 이미 필요 시 범위로 포함돼 있으므로 네 파일을 한 PR과 Pages 재배포로 정렬한다.
 
 Intel Mac 실기기 설치·실행은 수행하지 않았으며 성공으로 기록하지 않는다.
 
@@ -118,8 +145,9 @@ Intel Mac 실기기 설치·실행은 수행하지 않았으며 성공으로 기
 - clean official v0.1.9 baseline에서 실제 Sparkle update와 repair 없는 extension refresh가 통과했다.
 - public 설치본에서 HWP/HWPX app open, Quick Look, Thumbnail과 실제 `/Applications` provider provenance를 확인했다.
 - 신규 crash가 없고 대상 외 사용자 앱 파일과 registration을 복원했다.
-- Stage 5 official stable publish와 public surface gate를 통과로 판정한다. Homebrew sub-gate만 별도 승인 대기 상태다.
+- 별도 승인된 Homebrew Cask와 public tap 배포, style/audit/install/uninstall smoke가 통과했다.
+- Stage 5 official stable publish, public surface와 Homebrew sub-gate를 모두 통과로 판정한다.
 
 ## 다음 승인 요청
 
-확정된 public DMG URL과 SHA256을 기준으로 Homebrew Cask와 tap 반영, style/audit/install/uninstall smoke를 실행할지 별도 승인을 요청한다. 승인 전에는 Homebrew나 세 public 문서의 완료 문구를 변경하지 않는다.
+Stage 6 release record·최종 보고와 종료 정리 진입 승인을 요청한다. 승인 뒤 네 public 문서의 Homebrew 완료 문구를 단일 `main` 대상 closeout PR로 반영하고, merge 후 Pages 재배포를 확인한다.

--- a/mydocs/working/task_m900_472_stage5.md
+++ b/mydocs/working/task_m900_472_stage5.md
@@ -1,0 +1,125 @@
+# Task M900 #472 Stage 5 완료보고서
+
+## 단계 목적
+
+Stage 4 signed draft 차단 gate를 통과한 exact `v0.1.10` tag를 official stable release로 게시하고, public DMG, GitHub Pages, stable Sparkle appcast와 실제 `v0.1.9 -> v0.1.10` 업데이트·Finder provider를 공개 산출물 기준으로 검증한다. Homebrew는 이 단계 안에서도 별도 승인 gate로 유지한다.
+
+## Official stable Publish
+
+2026-08-15 KST 작업지시자의 별도 승인을 받아 annotated tag `v0.1.10`에서 다음 입력으로 `Release Publish DMG` workflow를 실행했다.
+
+| 입력 | 값 |
+|------|----|
+| `version` | `0.1.10` |
+| `previous_release_ref` | `v0.1.9` |
+| `expected_rhwp_tag` | `v0.8.4` |
+| `require_latest_rhwp` | `true` |
+| `include_rhwp_in_title` | `true` |
+| `draft` / `prerelease` | `false` / `false` |
+
+실행 전 `origin/main`, tag peeled commit과 checkout 대상이 모두 `fafed425d4b87162c2188d1384d618adc2211eb6`임을 확인했다. Stage 3 제품 경계와 tag 사이 source diff는 없었고 upstream latest도 `rhwp v0.8.4`였다. release environment의 필요한 variable/secret 이름은 값 노출 없이 확인했다.
+
+| 항목 | 결과 |
+|------|------|
+| workflow | [run `31812500336`](https://github.com/postmelee/alhangeul-macos/actions/runs/31812500336), success |
+| exact head | tag `v0.1.10`, `fafed425d4b87162c2188d1384d618adc2211eb6` |
+| release job | `94806246847`, 2026-08-15 00:02:32~00:19:40 KST, success |
+| Pages job | `94810917280`, 2026-08-15 00:19:44~00:19:53 KST, success |
+| GitHub Release | [`Alhangeul v0.1.10 (rhwp v0.8.4)`](https://github.com/postmelee/alhangeul-macos/releases/tag/v0.1.10) |
+| 공개 시각 | 2026-08-15 00:19:19 KST |
+| 상태 | non-draft, non-prerelease, latest |
+
+release job의 source/header/ABI/build-info 검증, Developer ID signing, notarization, staple, public artifact 검증, Release 게시, Sparkle EdDSA appcast 생성과 Pages artifact upload가 모두 통과했다. Pages job은 같은 release commit을 `pages_build_version`으로 사용해 성공했다. Actions에는 public DMG, appcast, Pages, release delta checklist와 PR analysis artifact가 남아 있다. runner의 `aws/tap` trust annotation은 build dependency 설치 환경 경고이며 Homebrew Cask 반영을 실행한 결과가 아니다.
+
+## Public DMG 검증
+
+| 항목 | 결과 |
+|------|------|
+| 파일 | `alhangeul-macos-0.1.10.dmg` |
+| URL | https://github.com/postmelee/alhangeul-macos/releases/download/v0.1.10/alhangeul-macos-0.1.10.dmg |
+| 크기 | 169,177,234 bytes |
+| SHA256 | `800ea0df2aee7ef380fb6af316f34d5a3c6bbbe60ef9b96054defac1e5dafd0e` |
+| GitHub asset digest | actual SHA256와 일치 |
+| checksum asset | `shasum -a 256 -c` 통과 |
+| DMG integrity | `hdiutil verify` 통과 |
+| version/build | 앱과 extension 모두 `0.1.10 (16)` |
+| architecture | 앱, Preview와 Thumbnail 모두 `x86_64 + arm64` |
+| code signature | deep/strict 검증 통과 |
+| notarization / staple | 앱과 DMG 모두 통과 |
+| Gatekeeper | 앱과 DMG 모두 `Notarized Developer ID` accepted |
+| layout / Legal | root 앱과 `Applications` link, background, canonical Legal resource 확인 |
+
+official run은 draft asset을 새로 생성한 public 산출물로 교체했다. 따라서 Stage 4 draft SHA256 `e54d5a1...a7af`가 아니라 위 public SHA256만 appcast와 후속 Homebrew 입력으로 사용할 수 있다. 다운로드한 public DMG와 checksum을 `build.noindex/task472-stage5-public/`에서 독립 검증한 뒤 DMG를 정상 detach했다.
+
+## Pages와 stable appcast
+
+| 표면 | 결과 |
+|------|------|
+| Pages home | https://postmelee.github.io/alhangeul-macos/, public v0.1.10 DMG 연결 |
+| release note | https://postmelee.github.io/alhangeul-macos/updates/v0.1.10.html |
+| 이전 release notice | v0.1.9 문서가 v0.1.10 note와 GitHub latest로 연결 |
+| stable appcast | https://postmelee.github.io/alhangeul-macos/appcast.xml |
+| appcast version/build | `0.1.10 (16)` |
+| enclosure | public tag 고정 DMG URL, length `169177234` |
+| signature | `sparkle:edSignature` 존재 |
+
+Pages deployment 직후 공개 URL을 cache-busting query로 다시 내려받았다. home과 v0.1.10 note의 다운로드 링크, v0.1.9 최신 버전 안내와 stable appcast가 같은 public release를 가리켰고 appcast XML validity도 통과했다. Homebrew가 아직 별도 승인 전이므로 v0.1.10 Pages의 “별도 배포 단계에서 반영” 문구는 의도대로 유지한다.
+
+## 실제 Sparkle 업데이트
+
+업데이트 전 `/Applications/Alhangeul.app`은 official `0.1.9 (15)`였고 deep/strict signature, Gatekeeper와 Preview/Thumbnail provider가 모두 유효했다. provenance가 섞이지 않도록 사용자 경로 `/Users/melee/Applications/Alhangeul.app` `0.1.8 (14)`의 registration만 잠시 해제해 `/Applications` v0.1.9을 유일한 기준선으로 만들었다. 기존 v0.1.9 app은 `build.noindex/task472-stage5-public/baseline-v0.1.9/`에 복구용으로 보관했다.
+
+| 경로 | 결과 |
+|------|------|
+| update 발견 | v0.1.9 실행 시 public `0.1.10` update alert 표시 |
+| download | Sparkle UI에서 169.2MB enclosure 다운로드 완료 |
+| install | `설치 & 재실행` 완료 |
+| 설치 결과 | `/Applications/Alhangeul.app`이 `0.1.10 (16)`으로 교체 |
+| 앱 provenance | 재실행 직후 `rhwp v0.8.4 (496333b)` 확인 |
+| trust | 설치본 deep/strict signature, staple와 Gatekeeper 통과 |
+| natural provider refresh | Preview/Thumbnail 모두 `/Applications/Alhangeul.app`, `0.1.10` 한 항목으로 자연 갱신 |
+| repair 사용 | 없음, `Registration repair used: 0` |
+
+`scripts/smoke-sparkle-extension-refresh.sh` 기본 모드가 통과했다. HWP와 HWPX fresh sample thumbnail은 각각 `768x544`, `544x768` PNG로 생성됐고 SHA256은 `7391735b...7414dbb`, `9751c84c...cb4f618`이다. registration repair를 쓰지 않았으므로 업데이트 뒤 app extension refresh의 자연 상태를 release gate 근거로 사용한다.
+
+## Public 앱과 Finder smoke
+
+| 항목 | 결과 |
+|------|------|
+| HWP 앱 열기 | `samples/basic/KTX.hwp`, 1페이지 render |
+| HWPX 앱 열기 | `samples/hwpx/hwpx-01.hwpx`, 9페이지 render |
+| HWP Quick Look | KTX 노선도 non-blank render 확인 |
+| HWPX Quick Look | 9페이지 navigation과 1페이지 non-blank render 확인 |
+| Preview process | `/Applications/Alhangeul.app/.../AlhangeulPreview`, PID `35552` |
+| Thumbnail process | `/Applications/Alhangeul.app/.../AlhangeulThumbnail`, PID `35312` |
+| extension log | 두 executable 모두 `/Applications/Alhangeul.app`에서 launch, expected bundle identity 확인 |
+| crash | publish·update·Finder smoke 이후 신규 DiagnosticReport 없음 |
+
+HWPX 글꼴 안내에서는 원본 파일을 수정하지 않도록 대체 글꼴 표시로 render만 완료했고, 종료 시 검증 중 생긴 미저장 UI 상태는 저장하지 않았다. 저장·PDF·인쇄는 같은 candidate의 Stage 4 signed draft 차단 gate에서 이미 통과했으므로 Stage 5에서는 public update provenance와 open/Finder 경로에 집중했다.
+
+## 등록과 설치 상태 정리
+
+actual update 결과인 `/Applications/Alhangeul.app` `0.1.10 (16)`은 public 설치본으로 유지한다. smoke 중 잠시 격리했던 사용자 경로 v0.1.8은 파일을 변경하지 않고 LaunchServices/PlugInKit registration을 원상 복원했다. 최종 PlugInKit에는 public v0.1.10과 기존 사용자 v0.1.8 두 설치 root만 있고 개발·candidate provider는 없다.
+
+과거 `build.noindex`의 비활성 LaunchServices record는 Stage 4와 같이 exact unregister가 `-10814`를 반환하는 상태다. 활성 provider provenance를 흐리지 않고 전역 reset은 다른 앱 등록까지 변경하므로 이번에도 수행하지 않았다. 실제 public smoke는 사용자 v0.1.8을 격리한 단일 v0.1.10 provider 상태에서 완료했다. 검증 앱과 provider process를 종료하고 DMG를 detach했으며 새 crash가 없음을 확인했다.
+
+## Homebrew와 미실행 항목
+
+Homebrew Cask는 별도 승인 전이므로 repository Cask, `postmelee/homebrew-tap`, install/uninstall smoke를 변경하거나 실행하지 않았다. public DMG URL과 SHA256은 확정됐지만 README, Pages home과 update index의 Homebrew 완료 문구도 아직 바꾸지 않는다. 승인되면 이 public SHA256만 사용해 tap-context style/audit/install/uninstall을 검증하고, 결과에 따라 Stage 6 main closeout PR의 exact public 문서 diff를 확정한다.
+
+Intel Mac 실기기 설치·실행은 수행하지 않았으며 성공으로 기록하지 않는다.
+
+## 판정
+
+- official Publish의 release job과 Pages job이 exact tag commit에서 성공했다.
+- GitHub Release는 public stable/latest이고 DMG URL, SHA256과 size가 확정됐다.
+- public DMG와 app/extension의 integrity, universal slice, signing, notarization, staple, Gatekeeper와 Legal gate가 통과했다.
+- Pages와 stable appcast가 `0.1.10 (16)` 및 같은 public DMG를 가리킨다.
+- clean official v0.1.9 baseline에서 실제 Sparkle update와 repair 없는 extension refresh가 통과했다.
+- public 설치본에서 HWP/HWPX app open, Quick Look, Thumbnail과 실제 `/Applications` provider provenance를 확인했다.
+- 신규 crash가 없고 대상 외 사용자 앱 파일과 registration을 복원했다.
+- Stage 5 official stable publish와 public surface gate를 통과로 판정한다. Homebrew sub-gate만 별도 승인 대기 상태다.
+
+## 다음 승인 요청
+
+확정된 public DMG URL과 SHA256을 기준으로 Homebrew Cask와 tap 반영, style/audit/install/uninstall smoke를 실행할지 별도 승인을 요청한다. 승인 전에는 Homebrew나 세 public 문서의 완료 문구를 변경하지 않는다.


### PR DESCRIPTION
## 요약

- 대상 타스크: v0.1.10 official publish, Homebrew 배포와 public communication closeout을 최종 기록합니다.
- 왜: `main`에 반영된 Cask·Pages closeout과 실제 release 검증 결과를 integration `devel`에도 정렬해야 합니다.
- 무엇: Cask/공개 문서, Stage 4~6 운영 기록, 최종 보고와 오늘할일을 실제 run·commit·SHA256 기준으로 반영합니다.
- 리뷰 포인트: 제품 source/project/workflow 변경 없이 운영·문서 13파일만 포함하며 stable appcast byte content를 보존합니다.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/ac6f3e432a483180807b11cad33b05c178e704fe/mydocs/working/task_m900_472_stage1.md)** ([58424de](https://github.com/postmelee/alhangeul-macos/commit/58424de)): app/extension과 release workflow 입력을 `0.1.10 (16)`, `v0.8.4`로 정렬했습니다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/ac6f3e432a483180807b11cad33b05c178e704fe/mydocs/working/task_m900_472_stage2.md)** ([95800ee](https://github.com/postmelee/alhangeul-macos/commit/95800ee)): release delta, 공개 communication 후보와 source candidate를 확정했습니다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/ac6f3e432a483180807b11cad33b05c178e704fe/mydocs/working/task_m900_472_stage3.md)** ([4613106](https://github.com/postmelee/alhangeul-macos/commit/4613106)): portable artifact 경계, local package와 Rehearsal을 검증했습니다.
- **[Stage 4](https://github.com/postmelee/alhangeul-macos/blob/ac6f3e432a483180807b11cad33b05c178e704fe/mydocs/working/task_m900_472_stage4.md)** ([8292782](https://github.com/postmelee/alhangeul-macos/commit/8292782)): exact tag의 signed/notarized draft와 저장·PDF·인쇄·Finder 차단 gate를 통과했습니다.
- **[Stage 5](https://github.com/postmelee/alhangeul-macos/blob/ac6f3e432a483180807b11cad33b05c178e704fe/mydocs/working/task_m900_472_stage5.md)** ([2c6ba3a](https://github.com/postmelee/alhangeul-macos/commit/2c6ba3a), [870fa90](https://github.com/postmelee/alhangeul-macos/commit/870fa90)): official publish, 실제 Sparkle update와 Homebrew install/uninstall을 검증했습니다.
- **[Stage 6·최종 보고](https://github.com/postmelee/alhangeul-macos/blob/ac6f3e432a483180807b11cad33b05c178e704fe/mydocs/report/task_m900_472_report.md)** ([ac6f3e4](https://github.com/postmelee/alhangeul-macos/commit/ac6f3e432a483180807b11cad33b05c178e704fe)): GitHub Release 문구, main closeout PR #477, Pages 재배포와 stable appcast 보존 결과를 확정했습니다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| Cask·공개 문서 | repository Cask와 README/Pages Homebrew 문구를 v0.1.10 public DMG에 정렬 | version/SHA256/설치 명령 일치 |
| release record | public artifact, Homebrew tap, PR #477 merge와 Pages run의 실제 결과 반영 | placeholder와 미실행 항목 혼동 없음 |
| Stage 4~5 보고 | signed candidate, official publish와 Homebrew smoke 기록 추가 | 제품 source 변경 없음 |
| 최종 보고·오늘할일 | 13파일 영향 범위, 정량 비교, 수용 기준과 종료 승인 기록 | Issue close와 cleanup 대상 명확화 |

- 수행 계획서: [task_m900_472.md](https://github.com/postmelee/alhangeul-macos/blob/ac6f3e432a483180807b11cad33b05c178e704fe/mydocs/plans/task_m900_472.md)
- 구현 계획서: [task_m900_472_impl.md](https://github.com/postmelee/alhangeul-macos/blob/ac6f3e432a483180807b11cad33b05c178e704fe/mydocs/plans/task_m900_472_impl.md)
- 릴리즈 기록: [v0.1.10.md](https://github.com/postmelee/alhangeul-macos/blob/ac6f3e432a483180807b11cad33b05c178e704fe/mydocs/release/v0.1.10.md)
- 최종 보고서: [task_m900_472_report.md](https://github.com/postmelee/alhangeul-macos/blob/ac6f3e432a483180807b11cad33b05c178e704fe/mydocs/report/task_m900_472_report.md)

## 핵심 리뷰 포인트

- `origin/devel...HEAD`는 Cask·공개 문서·운영 기록 13파일이며 `Sources/`, Xcode project와 workflow를 포함하지 않습니다.
- public DMG는 SHA256 `800ea0df2aee7ef380fb6af316f34d5a3c6bbbe60ef9b96054defac1e5dafd0e`, 169,177,234 bytes이고 repository/tap Cask와 일치합니다.
- PR #477 merge 뒤 public Pages의 Homebrew 문구를 확인했고 stable appcast SHA256 `36b5d62bc9477bf6b586c19888071ba8610be0ac42a116b2a8be7bf5cee3af5a`와 byte content를 보존했습니다.

## 검증

- `git diff --check origin/devel...HEAD`
- `scripts/ci/update-release-version-notices.sh --updates-dir docs/updates --check`
- `scripts/update-cask-sha256.sh --dry-run 0.1.10 build.noindex/task472-stage5-public/alhangeul-macos-0.1.10.dmg.sha256`
- `ruby -c Casks/alhangeul.rb`
- `scripts/ci/check-release-notes-template.sh build.noindex/task472-stage4/release-notes-v0.1.10.md`
- `scripts/validate-github-body.sh build.noindex/task472-stage4/release-notes-v0.1.10.md`
- prepared Pages artifact와 closeout 뒤 public appcast의 byte-identical 비교
- PR #477 merge commit `7162a80...`과 Docs-only Pages run `31975531842` success 확인
- GitHub Release v0.1.10 non-draft/non-prerelease 및 public DMG URL/SHA256/size 확인
- public 홈, 업데이트 목록, v0.1.10 note의 Homebrew 명령 직접 확인

## 관련 이슈

- [#474](https://github.com/postmelee/alhangeul-macos/issues/474): main/devel content gate 규칙과 자동화 후속
- [#459](https://github.com/postmelee/alhangeul-macos/issues/459): PDF·인쇄 lifecycle hardening
- [#469](https://github.com/postmelee/alhangeul-macos/issues/469), [#470](https://github.com/postmelee/alhangeul-macos/issues/470): render-tree golden과 decode 진단 후속

## 후속 이슈 제안

- 없음. 확인된 후속은 기존 Issue #459, #469, #470, #474 이슈로 추적합니다.

## 남은 리스크

- Intel Mac과 deployment target macOS 12 실기기 smoke는 미실행입니다. universal architecture와 자동 gate 결과와 분리해 기록했습니다.
- local strict static archive byte mismatch는 portable 승인 경계와 분리했으며 lock을 로컬 결과로 갱신하지 않았습니다.
- 비활성 개발 LaunchServices record 일부는 활성 provider와 무관해 전역 reset 없이 유지했습니다.

Closes #472
