### PR TITLE
Task #488: Release artifact endpoint preflight와 production host 고정

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -218,12 +218,6 @@ jobs:
           set -euo pipefail
           xcodegen generate
 
-      - name: Check analytics endpoint plist fixtures on macOS
-        shell: bash
-        run: |
-          set -euo pipefail
-          scripts/ci/test-app-execution-endpoint-config.sh
-
       - name: Build HostApp Debug
         shell: bash
         run: |
@@ -269,6 +263,12 @@ jobs:
           if ! command -v rg >/dev/null 2>&1; then
             brew install ripgrep
           fi
+
+      - name: Check analytics endpoint plist fixtures on macOS
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/ci/test-app-execution-endpoint-config.sh
 
       - name: Fetch release tags
         shell: bash

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -218,6 +218,12 @@ jobs:
           set -euo pipefail
           xcodegen generate
 
+      - name: Check analytics endpoint plist fixtures on macOS
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/ci/test-app-execution-endpoint-config.sh
+
       - name: Build HostApp Debug
         shell: bash
         run: |

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -312,6 +312,7 @@ jobs:
             echo
             echo "- release command: \`./scripts/release.sh \"$VERSION\"\`"
             echo "- Expected Team ID: \`${APPLE_TEAM_ID:-XH6JHKYXV8}\`"
+            echo "- The copied Release app endpoint must match the approved production endpoint before post-build Developer ID re-signing, notarization submit, and DMG creation."
             echo "- Before app notarization submit, \`release.sh\` verifies Developer ID authority, Team ID, secure timestamp, hardened runtime, \`get-task-allow\` absence, and required Sparkle nested components."
             echo "- Failure in this preflight blocks notarization submit."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -204,6 +204,7 @@ jobs:
             echo "## Signing preflight policy"
             echo
             echo "- release command: \`./scripts/release.sh --skip-notarize \"$VERSION\"\`"
+            echo "- The copied Release app endpoint must match the approved production endpoint before optional post-build Developer ID re-signing and DMG creation."
             echo "- Default rehearsal artifacts are unsigned and skip Developer ID signing preflight."
             echo "- If \`ALHANGEUL_DEVELOPER_ID_APPLICATION\` is provided, \`release.sh\` runs the same app/extension/Sparkle signing preflight before DMG creation."
             echo "- Rehearsal artifacts are never public release or Homebrew Cask inputs."

--- a/mydocs/manual/ci_workflow_guide.md
+++ b/mydocs/manual/ci_workflow_guide.md
@@ -65,7 +65,7 @@ PR CI는 외부 PR에서도 안전하게 실행할 수 있는 검증만 수행�
 | `run_macos_build` | HostApp Debug build와 shared Swift boundary 확인 필요 | `Sources/**`, `Sources/HostApp/Resources/rhwp-studio/**`, `project.yml`, `Alhangeul.xcodeproj/**`, 미분류 non-docs |
 | `run_rust_verify` | Rust bridge/core source/header/ABI lock 검증 필요 | `RustBridge/**`, `rhwp-core.lock`, `Frameworks/**`, bundled `rhwp-studio` provenance, core 관련 scripts |
 | `run_render_smoke` | native renderer smoke 필요 | `Sources/RhwpCoreBridge/**`, `Sources/Shared/**`, extension, samples, render smoke scripts |
-| `run_release_checks` | release helper dry-run 필요 | `.github/workflows/**`, `scripts/release.sh`, `scripts/ci/**`, `Sources/HostApp/Resources/rhwp-studio/**`, `Casks/**`, release manual/record |
+| `run_release_checks` | release helper dry-run과 macOS endpoint fixture 필요 | `.github/workflows/**`, `scripts/release.sh`, `scripts/ci/**`, `Sources/HostApp/Resources/rhwp-studio/**`, `Casks/**`, release manual/record |
 
 한 파일이 여러 영역에 걸치면 flag는 누적된다. 예를 들어 `Sources/RhwpCoreBridge/CGTreeRenderer.swift`는 `run_macos_build`와 `run_render_smoke`를 모두 켠다.
 
@@ -76,6 +76,8 @@ PR CI는 외부 PR에서도 안전하게 실행할 수 있는 검증만 수행�
 ### docs-only skip 기준
 
 docs-only PR에서도 `classify-changes`와 `script-checks`는 실행한다. 따라서 build-info helper fixture와 studio Cargo.lock fingerprint fixture는 항상 실행되지만 tracked Swift source verifier는 관련 변경이 `run_macos_build=true`를 켰을 때 macOS validation에서 실행한다. studio fixture는 production resource를 수정하지 않고 resource-only 하위 호환, strict commit/hash 일치, stale checkout, non-Git directory, 누락, malformed sha256, 실제 값 mismatch와 sync self-check를 독립적으로 검증한다. `run_macos_build=false`이면 `macos-validation` job은 skipped 상태가 된다. 단, release 관련 문서나 Pages/appcast 파일은 문서여도 `run_release_checks=true`가 될 수 있다.
+
+Analytics endpoint helper의 portable 분기는 Ubuntu `script-checks`에서 항상 실행한다. `scripts/ci/**` 또는 release workflow 변경으로 `run_release_checks=true`가 되면 macOS `release-checks`에서도 같은 helper를 실행해 `plutil`의 binary·key/type 분기를 검증한다. 따라서 `run_macos_build=false`인 script-only PR도 macOS endpoint fixture를 건너뛰지 않으며, 실제 HostApp Debug 산출물 검증만 `macos-validation`이 담당한다.
 
 ### PR CI 로컬 재현
 
@@ -110,7 +112,6 @@ rustup target add aarch64-apple-darwin x86_64-apple-darwin
 ./scripts/check-no-appkit.sh
 ./scripts/verify-rhwp-core-build-info.sh
 ./scripts/verify-rhwp-studio-assets.sh
-scripts/ci/test-app-execution-endpoint-config.sh
 xcodegen generate
 xcodebuild -project Alhangeul.xcodeproj \
   -scheme HostApp \
@@ -143,6 +144,7 @@ renderer/fixture 변경이 있으면 추가로 실행한다.
 release checks 재현:
 
 ```bash
+scripts/ci/test-app-execution-endpoint-config.sh
 ./scripts/release.sh --help
 scripts/ci/write-release-notes.sh 0.1.5 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef build.noindex/release/release-notes-0.1.5.md
 scripts/ci/check-release-notes-template.sh build.noindex/release/release-notes-0.1.5.md
@@ -367,7 +369,7 @@ scripts/verify-rhwp-studio-assets.sh \
 - `classify-changes` 실패: base/head ref나 변경 범위 helper 문제를 먼저 확인한다.
 - `script-checks` 실패: shell syntax, helper interface, build-info fixture 또는 studio Cargo.lock fingerprint fixture 회귀다. macOS build 전 수정한다.
 - `macos-validation` 실패: 앱 build, XcodeGen 입력, shared Swift boundary, Rust lock/build info, renderer smoke 중 하나가 깨진 것이다.
-- `release-checks` 실패: release helper, release note template, delta checklist, Sparkle appcast XML 생성 경계가 깨진 것이다.
+- `release-checks` 실패: macOS endpoint plist fixture, release helper, release note template, delta checklist, Sparkle appcast XML 생성 경계가 깨진 것이다.
 - `Release Rehearsal DMG` 실패: public release 전 core lock/build-info drift, packaging/release script 또는 ref delta 입력을 수정한다.
 - `Release Publish DMG` 실패: core lock/build-info와 public release 산출물 상태를 먼저 확인하고, 필요한 경우 GitHub Release asset/appcast/Pages/Homebrew 반영을 중단한다.
 - `Docs-only Pages Deploy` 실패: public appcast 다운로드/XML 검증 실패, Pages artifact 조립 실패, `github-pages` environment policy, 또는 `deploy-pages` 실패를 먼저 확인한다. stale `docs/appcast.xml` fallback으로 우회하지 않는다.

--- a/mydocs/manual/ci_workflow_guide.md
+++ b/mydocs/manual/ci_workflow_guide.md
@@ -9,8 +9,8 @@
 | workflow | trigger | 권한 | runner | 역할 |
 |----------|---------|------|--------|------|
 | `PR CI` | `pull_request` to `main`, `devel`, `native-viewer-editor` | `contents: read`, `pull-requests: read` | Ubuntu, macOS | PR 변경 범위 분류, script syntax/build-info fixture, 조건부 macOS build와 build-info verifier, 조건부 release helper dry-run |
-| `Release Rehearsal DMG` | `workflow_dispatch` | `contents: read`, `pull-requests: read` | macOS | core lock/build-info verifier, signed/notarized 전 universal rehearsal DMG/checksum, 포함 PR 분석 artifact, release delta checklist artifact 생성 |
-| `Release Publish DMG` | `workflow_dispatch` | `contents: write`/`pull-requests: read` for release job, `pages: write`/`id-token: write` for Pages job, `environment: release`/`github-pages` | macOS, Ubuntu | tag와 core lock/build-info 검증, signed/notarized universal DMG, GitHub Release asset, stable Sparkle appcast, Pages deployment, 포함 PR 분석 artifact, release delta checklist artifact 생성 |
+| `Release Rehearsal DMG` | `workflow_dispatch` | `contents: read`, `pull-requests: read` | macOS | core lock/build-info와 built Release endpoint 검증, signed/notarized 전 universal rehearsal DMG/checksum, 포함 PR 분석 artifact, release delta checklist artifact 생성 |
+| `Release Publish DMG` | `workflow_dispatch` | `contents: write`/`pull-requests: read` for release job, `pages: write`/`id-token: write` for Pages job, `environment: release`/`github-pages` | macOS, Ubuntu | tag, core lock/build-info와 built Release endpoint 검증, signed/notarized universal DMG, GitHub Release asset, stable Sparkle appcast, Pages deployment, 포함 PR 분석 artifact, release delta checklist artifact 생성 |
 | `Docs-only Pages Deploy` | `push` to `main` with `docs/**`, `workflow_dispatch` | `contents: read`, `pages: write`/`id-token: write` for Pages job, `environment: github-pages` | Ubuntu | 일반 Pages 문서 변경을 public Pages에 배포하고 기존 public appcast를 보존 |
 | `rhwp Upstream Release Check` | `workflow_dispatch`, schedule | `contents: read` | Ubuntu | upstream `rhwp` release와 `rhwp-core.lock` 비교 |
 | `rhwp Upstream Sync PR` | `workflow_dispatch`, schedule | workflow는 `contents: read`, `pull-requests: read`; PR 생성은 GitHub App token의 `contents: write`, `pull-requests: write`, `issues: write` | Ubuntu, macOS | upstream release를 감지해 `rhwp-core.lock`/RustBridge, Swift build info와 bundled `rhwp-studio`를 같은 core identity로 갱신하는 full sync 후보 PR 생성 |
@@ -110,6 +110,7 @@ rustup target add aarch64-apple-darwin x86_64-apple-darwin
 ./scripts/check-no-appkit.sh
 ./scripts/verify-rhwp-core-build-info.sh
 ./scripts/verify-rhwp-studio-assets.sh
+scripts/ci/test-app-execution-endpoint-config.sh
 xcodegen generate
 xcodebuild -project Alhangeul.xcodeproj \
   -scheme HostApp \
@@ -193,6 +194,7 @@ rehearsal 산출물은 public GitHub Release asset이나 Homebrew Cask URL에 �
 rehearsal workflow가 만든 app bundle도 `arm64 + x86_64` universal slice 검증을 통과해야 하지만, signed/notarized public DMG와 실제 Intel Mac 실기기 smoke를 대체하지 않는다.
 release owner는 rehearsal 전후로 merge PR title/body, linked Issue, 최종 보고서 기반 `포함 PR 분석` 표를 release record에 남기고, rehearsal delta checklist는 누락 확인과 smoke 영역 점검에만 사용한다.
 rehearsal DMG build 전에는 Rust/core lock verify에 이어 `verify-rhwp-core-build-info.sh`가 tracked Swift build info 정합성을 확인한다. 이 단계에서 drift를 자동 수정하지 않는다.
+공통 `release.sh`는 build한 Release app을 staging으로 복사한 뒤 전체 analytics endpoint가 `project.yml` 값과 정확히 같고 승인된 production origin을 쓰는지 확인한다. mismatch는 선택적 post-build Developer ID 재서명과 DMG 생성을 시작하기 전에 rehearsal을 실패시킨다.
 
 ## Release Publish DMG
 
@@ -232,6 +234,7 @@ workflow가 생성하거나 게시하는 주요 산출물:
 GitHub Release body 후보는 `mydocs/release/v<version>.md`의 사용자-facing 주요 변경 사항과 직접 반영된 PR/Issue section을 기준으로 작성한다. 첫 top-level section은 `이번 버전의 주요 변경 사항`이어야 하며, 설치/지원/업데이트 안내와 상세 기록은 그 뒤에 둔다. publish workflow의 delta checklist는 마지막 누락 확인용 보조 자료이며, release note의 주요 변경 사항 원천이 아니다.
 
 signed/notarized DMG build 전에는 Rust/core lock verify에 이어 `verify-rhwp-core-build-info.sh`가 실행된다. mismatch는 signing/notarization과 public artifact 생성을 차단하며 publish workflow는 writer를 실행하지 않는다.
+같은 공통 `release.sh`의 built Release endpoint preflight도 post-build Developer ID 재서명, 공증 제출과 public DMG 생성 전에 실행된다. `project.yml`의 전체 URL 불일치 또는 승인된 production origin 이탈은 public artifact pipeline을 즉시 차단한다.
 
 ## Docs-only Pages Deploy
 

--- a/mydocs/manual/release_packaging_dmg_guide.md
+++ b/mydocs/manual/release_packaging_dmg_guide.md
@@ -56,9 +56,9 @@ xcodebuild -project Alhangeul.xcodeproj \
   -derivedDataPath build.noindex/DerivedDataRelease \
   CODE_SIGNING_ALLOWED=NO \
   build
-scripts/ci/verify-universal-macos-app.sh build.noindex/DerivedDataRelease/Build/Products/Release/Alhangeul.app
 scripts/ci/verify-app-execution-endpoint-config.sh \
   --release-app build.noindex/DerivedDataRelease/Build/Products/Release/Alhangeul.app
+scripts/ci/verify-universal-macos-app.sh build.noindex/DerivedDataRelease/Build/Products/Release/Alhangeul.app
 ```
 
 `v0.1.1`부터 Release configuration 산출물은 app 본체와 Quick Look/Thumbnail extension 실행 파일이 `arm64 + x86_64` slice를 모두 포함해야 한다. 이 검증은 `lipo -verify_arch arm64 x86_64` 기준이며, 실제 Intel Mac 실기기 실행 smoke를 수행하지 않았다면 성공으로 기록하지 않는다.
@@ -97,9 +97,10 @@ build.noindex/release/alhangeul-macos-<version>.zip
 - Rust bridge와 `Rhwp.xcframework` 재생성 후 source/header/ABI 기준 `rhwp-core.lock` 검증
 - `xcodegen generate`
 - Release configuration으로 HostApp 빌드
+- 내부 산출물 `Alhangeul.app`을 release staging의 `Alhangeul.app`으로 복사
 - release staging으로 복사한 app의 analytics endpoint가 승인된 production origin과 `project.yml`의 전체 URL에 일치하는지 검증
 - `Alhangeul.app`, `AlhangeulPreview.appex`, `AlhangeulThumbnail.appex` 실행 파일의 `arm64 + x86_64` universal 검증
-- 내부 산출물 `Alhangeul.app`을 release staging으로 복사한 뒤 `Alhangeul.app` 이름으로 zip 압축
+- release staging의 `Alhangeul.app`을 `Alhangeul.app` 이름으로 zip 압축
 - Release staging app은 local signing과 sealed resources가 적용되어 Finder 통합 smoke test의 기준 산출물로 사용할 수 있음
 - SHA256 출력
 

--- a/mydocs/manual/release_packaging_dmg_guide.md
+++ b/mydocs/manual/release_packaging_dmg_guide.md
@@ -57,9 +57,13 @@ xcodebuild -project Alhangeul.xcodeproj \
   CODE_SIGNING_ALLOWED=NO \
   build
 scripts/ci/verify-universal-macos-app.sh build.noindex/DerivedDataRelease/Build/Products/Release/Alhangeul.app
+scripts/ci/verify-app-execution-endpoint-config.sh \
+  --release-app build.noindex/DerivedDataRelease/Build/Products/Release/Alhangeul.app
 ```
 
 `v0.1.1`부터 Release configuration 산출물은 app 본체와 Quick Look/Thumbnail extension 실행 파일이 `arm64 + x86_64` slice를 모두 포함해야 한다. 이 검증은 `lipo -verify_arch arm64 x86_64` 기준이며, 실제 Intel Mac 실기기 실행 smoke를 수행하지 않았다면 성공으로 기록하지 않는다.
+
+endpoint 검증은 source configuration의 Release URL이 승인된 production origin을 사용하는지와 built app의 전체 URL이 source 값과 정확히 일치하는지를 함께 확인한다. macOS에서는 `plutil`을 사용하고, `plutil`이 없는 환경의 fallback은 XML plist에만 허용한다.
 
 ## Release pipeline preflight check
 
@@ -93,6 +97,7 @@ build.noindex/release/alhangeul-macos-<version>.zip
 - Rust bridge와 `Rhwp.xcframework` 재생성 후 source/header/ABI 기준 `rhwp-core.lock` 검증
 - `xcodegen generate`
 - Release configuration으로 HostApp 빌드
+- release staging으로 복사한 app의 analytics endpoint가 승인된 production origin과 `project.yml`의 전체 URL에 일치하는지 검증
 - `Alhangeul.app`, `AlhangeulPreview.appex`, `AlhangeulThumbnail.appex` 실행 파일의 `arm64 + x86_64` universal 검증
 - 내부 산출물 `Alhangeul.app`을 release staging으로 복사한 뒤 `Alhangeul.app` 이름으로 zip 압축
 - Release staging app은 local signing과 sealed resources가 적용되어 Finder 통합 smoke test의 기준 산출물로 사용할 수 있음
@@ -140,6 +145,7 @@ build.noindex/release/alhangeul-macos-<version>.dmg.sha256
 - `scripts/check-no-appkit.sh`
 - `xcodegen generate`
 - Release configuration으로 HostApp 빌드
+- release staging으로 복사한 app의 analytics endpoint를 post-build Developer ID 재서명·공증 제출·DMG 생성 전에 검증
 - `Alhangeul.app`, `AlhangeulPreview.appex`, `AlhangeulThumbnail.appex` 실행 파일의 `arm64 + x86_64` universal 검증
 - Developer ID Application signing identity 확인
 - Sparkle nested component, Quick Look extension, Thumbnail extension, app bundle을 Developer ID/timestamp/hardened runtime 기준으로 재서명
@@ -185,6 +191,7 @@ rehearsal mode가 수행하는 일:
 - Rust bridge lock verify
 - shared Swift boundary check
 - Release build
+- release staging app의 analytics endpoint를 선택적 post-build Developer ID 재서명과 DMG 생성 전에 검증
 - app/extension 실행 파일의 `arm64 + x86_64` universal 검증
 - `ALHANGEUL_DEVELOPER_ID_APPLICATION`이 제공된 signed rehearsal이면 app notarization submit 전과 같은 release signing preflight 실행
 - DMG layout 생성

--- a/mydocs/orders/20260828.md
+++ b/mydocs/orders/20260828.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #488 | 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정 | 진행중 | M010, Stage 1 완료·Stage 2 승인 대기 |
+| #488 | 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정 | 진행중 | M010, Stage 2 완료·Stage 3 승인 대기 |

--- a/mydocs/orders/20260828.md
+++ b/mydocs/orders/20260828.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #488 | 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정 | 진행중 | M010, Stage 3 완료·최종 보고 승인 대기 |
+| #488 | 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정 | 완료 | M010, 완료: 20:20 |

--- a/mydocs/orders/20260828.md
+++ b/mydocs/orders/20260828.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #488 | 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정 | 진행중 | M010, 구현계획서 작성 후 승인 대기 |
+| #488 | 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정 | 진행중 | M010, Stage 1 완료·Stage 2 승인 대기 |

--- a/mydocs/orders/20260828.md
+++ b/mydocs/orders/20260828.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #488 | 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정 | 진행중 | M010, Stage 2 완료·Stage 3 승인 대기 |
+| #488 | 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정 | 진행중 | M010, Stage 3 완료·최종 보고 승인 대기 |

--- a/mydocs/orders/20260828.md
+++ b/mydocs/orders/20260828.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 8월 28일
+
+## M010 — v0.1
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #488 | 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정 | 진행중 | M010, 수행계획서 작성 후 승인 대기 |

--- a/mydocs/orders/20260828.md
+++ b/mydocs/orders/20260828.md
@@ -4,4 +4,4 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #488 | 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정 | 진행중 | M010, 수행계획서 작성 후 승인 대기 |
+| #488 | 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정 | 진행중 | M010, 구현계획서 작성 후 승인 대기 |

--- a/mydocs/plans/task_m010_488.md
+++ b/mydocs/plans/task_m010_488.md
@@ -1,0 +1,150 @@
+# Task M010 #488 수행계획서
+
+## 목적
+
+실제 배포 경로가 생성한 Release 앱 번들의 익명 실행 이벤트 endpoint를 서명·공증 전에 자동 검증하고, 설정 원본인 `project.yml`이 승인되지 않은 production host로 변경돼도 gate가 실패하도록 한다.
+
+기존 Debug 비활성·Release 전용 endpoint 계약은 유지한다. Built app의 endpoint는 `project.yml`의 전체 URL과 정확히 일치해야 하며, source configuration 자체도 별도로 고정한 production origin을 만족해야 한다. 검증은 production endpoint로 요청을 보내지 않는 정적 preflight로 한정한다.
+
+## 배경
+
+Task #479 / PR #487은 공통 `Info.plist`의 production URL literal을 build setting placeholder로 바꾸고, `project.yml`에서 Release configuration에만 endpoint를 주입했다. `scripts/ci/verify-app-execution-endpoint-config.sh`는 source configuration, 선택적 Debug app과 Release app을 검증한다.
+
+현재 PR CI는 source fixture와 Debug built app만 검사한다. `--release-app` 옵션은 어느 workflow와 release helper에서도 호출되지 않아 실제 rehearsal/public release 경로가 만든 앱 번들은 자동 검증되지 않는다. Task #479의 로컬 Stage 3에서 clean Release bundle을 수동 확인했지만 반복 release gate는 아니다.
+
+또한 verifier는 Release URL이 credential·query·fragment 없는 HTTPS URL인지 확인할 뿐 승인된 production host 또는 origin을 고정하지 않는다. 따라서 `project.yml`과 built app이 함께 다른 HTTPS host로 변경되면 exact-match 검증도 통과한다.
+
+Built app 검사에서 `plutil`이 없을 때 사용하는 Ruby REXML fallback은 XML plist만 처리한다. Xcode가 생성하는 binary `Info.plist`에는 동작하지 않으므로 실제 지원 계약과 구현이 어긋난다. Release app을 만드는 macOS 환경에는 `plutil`이 있으므로 built plist 검사는 이를 명시적 전제로 두는 편이 정확하다.
+
+## 범위(포함·제외)
+
+포함:
+
+- Release endpoint가 승인된 production origin과 일치하는지 source configuration 단계에서 검증
+- 다른 HTTPS host를 사용한 configuration이 실패하는 portable fixture 추가
+- Built Debug/Release app 검사에서 `plutil`을 명시적으로 요구하고 동작하지 않는 REXML fallback 제거 또는 동등한 의도 명시
+- Built Release app endpoint와 `project.yml` 전체 URL의 exact-match 계약 유지·보강
+- `scripts/release.sh`가 Release app 빌드 직후, Developer ID 재서명과 notarization submit 전에 `--release-app` verifier를 실행하도록 preflight 연결
+- Rehearsal과 publish workflow가 공통 release helper를 통해 같은 blocking gate를 사용한다는 계약 검증
+- 개발용 Release zip 경로인 `scripts/package-release.sh`에도 같은 built app gate를 적용할지 조사 후 책임 경계 확정
+- 정상 source, 잘못된 scheme, 승인되지 않은 origin, 잘못된 plist placeholder와 built app mismatch 회귀 검증
+- 관련 CI/release 운영 문서와 analytics 장기 계약의 검증 기준 최소 보강
+
+제외:
+
+- Production endpoint URL, Cloudflare Worker, 저장소나 payload schema 변경
+- Debug/Release build configuration 구조, bundle identifier 또는 sandbox state 분리
+- 분석 이벤트 생성·outbox·전송 runtime 변경
+- Production 또는 staging endpoint로 합성 이벤트 전송
+- Public release workflow dispatch, 버전 태그, GitHub Release, Pages/appcast, Homebrew 반영
+- Developer ID 서명, notarization credential 사용과 공개 DMG 게시
+- 기존 운영 데이터 삭제·재분류·보정
+- Release transport와 `main`/`devel` content divergence 정책 — Issue #474 범위
+
+## 설계 방향
+
+1. Endpoint 설정의 편집 원본은 계속 `project.yml`로 둔다. Verifier에는 승인된 production origin을 별도 불변값으로 두어, 설정 원본 자체가 다른 host로 바뀌면 명시적 verifier·fixture 변경과 review 없이는 통과하지 못하게 한다.
+2. Origin은 scheme, host와 유효 port를 기준으로 비교한다. Built Release app은 origin 확인에 더해 `project.yml`의 전체 endpoint 문자열과 exact 일치해야 한다.
+3. `--debug-app` 또는 `--release-app`이 주어졌을 때는 macOS built plist의 표준 reader인 `plutil`을 필수로 요구한다. Source XML plist 검증에 사용하는 REXML과 binary built plist 읽기 책임을 구분한다.
+4. Release artifact gate는 workflow 뒤쪽의 사후 검사보다 `scripts/release.sh` 내부의 `build_app` 완료 직후에 둔다. 이 위치에서 실패하면 Developer ID 재서명, app notarization submit, DMG 생성 전에 중단되며 rehearsal·publish workflow가 같은 계약을 공유한다.
+5. Workflow 파일에 동일 명령을 중복하지 않는다. 공통 helper 호출이 release path에서 실제로 실행되는지 shell fixture, 호출 순서 정적 검증 또는 제한된 unsigned rehearsal로 확인하고 workflow summary·매뉴얼에 preflight 순서를 명시한다.
+6. `scripts/package-release.sh`는 public release workflow와 별도인 개발용 zip 경로다. 같은 Release bundle을 산출한다는 점을 고려해 built app 검증을 재사용하되, Stage 1에서 중복 호출과 책임 범위를 확인한 뒤 포함 여부를 확정한다.
+7. Production endpoint로 네트워크 요청을 보내지 않는다. Source fixture, binary built plist fixture, unsigned Release build와 helper exit status만으로 검증한다.
+
+## 예상 변경 파일
+
+- `scripts/ci/verify-app-execution-endpoint-config.sh`
+- `scripts/ci/test-app-execution-endpoint-config.sh`
+- `scripts/release.sh`
+- 필요 시 `scripts/package-release.sh`
+- 필요 시 `.github/workflows/pr-ci.yml`
+- 필요 시 `.github/workflows/release-rehearsal.yml`
+- 필요 시 `.github/workflows/release-publish.yml`
+- `mydocs/tech/task_m040_453_app_execution_analytics_contract.md`
+- 필요 시 `mydocs/manual/ci_workflow_guide.md`
+- 필요 시 `mydocs/manual/release_packaging_dmg_guide.md`
+- `mydocs/plans/task_m010_488_impl.md` (수행계획 승인 후)
+- `mydocs/working/task_m010_488_stage{N}.md`
+- `mydocs/report/task_m010_488_report.md`
+- `mydocs/orders/20260828.md`
+
+`project.yml`의 endpoint와 제품 runtime source는 변경하지 않는다. Workflow는 공통 `release.sh` hook만으로 완료 기준을 충족하면 불필요한 중복 변경을 만들지 않는다.
+
+## 잠정 단계(3단계)
+
+1. Release artifact 경로와 endpoint 검증 계약 확정
+   - Verifier, portable fixture, PR CI, `release.sh`, `package-release.sh`, rehearsal/publish workflow의 실제 호출 순서를 추적한다.
+   - 승인된 production origin의 비교 단위와 intentional endpoint 변경 절차를 확정한다.
+   - Built plist의 binary 형식, `plutil` 전제와 pre-signing hook 위치를 재현·기록한다.
+2. Production origin 고정과 verifier 회귀 보강
+   - Verifier에 expected production origin 검증을 추가하고 다른 HTTPS origin 실패 fixture를 고정한다.
+   - Built plist REXML fallback을 제거하고 `plutil` 요구·오류 메시지·Release exact-match 테스트를 보강한다.
+   - Ubuntu portable source fixture와 macOS built plist 검증의 책임을 분리해 기존 PR CI 범위를 유지한다.
+3. Release preflight 연결과 전체 회귀 검증
+   - `release.sh`에서 built Release app verifier를 서명·notarization 전에 blocking 호출한다.
+   - 필요 시 개발용 Release zip과 workflow summary·운영 문서를 같은 계약에 맞춘다.
+   - Unsigned Release build 또는 승인된 rehearsal 경로에서 built endpoint exact match와 실패 시 조기 중단을 확인하고 전체 script/workflow gate를 검증한다.
+
+## 검증 계획
+
+정적·portable helper 검증:
+
+```bash
+bash -n scripts/ci/verify-app-execution-endpoint-config.sh
+bash -n scripts/ci/test-app-execution-endpoint-config.sh
+bash -n scripts/release.sh
+bash -n scripts/package-release.sh
+scripts/ci/test-app-execution-endpoint-config.sh
+ruby -e 'require "psych"; Dir[".github/workflows/*.yml"].sort.each { |path| Psych.parse_file(path) }'
+git diff --check
+```
+
+Fixture 검증 항목:
+
+- 현재 `project.yml`과 source plist는 통과
+- base/Debug endpoint 활성화는 실패
+- HTTP 또는 credential·query·fragment 포함 Release URL은 실패
+- 승인되지 않은 다른 HTTPS origin은 구체적 오류와 함께 실패
+- source plist placeholder drift는 실패
+- macOS binary built Debug plist의 빈 endpoint는 통과
+- macOS binary built Release plist가 `project.yml` exact URL이면 통과
+- Built Release endpoint mismatch는 실패
+- Built app 옵션에 `plutil`을 사용할 수 없으면 조용히 REXML로 진행하지 않고 명시적으로 실패
+
+Release 산출물 검증은 `build.noindex/` 아래의 unsigned app만 사용한다.
+
+```bash
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Release \
+  -derivedDataPath build.noindex/task488-release \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+scripts/ci/verify-app-execution-endpoint-config.sh \
+  --release-app build.noindex/task488-release/Build/Products/Release/Alhangeul.app
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+```
+
+`scripts/release.sh`의 실제 hook은 command ordering 검증과 필요 시 `--skip-notarize` rehearsal로 확인한다. Public workflow를 dispatch하거나 production endpoint로 앱을 실행하지 않는다.
+
+## 리스크
+
+- Expected origin을 verifier에 별도로 고정하면 intentional endpoint 이전 시 `project.yml`, verifier와 fixture를 함께 변경해야 한다. 이는 의도한 review gate이지만 변경 절차를 문서화하지 않으면 운영자가 중복 상수로 오해할 수 있다.
+- URL 문자열 비교만 사용하면 기본 port, 대소문자, trailing slash 같은 표현 차이가 origin 판정을 흔들 수 있다. Origin은 URI 구성요소로 정규화하고 built endpoint의 전체 문자열 exact match와 역할을 분리한다.
+- `plutil` 요구를 verifier 시작 시 무조건 적용하면 source-only fixture가 실행되는 Ubuntu PR CI가 깨질 수 있다. Built app 옵션을 사용할 때만 요구하도록 범위를 제한한다.
+- `release.sh`에서 검증 위치가 signing 뒤로 밀리면 잘못된 endpoint 산출물에 서명·notarization 비용을 이미 사용하게 된다. `build_app` 직후와 `sign_release_app_for_notarization` 이전의 호출 순서를 자동 검증한다.
+- Workflow에 별도 명령을 추가하면 공통 helper와 drift가 생길 수 있고, workflow 뒤에서 검사하면 pre-signing 요구를 충족하지 못한다. `release.sh`를 실행 진실 원천으로 두고 workflow는 이를 호출하는 역할만 유지한다.
+- `package-release.sh`까지 변경하면 범위가 넓어질 수 있다. 동일 Release app의 검증 누락을 막는 최소 호출인지 Stage 1에서 판단하고 불필요하면 제외한다.
+- Unsigned Release app도 production endpoint를 포함한다. Built plist만 읽고 앱을 실행하지 않아 개발 이벤트가 production으로 전송되지 않게 한다.
+
+## 승인 요청 사항
+
+1. Verifier에 `project.yml`과 독립된 expected production origin을 고정하고 intentional host 변경 시 verifier·fixture도 함께 review하도록 하는 방향 승인
+2. Built app 검사에서 동작하지 않는 REXML fallback을 제거하고 built 옵션이 있을 때 macOS `plutil`을 필수로 하는 방향 승인
+3. `scripts/release.sh`의 Release app 빌드 직후, Developer ID 재서명·notarization 전에 `--release-app` 검증을 blocking 호출하는 방향 승인
+4. Workflow에 중복 검증 단계를 두기보다 공통 release helper를 rehearsal/publish 실행 진실 원천으로 유지하는 방향 승인
+5. Production 전송·public release 없이 fixture와 unsigned Release bundle, 필요 시 `--skip-notarize` rehearsal로 검증하는 범위 승인
+6. 위 범위와 3단계 진행 구조 승인 후 구현계획서 `mydocs/plans/task_m010_488_impl.md` 작성 단계 진행 승인

--- a/mydocs/plans/task_m010_488_impl.md
+++ b/mydocs/plans/task_m010_488_impl.md
@@ -23,9 +23,9 @@ Task #479가 도입한 Release-only 익명 실행 이벤트 endpoint 계약을 �
 | Source 진실 원천 | `project.yml`의 HostApp Release `ALHANGEUL_APP_EXECUTION_ENDPOINT`가 전체 URL을 소유한다. | URL 편집 원본은 유지하고 verifier에 승인 origin guard를 독립적으로 둔다. |
 | Source verifier | HTTPS 절대 URL과 credential·query·fragment 부재만 확인한다. | 다른 HTTPS host 실패 fixture와 origin 비교가 필요하다. |
 | Built Release verifier | `--release-app`은 built plist 값이 `project.yml` endpoint와 exact 일치하는지 확인한다. | Exact-match 계약은 유지하되 실제 release helper에서 호출해야 한다. |
-| Built plist reader | `plutil`이 없으면 REXML로 fallback한다. | Binary plist에 동작하지 않는 fallback을 제거하고 built 옵션에서만 `plutil`을 필수화한다. |
-| Portable fixture | Ubuntu `script-checks`에서 source 정상과 실패 fixture 3개를 실행한다. | Origin failure는 portable하게 추가하고 binary built fixture는 macOS로 분리한다. |
-| macOS PR CI | Debug app을 빌드한 뒤 `--debug-app`만 실행한다. | Mac에서 test helper를 한 번 더 실행해 binary built fixture를 검증할 수 있다. |
+| Built plist reader | `plutil`이 없으면 REXML로 fallback한다. Current Release plist는 `same-as-input` XML이며 fallback으로도 읽힌다. | XML-only fallback 의도를 명시하고, `plutil` 없는 binary 입력은 명확히 실패하게 한다. |
+| Portable fixture | Ubuntu `script-checks`에서 source 정상과 실패 fixture 3개를 실행한다. | Origin failure와 XML built fixture를 portable하게 추가하고 synthetic binary fixture는 macOS로 분리한다. |
+| macOS PR CI | Debug app을 빌드한 뒤 `--debug-app`만 실행한다. | Mac에서 test helper를 한 번 더 실행해 current XML과 synthetic binary fixture를 검증한다. |
 | Public/rehearsal workflow | 둘 다 공통 `scripts/release.sh`를 호출한다. | Workflow에 build 검증 명령을 중복하지 않고 공통 helper에 pre-signing hook을 둔다. |
 | `release.sh` 순서 | `build_app` 다음에 곧바로 `sign_release_app_for_notarization`을 호출한다. | 두 호출 사이가 built endpoint preflight의 단일 위치다. |
 | 개발용 zip | `package-release.sh`도 Release app을 만든 뒤 universal slice만 검증한다. | 같은 built endpoint verifier를 복사 직후 실행해 Release zip 우회 경로도 닫는다. |
@@ -45,9 +45,10 @@ Task #479가 도입한 Release-only 익명 실행 이벤트 endpoint 계약을 �
 ### 3.2 Source와 built plist reader 경계
 
 - Source `Info.plist`는 tracked XML이므로 기존 REXML 검증을 유지한다.
-- `--debug-app` 또는 `--release-app`은 Xcode 산출물의 binary plist를 읽으므로 `plutil`을 요구한다.
+- Current `--debug-app`·`--release-app` 산출물은 `INFOPLIST_OUTPUT_FORMAT = same-as-input`에 따라 tracked source와 같은 XML이다.
+- macOS에서는 XML·binary 형식 모두 처리하는 `plutil`을 우선 사용한다.
+- `plutil`이 없는 환경에서는 REXML fallback으로 XML built plist만 지원하고, binary 입력은 명확한 오류로 종료한다.
 - Built 옵션이 없으면 Ubuntu source fixture는 `plutil` 없이 계속 실행돼야 한다.
-- Built 옵션이 있는데 `plutil`이 없으면 명확한 오류로 종료한다. XML-only fallback이나 조용한 skip은 허용하지 않는다.
 - 오류 메시지는 secret이나 문서 정보를 포함하지 않고 설정 이름, 예상 origin과 대상 app path 정도만 제공한다.
 
 ### 3.3 Release preflight 실행 순서
@@ -62,7 +63,7 @@ Task #479가 도입한 Release-only 익명 실행 이벤트 endpoint 계약을 �
 ### 3.4 테스트 플랫폼 분리
 
 - Ubuntu `script-checks`: source 정상, invalid base, invalid scheme, invalid origin, invalid placeholder fixture를 실행한다.
-- macOS validation: 같은 source fixture와 `plutil`로 만든 binary Debug/Release app fixture를 실행한다.
+- macOS validation: 같은 source·XML built fixture와 `plutil`로 만든 synthetic binary Debug/Release app fixture를 실행한다.
 - 기존 실제 Debug built app `--debug-app` 검증을 유지한다.
 - 실제 Release path는 로컬 unsigned Release build와 필요 시 `release.sh --skip-notarize`로 확인한다.
 - Public release workflow와 production endpoint HTTP 요청은 테스트에 사용하지 않는다.
@@ -71,7 +72,7 @@ Task #479가 도입한 Release-only 익명 실행 이벤트 endpoint 계약을 �
 
 ### 4.1 목적
 
-제품·helper 구현을 바꾸기 전에 현재 verifier가 승인되지 않은 HTTPS origin을 통과시키고 `--release-app`이 release 경로에서 호출되지 않는 사실을 재현한다. Binary plist reader와 `release.sh`의 pre-signing 삽입 지점을 고정해 Stage 2·3의 책임 경계를 확정한다.
+제품·helper 구현을 바꾸기 전에 현재 verifier가 승인되지 않은 HTTPS origin을 통과시키고 `--release-app`이 release 경로에서 호출되지 않는 사실을 재현한다. Current plist 출력 형식과 fallback 동작, `release.sh`의 pre-signing 삽입 지점을 고정해 Stage 2·3의 책임 경계를 확정한다.
 
 ### 4.2 작업 범위
 
@@ -80,7 +81,7 @@ Task #479가 도입한 Release-only 익명 실행 이벤트 endpoint 계약을 �
 3. `rg`로 `--release-app` 호출이 verifier help 외에 없는지 확인한다.
 4. `release.sh` main 순서와 `build_app`이 copied `APP_OUTPUT`을 만드는 지점을 확인한다.
 5. `package-release.sh`의 copied app·universal 검증·zip 순서를 확인해 built endpoint gate 포함을 확정한다.
-6. Xcode built `Info.plist`가 binary 형식이며 REXML fallback이 이를 처리하지 못하는 계약 불일치를 기록한다.
+6. Xcode built `Info.plist`의 실제 출력 형식과 REXML fallback 동작을 측정하고, current XML·future binary 책임을 구분한다.
 7. Expected origin 비교 단위, `plutil` 적용 조건, Ubuntu/macOS fixture 분리를 확정한다.
 
 ### 4.3 예상 산출물
@@ -108,7 +109,7 @@ Binary plist 형식 확인에 app build가 필요하면 `build.noindex/task488-s
 - 다른 HTTPS origin이 현재 source verifier를 통과하는 재현 결과가 있다.
 - `--release-app`이 rehearsal/publish/package helper에서 호출되지 않는 현재 상태가 기록된다.
 - `release.sh`의 endpoint gate가 `build_app`과 signing 사이에 들어가야 하는 근거가 확정된다.
-- Built plist의 binary reader를 `plutil`로 제한할 근거와 portable fixture 경계가 기록된다.
+- Built plist가 current XML임을 확인하고 `plutil` 우선·XML-only fallback·binary 명시 실패 경계가 기록된다.
 - Stage 2·3의 변경 파일과 검증 명령이 구현 가능한 수준으로 확정된다.
 
 ### 4.6 커밋
@@ -119,7 +120,7 @@ Binary plist 형식 확인에 app build가 필요하면 `build.noindex/task488-s
 
 ### 5.1 목적
 
-승인되지 않은 HTTPS origin을 source gate에서 차단하고 built app 검사를 실제 binary plist 계약에 맞춘다. Portable source fixture와 macOS binary built fixture로 회귀를 자동 검증한다.
+승인되지 않은 HTTPS origin을 source gate에서 차단하고 built app 검사를 current XML·future binary plist 계약에 맞춘다. Portable source/XML fixture와 macOS synthetic binary fixture로 회귀를 자동 검증한다.
 
 ### 5.2 예상 변경 파일
 
@@ -135,12 +136,13 @@ Binary plist 형식 확인에 app build가 필요하면 `build.noindex/task488-s
 2. Expected origin 자체가 credential·query·fragment와 비-root path를 갖지 않는 유효한 HTTPS origin인지 방어적으로 검증한다.
 3. Release endpoint를 URI로 파싱한 뒤 scheme·host·effective port 기준 origin을 비교한다.
 4. 승인되지 않은 HTTPS origin에 expected/actual을 구분하는 오류를 출력한다.
-5. Built plist reader의 REXML fallback을 제거한다.
-6. Built app 옵션이 주어졌을 때만 `plutil` 존재를 확인하고 없으면 명시적으로 실패한다.
+5. Built plist reader의 REXML fallback을 XML-only로 명시하고 parse 오류를 구체화한다.
+6. `plutil`이 없는 상태에서 binary built plist가 입력되면 명시적으로 실패한다.
 7. Existing exact Release endpoint 비교와 Debug empty endpoint 검사를 유지한다.
 8. Portable fixture에 invalid HTTPS origin을 추가한다.
-9. macOS에서 synthetic binary Debug/Release app을 만들어 empty/exact/mismatch를 검증한다.
-10. PR CI macOS validation에서 test helper를 실행해 binary fixture를 활성화하고 기존 실제 Debug app 검증을 유지한다.
+9. Portable XML Debug/Release app fixture로 empty/exact/mismatch와 REXML fallback을 검증한다.
+10. macOS에서 synthetic binary Debug/Release app을 만들어 `plutil` 성공과 no-`plutil` 실패를 검증한다.
+11. PR CI macOS validation에서 test helper를 실행해 binary fixture를 활성화하고 기존 실제 Debug app 검증을 유지한다.
 
 ### 5.4 자동 회귀
 
@@ -149,11 +151,12 @@ Binary plist 형식 확인에 app build가 필요하면 `build.noindex/task488-s
 - HTTP Release endpoint 실패
 - 다른 HTTPS origin 실패
 - Source plist literal/placeholder drift 실패
-- Binary Debug empty endpoint 통과
-- Binary Release exact endpoint 통과
-- Binary Release mismatch 실패
+- XML Debug empty endpoint 통과
+- XML Release exact endpoint 통과와 mismatch 실패
+- Synthetic binary Debug/Release endpoint의 `plutil` 경로 통과
 - Source-only Ubuntu 실행에서 `plutil` 비필수
-- Built app 검사에서 `plutil` 없는 환경은 명시적 실패
+- `plutil` 없는 XML built app은 REXML fallback 통과
+- `plutil` 없는 binary built app은 명시적 실패
 
 ### 5.5 검증
 
@@ -172,8 +175,8 @@ git diff --check
 
 - `https://다른-host/...` source fixture가 HTTPS여도 실패한다.
 - 현재 production source configuration과 exact built Release fixture는 통과한다.
-- Built binary plist는 `plutil`로만 읽고 REXML fallback이 없다.
-- Ubuntu source fixture와 macOS binary fixture가 각 플랫폼에서 자동 실행된다.
+- Current XML built plist는 `plutil` 우선·REXML fallback 모두 읽고 binary plist는 `plutil` 없이 명시적으로 실패한다.
+- Ubuntu source/XML fixture와 macOS synthetic binary fixture가 각 플랫폼에서 자동 실행된다.
 - 기존 Debug endpoint 비활성과 Release exact-match 계약이 유지된다.
 
 ### 5.7 커밋
@@ -252,7 +255,7 @@ env -u ALHANGEUL_DEVELOPER_ID_APPLICATION \
 - `release.sh`가 copied built app을 signing/notarization 전에 `--release-app`으로 검증한다.
 - Rehearsal과 publish workflow가 별도 복제 없이 같은 blocking gate를 사용한다.
 - `package-release.sh`도 Release zip 생성 전에 exact built endpoint를 검증한다.
-- Origin drift, built mismatch와 binary plist fixture가 자동 실패한다.
+- Origin drift, built mismatch와 XML/binary plist fixture가 자동 실패한다.
 - Current unsigned Release app은 exact endpoint gate와 기존 universal/provenance 검증을 통과한다.
 - 운영 문서가 source origin guard와 release artifact preflight 순서를 정확히 설명한다.
 - Public release, signing/notarization과 production 네트워크 요청은 수행하지 않는다.
@@ -264,7 +267,7 @@ env -u ALHANGEUL_DEVELOPER_ID_APPLICATION \
 ## 7. 단계별 중단·승인 기준
 
 - Stage 1에서 expected origin 비교가 endpoint의 합법적 운영 변경을 과도하게 막거나 `release.sh` hook이 signing 전 copied app을 볼 수 없으면 구현을 시작하지 않고 설계를 재승인받는다.
-- Stage 2에서 Ubuntu portable fixture가 `plutil`에 의존하거나 macOS binary fixture가 실제 built plist와 다른 형식만 검증하면 단계 완료로 보지 않는다.
+- Stage 2에서 Ubuntu portable fixture가 `plutil`에 의존하거나 current XML output과 synthetic binary 미래 경계 중 하나만 검증하면 단계 완료로 보지 않는다.
 - Stage 3에서 endpoint verifier가 signing/notarization 뒤에 실행되거나 workflow별 중복 명령이 생기면 완료로 보지 않는다.
 - 어느 Stage에서도 public workflow dispatch, Developer ID/notary credential 사용 또는 production 합성 이벤트가 필요해지면 즉시 멈추고 별도 승인을 요청한다.
 - 검증 실패가 해당 단계 범위를 넘어 runtime, payload, endpoint 값 변경을 요구하면 구현계획을 보정하고 승인받는다.
@@ -272,7 +275,7 @@ env -u ALHANGEUL_DEVELOPER_ID_APPLICATION \
 ## 8. 승인 요청 사항
 
 1. Stage 1에서 우회 가능성과 release hook 위치를 먼저 재현·고정한 뒤 구현하는 순서 승인
-2. Stage 2에서 expected origin, built-only `plutil`과 Ubuntu/macOS fixture 분리를 한 묶음으로 구현하는 범위 승인
+2. Stage 2에서 expected origin, `plutil` 우선·XML-only fallback과 Ubuntu/macOS fixture 분리를 한 묶음으로 구현하는 범위 승인
 3. Stage 3에서 `release.sh`와 `package-release.sh`에 공통 verifier를 연결하고 workflow에는 중복 명령 대신 summary만 보강하는 방향 승인
 4. Public release·서명·공증·production 요청 없이 unsigned Release build와 필요 시 `--skip-notarize` rehearsal까지만 수행하는 검증 범위 승인
 5. 구현계획 승인 후 Stage 1 재현과 계약 확정 작업 시작 승인

--- a/mydocs/plans/task_m010_488_impl.md
+++ b/mydocs/plans/task_m010_488_impl.md
@@ -63,8 +63,8 @@ Task #479가 도입한 Release-only 익명 실행 이벤트 endpoint 계약을 �
 ### 3.4 테스트 플랫폼 분리
 
 - Ubuntu `script-checks`: source 정상, invalid base, invalid scheme, invalid origin, invalid placeholder fixture를 실행한다.
-- macOS validation: 같은 source·XML built fixture와 `plutil`로 만든 synthetic binary Debug/Release app fixture를 실행한다.
-- 기존 실제 Debug built app `--debug-app` 검증을 유지한다.
+- macOS release-checks: 같은 source·XML built fixture와 `plutil`로 만든 synthetic binary Debug/Release app fixture를 실행한다.
+- 기존 macOS validation의 실제 Debug built app `--debug-app` 검증을 유지한다.
 - 실제 Release path는 로컬 unsigned Release build와 필요 시 `release.sh --skip-notarize`로 확인한다.
 - Public release workflow와 production endpoint HTTP 요청은 테스트에 사용하지 않는다.
 
@@ -142,7 +142,7 @@ Binary plist 형식 확인에 app build가 필요하면 `build.noindex/task488-s
 8. Portable fixture에 invalid HTTPS origin을 추가한다.
 9. Portable XML Debug/Release app fixture로 empty/exact/mismatch와 REXML fallback을 검증한다.
 10. macOS에서 synthetic binary Debug/Release app을 만들어 `plutil` 성공과 no-`plutil` 실패를 검증한다.
-11. PR CI macOS validation에서 test helper를 실행해 binary fixture를 활성화하고 기존 실제 Debug app 검증을 유지한다.
+11. PR CI macOS release-checks에서 test helper를 실행해 script-only 변경에도 binary fixture를 활성화하고, macOS validation의 기존 실제 Debug app 검증을 유지한다.
 
 ### 5.4 자동 회귀
 

--- a/mydocs/plans/task_m010_488_impl.md
+++ b/mydocs/plans/task_m010_488_impl.md
@@ -1,0 +1,278 @@
+# Task M010 #488 구현계획서
+
+수행계획서: `mydocs/plans/task_m010_488.md`
+
+## 1. 작업 개요
+
+- 이슈: [#488 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정](https://github.com/postmelee/alhangeul-macos/issues/488)
+- 마일스톤: `M010` (`v0.1`)
+- 대상 통합 브랜치: `devel`
+- 작업 브랜치: `local/task488`
+- 게시 브랜치: `publish/task488`
+- 기준 커밋: `615573a91294ff35ef73b2b9e992fa614f242e7d`
+- 단계 수: 3
+
+Task #479가 도입한 Release-only 익명 실행 이벤트 endpoint 계약을 실제 release artifact까지 확장한다. Source configuration은 승인된 production origin을 벗어나지 못하게 하고, built Release app은 `project.yml`의 전체 endpoint와 정확히 일치해야 한다. `release.sh`는 앱 빌드 직후·Developer ID 재서명과 notarization 전에 이 검증을 blocking preflight로 실행한다.
+
+구현계획 승인 전에는 Stage 1을 시작하지 않는다. 각 Stage 종료 뒤에는 `task-stage-report` 절차로 해당 단계 변경과 보고서를 함께 커밋하고 다음 단계 승인을 받는다. Public workflow dispatch, Developer ID 서명·공증, production 이벤트 전송은 어느 Stage에서도 실행하지 않는다.
+
+## 2. 구현 전 확인 결과
+
+| 항목 | 현재 상태 | 구현 영향 |
+|------|-----------|-----------|
+| Source 진실 원천 | `project.yml`의 HostApp Release `ALHANGEUL_APP_EXECUTION_ENDPOINT`가 전체 URL을 소유한다. | URL 편집 원본은 유지하고 verifier에 승인 origin guard를 독립적으로 둔다. |
+| Source verifier | HTTPS 절대 URL과 credential·query·fragment 부재만 확인한다. | 다른 HTTPS host 실패 fixture와 origin 비교가 필요하다. |
+| Built Release verifier | `--release-app`은 built plist 값이 `project.yml` endpoint와 exact 일치하는지 확인한다. | Exact-match 계약은 유지하되 실제 release helper에서 호출해야 한다. |
+| Built plist reader | `plutil`이 없으면 REXML로 fallback한다. | Binary plist에 동작하지 않는 fallback을 제거하고 built 옵션에서만 `plutil`을 필수화한다. |
+| Portable fixture | Ubuntu `script-checks`에서 source 정상과 실패 fixture 3개를 실행한다. | Origin failure는 portable하게 추가하고 binary built fixture는 macOS로 분리한다. |
+| macOS PR CI | Debug app을 빌드한 뒤 `--debug-app`만 실행한다. | Mac에서 test helper를 한 번 더 실행해 binary built fixture를 검증할 수 있다. |
+| Public/rehearsal workflow | 둘 다 공통 `scripts/release.sh`를 호출한다. | Workflow에 build 검증 명령을 중복하지 않고 공통 helper에 pre-signing hook을 둔다. |
+| `release.sh` 순서 | `build_app` 다음에 곧바로 `sign_release_app_for_notarization`을 호출한다. | 두 호출 사이가 built endpoint preflight의 단일 위치다. |
+| 개발용 zip | `package-release.sh`도 Release app을 만든 뒤 universal slice만 검증한다. | 같은 built endpoint verifier를 복사 직후 실행해 Release zip 우회 경로도 닫는다. |
+| 운영 문서 | Release build·서명·공증 순서는 기록돼 있으나 endpoint preflight는 없다. | Analytics 계약과 release/CI 가이드에 origin·exact match·실행 순서를 최소 보강한다. |
+
+## 3. 공통 설계·안전 계약
+
+### 3.1 Endpoint 검증의 두 계층
+
+- `project.yml`은 endpoint 전체 URL의 단일 편집 원본으로 유지한다.
+- Verifier의 `EXPECTED_PRODUCTION_ORIGIN`은 승인된 전송 목적지를 보호하는 별도 review gate다.
+- Source endpoint는 기존 HTTPS·host·credential/query/fragment 정책과 expected origin을 모두 통과해야 한다.
+- Origin은 URI의 lowercase scheme·lowercase host·effective port로 비교한다. Path는 origin 비교에서 제외한다.
+- Built Release endpoint는 `project.yml` 전체 문자열과 exact 일치해야 한다. 따라서 같은 origin 안의 path drift도 built configuration 불일치라면 실패한다.
+- Intentional host 이전은 `project.yml`, expected origin, 정상·실패 fixture와 운영 문서를 같은 PR에서 명시적으로 변경해야 한다.
+
+### 3.2 Source와 built plist reader 경계
+
+- Source `Info.plist`는 tracked XML이므로 기존 REXML 검증을 유지한다.
+- `--debug-app` 또는 `--release-app`은 Xcode 산출물의 binary plist를 읽으므로 `plutil`을 요구한다.
+- Built 옵션이 없으면 Ubuntu source fixture는 `plutil` 없이 계속 실행돼야 한다.
+- Built 옵션이 있는데 `plutil`이 없으면 명확한 오류로 종료한다. XML-only fallback이나 조용한 skip은 허용하지 않는다.
+- 오류 메시지는 secret이나 문서 정보를 포함하지 않고 설정 이름, 예상 origin과 대상 app path 정도만 제공한다.
+
+### 3.3 Release preflight 실행 순서
+
+- `release.sh`는 `build_app` 완료 후 copied `APP_OUTPUT`을 `--release-app`으로 검증한다.
+- 이 호출은 `sign_release_app_for_notarization`, universal/signature preflight, app notarization, DMG 생성보다 앞선다.
+- Rehearsal과 publish workflow는 모두 `release.sh`를 실행하므로 같은 gate를 자동 공유한다.
+- `package-release.sh`도 copied Release app을 zip·staging 정리 전에 같은 verifier로 검사한다.
+- Workflow 파일에는 verifier 명령을 복제하지 않고 summary에 공통 preflight 계약만 기록한다.
+- 검증 실패 시 app 실행, production 네트워크 요청, signing/notarization과 DMG/zip 생성을 진행하지 않는다.
+
+### 3.4 테스트 플랫폼 분리
+
+- Ubuntu `script-checks`: source 정상, invalid base, invalid scheme, invalid origin, invalid placeholder fixture를 실행한다.
+- macOS validation: 같은 source fixture와 `plutil`로 만든 binary Debug/Release app fixture를 실행한다.
+- 기존 실제 Debug built app `--debug-app` 검증을 유지한다.
+- 실제 Release path는 로컬 unsigned Release build와 필요 시 `release.sh --skip-notarize`로 확인한다.
+- Public release workflow와 production endpoint HTTP 요청은 테스트에 사용하지 않는다.
+
+## 4. Stage 1 — Release 경로 재현과 preflight 계약 확정
+
+### 4.1 목적
+
+제품·helper 구현을 바꾸기 전에 현재 verifier가 승인되지 않은 HTTPS origin을 통과시키고 `--release-app`이 release 경로에서 호출되지 않는 사실을 재현한다. Binary plist reader와 `release.sh`의 pre-signing 삽입 지점을 고정해 Stage 2·3의 책임 경계를 확정한다.
+
+### 4.2 작업 범위
+
+1. 현재 verifier와 fixture를 실행해 portable baseline을 기록한다.
+2. 일회용 fixture의 Release endpoint를 다른 HTTPS origin으로 바꾸고 현 verifier가 통과하는 상태를 재현한다.
+3. `rg`로 `--release-app` 호출이 verifier help 외에 없는지 확인한다.
+4. `release.sh` main 순서와 `build_app`이 copied `APP_OUTPUT`을 만드는 지점을 확인한다.
+5. `package-release.sh`의 copied app·universal 검증·zip 순서를 확인해 built endpoint gate 포함을 확정한다.
+6. Xcode built `Info.plist`가 binary 형식이며 REXML fallback이 이를 처리하지 못하는 계약 불일치를 기록한다.
+7. Expected origin 비교 단위, `plutil` 적용 조건, Ubuntu/macOS fixture 분리를 확정한다.
+
+### 4.3 예상 산출물
+
+- `mydocs/working/task_m010_488_stage1.md`
+- `mydocs/orders/20260828.md`
+
+Stage 1에서는 verifier, workflow, release helper와 운영 매뉴얼을 수정하지 않는다. 재현 fixture는 임시 디렉터리에만 만들고 커밋하지 않는다.
+
+### 4.4 검증
+
+```bash
+scripts/ci/test-app-execution-endpoint-config.sh
+scripts/ci/verify-app-execution-endpoint-config.sh
+rg -n -- '--release-app' .github scripts mydocs/manual
+rg -n 'build_app|sign_release_app_for_notarization|main\(\)' scripts/release.sh
+file build.noindex/task488-stage1/Alhangeul.app/Contents/Info.plist
+git diff --check
+```
+
+Binary plist 형식 확인에 app build가 필요하면 `build.noindex/task488-stage1/` 아래에 unsigned Release app을 만들며 실행하지 않는다. 다른 origin 재현은 일회용 source fixture에서만 수행한다.
+
+### 4.5 완료 기준
+
+- 다른 HTTPS origin이 현재 source verifier를 통과하는 재현 결과가 있다.
+- `--release-app`이 rehearsal/publish/package helper에서 호출되지 않는 현재 상태가 기록된다.
+- `release.sh`의 endpoint gate가 `build_app`과 signing 사이에 들어가야 하는 근거가 확정된다.
+- Built plist의 binary reader를 `plutil`로 제한할 근거와 portable fixture 경계가 기록된다.
+- Stage 2·3의 변경 파일과 검증 명령이 구현 가능한 수준으로 확정된다.
+
+### 4.6 커밋
+
+`Task #488 Stage 1: Release endpoint preflight 계약 확정`
+
+## 5. Stage 2 — Production origin 고정과 verifier 회귀 보강
+
+### 5.1 목적
+
+승인되지 않은 HTTPS origin을 source gate에서 차단하고 built app 검사를 실제 binary plist 계약에 맞춘다. Portable source fixture와 macOS binary built fixture로 회귀를 자동 검증한다.
+
+### 5.2 예상 변경 파일
+
+- `scripts/ci/verify-app-execution-endpoint-config.sh`
+- `scripts/ci/test-app-execution-endpoint-config.sh`
+- `.github/workflows/pr-ci.yml`
+- `mydocs/working/task_m010_488_stage2.md`
+- `mydocs/orders/20260828.md`
+
+### 5.3 구현 항목
+
+1. Verifier에 expected production origin 상수를 추가한다.
+2. Expected origin 자체가 credential·query·fragment와 비-root path를 갖지 않는 유효한 HTTPS origin인지 방어적으로 검증한다.
+3. Release endpoint를 URI로 파싱한 뒤 scheme·host·effective port 기준 origin을 비교한다.
+4. 승인되지 않은 HTTPS origin에 expected/actual을 구분하는 오류를 출력한다.
+5. Built plist reader의 REXML fallback을 제거한다.
+6. Built app 옵션이 주어졌을 때만 `plutil` 존재를 확인하고 없으면 명시적으로 실패한다.
+7. Existing exact Release endpoint 비교와 Debug empty endpoint 검사를 유지한다.
+8. Portable fixture에 invalid HTTPS origin을 추가한다.
+9. macOS에서 synthetic binary Debug/Release app을 만들어 empty/exact/mismatch를 검증한다.
+10. PR CI macOS validation에서 test helper를 실행해 binary fixture를 활성화하고 기존 실제 Debug app 검증을 유지한다.
+
+### 5.4 자동 회귀
+
+- 정상 production source configuration 통과
+- Base/Debug endpoint 활성화 실패
+- HTTP Release endpoint 실패
+- 다른 HTTPS origin 실패
+- Source plist literal/placeholder drift 실패
+- Binary Debug empty endpoint 통과
+- Binary Release exact endpoint 통과
+- Binary Release mismatch 실패
+- Source-only Ubuntu 실행에서 `plutil` 비필수
+- Built app 검사에서 `plutil` 없는 환경은 명시적 실패
+
+### 5.5 검증
+
+```bash
+bash -n scripts/ci/verify-app-execution-endpoint-config.sh
+bash -n scripts/ci/test-app-execution-endpoint-config.sh
+scripts/ci/test-app-execution-endpoint-config.sh
+scripts/ci/verify-app-execution-endpoint-config.sh
+shellcheck scripts/ci/verify-app-execution-endpoint-config.sh \
+  scripts/ci/test-app-execution-endpoint-config.sh
+ruby -e 'require "psych"; Psych.parse_file(".github/workflows/pr-ci.yml")'
+git diff --check
+```
+
+### 5.6 완료 기준
+
+- `https://다른-host/...` source fixture가 HTTPS여도 실패한다.
+- 현재 production source configuration과 exact built Release fixture는 통과한다.
+- Built binary plist는 `plutil`로만 읽고 REXML fallback이 없다.
+- Ubuntu source fixture와 macOS binary fixture가 각 플랫폼에서 자동 실행된다.
+- 기존 Debug endpoint 비활성과 Release exact-match 계약이 유지된다.
+
+### 5.7 커밋
+
+`Task #488 Stage 2: Production endpoint verifier 보강`
+
+## 6. Stage 3 — Release artifact preflight 연결과 통합 검증
+
+### 6.1 목적
+
+보강된 verifier를 실제 Release app 산출 경로에 연결한다. Rehearsal/public release helper는 signing/notarization 전에, 개발용 Release zip은 압축 전에 built endpoint mismatch를 차단하도록 하고 운영 문서를 실제 순서와 맞춘다.
+
+### 6.2 예상 변경 파일
+
+- `scripts/release.sh`
+- `scripts/package-release.sh`
+- `.github/workflows/release-rehearsal.yml`
+- `.github/workflows/release-publish.yml`
+- `mydocs/tech/task_m040_453_app_execution_analytics_contract.md`
+- `mydocs/manual/ci_workflow_guide.md`
+- `mydocs/manual/release_packaging_dmg_guide.md`
+- `mydocs/working/task_m010_488_stage3.md`
+- `mydocs/orders/20260828.md`
+
+Workflow 파일은 실행 명령을 중복하지 않고 summary의 preflight 설명만 실제 공통 helper 순서에 맞춰 보강한다. 문서는 기존 문단에 origin guard와 built exact-match 항목을 최소 추가한다.
+
+### 6.3 구현 항목
+
+1. `release.sh`에 built Release app endpoint 검증 함수를 추가한다.
+2. Main 순서를 `build_app -> endpoint preflight -> signing/notarization`으로 고정한다.
+3. Preflight 실패가 universal/signing/notarization/DMG 단계 전에 non-zero로 종료되는지 확인한다.
+4. `package-release.sh`가 copied Release app을 zip으로 만들기 전에 같은 verifier를 호출한다.
+5. Rehearsal/publish workflow summary에 built endpoint preflight가 signing/notarization보다 먼저 실행된다고 기록한다.
+6. Analytics 계약에 expected origin review gate, built exact-match와 unsigned Release 비실행 원칙을 추가한다.
+7. CI/release packaging 가이드에 verifier 명령과 `release.sh` 실행 순서를 추가한다.
+8. Clean unsigned Release app에서 `--release-app` exact match를 검증한다.
+9. 필요 시 `release.sh --skip-notarize 0.1.10`을 실행해 로그에서 endpoint gate가 signing skip·DMG 생성보다 앞서는지 확인한다.
+10. 전체 helper fixture, workflow YAML, XcodeGen, shared boundary와 provenance gate를 최종 실행한다.
+
+### 6.4 검증
+
+```bash
+bash -n scripts/release.sh
+bash -n scripts/package-release.sh
+for workflow in .github/workflows/*.yml; do
+  ruby -e 'require "psych"; Psych.parse_file(ARGV.fetch(0))' "$workflow"
+done
+scripts/ci/test-app-execution-endpoint-config.sh
+xcodegen generate
+xcodebuild -project Alhangeul.xcodeproj \
+  -scheme HostApp \
+  -configuration Release \
+  -derivedDataPath build.noindex/task488-stage3-release \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+scripts/ci/verify-app-execution-endpoint-config.sh \
+  --release-app build.noindex/task488-stage3-release/Build/Products/Release/Alhangeul.app
+./scripts/check-no-appkit.sh
+./scripts/verify-rhwp-core-build-info.sh
+./scripts/verify-rhwp-studio-assets.sh
+git diff --check
+```
+
+공통 release helper의 end-to-end 순서 확인이 필요하면 다음 rehearsal만 수행한다.
+
+```bash
+env -u ALHANGEUL_DEVELOPER_ID_APPLICATION \
+  -u ALHANGEUL_NOTARY_PROFILE \
+  ./scripts/release.sh --skip-notarize 0.1.10
+```
+
+이 rehearsal은 public asset으로 게시하지 않고 완료 뒤 개발 산출물 등록 상태를 확인한다. Production endpoint로 앱을 실행하거나 이벤트를 전송하지 않는다.
+
+### 6.5 완료 기준
+
+- `release.sh`가 copied built app을 signing/notarization 전에 `--release-app`으로 검증한다.
+- Rehearsal과 publish workflow가 별도 복제 없이 같은 blocking gate를 사용한다.
+- `package-release.sh`도 Release zip 생성 전에 exact built endpoint를 검증한다.
+- Origin drift, built mismatch와 binary plist fixture가 자동 실패한다.
+- Current unsigned Release app은 exact endpoint gate와 기존 universal/provenance 검증을 통과한다.
+- 운영 문서가 source origin guard와 release artifact preflight 순서를 정확히 설명한다.
+- Public release, signing/notarization과 production 네트워크 요청은 수행하지 않는다.
+
+### 6.6 커밋
+
+`Task #488 Stage 3: Release artifact endpoint preflight 연결`
+
+## 7. 단계별 중단·승인 기준
+
+- Stage 1에서 expected origin 비교가 endpoint의 합법적 운영 변경을 과도하게 막거나 `release.sh` hook이 signing 전 copied app을 볼 수 없으면 구현을 시작하지 않고 설계를 재승인받는다.
+- Stage 2에서 Ubuntu portable fixture가 `plutil`에 의존하거나 macOS binary fixture가 실제 built plist와 다른 형식만 검증하면 단계 완료로 보지 않는다.
+- Stage 3에서 endpoint verifier가 signing/notarization 뒤에 실행되거나 workflow별 중복 명령이 생기면 완료로 보지 않는다.
+- 어느 Stage에서도 public workflow dispatch, Developer ID/notary credential 사용 또는 production 합성 이벤트가 필요해지면 즉시 멈추고 별도 승인을 요청한다.
+- 검증 실패가 해당 단계 범위를 넘어 runtime, payload, endpoint 값 변경을 요구하면 구현계획을 보정하고 승인받는다.
+
+## 8. 승인 요청 사항
+
+1. Stage 1에서 우회 가능성과 release hook 위치를 먼저 재현·고정한 뒤 구현하는 순서 승인
+2. Stage 2에서 expected origin, built-only `plutil`과 Ubuntu/macOS fixture 분리를 한 묶음으로 구현하는 범위 승인
+3. Stage 3에서 `release.sh`와 `package-release.sh`에 공통 verifier를 연결하고 workflow에는 중복 명령 대신 summary만 보강하는 방향 승인
+4. Public release·서명·공증·production 요청 없이 unsigned Release build와 필요 시 `--skip-notarize` rehearsal까지만 수행하는 검증 범위 승인
+5. 구현계획 승인 후 Stage 1 재현과 계약 확정 작업 시작 승인

--- a/mydocs/report/task_m010_488_report.md
+++ b/mydocs/report/task_m010_488_report.md
@@ -12,15 +12,17 @@ Task #479가 도입한 Release-only 익명 실행 이벤트 endpoint 계약을 s
 
 Stage 1에서 기존 HTTPS host 우회와 release helper 미연결 상태, current XML plist 형식을 재현했다. Stage 2에서 origin guard, XML/binary reader 경계와 portable/macOS fixture를 구현했다. Stage 3에서 `release.sh`와 `package-release.sh`에 built artifact gate를 연결하고 무서명 DMG·개발 zip end-to-end 검증으로 실제 실행 순서를 확인했다.
 
+PR #490 리뷰 보정에서는 macOS fixture를 `run_release_checks` job으로 옮겨 script-only 변경에서도 실행되도록 하고, Debug populated·key 누락·non-string 음성 fixture를 추가했다. 제한 PATH는 `RbConfig.ruby`로 실제 Ruby interpreter를 연결하며, `plutil` 경로의 key/type 오류도 XML fallback과 같은 의미의 진단으로 정규화했다. 패키징 가이드는 실제 copy → endpoint → universal → zip 순서와 일치시켰다.
+
 ## 변경 파일 목록과 영향 범위
 
 | 파일 | 내용 |
 |------|------|
-| `.github/workflows/pr-ci.yml` | macOS validation에서 endpoint XML/binary fixture helper 실행 |
+| `.github/workflows/pr-ci.yml` | macOS release-checks에서 endpoint XML/binary fixture helper 실행 |
 | `.github/workflows/release-rehearsal.yml` | Rehearsal summary에 built endpoint preflight 순서 명시 |
 | `.github/workflows/release-publish.yml` | Publish summary에 재서명·공증·DMG 전 endpoint gate 명시 |
 | `scripts/ci/verify-app-execution-endpoint-config.sh` | 승인 production origin 고정, exact built endpoint와 XML/binary plist reader 계약 보강 |
-| `scripts/ci/test-app-execution-endpoint-config.sh` | Invalid origin, XML/binary built app, mismatch와 no-`plutil` fixture 추가 |
+| `scripts/ci/test-app-execution-endpoint-config.sh` | Invalid origin, Debug populated, key/type, XML/binary built app, mismatch와 no-`plutil` fixture 추가 |
 | `scripts/release.sh` | Copied Release app endpoint 검증을 post-build 재서명·공증·DMG 전에 연결 |
 | `scripts/package-release.sh` | Copied Release app endpoint 검증을 universal 검증·zip 생성 전에 연결 |
 | `mydocs/tech/task_m040_453_app_execution_analytics_contract.md` | Origin review gate, built exact-match와 plist reader 운영 계약 기록 |
@@ -42,13 +44,13 @@ Stage 1에서 기존 HTTPS host 우회와 release helper 미연결 상태, curre
 |------|---------|---------|
 | 승인 production origin guard | 없음 — 임의의 유효한 HTTPS host 허용 | `https://alhangeul-install-events.postmelee.workers.dev` scheme·host·effective port 고정 |
 | Built Release endpoint 자동 gate | Verifier option만 있고 release 경로 호출 0개 | `release.sh`, `package-release.sh` 2개 산출 경로에서 blocking 실행 |
-| Built plist fixture 분기 | 자동 fixture 없음 | XML Debug/Release/mismatch/fallback 4개 + binary Debug/Release/no-`plutil` 3개 |
+| Built plist fixture 분기 | 자동 fixture 없음 | Portable XML Debug empty/populated·Release/mismatch/fallback 5개 + macOS key/type·binary Debug/Release/no-`plutil` 5개 |
 | Release artifact end-to-end | Endpoint preflight 순서 미검증 | Universal rehearsal DMG 1개, locally signed 개발 zip 1개 생성·무결성 검증 |
 | 구현 단계/단계 보고서 | 0 | 3단계 / 3개 |
-| 최종 보고 전 Git diff | 해당 없음 | 16개 파일, 1,040줄 추가·18줄 삭제 |
-| 최종 보고 전 작업 커밋 | 0 | 계획 2개 + Stage 3개 = 5개 |
+| PR 리뷰 보정 후 Git diff | 해당 없음 | 17개 파일, 1,224줄 추가·22줄 삭제 |
+| PR 리뷰 보정 후 작업 커밋 | 0 | 계획 2개 + Stage 3개 + 최종 보고 1개 + 리뷰 보정 1개 = 7개 |
 
-Stage 1–3 계획·보고 문서는 총 851줄이다. 자동 검증은 source origin drift, XML/binary plist, 실제 Release bundle, workflow YAML과 release packaging 순서를 함께 다룬다.
+Stage 1–3 계획·단계 보고 문서는 총 860줄이고 최종 보고서는 121줄이다. 자동 검증은 source origin drift, XML/binary plist, 실제 Release bundle, workflow YAML과 release packaging 순서를 함께 다룬다.
 
 검증용 산출물 checksum은 다음과 같다.
 
@@ -68,7 +70,7 @@ Stage 1–3 계획·보고 문서는 총 851줄이다. 자동 검증은 source o
 | 다른 HTTPS origin도 source gate에서 실패 | OK | `invalid-origin` fixture가 expected/actual origin 오류로 실패 |
 | Current production source와 exact built Release endpoint 통과 | OK | Source verifier와 실제 Release app `--release-app` 성공 |
 | XML fallback과 binary `plutil` 경계 명확화 | OK | XML no-`plutil` 통과, binary no-`plutil` 명시 실패 fixture 통과 |
-| Ubuntu portable + macOS synthetic binary 자동 회귀 | OK | PR CI script-checks 유지, macOS validation에 fixture helper 추가 |
+| Ubuntu portable + macOS synthetic binary 자동 회귀 | OK | PR CI script-checks 유지, `run_release_checks` macOS job에 fixture helper 연결 |
 | `release.sh`가 signing/notarization/DMG 전에 검증 | OK | 무서명 rehearsal 로그에서 endpoint → universal/signing skip → DMG 순서 확인 |
 | `package-release.sh`가 zip 전에 검증 | OK | 전용 build root에서 endpoint → universal → zip/checksum 순서 성공 |
 | Workflow별 verifier 명령 중복 없음 | OK | Rehearsal/publish 모두 공통 `release.sh` 사용, summary만 보강 |
@@ -84,7 +86,8 @@ MISS 항목은 없다.
 | `bash -n` release/package/verifier/test helper | OK |
 | Verifier/test helper `shellcheck` | OK |
 | 전체 6개 workflow `Psych.parse_file` | OK |
-| `scripts/ci/test-app-execution-endpoint-config.sh` | OK |
+| `scripts/ci/test-app-execution-endpoint-config.sh` | OK — Debug populated, key 누락·non-string 진단 포함 |
+| `classify-pr-changes.sh origin/devel HEAD` | OK — `run_macos_build=false`, `run_release_checks=true` |
 | `xcodegen generate` | OK, tracked project diff 없음 |
 | Unsigned HostApp Release build | OK, `** BUILD SUCCEEDED **` |
 | 실제 built Release app `--release-app` | OK |

--- a/mydocs/report/task_m010_488_report.md
+++ b/mydocs/report/task_m010_488_report.md
@@ -1,0 +1,118 @@
+# Task M010 #488 최종 결과 보고서
+
+## 작업 요약
+
+- 이슈: [#488 분석 endpoint 검증 gate 보강: release artifact preflight와 production host 고정](https://github.com/postmelee/alhangeul-macos/issues/488)
+- 마일스톤: `M010` (`v0.1`)
+- 대상 통합 브랜치: `devel`
+- 작업 브랜치: `local/task488`
+- 구현 단계: 3단계
+
+Task #479가 도입한 Release-only 익명 실행 이벤트 endpoint 계약을 source configuration에서 실제 Release artifact까지 확장했다. 승인된 production origin을 verifier에 독립적으로 고정하고, built Release app의 전체 endpoint가 `project.yml`과 정확히 일치해야만 post-build 재서명·공증·DMG·zip 생성으로 진행하도록 blocking preflight를 연결했다.
+
+Stage 1에서 기존 HTTPS host 우회와 release helper 미연결 상태, current XML plist 형식을 재현했다. Stage 2에서 origin guard, XML/binary reader 경계와 portable/macOS fixture를 구현했다. Stage 3에서 `release.sh`와 `package-release.sh`에 built artifact gate를 연결하고 무서명 DMG·개발 zip end-to-end 검증으로 실제 실행 순서를 확인했다.
+
+## 변경 파일 목록과 영향 범위
+
+| 파일 | 내용 |
+|------|------|
+| `.github/workflows/pr-ci.yml` | macOS validation에서 endpoint XML/binary fixture helper 실행 |
+| `.github/workflows/release-rehearsal.yml` | Rehearsal summary에 built endpoint preflight 순서 명시 |
+| `.github/workflows/release-publish.yml` | Publish summary에 재서명·공증·DMG 전 endpoint gate 명시 |
+| `scripts/ci/verify-app-execution-endpoint-config.sh` | 승인 production origin 고정, exact built endpoint와 XML/binary plist reader 계약 보강 |
+| `scripts/ci/test-app-execution-endpoint-config.sh` | Invalid origin, XML/binary built app, mismatch와 no-`plutil` fixture 추가 |
+| `scripts/release.sh` | Copied Release app endpoint 검증을 post-build 재서명·공증·DMG 전에 연결 |
+| `scripts/package-release.sh` | Copied Release app endpoint 검증을 universal 검증·zip 생성 전에 연결 |
+| `mydocs/tech/task_m040_453_app_execution_analytics_contract.md` | Origin review gate, built exact-match와 plist reader 운영 계약 기록 |
+| `mydocs/manual/ci_workflow_guide.md` | PR CI, rehearsal/publish endpoint preflight와 로컬 재현 절차 보강 |
+| `mydocs/manual/release_packaging_dmg_guide.md` | Release build, 개발 zip, public/rehearsal DMG 검증 순서 보강 |
+| `mydocs/plans/task_m010_488.md` | 작업 범위, 안전 제약과 단계 계획 수립 |
+| `mydocs/plans/task_m010_488_impl.md` | 3단계 구현 설계, 수용 기준과 검증 명령 확정 |
+| `mydocs/working/task_m010_488_stage1.md` | HTTPS origin 우회, release 경로와 current plist 측정 기록 |
+| `mydocs/working/task_m010_488_stage2.md` | Origin guard, reader와 fixture 구현·검증 기록 |
+| `mydocs/working/task_m010_488_stage3.md` | Release helper 통합과 DMG/zip 검증 기록 |
+| `mydocs/orders/20260828.md` | Task #488 진행 단계와 완료 시간 기록 |
+| `mydocs/report/task_m010_488_report.md` | 전체 변경, 수용 기준, 잔여 위험과 PR handoff 정리 |
+
+제품 HostApp·Quick Look·Thumbnail Swift/Rust source, `project.yml` production endpoint 값, analytics payload/outbox와 workflow trigger·권한·secret은 변경하지 않았다.
+
+## 변경 전·후 정량 비교
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| 승인 production origin guard | 없음 — 임의의 유효한 HTTPS host 허용 | `https://alhangeul-install-events.postmelee.workers.dev` scheme·host·effective port 고정 |
+| Built Release endpoint 자동 gate | Verifier option만 있고 release 경로 호출 0개 | `release.sh`, `package-release.sh` 2개 산출 경로에서 blocking 실행 |
+| Built plist fixture 분기 | 자동 fixture 없음 | XML Debug/Release/mismatch/fallback 4개 + binary Debug/Release/no-`plutil` 3개 |
+| Release artifact end-to-end | Endpoint preflight 순서 미검증 | Universal rehearsal DMG 1개, locally signed 개발 zip 1개 생성·무결성 검증 |
+| 구현 단계/단계 보고서 | 0 | 3단계 / 3개 |
+| 최종 보고 전 Git diff | 해당 없음 | 16개 파일, 1,040줄 추가·18줄 삭제 |
+| 최종 보고 전 작업 커밋 | 0 | 계획 2개 + Stage 3개 = 5개 |
+
+Stage 1–3 계획·보고 문서는 총 851줄이다. 자동 검증은 source origin drift, XML/binary plist, 실제 Release bundle, workflow YAML과 release packaging 순서를 함께 다룬다.
+
+검증용 산출물 checksum은 다음과 같다.
+
+| 산출물 | SHA-256 |
+|--------|---------|
+| `alhangeul-macos-0.1.10-rehearsal.dmg` | `7a742cc862b7313fe7d74395f686375d4382424f1c7fa1add3c43de92b4d92a0` |
+| `alhangeul-macos-0.1.10.zip` | `ec25b6f87599a942687481ba0b119c29f18c5fc184465d031b6118a7b678ac44` |
+
+두 산출물은 Task 전용 `build.noindex/task488-stage3-*` 경로에만 생성했으며 public asset으로 게시하지 않았다.
+
+## 검증 결과
+
+### 수용 기준
+
+| 수용 기준 | 결과 | 근거 |
+|-----------|------|------|
+| 다른 HTTPS origin도 source gate에서 실패 | OK | `invalid-origin` fixture가 expected/actual origin 오류로 실패 |
+| Current production source와 exact built Release endpoint 통과 | OK | Source verifier와 실제 Release app `--release-app` 성공 |
+| XML fallback과 binary `plutil` 경계 명확화 | OK | XML no-`plutil` 통과, binary no-`plutil` 명시 실패 fixture 통과 |
+| Ubuntu portable + macOS synthetic binary 자동 회귀 | OK | PR CI script-checks 유지, macOS validation에 fixture helper 추가 |
+| `release.sh`가 signing/notarization/DMG 전에 검증 | OK | 무서명 rehearsal 로그에서 endpoint → universal/signing skip → DMG 순서 확인 |
+| `package-release.sh`가 zip 전에 검증 | OK | 전용 build root에서 endpoint → universal → zip/checksum 순서 성공 |
+| Workflow별 verifier 명령 중복 없음 | OK | Rehearsal/publish 모두 공통 `release.sh` 사용, summary만 보강 |
+| 운영 문서가 origin·exact-match·실행 순서 설명 | OK | Analytics 계약, CI와 release packaging 가이드 갱신 |
+| Public release·production 네트워크 요청 미실행 | OK | Unsigned rehearsal과 locally signed 개발 zip만 생성, 앱 실행·업로드 없음 |
+
+MISS 항목은 없다.
+
+### 최종 통합 검증
+
+| 검증 | 결과 |
+|------|------|
+| `bash -n` release/package/verifier/test helper | OK |
+| Verifier/test helper `shellcheck` | OK |
+| 전체 6개 workflow `Psych.parse_file` | OK |
+| `scripts/ci/test-app-execution-endpoint-config.sh` | OK |
+| `xcodegen generate` | OK, tracked project diff 없음 |
+| Unsigned HostApp Release build | OK, `** BUILD SUCCEEDED **` |
+| 실제 built Release app `--release-app` | OK |
+| `scripts/check-no-appkit.sh` | OK |
+| `scripts/verify-rhwp-core-build-info.sh` | OK |
+| `scripts/verify-rhwp-studio-assets.sh` | OK |
+| Rehearsal DMG `hdiutil verify`와 SHA-256 | OK |
+| Package zip `unzip -tq`, local signature와 SHA-256 | OK |
+| `git diff --check` | OK |
+
+Local Ruby가 미사용 `ffi-1.13.1` native extension 경고를 출력했지만 Psych/REXML helper는 모두 exit 0으로 완료됐다. Xcode 검증이 등록한 Task 전용 개발 app/extension 경로는 해제했고, 최종 PlugInKit 조회에는 `build.noindex/task488-stage3-*` 경로가 남지 않았다.
+
+## 잔여 위험과 후속 작업
+
+- Public mode의 실제 Developer ID 재서명, notarization submit과 GitHub Actions workflow dispatch는 이번 작업의 권한 범위 밖이라 실행하지 않았다. 공통 helper의 unsigned rehearsal로 gate 위치를 검증했으며 실제 credential 검증은 정식 release 단계에서 수행한다.
+- 승인 origin은 destination 변경을 자동 통과시키지 않기 위해 `project.yml`과 verifier에 의도적으로 이중화했다. Host 이전 시 project, verifier, fixture와 운영 문서를 같은 review에서 갱신해야 한다.
+- Non-macOS fallback은 XML plist만 지원한다. Future binary plist는 macOS `plutil`이 필요하며 synthetic fixture가 이 계약을 보호한다.
+- `scripts/release.sh`에는 Task #488 이전부터 존재한 `shellcheck SC2054` warning 1건이 있다. 변경 줄과 무관하고 Task verifier helper lint는 깨끗하므로 이번 범위에서 수정하지 않았다.
+
+별도 후속 이슈를 새로 만들 필요는 없다고 판단한다. Public signing/notarization 검증은 기존 release 절차의 필수 gate이고, intentional host 이전은 운영 변경 시 함께 수정할 계약이며, 기존 `SC2054` warning은 기능 결함이나 Task #488 수용 기준 누락이 아니다.
+
+## 작업지시자 승인 요청
+
+Task #488의 3개 구현 단계와 전체 수용 기준 검증을 완료했다. `publish/task488` 브랜치와 `devel` 대상 PR에서 다음을 중심으로 리뷰해 달라.
+
+1. 승인 production origin을 전체 endpoint 진실 원천과 별도 review gate로 둔 설계
+2. `release.sh`의 `build_app → endpoint preflight → post-build signing/notarization/DMG` 순서
+3. `package-release.sh`의 copied app endpoint preflight와 zip 우회 차단
+4. XML-only fallback과 binary `plutil` 요구를 fixture·운영 문서에 같은 계약으로 반영한 부분
+
+리뷰 완료 후 merge 승인을 요청한다.

--- a/mydocs/tech/task_m040_453_app_execution_analytics_contract.md
+++ b/mydocs/tech/task_m040_453_app_execution_analytics_contract.md
@@ -47,6 +47,10 @@ Production endpoint의 단일 편집 원본은 `project.yml`의 HostApp `ALHANGE
 
 - HostApp base 값은 빈 문자열이며 Debug와 별도로 승인되지 않은 개발 configuration은 production endpoint를 얻지 않는다.
 - 표준 Release configuration만 공개 production HTTPS endpoint를 주입한다.
+- 검증 helper는 `project.yml`의 전체 URL과 별도로 승인된 production origin `https://alhangeul-install-events.postmelee.workers.dev`를 고정한다. Release URL의 scheme·host·port가 이 origin과 다르면 source 단계에서 실패한다.
+- production endpoint host를 의도적으로 변경할 때는 `project.yml`, 검증 helper의 승인 origin, fixture와 이 문서를 같은 변경으로 갱신하고 검토한다.
+- `scripts/release.sh`와 `scripts/package-release.sh`는 Release build를 staging으로 복사한 직후 bundle의 전체 endpoint가 `project.yml` 값과 정확히 일치하는지 검증한다. mismatch는 post-build Developer ID 재서명, 공증 제출, DMG 또는 zip 생성을 시작하기 전에 실패한다.
+- macOS에서는 built `Info.plist` 형식과 무관하게 `plutil`로 값을 읽는다. `plutil`을 쓸 수 없는 환경은 XML plist만 Ruby 표준 라이브러리로 확인하며 binary plist는 명확히 실패한다.
 - 빈 값이나 유효하지 않은 endpoint는 `AppExecutionAnalyticsEndpoint.resolve()`가 `nil`로 거부한다. Coordinator는 connectivity 확인과 transport 생성을 시작하지 않고 outbox와 앱·문서 기능을 비차단 상태로 유지한다.
 - Endpoint가 없는 실행은 event를 전송하지 않을 뿐 아니라 **생성·적재하지도 않는다**. `AppExecutionAnalyticsRuntime.prepareForLaunch()`는 delivery가 구성되지 않았으면 observer를 호출하지 않고 반환하므로 `lastObservedVersion`·`pendingSparkleUpdate`·outbox가 모두 그대로 유지된다.
 - 이 gate가 필요한 이유는 Debug와 Release가 같은 `PRODUCT_BUNDLE_IDENTIFIER`를 쓰고 따라서 같은 sandbox container의 `UserDefaults`와 outbox를 공유하기 때문이다. 전송만 막고 적재를 허용하면 Debug 실행이 남긴 event를 같은 머신의 이후 Release 실행이 production으로 flush한다. 미시도 항목 보존 기간이 30일이므로 차단이 아니라 지연에 그친다.

--- a/mydocs/working/task_m010_488_stage1.md
+++ b/mydocs/working/task_m010_488_stage1.md
@@ -1,0 +1,149 @@
+# Task M010 #488 Stage 1 완료 보고서
+
+## 단계 목적
+
+현재 endpoint verifier가 승인되지 않은 다른 HTTPS origin을 통과시키는지 재현하고, `--release-app`이 실제 release artifact 경로에 연결되지 않은 상태와 pre-signing hook 위치를 확정한다. Built `Info.plist`의 실제 출력 형식과 REXML fallback 동작을 측정해 Stage 2 구현 계약을 증거에 맞춘다.
+
+## 산출물
+
+| 파일 | 변경 정도 | 내용 |
+|------|-----------|------|
+| `mydocs/working/task_m010_488_stage1.md` | 신규 1개 | Origin 우회, release 호출 경로, plist 형식과 Stage 2 보정안 기록 |
+| `mydocs/orders/20260828.md` | 1행 수정 | Stage 1 완료·Stage 2 승인 대기로 진행 상태 갱신 |
+
+Stage 1은 조사·재현 단계이므로 verifier, fixture, workflow, release helper와 제품 source를 변경하지 않았다. 진단용 unsigned Release app은 `build.noindex/task488-stage1/` 아래에만 생성했으며 Git 추적 대상이 아니다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- 제품 source 변경: 0개
+- CI·release script 변경: 0개
+- 기존 계획서 본문 변경: 0개
+- 신규 단계 보고서와 오늘할일 상태 외 tracked 변경: 없음
+- Production endpoint 요청·앱 실행·이벤트 생성: 수행하지 않음
+- Public workflow dispatch, Developer ID 서명, notarization: 수행하지 않음
+
+Unsigned Release build 과정에서 Xcode가 `build.noindex/task488-stage1/.../Alhangeul.app`을 LaunchServices에 자동 등록했다. 검증 뒤 해당 app과 내부 Preview/Thumbnail extension 경로만 `lsregister -u`, `pluginkit -r`로 등록 해제했으며 파일과 사용자 설치본은 삭제하지 않았다.
+
+## 조사 결과
+
+### 1. 다른 HTTPS origin이 현재 gate를 통과한다
+
+일회용 fixture에서 Release endpoint만 다음과 같이 교체했다.
+
+```text
+기존: https://alhangeul-install-events.postmelee.workers.dev/v1/install-events
+변경: https://collector.example/v1/install-events
+```
+
+현재 verifier는 exit 0으로 통과했다.
+
+```text
+Verified analytics endpoint source configuration (Release only).
+Verified current gate accepts alternate HTTPS origin: https://collector.example
+```
+
+현재 검증은 HTTPS 절대 URL과 credential·query·fragment 부재만 확인하므로 Issue #488의 production origin 고정 필요성이 재현됐다.
+
+### 2. `--release-app`은 실제 artifact 경로에서 호출되지 않는다
+
+`.github`, `scripts`, release manual을 검색한 결과 `--release-app`은 verifier의 help와 argument parser 세 곳에만 있었다.
+
+```text
+scripts/ci/verify-app-execution-endpoint-config.sh:20:  --release-app PATH ...
+scripts/ci/verify-app-execution-endpoint-config.sh:42:    --release-app)
+scripts/ci/verify-app-execution-endpoint-config.sh:43:      ...
+```
+
+`release.sh` main은 다음처럼 endpoint gate 없이 build에서 signing으로 바로 이동한다.
+
+```text
+856:  build_app
+857:  sign_release_app_for_notarization
+```
+
+`release-rehearsal.yml`과 `release-publish.yml`은 모두 공통 `release.sh`를 실행한다. 따라서 `build_app` 다음, `sign_release_app_for_notarization` 이전이 두 workflow를 함께 보호하는 단일 pre-signing hook이다.
+
+`package-release.sh`도 Release app을 staging으로 복사한 뒤 universal 검증과 zip 생성을 수행하지만 endpoint verifier를 호출하지 않는다. 개발용 zip도 동일한 Release configuration을 사용하므로 copied app 직후 verifier를 재사용하는 것으로 Stage 3 범위를 확정한다.
+
+### 3. Built plist의 binary 전제는 현재 빌드에서 성립하지 않는다
+
+Sandbox 제한을 해제한 동일 unsigned Release build는 31.114초에 성공했다.
+
+```text
+** BUILD SUCCEEDED ** [31.114 sec]
+```
+
+Source와 built plist는 모두 XML이었다.
+
+```text
+Sources/HostApp/Info.plist: XML 1.0 document text, Unicode text, UTF-8 text
+build.noindex/task488-stage1/Build/Products/Release/Alhangeul.app/Contents/Info.plist: XML 1.0 document text, Unicode text, UTF-8 text
+```
+
+Release build setting도 이를 설명한다.
+
+```text
+GENERATE_INFOPLIST_FILE = NO
+INFOPLIST_FILE = Sources/HostApp/Info.plist
+INFOPLIST_OUTPUT_FORMAT = same-as-input
+```
+
+따라서 이슈 본문의 “Xcode built plist는 binary이므로 REXML fallback이 동작하지 않는다”는 전제는 현재 project/release 경로에서는 사실이 아니다. REXML로 실제 built plist를 읽는 실험도 성공했다. `plutil` 우선 경로의 exact endpoint 검증 역시 통과했다.
+
+```text
+Verified Release built endpoint: build.noindex/task488-stage1/Build/Products/Release/Alhangeul.app
+Verified analytics endpoint source configuration (Release only).
+```
+
+Stage 2에서는 동작하는 fallback을 근거 없이 삭제하지 않는다. 대신 다음 계약으로 구현계획을 보정하는 편이 정확하다.
+
+- macOS release 경로에서는 기존처럼 `plutil`을 우선 사용한다.
+- `plutil`이 없는 환경의 REXML fallback은 현재 `same-as-input` XML built plist만 지원한다고 주석·오류로 명시한다.
+- Binary plist가 입력됐는데 `plutil`이 없으면 명확히 실패한다.
+- Synthetic binary fixture는 macOS `plutil` 경로가 읽는지 검증하되, 실제 current Release output은 XML이라는 사실을 문서에 유지한다.
+
+이 보정은 수행계획서의 “fallback 제거 또는 동등한 의도 명시” 범위 안이지만, 승인된 구현계획서의 “fallback 제거” 문구는 Stage 2 진입 승인 후 위 계약으로 함께 정정한다.
+
+## 검증 결과
+
+| 검증 | 결과 | 핵심 출력 |
+|------|------|-----------|
+| `scripts/ci/test-app-execution-endpoint-config.sh` | OK | 정상 configuration과 invalid base/release/plist fixture 통과 |
+| `scripts/ci/verify-app-execution-endpoint-config.sh` | OK | Current Release-only source configuration 통과 |
+| 다른 HTTPS origin fixture | 재현 성공 | `https://collector.example`이 현재 gate에서 exit 0 |
+| `rg -n -- '--release-app' .github scripts mydocs/manual` | 확인 | Verifier 정의 3곳 외 호출 없음 |
+| `release.sh` main 순서 검색 | 확인 | `build_app` 직후 `sign_release_app_for_notarization` |
+| Unsigned Release build | OK | `BUILD SUCCEEDED`, 31.114초 |
+| Built plist 형식 | 확인 | XML 1.0, `same-as-input` |
+| Current built `--release-app` | OK | `project.yml` exact endpoint 일치 |
+| REXML built plist parse | OK | 실제 XML built plist parse 성공 |
+| `git diff --check` | OK | 오류 없음 |
+
+첫 sandbox 내부 build는 Sparkle package cache/network 접근 제한으로 dependency resolution에서 중단됐다. 동일 명령을 로컬 Xcode 권한으로 재실행해 성공했으므로 source·project 실패가 아니라 실행 환경 제한으로 판정했다.
+
+## 잔여 위험
+
+- 다른 HTTPS host가 아직 gate를 통과하므로 Stage 2 완료 전 source configuration 변경을 production destination 승인으로 간주할 수 없다.
+- `--release-app`은 아직 release helper에서 호출되지 않으므로 실제 rehearsal/public artifact 자동 검증은 Stage 3 전까지 없다.
+- Current built plist는 XML이지만 향후 `INFOPLIST_OUTPUT_FORMAT` 변경으로 binary가 될 수 있다. `plutil` 없는 fallback은 형식을 판별해 binary를 조용히 처리하지 않아야 한다.
+- Expected origin을 별도 상수로 고정하면 intentional host 이전 시 `project.yml`, verifier, fixture와 운영 문서를 함께 변경해야 한다. 이는 의도한 review gate다.
+- Unsigned Release app에는 production endpoint가 포함된다. Stage 1에서는 plist만 읽고 app을 실행하지 않았다.
+
+## 다음 단계 영향
+
+Stage 2는 다음 범위로 진행한다.
+
+1. Expected production origin을 verifier에 독립적으로 고정한다.
+2. 다른 HTTPS origin 실패 fixture를 portable source gate에 추가한다.
+3. Current XML output을 반영해 REXML fallback을 삭제하지 않고 XML-only 지원과 binary/plutil 요구를 명시한다.
+4. macOS fixture에서 current XML과 synthetic binary plist의 `plutil` 경로, Release exact-match와 mismatch를 검증한다.
+5. PR CI의 Ubuntu source fixture와 macOS built fixture 책임을 분리한다.
+
+Stage 3의 `release.sh` pre-signing hook과 `package-release.sh` copied app gate 방향은 구현계획대로 유지한다.
+
+## 승인 요청
+
+Stage 1 조사·재현과 검증을 완료했다. 다음 두 사항을 포함해 Stage 2 진입 승인을 요청한다.
+
+1. Production origin 고정과 다른 HTTPS origin 실패 fixture를 구현한다.
+2. 실제 Release plist가 XML이라는 증거에 따라 REXML fallback을 제거하지 않고, XML-only fallback과 binary 입력의 `plutil` 요구를 명시하는 방향으로 구현계획을 보정한다.

--- a/mydocs/working/task_m010_488_stage2.md
+++ b/mydocs/working/task_m010_488_stage2.md
@@ -10,7 +10,7 @@
 |------|-----------|------|
 | `scripts/ci/verify-app-execution-endpoint-config.sh` | +53/-5 | Expected production origin 고정, URI origin 비교, XML-only fallback과 binary 오류 명시 |
 | `scripts/ci/test-app-execution-endpoint-config.sh` | +94/-11 | Invalid origin, XML/binary built app, mismatch와 no-`plutil` fixture 추가 |
-| `.github/workflows/pr-ci.yml` | +6/-0 | macOS validation에서 plist fixture helper 실행 |
+| `.github/workflows/pr-ci.yml` | +6/-0 | macOS release-checks에서 plist fixture helper 실행 |
 | `mydocs/plans/task_m010_488_impl.md` | +26/-23 | Stage 1 측정에 따라 binary 전제를 current XML·future binary 계약으로 보정 |
 | `mydocs/working/task_m010_488_stage2.md` | 신규 1개 | Stage 2 구현·검증·잔여 위험 기록 |
 | `mydocs/orders/20260828.md` | 1행 수정 | Stage 2 완료·Stage 3 승인 대기로 상태 갱신 |
@@ -68,6 +68,7 @@ Portable fixture는 다음 계약을 검증한다.
 - 다른 HTTPS origin 실패
 - Source plist placeholder drift 실패
 - XML Debug empty endpoint 통과
+- XML Debug populated endpoint 실패
 - XML Release exact endpoint 통과
 - XML Release same-origin path mismatch 실패
 - `plutil` 없는 제한 PATH에서 XML REXML fallback 통과
@@ -76,9 +77,12 @@ macOS에서 `plutil`이 있으면 추가로 다음을 검증한다.
 
 - Synthetic binary Debug empty endpoint 통과
 - Synthetic binary Release exact endpoint 통과
+- Endpoint key 누락과 non-string 값이 정규화된 진단으로 실패
 - 같은 binary Release app이 no-`plutil` 제한 PATH에서는 명시적 실패
 
-`pr-ci.yml`의 macOS validation에 동일 helper 실행 단계를 추가했다. Ubuntu `script-checks`는 기존 helper 호출을 유지해 source/XML portable 계약을 검증하고, macOS job은 binary 분기를 추가로 실행한다. 실제 Debug built app에 대한 기존 `--debug-app` gate도 유지했다.
+`pr-ci.yml`의 macOS release-checks에 동일 helper 실행 단계를 추가했다. Ubuntu `script-checks`는 기존 helper 호출을 유지해 source/XML portable 계약을 검증하고, `run_release_checks=true`인 macOS job은 binary와 `plutil` 진단 분기를 추가로 실행한다. macOS validation의 실제 Debug built app `--debug-app` gate도 유지했다.
+
+PR #490 리뷰 보정에서는 Debug endpoint가 채워진 음성 fixture, key 누락·non-string `plutil` fixture를 추가했다. 제한 PATH에 연결하는 Ruby는 shim 경로가 아니라 `RbConfig.ruby`가 가리키는 실제 interpreter로 고정했다. 또한 endpoint helper를 `run_macos_build` 조건의 macOS validation에서 `run_release_checks` 조건의 release-checks로 이동해 script-only PR에서도 macOS fixture가 실행되도록 했다.
 
 ### 4. 구현계획 보정
 
@@ -95,7 +99,7 @@ Stage 3의 `release.sh` pre-signing hook, `package-release.sh` copied app gate�
 | 검증 | 결과 | 핵심 출력 |
 |------|------|-----------|
 | `bash -n` verifier/test helper | OK | 구문 오류 없음 |
-| `scripts/ci/test-app-execution-endpoint-config.sh` | OK | Source 실패 4개, XML built, mismatch, XML fallback, binary 성공/실패 fixture 통과 |
+| `scripts/ci/test-app-execution-endpoint-config.sh` | OK | Source 실패 4개, Debug populated, XML built/mismatch/fallback, key/type, binary 성공/실패 fixture 통과 |
 | `scripts/ci/verify-app-execution-endpoint-config.sh` | OK | Current Release-only source configuration 통과 |
 | `shellcheck` 두 helper | OK | 진단 없음 |
 | `Psych.parse_file(.github/workflows/pr-ci.yml)` | OK | Workflow YAML parse 성공 |
@@ -108,9 +112,14 @@ macOS 전체 fixture의 주요 출력은 다음과 같다.
 ```text
 Verified failure fixture: invalid-origin
 Verified Debug built endpoint is disabled: .../debug-xml/Alhangeul.app
+Verified failure fixture: debug-populated-xml
 Verified Release built endpoint: .../release-xml/Alhangeul.app
 Verified failure fixture: release-mismatch-xml
 Verified XML built endpoint fallback without plutil.
+Verified failure fixture: missing-key
+Verified failure fixture: missing-key-xml-fallback
+Verified failure fixture: non-string
+Verified failure fixture: non-string-xml-fallback
 Verified Debug built endpoint is disabled: .../debug-binary/Alhangeul.app
 Verified Release built endpoint: .../release-binary/Alhangeul.app
 Verified failure fixture: release-binary-without-plutil
@@ -124,7 +133,7 @@ Local system Ruby는 미사용 `ffi-1.13.1` native extension 경고를 출력했
 - `--release-app`은 아직 `release.sh`와 `package-release.sh`에서 호출되지 않는다. 실제 artifact 자동 차단은 Stage 3 완료 전까지 없다.
 - Expected origin은 `project.yml` endpoint와 별도 상수다. 중복은 destination 변경을 명시적으로 review하기 위한 의도된 gate이며 운영 문서 설명이 Stage 3에 필요하다.
 - Current Xcode output은 XML이지만 설정 변경으로 binary가 될 수 있다. macOS `plutil` 경로는 synthetic binary fixture로 보호하고, non-macOS fallback은 binary를 지원하지 않는다.
-- PR CI의 macOS fixture 단계는 `run_macos_build` job 조건 안에서 실행된다. 실제 Release artifact의 pre-signing 순서는 Stage 3 release helper 통합 검증으로 별도 확인해야 한다.
+- PR CI의 synthetic macOS fixture는 `run_release_checks` job 조건으로 실행된다. 실제 Release artifact의 pre-signing 순서는 Stage 3 release helper 통합 검증으로 별도 확인해야 한다.
 - 같은 production origin 안의 endpoint path 변경은 origin guard가 허용한다. Source diff review와 built app의 `project.yml` exact-match가 path 계약을 담당한다.
 
 ## 다음 단계 영향

--- a/mydocs/working/task_m010_488_stage2.md
+++ b/mydocs/working/task_m010_488_stage2.md
@@ -1,0 +1,146 @@
+# Task M010 #488 Stage 2 완료 보고서
+
+## 단계 목적
+
+승인되지 않은 다른 HTTPS origin을 source configuration gate에서 차단하고, built app endpoint reader를 current XML·future binary plist 계약에 맞춘다. Ubuntu portable fixture와 macOS XML/binary fixture를 분리해 production origin, Debug empty, Release exact-match와 fallback 한계를 자동 검증한다.
+
+## 산출물
+
+| 파일 | 변경 정도 | 내용 |
+|------|-----------|------|
+| `scripts/ci/verify-app-execution-endpoint-config.sh` | +53/-5 | Expected production origin 고정, URI origin 비교, XML-only fallback과 binary 오류 명시 |
+| `scripts/ci/test-app-execution-endpoint-config.sh` | +94/-11 | Invalid origin, XML/binary built app, mismatch와 no-`plutil` fixture 추가 |
+| `.github/workflows/pr-ci.yml` | +6/-0 | macOS validation에서 plist fixture helper 실행 |
+| `mydocs/plans/task_m010_488_impl.md` | +26/-23 | Stage 1 측정에 따라 binary 전제를 current XML·future binary 계약으로 보정 |
+| `mydocs/working/task_m010_488_stage2.md` | 신규 1개 | Stage 2 구현·검증·잔여 위험 기록 |
+| `mydocs/orders/20260828.md` | 1행 수정 | Stage 2 완료·Stage 3 승인 대기로 상태 갱신 |
+
+보고서 작성 전 source diff는 4개 파일, 179줄 추가·39줄 삭제였다. 제품 runtime, `project.yml`, endpoint 값, payload/outbox와 Release helper는 Stage 2에서 변경하지 않았다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- HostApp·Quick Look·Thumbnail Swift/Rust source 변경: 0개
+- `project.yml` production endpoint 변경: 없음
+- 공개 payload, endpoint path, analytics runtime 변경: 없음
+- `release.sh`, `package-release.sh` 변경: 없음 — Stage 3 범위 유지
+- Public workflow dispatch, app 실행, production 네트워크 요청: 수행하지 않음
+- 계획 보정: Stage 1에서 실제 Release plist가 XML임을 측정한 결과만 반영했으며 전체 3단계 범위와 Stage 3 목표는 유지
+
+## 구현 내용
+
+### 1. Production origin을 독립적으로 고정
+
+Verifier에 다음 expected origin을 명시했다.
+
+```text
+https://alhangeul-install-events.postmelee.workers.dev
+```
+
+`project.yml`은 endpoint 전체 URL의 단일 편집 원본으로 유지한다. 별도 expected origin은 scheme·lowercase host·effective port 배열로 비교하며, path는 origin 비교에서 제외한다. Expected origin 자체도 HTTPS 절대 origin인지, credential·query·fragment와 비-root path가 없는지 방어적으로 검증한다.
+
+Current endpoint와 다른 `https://collector.example/v1/install-events` fixture는 다음 오류로 실패한다.
+
+```text
+HostApp Release endpoint origin must be https://alhangeul-install-events.postmelee.workers.dev, got: https://collector.example
+```
+
+같은 origin 안의 path는 source 진실 원천인 `project.yml`이 소유하고, built Release app은 기존처럼 전체 문자열 exact match를 통과해야 한다. Intentional host 이전은 verifier constant, project configuration, fixture와 문서를 같은 review에서 변경해야 한다.
+
+### 2. Current XML과 future binary plist 책임을 분리
+
+macOS에서는 기존처럼 `plutil`을 우선 사용해 XML·binary plist를 읽는다. `plutil`이 없는 환경에서는 current `INFOPLIST_OUTPUT_FORMAT = same-as-input` 출력과 같은 XML plist만 REXML fallback으로 지원한다.
+
+Fallback은 `File.binread`로 header를 먼저 확인한다. `bplist` binary 입력이면 REXML parse를 시도하지 않고 다음 오류로 중단한다.
+
+```text
+plutil is required to read binary built Info.plist
+```
+
+XML parse 실패, endpoint key 누락과 non-string 값도 `error:` prefix가 있는 구체적 메시지로 통일했다. Stage 1에서 실제로 동작한 XML fallback은 유지하고, 지원하지 않는 binary를 처리하는 것처럼 보이던 모호함만 제거했다.
+
+### 3. Portable·macOS fixture를 확장
+
+Portable fixture는 다음 계약을 검증한다.
+
+- Current source configuration 정상
+- Invalid base/Debug override 실패
+- HTTP Release endpoint 실패
+- 다른 HTTPS origin 실패
+- Source plist placeholder drift 실패
+- XML Debug empty endpoint 통과
+- XML Release exact endpoint 통과
+- XML Release same-origin path mismatch 실패
+- `plutil` 없는 제한 PATH에서 XML REXML fallback 통과
+
+macOS에서 `plutil`이 있으면 추가로 다음을 검증한다.
+
+- Synthetic binary Debug empty endpoint 통과
+- Synthetic binary Release exact endpoint 통과
+- 같은 binary Release app이 no-`plutil` 제한 PATH에서는 명시적 실패
+
+`pr-ci.yml`의 macOS validation에 동일 helper 실행 단계를 추가했다. Ubuntu `script-checks`는 기존 helper 호출을 유지해 source/XML portable 계약을 검증하고, macOS job은 binary 분기를 추가로 실행한다. 실제 Debug built app에 대한 기존 `--debug-app` gate도 유지했다.
+
+### 4. 구현계획 보정
+
+승인된 Stage 1 보고서에 따라 `task_m010_488_impl.md`의 다음 전제를 고쳤다.
+
+- “Xcode built plist는 binary” → Current Release output은 `same-as-input` XML
+- “REXML fallback 제거” → `plutil` 우선, XML-only fallback 유지, binary 명시 실패
+- Ubuntu source fixture와 macOS binary fixture → Ubuntu source/XML + macOS synthetic binary fixture
+
+Stage 3의 `release.sh` pre-signing hook, `package-release.sh` copied app gate와 운영 문서 보강 범위는 변경하지 않았다.
+
+## 검증 결과
+
+| 검증 | 결과 | 핵심 출력 |
+|------|------|-----------|
+| `bash -n` verifier/test helper | OK | 구문 오류 없음 |
+| `scripts/ci/test-app-execution-endpoint-config.sh` | OK | Source 실패 4개, XML built, mismatch, XML fallback, binary 성공/실패 fixture 통과 |
+| `scripts/ci/verify-app-execution-endpoint-config.sh` | OK | Current Release-only source configuration 통과 |
+| `shellcheck` 두 helper | OK | 진단 없음 |
+| `Psych.parse_file(.github/workflows/pr-ci.yml)` | OK | Workflow YAML parse 성공 |
+| 제한 PATH 전체 fixture | OK | `plutil` 없이 source/XML fixture 전체 통과, binary 분기 미실행 |
+| Stage 1 실제 Release app `--release-app` | OK | Current production endpoint exact match 통과 |
+| `git diff --check` | OK | 오류 없음 |
+
+macOS 전체 fixture의 주요 출력은 다음과 같다.
+
+```text
+Verified failure fixture: invalid-origin
+Verified Debug built endpoint is disabled: .../debug-xml/Alhangeul.app
+Verified Release built endpoint: .../release-xml/Alhangeul.app
+Verified failure fixture: release-mismatch-xml
+Verified XML built endpoint fallback without plutil.
+Verified Debug built endpoint is disabled: .../debug-binary/Alhangeul.app
+Verified Release built endpoint: .../release-binary/Alhangeul.app
+Verified failure fixture: release-binary-without-plutil
+Analytics endpoint configuration fixtures passed.
+```
+
+Local system Ruby는 미사용 `ffi-1.13.1` native extension 경고를 출력했지만 모든 helper exit status와 REXML/Psych 검증은 성공했다. 이 경고는 변경 전 baseline에서도 동일하며 Stage 2 source 실패가 아니다.
+
+## 잔여 위험
+
+- `--release-app`은 아직 `release.sh`와 `package-release.sh`에서 호출되지 않는다. 실제 artifact 자동 차단은 Stage 3 완료 전까지 없다.
+- Expected origin은 `project.yml` endpoint와 별도 상수다. 중복은 destination 변경을 명시적으로 review하기 위한 의도된 gate이며 운영 문서 설명이 Stage 3에 필요하다.
+- Current Xcode output은 XML이지만 설정 변경으로 binary가 될 수 있다. macOS `plutil` 경로는 synthetic binary fixture로 보호하고, non-macOS fallback은 binary를 지원하지 않는다.
+- PR CI의 macOS fixture 단계는 `run_macos_build` job 조건 안에서 실행된다. 실제 Release artifact의 pre-signing 순서는 Stage 3 release helper 통합 검증으로 별도 확인해야 한다.
+- 같은 production origin 안의 endpoint path 변경은 origin guard가 허용한다. Source diff review와 built app의 `project.yml` exact-match가 path 계약을 담당한다.
+
+## 다음 단계 영향
+
+Stage 3는 보강된 verifier를 다음 위치에 연결한다.
+
+1. `release.sh`: `build_app` 완료 후, `sign_release_app_for_notarization` 이전에 copied `APP_OUTPUT`을 `--release-app`으로 검증
+2. `package-release.sh`: copied Release app을 zip으로 만들기 전에 동일 verifier 실행
+3. Rehearsal/publish workflow: 명령 중복 없이 공통 helper의 pre-signing gate를 summary에 명시
+4. Analytics 계약과 CI/release packaging 가이드: expected origin review gate, built exact-match, XML/binary reader와 실행 순서 기록
+5. Unsigned Release build와 필요 시 `--skip-notarize` rehearsal에서 endpoint gate가 signing/DMG 생성보다 먼저 실행되는지 확인
+
+Stage 3에서도 production endpoint로 앱을 실행하거나 이벤트를 전송하지 않으며 public workflow, Developer ID 서명과 notarization을 수행하지 않는다.
+
+## 승인 요청
+
+Stage 2 production origin guard, XML/binary reader 계약, portable/macOS fixture와 PR CI 연결을 완료했다. 구현계획서의 Stage 1 반증 보정도 승인 내용대로 반영했다.
+
+Stage 3의 release artifact preflight 연결, workflow summary·운영 문서 보강과 unsigned 통합 검증 진행 승인을 요청한다.

--- a/mydocs/working/task_m010_488_stage3.md
+++ b/mydocs/working/task_m010_488_stage3.md
@@ -1,0 +1,125 @@
+# Task M010 #488 Stage 3 완료 보고서
+
+## 단계 목적
+
+Stage 2에서 보강한 production origin·built app exact-match verifier를 실제 Release 산출물 생성 경로에 연결한다. Rehearsal/public DMG와 개발용 zip 모두 staging app을 복사한 직후 endpoint를 검증하고, 불일치 시 post-build 재서명·공증·DMG·zip 생성 전에 실패하도록 한다. CI 안내와 analytics/패키징 운영 문서를 같은 계약으로 맞추고 로컬 무서명 리허설로 실행 순서를 확인한다.
+
+## 산출물
+
+| 파일 | 변경 정도 | 내용 |
+|------|-----------|------|
+| `scripts/release.sh` | +8/-0 | Ruby preflight 의존성 확인, copied Release app endpoint gate를 post-build 재서명 전에 연결 |
+| `scripts/package-release.sh` | +3/-0 | copied Release app endpoint gate를 universal 검증·zip 생성 전에 연결 |
+| `.github/workflows/release-rehearsal.yml` | +1/-0 | Rehearsal summary에 built endpoint preflight 순서 명시 |
+| `.github/workflows/release-publish.yml` | +1/-0 | Publish summary에 built endpoint preflight 차단 범위 명시 |
+| `mydocs/tech/task_m040_453_app_execution_analytics_contract.md` | +4/-0 | 승인 origin, exact-match, plist reader와 endpoint 이전 규칙 기록 |
+| `mydocs/manual/ci_workflow_guide.md` | +5/-2 | Workflow 역할, 로컬 fixture, rehearsal/publish gate 문서화 |
+| `mydocs/manual/release_packaging_dmg_guide.md` | +7/-0 | Release build, 개발 zip, public/rehearsal DMG 검증 순서 문서화 |
+| `mydocs/working/task_m010_488_stage3.md` | 신규 1개 | Stage 3 구현·검증·잔여 위험 기록 |
+| `mydocs/orders/20260828.md` | 1행 수정 | Stage 3 완료·최종 보고 승인 대기로 상태 갱신 |
+
+보고서 작성 전 source diff는 7개 파일, 29줄 추가·2줄 삭제였다. 제품 runtime Swift/Rust source와 `project.yml` endpoint 값은 변경하지 않았다.
+
+## 본문 변경 정도 / 본문 무손실 여부
+
+- HostApp·Quick Look·Thumbnail Swift/Rust source 변경: 0개
+- `project.yml` production endpoint와 payload/outbox 계약 변경: 없음
+- Release helper의 산출물 처리 순서만 보강: build와 staging 복사는 유지하고 검증 단계를 재서명·공증·패키징 전에 추가
+- Workflow trigger, 권한, secret, signing/notarization 설정 변경: 없음
+- Public workflow dispatch, GitHub Release/Homebrew 업로드, production endpoint 앱 실행·이벤트 전송: 수행하지 않음
+- 검증 산출물은 모두 `build.noindex/task488-stage3-*` 전용 경로에 생성
+
+## 구현 내용
+
+### 1. Public/rehearsal DMG 경로 연결
+
+`scripts/release.sh`에 `verify_app_execution_endpoint()`를 추가하고 다음 순서를 고정했다.
+
+```text
+build_app
+→ copied APP_OUTPUT endpoint 검증
+→ sign_release_app_for_notarization
+→ universal/signing preflight
+→ notarization
+→ DMG 생성
+```
+
+Verifier가 Ruby 표준 라이브러리로 source configuration을 파싱하므로 `run_preflight`의 required tool에 `ruby`를 추가했다. Built app 검증은 `--release-app "$APP_OUTPUT"`을 사용하며, production origin이나 `project.yml` 전체 URL과 다르면 뒤 단계가 실행되지 않는다.
+
+### 2. 개발용 zip 경로 연결
+
+`scripts/package-release.sh`는 Xcode build app을 release staging의 `Alhangeul.app`으로 복사한 직후 동일 verifier를 실행한다. 검증 성공 후에만 app/extension universal architecture를 확인하고 zip을 만든다. 기본 `build.noindex/release` 대신 전용 `ALHANGEUL_BUILD_ROOT`에서 실제 package helper를 실행해 copied app 검증, universal app 검증과 zip 생성까지 확인했다.
+
+### 3. Workflow와 운영 문서 정합화
+
+Rehearsal/publish workflow에는 별도 검증 명령을 중복하지 않고 공통 `release.sh`가 소유하는 built artifact gate를 summary에 명시했다. Rehearsal은 선택적 post-build Developer ID 재서명과 DMG 생성 전, publish는 재서명·공증 제출·public DMG 생성 전 차단임을 구분했다.
+
+Analytics 계약과 CI/패키징 가이드에는 다음을 기록했다.
+
+- `project.yml` 전체 URL과 별도 승인 production origin의 책임 분리
+- 의도적인 host 이전 시 project, verifier, fixture와 문서를 같은 review에서 갱신
+- built Release app 전체 URL exact-match
+- macOS `plutil` 우선, non-macOS XML-only fallback, binary plist의 `plutil` 요구
+- 개발 zip, rehearsal DMG와 public DMG의 공통 preflight 순서
+
+## 검증 결과
+
+| 검증 | 결과 | 핵심 출력 |
+|------|------|-----------|
+| `bash -n scripts/release.sh scripts/package-release.sh` | OK | 구문 오류 없음 |
+| 전체 workflow `Psych.parse_file` | OK | 6개 YAML parse 성공 |
+| `scripts/ci/test-app-execution-endpoint-config.sh` | OK | Origin, XML/binary, mismatch, no-`plutil` fixture 통과 |
+| `shellcheck -e SC2054` 관련 helper | OK | 신규 진단 없음 |
+| `xcodegen generate` | OK | `Alhangeul.xcodeproj` 재생성, tracked diff 없음 |
+| unsigned Release HostApp build | OK | `** BUILD SUCCEEDED **` |
+| 실제 Release app `--release-app` | OK | Built endpoint exact-match 통과 |
+| `check-no-appkit`, core build info, studio assets | OK | 세 검증 모두 통과 |
+| `release.sh --skip-notarize --output build.noindex/task488-stage3-rehearsal 0.1.10` | OK | Universal app, endpoint preflight, DMG 생성·검증·checksum 성공 |
+| 전용 build root `package-release.sh 0.1.10` | OK | Endpoint preflight, universal app, locally signed zip 생성 성공 |
+| Rehearsal DMG checksum | OK | `7a742cc862b7313fe7d74395f686375d4382424f1c7fa1add3c43de92b4d92a0` |
+| Package zip checksum / 압축 검사 | OK | `ec25b6f87599a942687481ba0b119c29f18c5fc184465d031b6118a7b678ac44`, `unzip -tq` 성공 |
+| `git diff --check` | OK | 오류 없음 |
+
+전체 DMG 리허설의 핵심 실행 순서는 다음 출력으로 확인했다.
+
+```text
+INFO: Building Release app
+INFO: Verifying Release analytics endpoint
+Verified Release built endpoint: .../task488-stage3-rehearsal/Alhangeul.app
+INFO: Verifying universal app architectures
+WARN: Skipping codesign verification because this rehearsal build is unsigned.
+WARN: Skipping release signing preflight because this rehearsal build is unsigned.
+INFO: Creating DMG
+...
+hdiutil: verify: checksum of ".../alhangeul-macos-0.1.10-rehearsal.dmg" is VALID
+```
+
+따라서 endpoint gate가 DMG 생성 전에 실제 실행됨을 확인했다. Package helper도 `Verifying Release analytics endpoint` 성공 뒤 universal architecture와 zip checksum을 출력했다.
+
+일반 `shellcheck`는 변경 전부터 있던 `scripts/release.sh:340`의 `SC2054` 경고 1건을 재현했다. 해당 줄은 2026-05-11 도입된 기존 `codesign_developer_id` 배열이며 Stage 3 변경 범위가 아니다. 이 known baseline 규칙만 제외한 네 관련 script 검증은 통과했다.
+
+Local Ruby는 미사용 `ffi-1.13.1` native extension 경고를 출력했지만 모든 Psych/REXML helper가 exit 0으로 완료됐다. Xcode build가 자동 등록한 정확한 direct Release 개발 app/extension 경로는 해제했고, 최종 PlugInKit 조회에는 `build.noindex/task488-stage3-*` 경로가 남지 않았다. 기존 `/Applications`와 사용자 `Applications` 설치본 등록은 변경하지 않았다.
+
+## 잔여 위험
+
+- Public mode의 실제 Developer ID 재서명·공증 submit은 권한 범위 밖이므로 실행하지 않았다. 공통 함수 순서와 unsigned rehearsal로 preflight 위치를 확인했으며 실제 public credential 검증은 release 단계에서 필요하다.
+- Workflow dispatch 자체는 실행하지 않았다. YAML parse, summary 문구와 workflow가 호출하는 공통 `release.sh`의 로컬 end-to-end 리허설로 검증했다.
+- 승인 production origin은 의도적으로 `project.yml`과 verifier에 이중화되어 있다. Host 이전은 자동 동기화 대상이 아니라 명시적 review 대상이다.
+- Current built plist는 XML이지만 future binary 출력은 macOS `plutil`에 의존한다. Stage 2 synthetic binary fixture가 이 경로를 보호한다.
+- 일반 `shellcheck`의 기존 `SC2054` warning은 Task #488 범위에서 수정하지 않았다. 신규 변경 회귀와 무관하지만 전체 lint 무경고를 목표로 한다면 별도 범위 판단이 필요하다.
+
+## 다음 단계 영향
+
+승인된 3개 구현 단계를 모두 완료했다. 다음 단계에서는 Task #488 최종 결과 보고서에 Stage 1의 실제 artifact 계약 측정, Stage 2의 production origin/plist reader 보강, Stage 3의 Release helper 통합과 end-to-end 검증을 합쳐 기록한다.
+
+최종 보고 단계 전까지 다음 작업은 수행하지 않는다.
+
+- `task-final-report`에 따른 최종 보고서 작성
+- 오늘할일 완료 처리
+- 최종 커밋, `publish/task488` push와 PR 생성
+
+## 승인 요청
+
+Stage 3 Release artifact preflight 연결, workflow summary·운영 문서 보강, unsigned DMG와 개발 zip 통합 검증을 완료했다.
+
+Task #488 최종 결과 보고서 작성과 PR 게시 단계 진행 승인을 요청한다.

--- a/mydocs/working/task_m010_488_stage3.md
+++ b/mydocs/working/task_m010_488_stage3.md
@@ -68,7 +68,7 @@ Analytics 계약과 CI/패키징 가이드에는 다음을 기록했다.
 |------|------|-----------|
 | `bash -n scripts/release.sh scripts/package-release.sh` | OK | 구문 오류 없음 |
 | 전체 workflow `Psych.parse_file` | OK | 6개 YAML parse 성공 |
-| `scripts/ci/test-app-execution-endpoint-config.sh` | OK | Origin, XML/binary, mismatch, no-`plutil` fixture 통과 |
+| `scripts/ci/test-app-execution-endpoint-config.sh` | OK | Origin, Debug populated, XML/binary, key/type, mismatch, no-`plutil` fixture 통과 |
 | `shellcheck -e SC2054` 관련 helper | OK | 신규 진단 없음 |
 | `xcodegen generate` | OK | `Alhangeul.xcodeproj` 재생성, tracked diff 없음 |
 | unsigned Release HostApp build | OK | `** BUILD SUCCEEDED **` |

--- a/scripts/ci/test-app-execution-endpoint-config.sh
+++ b/scripts/ci/test-app-execution-endpoint-config.sh
@@ -47,11 +47,12 @@ RUBY
 
 make_xml_fallback_path() {
   local path="$FIXTURE_ROOT/xml-fallback-bin"
+  local ruby_path
   local tool
   local tool_path
 
   mkdir -p "$path"
-  for tool in bash dirname ruby uname; do
+  for tool in bash dirname uname; do
     tool_path="$(command -v "$tool")"
     [[ -n "$tool_path" ]] || {
       echo "error: required fallback fixture tool not found: $tool" >&2
@@ -59,6 +60,12 @@ make_xml_fallback_path() {
     }
     ln -s "$tool_path" "$path/$tool"
   done
+  ruby_path="$(ruby -rrbconfig -e 'print RbConfig.ruby')"
+  [[ -x "$ruby_path" ]] || {
+    echo "error: resolved Ruby interpreter is not executable: $ruby_path" >&2
+    exit 1
+  }
+  ln -s "$ruby_path" "$path/ruby"
   echo "$path"
 }
 
@@ -138,6 +145,12 @@ expect_failure \
 debug_xml_app="$(make_built_app debug-xml "")"
 "$VERIFIER" --root "$REPO_ROOT" --debug-app "$debug_xml_app"
 
+debug_populated_xml_app="$(make_built_app debug-populated-xml "$PRODUCTION_ENDPOINT")"
+expect_failure \
+  debug-populated-xml \
+  "Debug built endpoint must be empty" \
+  "$VERIFIER" --root "$REPO_ROOT" --debug-app "$debug_populated_xml_app"
+
 release_xml_app="$(make_built_app release-xml "$PRODUCTION_ENDPOINT")"
 "$VERIFIER" --root "$REPO_ROOT" --release-app "$release_xml_app"
 
@@ -153,6 +166,32 @@ env PATH="$xml_fallback_path" \
 echo "Verified XML built endpoint fallback without plutil."
 
 if command -v plutil >/dev/null 2>&1; then
+  missing_key_app="$(make_built_app missing-key "$PRODUCTION_ENDPOINT")"
+  plutil -remove AlhangeulAppExecutionEndpoint \
+    "$missing_key_app/Contents/Info.plist"
+  expect_failure \
+    missing-key \
+    "endpoint key is missing" \
+    "$VERIFIER" --root "$REPO_ROOT" --release-app "$missing_key_app"
+  expect_failure \
+    missing-key-xml-fallback \
+    "endpoint key is missing" \
+    env PATH="$xml_fallback_path" \
+    "$VERIFIER" --root "$REPO_ROOT" --release-app "$missing_key_app"
+
+  non_string_app="$(make_built_app non-string "$PRODUCTION_ENDPOINT")"
+  plutil -replace AlhangeulAppExecutionEndpoint -bool true \
+    "$non_string_app/Contents/Info.plist"
+  expect_failure \
+    non-string \
+    "endpoint value is not a string" \
+    "$VERIFIER" --root "$REPO_ROOT" --release-app "$non_string_app"
+  expect_failure \
+    non-string-xml-fallback \
+    "endpoint value is not a string" \
+    env PATH="$xml_fallback_path" \
+    "$VERIFIER" --root "$REPO_ROOT" --release-app "$non_string_app"
+
   debug_binary_app="$(make_built_app debug-binary "")"
   plutil -convert binary1 "$debug_binary_app/Contents/Info.plist"
   "$VERIFIER" --root "$REPO_ROOT" --debug-app "$debug_binary_app"

--- a/scripts/ci/test-app-execution-endpoint-config.sh
+++ b/scripts/ci/test-app-execution-endpoint-config.sh
@@ -6,6 +6,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 VERIFIER="$SCRIPT_DIR/verify-app-execution-endpoint-config.sh"
 FIXTURE_ROOT="$(mktemp -d)"
+PRODUCTION_ENDPOINT="https://alhangeul-install-events.postmelee.workers.dev/v1/install-events"
+ALTERNATE_ORIGIN_ENDPOINT="https://collector.example/v1/install-events"
+MISMATCH_ENDPOINT="https://alhangeul-install-events.postmelee.workers.dev/v1/other-events"
 
 cleanup() {
   rm -rf "$FIXTURE_ROOT"
@@ -19,6 +22,43 @@ make_fixture() {
   mkdir -p "$path/Sources/HostApp"
   cp "$REPO_ROOT/project.yml" "$path/project.yml"
   cp "$REPO_ROOT/Sources/HostApp/Info.plist" "$path/Sources/HostApp/Info.plist"
+  echo "$path"
+}
+
+make_built_app() {
+  local name="$1"
+  local endpoint="$2"
+  local app_path="$FIXTURE_ROOT/$name/Alhangeul.app"
+  local plist_path="$app_path/Contents/Info.plist"
+
+  mkdir -p "$app_path/Contents"
+  ruby - \
+    "$REPO_ROOT/Sources/HostApp/Info.plist" \
+    "$plist_path" \
+    "$endpoint" <<'RUBY'
+source_path, output_path, endpoint = ARGV
+placeholder = "$(ALHANGEUL_APP_EXECUTION_ENDPOINT)"
+contents = File.read(source_path)
+abort "source plist placeholder not found" unless contents.include?(placeholder)
+File.write(output_path, contents.sub(placeholder, endpoint))
+RUBY
+  echo "$app_path"
+}
+
+make_xml_fallback_path() {
+  local path="$FIXTURE_ROOT/xml-fallback-bin"
+  local tool
+  local tool_path
+
+  mkdir -p "$path"
+  for tool in bash dirname ruby uname; do
+    tool_path="$(command -v "$tool")"
+    [[ -n "$tool_path" ]] || {
+      echo "error: required fallback fixture tool not found: $tool" >&2
+      exit 1
+    }
+    ln -s "$tool_path" "$path/$tool"
+  done
   echo "$path"
 }
 
@@ -37,11 +77,11 @@ RUBY
 
 expect_failure() {
   local name="$1"
-  local root="$2"
-  local expected="$3"
+  local expected="$2"
   local output="$FIXTURE_ROOT/$name.output"
+  shift 2
 
-  if "$VERIFIER" --root "$root" >"$output" 2>&1; then
+  if "$@" >"$output" 2>&1; then
     echo "error: fixture unexpectedly passed: $name" >&2
     exit 1
   fi
@@ -62,27 +102,70 @@ replace_once \
   'ALHANGEUL_APP_EXECUTION_ENDPOINT: https://debug.example/v1/install-events'
 expect_failure \
   invalid-base \
-  "$invalid_base" \
-  "HostApp base ALHANGEUL_APP_EXECUTION_ENDPOINT must be an empty string"
+  "HostApp base ALHANGEUL_APP_EXECUTION_ENDPOINT must be an empty string" \
+  "$VERIFIER" --root "$invalid_base"
 
 invalid_release="$(make_fixture invalid-release)"
 replace_once \
   "$invalid_release/project.yml" \
-  'https://alhangeul-install-events.postmelee.workers.dev/v1/install-events' \
+  "$PRODUCTION_ENDPOINT" \
   'http://collector.example/v1/install-events'
 expect_failure \
   invalid-release \
-  "$invalid_release" \
-  "HostApp Release endpoint must be an absolute HTTPS URL"
+  "HostApp Release endpoint must be an absolute HTTPS URL" \
+  "$VERIFIER" --root "$invalid_release"
+
+invalid_origin="$(make_fixture invalid-origin)"
+replace_once \
+  "$invalid_origin/project.yml" \
+  "$PRODUCTION_ENDPOINT" \
+  "$ALTERNATE_ORIGIN_ENDPOINT"
+expect_failure \
+  invalid-origin \
+  "HostApp Release endpoint origin must be https://alhangeul-install-events.postmelee.workers.dev" \
+  "$VERIFIER" --root "$invalid_origin"
 
 invalid_plist="$(make_fixture invalid-plist)"
 replace_once \
   "$invalid_plist/Sources/HostApp/Info.plist" \
   "\$(ALHANGEUL_APP_EXECUTION_ENDPOINT)" \
-  'https://collector.example/v1/install-events'
+  "$ALTERNATE_ORIGIN_ENDPOINT"
 expect_failure \
   invalid-plist \
-  "$invalid_plist" \
-  "source plist AlhangeulAppExecutionEndpoint must reference \$(ALHANGEUL_APP_EXECUTION_ENDPOINT)"
+  "source plist AlhangeulAppExecutionEndpoint must reference \$(ALHANGEUL_APP_EXECUTION_ENDPOINT)" \
+  "$VERIFIER" --root "$invalid_plist"
+
+debug_xml_app="$(make_built_app debug-xml "")"
+"$VERIFIER" --root "$REPO_ROOT" --debug-app "$debug_xml_app"
+
+release_xml_app="$(make_built_app release-xml "$PRODUCTION_ENDPOINT")"
+"$VERIFIER" --root "$REPO_ROOT" --release-app "$release_xml_app"
+
+mismatch_xml_app="$(make_built_app release-mismatch-xml "$MISMATCH_ENDPOINT")"
+expect_failure \
+  release-mismatch-xml \
+  "Release built endpoint does not match project.yml" \
+  "$VERIFIER" --root "$REPO_ROOT" --release-app "$mismatch_xml_app"
+
+xml_fallback_path="$(make_xml_fallback_path)"
+env PATH="$xml_fallback_path" \
+  "$VERIFIER" --root "$REPO_ROOT" --release-app "$release_xml_app"
+echo "Verified XML built endpoint fallback without plutil."
+
+if command -v plutil >/dev/null 2>&1; then
+  debug_binary_app="$(make_built_app debug-binary "")"
+  plutil -convert binary1 "$debug_binary_app/Contents/Info.plist"
+  "$VERIFIER" --root "$REPO_ROOT" --debug-app "$debug_binary_app"
+
+  release_binary_app="$(make_built_app release-binary "$PRODUCTION_ENDPOINT")"
+  plutil -convert binary1 "$release_binary_app/Contents/Info.plist"
+  "$VERIFIER" --root "$REPO_ROOT" --release-app "$release_binary_app"
+
+  expect_failure \
+    release-binary-without-plutil \
+    "plutil is required to read binary built Info.plist" \
+    env PATH="$xml_fallback_path" \
+    "$VERIFIER" --root "$REPO_ROOT" --release-app "$release_binary_app"
+fi
 
 echo "Analytics endpoint configuration fixtures passed."

--- a/scripts/ci/verify-app-execution-endpoint-config.sh
+++ b/scripts/ci/verify-app-execution-endpoint-config.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 DEBUG_APP=""
 RELEASE_APP=""
+EXPECTED_PRODUCTION_ORIGIN="https://alhangeul-install-events.postmelee.workers.dev"
 
 usage() {
   cat <<'USAGE'
@@ -61,12 +62,12 @@ SOURCE_PLIST="$REPO_ROOT/Sources/HostApp/Info.plist"
 [[ -f "$SOURCE_PLIST" ]] || fail "missing HostApp Info.plist: $SOURCE_PLIST"
 command -v ruby >/dev/null 2>&1 || fail "ruby is required"
 
-release_endpoint="$(ruby - "$PROJECT_FILE" "$SOURCE_PLIST" <<'RUBY'
+release_endpoint="$(ruby - "$PROJECT_FILE" "$SOURCE_PLIST" "$EXPECTED_PRODUCTION_ORIGIN" <<'RUBY'
 require "psych"
 require "rexml/document"
 require "uri"
 
-project_path, plist_path = ARGV
+project_path, plist_path, expected_origin_value = ARGV
 setting_name = "ALHANGEUL_APP_EXECUTION_ENDPOINT"
 plist_key = "AlhangeulAppExecutionEndpoint"
 placeholder = "$(#{setting_name})"
@@ -74,6 +75,30 @@ placeholder = "$(#{setting_name})"
 def abort_check(message)
   warn "error: #{message}"
   exit 1
+end
+
+def normalized_origin(uri)
+  [uri.scheme.downcase, uri.host.downcase, uri.port]
+end
+
+def origin_label(uri)
+  port = uri.port == 443 ? "" : ":#{uri.port}"
+  "#{uri.scheme.downcase}://#{uri.host.downcase}#{port}"
+end
+
+begin
+  expected_origin = URI.parse(expected_origin_value)
+rescue URI::InvalidURIError => error
+  abort_check("expected production origin is invalid: #{error.message}")
+end
+unless expected_origin.is_a?(URI::HTTPS) && expected_origin.host && !expected_origin.host.empty?
+  abort_check("expected production origin must be an absolute HTTPS origin")
+end
+unless expected_origin.userinfo.nil? && expected_origin.query.nil? && expected_origin.fragment.nil?
+  abort_check("expected production origin must not contain credentials, query, or fragment")
+end
+unless expected_origin.path.nil? || expected_origin.path.empty? || expected_origin.path == "/"
+  abort_check("expected production origin must not contain a path")
 end
 
 begin
@@ -120,6 +145,11 @@ end
 if uri.userinfo || uri.query || uri.fragment
   abort_check("HostApp Release endpoint must not contain credentials, query, or fragment")
 end
+unless normalized_origin(uri) == normalized_origin(expected_origin)
+  abort_check(
+    "HostApp Release endpoint origin must be #{origin_label(expected_origin)}, got: #{origin_label(uri)}"
+  )
+end
 
 begin
   document = REXML::Document.new(File.read(plist_path))
@@ -154,20 +184,38 @@ read_built_endpoint() {
     return
   fi
 
+  # Xcode currently preserves the tracked XML plist because
+  # INFOPLIST_OUTPUT_FORMAT is same-as-input. Keep a portable XML-only reader,
+  # but never pretend that REXML can decode a binary plist without plutil.
   ruby - "$plist_path" <<'RUBY'
 require "rexml/document"
 
-document = REXML::Document.new(File.read(ARGV.fetch(0)))
+def abort_check(message)
+  warn "error: #{message}"
+  exit 1
+end
+
+plist_path = ARGV.fetch(0)
+contents = File.binread(plist_path)
+if contents.start_with?("bplist")
+  abort_check("plutil is required to read binary built Info.plist: #{plist_path}")
+end
+
+begin
+  document = REXML::Document.new(contents)
+rescue StandardError => error
+  abort_check("cannot parse XML built Info.plist without plutil: #{error.message}")
+end
 elements = document.elements.to_a("plist/dict/*")
 elements.each_with_index do |element, index|
   next unless element.name == "key" && element.text == "AlhangeulAppExecutionEndpoint"
 
   value_element = elements[index + 1]
-  abort "endpoint value is not a string" unless value_element&.name == "string"
+  abort_check("endpoint value is not a string") unless value_element&.name == "string"
   print value_element.text.to_s
   exit 0
 end
-abort "endpoint key is missing"
+abort_check("endpoint key is missing")
 RUBY
 }
 

--- a/scripts/ci/verify-app-execution-endpoint-config.sh
+++ b/scripts/ci/verify-app-execution-endpoint-config.sh
@@ -176,11 +176,19 @@ RUBY
 
 read_built_endpoint() {
   local app_path="$1"
+  local endpoint_type
   local plist_path="$app_path/Contents/Info.plist"
 
   [[ -f "$plist_path" ]] || fail "missing built Info.plist: $plist_path"
   if command -v plutil >/dev/null 2>&1; then
-    plutil -extract AlhangeulAppExecutionEndpoint raw -o - "$plist_path"
+    plutil -lint "$plist_path" >/dev/null 2>&1 || \
+      fail "cannot parse built Info.plist: $plist_path"
+    endpoint_type="$(
+      plutil -type AlhangeulAppExecutionEndpoint "$plist_path" 2>/dev/null
+    )" || fail "endpoint key is missing: $plist_path"
+    [[ "$endpoint_type" == "string" ]] || \
+      fail "endpoint value is not a string: $plist_path"
+    plutil -extract AlhangeulAppExecutionEndpoint raw -expect string -o - "$plist_path"
     return
   fi
 

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -50,6 +50,9 @@ rm -rf "${BUILD_DIR:?}/$APP_NAME"
 # Keep the filesystem bundle name ASCII. Localized user-facing names are provided
 # by Info.plist; a non-ASCII .app path can break ExtensionKit lookup.
 ditto "$XCODE_BUILD_DIR/$BUILD_APP_NAME" "$BUILD_DIR/$APP_NAME"
+echo "Verifying Release analytics endpoint"
+"$ROOT/scripts/ci/verify-app-execution-endpoint-config.sh" \
+  --release-app "$BUILD_DIR/$APP_NAME"
 "$ROOT/scripts/ci/verify-universal-macos-app.sh" "$BUILD_DIR/$APP_NAME"
 if [ -x "$LSREGISTER" ]; then
   "$LSREGISTER" -u "$XCODE_BUILD_DIR/$BUILD_APP_NAME" >/dev/null 2>&1 || true

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -231,6 +231,7 @@ run_preflight() {
     spctl
     shasum
     plutil
+    ruby
     sed
     security
     swift
@@ -323,6 +324,12 @@ build_app() {
   # Keep the filesystem bundle name ASCII. Localized user-facing names are
   # provided by Info.plist; a non-ASCII .app path can break ExtensionKit lookup.
   ditto "$XCODE_BUILD_DIR/$BUILD_APP_NAME" "$APP_OUTPUT"
+}
+
+verify_app_execution_endpoint() {
+  info "Verifying Release analytics endpoint"
+  "$ROOT/scripts/ci/verify-app-execution-endpoint-config.sh" \
+    --release-app "$APP_OUTPUT"
 }
 
 codesign_developer_id() {
@@ -854,6 +861,7 @@ main() {
   check_shared_code
   generate_project
   build_app
+  verify_app_execution_endpoint
   sign_release_app_for_notarization
   verify_universal_app
   verify_app_signature


### PR DESCRIPTION
## 요약

- 대상 타스크: #488 분석 endpoint 검증 gate 보강
- 왜: 유효한 HTTPS URL이면 승인되지 않은 다른 host도 source gate를 통과했고, built Release endpoint verifier가 실제 release artifact 경로에서 호출되지 않았습니다.
- 무엇: Production origin 고정, XML/binary plist fixture, `release.sh`·`package-release.sh`의 copied app blocking preflight와 운영 문서를 추가했습니다.
- PR 리뷰 보정: macOS fixture를 `run_release_checks` job으로 이동하고 Debug populated·key 누락·non-string 음성 fixture, 실제 Ruby interpreter 해석과 일관된 plist 진단을 추가했습니다.
- 리뷰 포인트: `project.yml` 전체 URL과 별도 origin guard의 책임, build 이후 재서명·공증·DMG/zip 이전 검증 순서를 먼저 확인해 주세요.

## PR base

- base: `devel`

## 변경 내역

- **[Stage 1](https://github.com/postmelee/alhangeul-macos/blob/831b4c7789bf6dc717f9f9ee9f8b0502da647e12/mydocs/working/task_m010_488_stage1.md)** ([bc4595f](https://github.com/postmelee/alhangeul-macos/commit/bc4595ffafea10ec90550a5788091b61dec248ad)): HTTPS origin 우회, release helper 미연결 상태와 current XML plist 계약을 재현했습니다.
- **[Stage 2](https://github.com/postmelee/alhangeul-macos/blob/831b4c7789bf6dc717f9f9ee9f8b0502da647e12/mydocs/working/task_m010_488_stage2.md)** ([5667fad](https://github.com/postmelee/alhangeul-macos/commit/5667fad3397e52d808934404e9c99edc706ed9f9)): 승인 production origin, XML-only fallback·binary `plutil` 경계와 portable/macOS fixture를 구현했습니다.
- **[Stage 3](https://github.com/postmelee/alhangeul-macos/blob/831b4c7789bf6dc717f9f9ee9f8b0502da647e12/mydocs/working/task_m010_488_stage3.md)** ([5ec80c1](https://github.com/postmelee/alhangeul-macos/commit/5ec80c1dce707a45aad7940f2944a95566b9791d)): Release helper gate, workflow summary·운영 문서와 unsigned DMG/개발 zip 통합 검증을 완료했습니다.
- **PR 리뷰 보정** ([831b4c7](https://github.com/postmelee/alhangeul-macos/commit/831b4c7789bf6dc717f9f9ee9f8b0502da647e12)): macOS fixture 실행 조건, 음성 fixture, plist 진단, Ruby 경로와 패키징 문서 순서를 보정했습니다.

| 영역 | 변경 | 리뷰 포인트 |
|------|------|-------------|
| Endpoint verifier | 승인 origin 비교, exact built value, XML/binary reader와 key/type 진단 보강 | Host 이전이 명시적 multi-file review를 요구하는지 |
| Fixture / PR CI | Invalid origin, Debug populated, key/type와 XML/binary/no-`plutil` fixture, macOS `release-checks` 연결 | `run_macos_build=false`인 script-only PR에서도 macOS 분기가 실행되는지 |
| Release helpers | Copied app을 `--release-app`으로 검증 | `build → copy → endpoint → universal/signing/notarization/DMG·zip` 순서인지 |
| Workflow / 운영 문서 | 공통 helper 계약을 summary와 가이드에 기록 | Workflow별 중복 명령 없이 실제 helper 동작과 일치하는지 |

- 수행 계획서: [task_m010_488.md](https://github.com/postmelee/alhangeul-macos/blob/831b4c7789bf6dc717f9f9ee9f8b0502da647e12/mydocs/plans/task_m010_488.md)
- 구현 계획서: [task_m010_488_impl.md](https://github.com/postmelee/alhangeul-macos/blob/831b4c7789bf6dc717f9f9ee9f8b0502da647e12/mydocs/plans/task_m010_488_impl.md)
- 최종 보고서: [task_m010_488_report.md](https://github.com/postmelee/alhangeul-macos/blob/831b4c7789bf6dc717f9f9ee9f8b0502da647e12/mydocs/report/task_m010_488_report.md)

## 핵심 리뷰 포인트

- `project.yml`은 전체 endpoint의 단일 편집 원본이고 verifier의 `EXPECTED_PRODUCTION_ORIGIN`은 destination 변경을 자동 통과시키지 않는 별도 review gate입니다.
- `release.sh`는 copied `APP_OUTPUT`을 post-build Developer ID 재서명·공증·DMG 전에 검증하고, `package-release.sh`도 zip 생성 전에 같은 verifier를 사용합니다.
- Ubuntu `script-checks`는 portable XML 분기를, macOS `release-checks`는 `plutil` binary·key/type 분기를 검증합니다. 실제 HostApp Debug 산출물 gate는 기존 `macos-validation`에 유지됩니다.
- 제한 PATH fixture는 `RbConfig.ruby`로 실제 interpreter를 연결하고 `uname`을 유지합니다.

## 검증

- `bash -n` release/package/verifier/test helper: OK
- Verifier/test helper `shellcheck`: OK
- 전체 6개 workflow `Psych.parse_file`: OK
- `scripts/ci/test-app-execution-endpoint-config.sh`: OK
  - Debug populated 실패
  - key 누락·non-string 값의 `plutil`/XML fallback 동일 진단
  - XML/binary 정상 및 no-`plutil` 경계
- `scripts/ci/classify-pr-changes.sh origin/devel HEAD`: `run_macos_build=false`, `run_release_checks=true`
- `xcodegen generate`: OK, tracked project diff 없음
- Unsigned HostApp Release build: OK (`** BUILD SUCCEEDED **`)
- 실제 built Release app `--release-app`: OK
- `scripts/check-no-appkit.sh`: OK
- `scripts/verify-rhwp-core-build-info.sh`: OK
- `scripts/verify-rhwp-studio-assets.sh`: OK
- `release.sh --skip-notarize --output build.noindex/task488-stage3-rehearsal 0.1.10`: endpoint → signing skip → DMG 순서와 `hdiutil verify` OK
- 전용 `ALHANGEUL_BUILD_ROOT`의 `package-release.sh 0.1.10`: endpoint → universal → zip/checksum 및 `unzip -tq` OK
- Task 전용 개발 app/extension 등록 잔여 없음, `git diff --check`: OK

## 관련 이슈

- #479: Release-only endpoint 설정 분리의 선행 작업

## 후속 이슈 제안

- 없음. Public signing/notarization은 기존 release gate에서 검증하고, host 이전은 이 PR이 문서화한 동시 변경 계약으로 처리합니다.

## 남은 리스크

- 실제 Developer ID 재서명·notarization submit과 GitHub Actions workflow dispatch는 이번 권한 범위에서 실행하지 않았습니다.
- 승인 origin은 의도적으로 `project.yml`과 verifier에 이중화되어 있어 host 이전 시 두 값과 fixture·문서를 함께 변경해야 합니다.
- `scripts/release.sh`의 기존 `shellcheck SC2054` warning 1건은 이번 변경 줄과 무관해 범위에서 제외했습니다.

Closes #488
