### PR TITLE
Task #470: known render node 오류 진단과 core index 타입 보정

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,6 @@ Workflow and verification:
 - PRs normally target `devel`; native shell, Skia viewport, and Swift editing work targets `native-viewer-editor`. Retired `devel-webview` is not a PR target. Maintainer PR heads use `publish/taskN` with a GitHub Issue and Korean `mydocs/` task docs.
 - PR descriptions should use `.github/pull_request_template.md`, separate target task from related context, link each Stage summary to its report and commit, and list only verification actually run.
 - For `mydocs/plans/**`, `mydocs/working/**`, and `mydocs/report/**`, apply `.github/instructions/hyperfall-documents.instructions.md`; use this file for branch, build, architecture, and release-risk checks.
-- When a change touches RustBridge, core dependency, FFI, or generated bridge artifacts, expect `./scripts/build-rust-macos.sh` or `--verify-lock`, `./scripts/check-no-appkit.sh`, `xcodegen generate`, and HostApp `xcodebuild` as applicable.
+- When a change touches RustBridge, core dependency, FFI, or generated bridge artifacts, expect `./scripts/build-rust-macos.sh` or `--verify-portable`, `./scripts/check-no-appkit.sh`, `xcodegen generate`, and HostApp `xcodebuild` as applicable.
 - When rendering behavior changes, expect `./scripts/validate-stage3-render.sh`; for visual differences or renderer bug fixes, expect `./scripts/render-debug-compare.sh` on relevant samples.
 - Do not request release, signing, notarization, or Homebrew Cask work unless the PR is explicitly about distribution.

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -93,6 +93,10 @@ jobs:
           bash scripts/verify-rhwp-core-build-info.sh --help
           bash scripts/verify-rhwp-studio-assets.sh --help
 
+      - name: Check Rust verification mode fixtures
+        shell: bash
+        run: python3 scripts/ci/test-rust-verification-modes.py
+
       - name: Check core build info helper fixtures
         shell: bash
         run: |
@@ -144,9 +148,6 @@ jobs:
     timeout-minutes: 120
     needs: classify-changes
     if: ${{ needs.classify-changes.outputs.run_macos_build == 'true' }}
-    env:
-      ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY: "1"
-
     steps:
       - name: Check out repository
         uses: actions/checkout@v6
@@ -178,8 +179,8 @@ jobs:
             echo "## Rust bridge lock policy"
             echo
             echo "- run_rust_verify: \`${{ needs.classify-changes.outputs.run_rust_verify }}\`"
-            echo "- ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY: \`${ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY:-0}\`"
-            echo "- When lock verification runs with this skip flag, only \`Frameworks/universal/librhwp.a\` byte hash/size comparison is skipped."
+            echo "- verification mode: portable (explicit --verify-portable)"
+            echo "- Portable mode excludes only staticlib byte hash/size comparison; reference metadata remains required."
             echo "- Source provenance, Cargo lock, generated header, and FFI symbol checks still run."
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -189,7 +190,7 @@ jobs:
           set -euo pipefail
           rustup target add aarch64-apple-darwin x86_64-apple-darwin
           if [ "${{ needs.classify-changes.outputs.run_rust_verify }}" = "true" ]; then
-            ./scripts/build-rust-macos.sh --verify-lock
+            ./scripts/build-rust-macos.sh --verify-portable
           else
             ./scripts/build-rust-macos.sh
           fi

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -64,7 +64,6 @@ jobs:
       PRERELEASE: ${{ inputs.prerelease }}
       GH_TOKEN: ${{ github.token }}
       ALHANGEUL_BUILD_ROOT: ${{ github.workspace }}/build.noindex
-      ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY: "1"
       ALHANGEUL_DEVELOPER_ID_APPLICATION: ${{ vars.ALHANGEUL_DEVELOPER_ID_APPLICATION }}
       ALHANGEUL_DEVELOPER_ID_DMG: ${{ vars.ALHANGEUL_DEVELOPER_ID_DMG }}
       ALHANGEUL_NOTARY_PROFILE: ${{ vars.ALHANGEUL_NOTARY_PROFILE }}
@@ -295,10 +294,10 @@ jobs:
           {
             echo "## Rust bridge lock policy"
             echo
-            echo "- lock command: \`./scripts/build-rust-macos.sh --verify-lock\`"
+            echo "- lock command: \`./scripts/build-rust-macos.sh --verify-portable\`"
             echo "- build info command: \`./scripts/verify-rhwp-core-build-info.sh\`"
-            echo "- ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY: \`${ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY:-0}\`"
-            echo "- With this release workflow setting, only \`Frameworks/universal/librhwp.a\` byte hash/size comparison is skipped."
+            echo "- verification mode: portable (explicit --verify-portable)"
+            echo "- Portable mode excludes only staticlib byte hash/size comparison; reference metadata remains required."
             echo "- Source provenance, Cargo lock, generated header, and FFI symbol checks still run."
             echo "- Swift core build info must match the locked release baseline, commit, and enabled features."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -321,7 +320,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ./scripts/build-rust-macos.sh --verify-lock
+          ./scripts/build-rust-macos.sh --verify-portable
           ./scripts/verify-rhwp-core-build-info.sh
 
       - name: Build signed and notarized DMG

--- a/.github/workflows/release-rehearsal.yml
+++ b/.github/workflows/release-rehearsal.yml
@@ -36,7 +36,6 @@ jobs:
       EXPECTED_RHWP_TAG: ${{ inputs.expected_rhwp_tag }}
       GH_TOKEN: ${{ github.token }}
       ALHANGEUL_BUILD_ROOT: ${{ github.workspace }}/build.noindex
-      ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY: "1"
 
     steps:
       - name: Check out repository
@@ -188,10 +187,10 @@ jobs:
           {
             echo "## Rust bridge lock policy"
             echo
-            echo "- lock command: \`./scripts/build-rust-macos.sh --verify-lock\`"
+            echo "- lock command: \`./scripts/build-rust-macos.sh --verify-portable\`"
             echo "- build info command: \`./scripts/verify-rhwp-core-build-info.sh\`"
-            echo "- ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY: \`${ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY:-0}\`"
-            echo "- With this release workflow setting, only \`Frameworks/universal/librhwp.a\` byte hash/size comparison is skipped."
+            echo "- verification mode: portable (explicit --verify-portable)"
+            echo "- Portable mode excludes only staticlib byte hash/size comparison; reference metadata remains required."
             echo "- Source provenance, Cargo lock, generated header, and FFI symbol checks still run."
             echo "- Swift core build info must match the locked release baseline, commit, and enabled features."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -214,7 +213,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          ./scripts/build-rust-macos.sh --verify-lock
+          ./scripts/build-rust-macos.sh --verify-portable
           ./scripts/verify-rhwp-core-build-info.sh
 
       - name: Build rehearsal DMG

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ HWP/HWPX 파일이 한컴 또는 rhwp core와 다르게 렌더링되거나, Find
 공통 체크:
 
 ```bash
-./scripts/build-rust-macos.sh           # Rust bridge 빌드 + lock 검증
+./scripts/build-rust-macos.sh --verify-portable # Rust bridge 빌드 + source/header/FFI 검증
 ./scripts/check-no-appkit.sh            # 공통 계층 AppKit 의존성 검사
 xcodegen generate
 xcodebuild -project Alhangeul.xcodeproj \

--- a/RustBridge/README.md
+++ b/RustBridge/README.md
@@ -31,8 +31,9 @@
 ## 기본 명령
 
 ```bash
-./scripts/build-rust-macos.sh
-./scripts/build-rust-macos.sh --verify-lock
+./scripts/build-rust-macos.sh                   # build-only
+./scripts/build-rust-macos.sh --verify-portable # 일반 source/header/FFI 검증
+./scripts/build-rust-macos.sh --verify-strict   # 기준 환경 staticlib byte까지 비교
 ./scripts/build-rust-macos.sh --update-lock
 ```
 

--- a/Sources/RhwpCoreBridge/RenderTree.swift
+++ b/Sources/RhwpCoreBridge/RenderTree.swift
@@ -46,7 +46,7 @@ struct RenderTreeDecodingFailure: Error, CustomStringConvertible {
     }
 
     var description: String {
-        "render-tree decode failed: variant=\(variant ?? "envelope") path=\(path) cause=\(reason.rawValue)"
+        "render-tree decode failed: variant=\(variant ?? "unresolved") path=\(path) cause=\(reason.rawValue)"
     }
 }
 
@@ -118,84 +118,87 @@ enum RenderNodeType: Decodable {
     case footnoteMarker(FootnoteMarkerNode)
     case unknown
 
-    static let knownVariantNames: Set<String> = [
-        "Page",
-        "PageBackground",
-        "Body",
-        "Column",
-        "TextLine",
-        "TextRun",
-        "Table",
-        "TableCell",
-        "Line",
-        "Rectangle",
-        "Ellipse",
-        "Path",
-        "Image",
-        "Group",
-        "Equation",
-        "FormObject",
-        "Placeholder",
-        "RawSvg",
-        "FootnoteMarker",
-        "MasterPage",
-        "Header",
-        "Footer",
-        "FootnoteArea",
-        "TextBox",
-    ]
+    // Raw tag names and decoder dispatch share one enum; new tags require an exhaustive case.
+    enum KnownVariant: String, CaseIterable {
+        case page = "Page"
+        case pageBackground = "PageBackground"
+        case body = "Body"
+        case column = "Column"
+        case textLine = "TextLine"
+        case textRun = "TextRun"
+        case table = "Table"
+        case tableCell = "TableCell"
+        case line = "Line"
+        case rectangle = "Rectangle"
+        case ellipse = "Ellipse"
+        case path = "Path"
+        case image = "Image"
+        case group = "Group"
+        case equation = "Equation"
+        case formObject = "FormObject"
+        case placeholder = "Placeholder"
+        case rawSvg = "RawSvg"
+        case footnoteMarker = "FootnoteMarker"
+        case masterPage = "MasterPage"
+        case header = "Header"
+        case footer = "Footer"
+        case footnoteArea = "FootnoteArea"
+        case textBox = "TextBox"
+    }
+    static let knownVariantNames = Set(KnownVariant.allCases.map(\.rawValue))
 
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
         if let name = try? container.decode(String.self) {
-            switch name {
-            case "MasterPage": self = .masterPage
-            case "Header": self = .header
-            case "Footer": self = .footer
-            case "FootnoteArea": self = .footnoteArea
-            case "TextBox": self = .textBox
-            default:
-                guard !Self.knownVariantNames.contains(name) else {
-                    throw RenderTreeDecodingFailure(variant: name, codingPath: decoder.codingPath,
-                                                    reason: .invalidVariantShape)
-                }
+            guard let tag = KnownVariant(rawValue: name) else {
                 self = .unknown
+                return
+            }
+            switch tag {
+            case .masterPage: self = .masterPage
+            case .header: self = .header
+            case .footer: self = .footer
+            case .footnoteArea: self = .footnoteArea
+            case .textBox: self = .textBox
+            default:
+                throw RenderTreeDecodingFailure(variant: name, codingPath: decoder.codingPath,
+                                                reason: .invalidVariantShape)
             }
             return
         }
         let keyed = try decoder.container(keyedBy: DynamicKey.self)
         guard keyed.allKeys.count == 1, let key = keyed.allKeys.first else {
-            let known = keyed.allKeys.map(\.stringValue).filter(Self.knownVariantNames.contains).sorted().first
-            throw RenderTreeDecodingFailure(variant: known, codingPath: decoder.codingPath,
+            throw RenderTreeDecodingFailure(variant: nil, codingPath: decoder.codingPath,
                                             reason: .invalidVariantShape)
         }
+        guard let tag = KnownVariant(rawValue: key.stringValue) else {
+            self = .unknown
+            return
+        }
         do {
-            switch key.stringValue {
-            case "Page": self = .page(try keyed.decode(PageNode.self, forKey: key))
-            case "PageBackground": self = .pageBackground(try keyed.decode(PageBackgroundNode.self, forKey: key))
-            case "Body": self = .body(try keyed.decode(BodyNode.self, forKey: key))
-            case "Column": self = .column(try keyed.decode(UInt16.self, forKey: key))
-            case "TextLine": self = .textLine(try keyed.decode(TextLineNode.self, forKey: key))
-            case "TextRun": self = .textRun(try keyed.decode(TextRunNode.self, forKey: key))
-            case "Table": self = .table(try keyed.decode(TableNode.self, forKey: key))
-            case "TableCell": self = .tableCell(try keyed.decode(TableCellNode.self, forKey: key))
-            case "Line": self = .line(try keyed.decode(LineNode.self, forKey: key))
-            case "Rectangle": self = .rectangle(try keyed.decode(RectangleNode.self, forKey: key))
-            case "Ellipse": self = .ellipse(try keyed.decode(EllipseNode.self, forKey: key))
-            case "Path": self = .path(try keyed.decode(PathNode.self, forKey: key))
-            case "Image": self = .image(try keyed.decode(ImageNode.self, forKey: key))
-            case "Group": self = .group(try keyed.decode(GroupNode.self, forKey: key))
-            case "Equation": self = .equation(try keyed.decode(EquationNode.self, forKey: key))
-            case "FormObject": self = .formObject(try keyed.decode(FormObjectNode.self, forKey: key))
-            case "Placeholder": self = .placeholder(try keyed.decode(PlaceholderNode.self, forKey: key))
-            case "RawSvg": self = .rawSvg(try keyed.decode(RawSvgNode.self, forKey: key))
-            case "FootnoteMarker": self = .footnoteMarker(try keyed.decode(FootnoteMarkerNode.self, forKey: key))
-            default:
-                guard !Self.knownVariantNames.contains(key.stringValue) else {
-                    throw RenderTreeDecodingFailure(variant: key.stringValue, codingPath: decoder.codingPath,
-                                                    reason: .invalidVariantShape)
-                }
-                self = .unknown
+            switch tag {
+            case .page: self = .page(try keyed.decode(PageNode.self, forKey: key))
+            case .pageBackground: self = .pageBackground(try keyed.decode(PageBackgroundNode.self, forKey: key))
+            case .body: self = .body(try keyed.decode(BodyNode.self, forKey: key))
+            case .column: self = .column(try keyed.decode(UInt16.self, forKey: key))
+            case .textLine: self = .textLine(try keyed.decode(TextLineNode.self, forKey: key))
+            case .textRun: self = .textRun(try keyed.decode(TextRunNode.self, forKey: key))
+            case .table: self = .table(try keyed.decode(TableNode.self, forKey: key))
+            case .tableCell: self = .tableCell(try keyed.decode(TableCellNode.self, forKey: key))
+            case .line: self = .line(try keyed.decode(LineNode.self, forKey: key))
+            case .rectangle: self = .rectangle(try keyed.decode(RectangleNode.self, forKey: key))
+            case .ellipse: self = .ellipse(try keyed.decode(EllipseNode.self, forKey: key))
+            case .path: self = .path(try keyed.decode(PathNode.self, forKey: key))
+            case .image: self = .image(try keyed.decode(ImageNode.self, forKey: key))
+            case .group: self = .group(try keyed.decode(GroupNode.self, forKey: key))
+            case .equation: self = .equation(try keyed.decode(EquationNode.self, forKey: key))
+            case .formObject: self = .formObject(try keyed.decode(FormObjectNode.self, forKey: key))
+            case .placeholder: self = .placeholder(try keyed.decode(PlaceholderNode.self, forKey: key))
+            case .rawSvg: self = .rawSvg(try keyed.decode(RawSvgNode.self, forKey: key))
+            case .footnoteMarker: self = .footnoteMarker(try keyed.decode(FootnoteMarkerNode.self, forKey: key))
+            case .masterPage, .header, .footer, .footnoteArea, .textBox:
+                throw RenderTreeDecodingFailure(variant: key.stringValue, codingPath: decoder.codingPath,
+                                                reason: .invalidVariantShape)
             }
         } catch let failure as RenderTreeDecodingFailure {
             throw failure
@@ -783,7 +786,7 @@ struct CharOverlapInfo: Decodable {
 }
 
 struct CellContext: Decodable {
-    let parentParaIndex: Int
+    let parentParaIndex: UInt
     let path: [CellPathEntry]
 
     enum CodingKeys: String, CodingKey {
@@ -794,8 +797,8 @@ struct CellContext: Decodable {
 
 struct CellPathEntry: Decodable {
     let controlIndex: UInt
-    let cellIndex: Int
-    let cellParaIndex: Int
+    let cellIndex: UInt
+    let cellParaIndex: UInt
     let textDirection: UInt8
 
     enum CodingKeys: String, CodingKey {

--- a/Sources/RhwpCoreBridge/RenderTree.swift
+++ b/Sources/RhwpCoreBridge/RenderTree.swift
@@ -6,6 +6,62 @@
 
 import Foundation
 
+// 오류에는 schema 위치와 분류만 보존한다. 문서 값이나 Foundation의
+// debugDescription/underlyingError는 저장·출력하지 않는다.
+struct RenderTreeDecodingFailure: Error, CustomStringConvertible {
+    enum Reason: String {
+        case keyNotFound, typeMismatch, valueNotFound, dataCorrupted, invalidVariantShape
+    }
+
+    let variant: String?
+    let path: String
+    let reason: Reason
+
+    init(variant: String?, codingPath: [CodingKey], reason: Reason) {
+        self.variant = variant.flatMap { RenderNodeType.knownVariantNames.contains($0) ? $0 : nil }
+        self.path = "$" + codingPath.map { key in
+            if let index = key.intValue { return "[\(index)]" }
+            // DynamicKey comes from enum tags; arbitrary future names must not enter diagnostics.
+            if key is DynamicKey && !RenderNodeType.knownVariantNames.contains(key.stringValue) {
+                return ".<tag>"
+            }
+            return "." + key.stringValue
+        }.joined()
+        self.reason = reason
+    }
+
+    init(_ error: Error, variant: String? = nil) {
+        switch error {
+        case DecodingError.keyNotFound(let key, let context):
+            self.init(variant: variant, codingPath: context.codingPath + [key], reason: .keyNotFound)
+        case DecodingError.typeMismatch(_, let context):
+            self.init(variant: variant, codingPath: context.codingPath, reason: .typeMismatch)
+        case DecodingError.valueNotFound(_, let context):
+            self.init(variant: variant, codingPath: context.codingPath, reason: .valueNotFound)
+        case DecodingError.dataCorrupted(let context):
+            self.init(variant: variant, codingPath: context.codingPath, reason: .dataCorrupted)
+        default:
+            self.init(variant: variant, codingPath: [], reason: .dataCorrupted)
+        }
+    }
+
+    var description: String {
+        "render-tree decode failed: variant=\(variant ?? "envelope") path=\(path) cause=\(reason.rawValue)"
+    }
+}
+
+enum RenderTreeDecoder {
+    static func decode(_ data: Data) throws -> RenderNode {
+        do {
+            return try JSONDecoder().decode(RenderNode.self, from: data)
+        } catch let failure as RenderTreeDecodingFailure {
+            throw failure
+        } catch {
+            throw RenderTreeDecodingFailure(error)
+        }
+    }
+}
+
 // MARK: - 렌더 노드
 
 // Upstream에서 제거된 필드는 모델에 남기지 않는다. JSONDecoder는 구버전 JSON의
@@ -62,42 +118,90 @@ enum RenderNodeType: Decodable {
     case footnoteMarker(FootnoteMarkerNode)
     case unknown
 
+    static let knownVariantNames: Set<String> = [
+        "Page",
+        "PageBackground",
+        "Body",
+        "Column",
+        "TextLine",
+        "TextRun",
+        "Table",
+        "TableCell",
+        "Line",
+        "Rectangle",
+        "Ellipse",
+        "Path",
+        "Image",
+        "Group",
+        "Equation",
+        "FormObject",
+        "Placeholder",
+        "RawSvg",
+        "FootnoteMarker",
+        "MasterPage",
+        "Header",
+        "Footer",
+        "FootnoteArea",
+        "TextBox",
+    ]
+
     init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        // Unit variant: "MasterPage" 등
-        if let str = try? container.decode(String.self) {
-            switch str {
+        if let name = try? container.decode(String.self) {
+            switch name {
             case "MasterPage": self = .masterPage
             case "Header": self = .header
             case "Footer": self = .footer
             case "FootnoteArea": self = .footnoteArea
             case "TextBox": self = .textBox
-            default: self = .unknown
+            default:
+                guard !Self.knownVariantNames.contains(name) else {
+                    throw RenderTreeDecodingFailure(variant: name, codingPath: decoder.codingPath,
+                                                    reason: .invalidVariantShape)
+                }
+                self = .unknown
             }
             return
         }
-        // Newtype/Struct variant: {"Page": {...}} 등
         let keyed = try decoder.container(keyedBy: DynamicKey.self)
-        if let v = try? keyed.decode(PageNode.self, forKey: .init("Page")) { self = .page(v); return }
-        if let v = try? keyed.decode(PageBackgroundNode.self, forKey: .init("PageBackground")) { self = .pageBackground(v); return }
-        if let v = try? keyed.decode(BodyNode.self, forKey: .init("Body")) { self = .body(v); return }
-        if let v = try? keyed.decode(UInt16.self, forKey: .init("Column")) { self = .column(v); return }
-        if let v = try? keyed.decode(TextLineNode.self, forKey: .init("TextLine")) { self = .textLine(v); return }
-        if let v = try? keyed.decode(TextRunNode.self, forKey: .init("TextRun")) { self = .textRun(v); return }
-        if let v = try? keyed.decode(TableNode.self, forKey: .init("Table")) { self = .table(v); return }
-        if let v = try? keyed.decode(TableCellNode.self, forKey: .init("TableCell")) { self = .tableCell(v); return }
-        if let v = try? keyed.decode(LineNode.self, forKey: .init("Line")) { self = .line(v); return }
-        if let v = try? keyed.decode(RectangleNode.self, forKey: .init("Rectangle")) { self = .rectangle(v); return }
-        if let v = try? keyed.decode(EllipseNode.self, forKey: .init("Ellipse")) { self = .ellipse(v); return }
-        if let v = try? keyed.decode(PathNode.self, forKey: .init("Path")) { self = .path(v); return }
-        if let v = try? keyed.decode(ImageNode.self, forKey: .init("Image")) { self = .image(v); return }
-        if let v = try? keyed.decode(GroupNode.self, forKey: .init("Group")) { self = .group(v); return }
-        if let v = try? keyed.decode(EquationNode.self, forKey: .init("Equation")) { self = .equation(v); return }
-        if let v = try? keyed.decode(FormObjectNode.self, forKey: .init("FormObject")) { self = .formObject(v); return }
-        if let v = try? keyed.decode(PlaceholderNode.self, forKey: .init("Placeholder")) { self = .placeholder(v); return }
-        if let v = try? keyed.decode(RawSvgNode.self, forKey: .init("RawSvg")) { self = .rawSvg(v); return }
-        if let v = try? keyed.decode(FootnoteMarkerNode.self, forKey: .init("FootnoteMarker")) { self = .footnoteMarker(v); return }
-        self = .unknown
+        guard keyed.allKeys.count == 1, let key = keyed.allKeys.first else {
+            let known = keyed.allKeys.map(\.stringValue).filter(Self.knownVariantNames.contains).sorted().first
+            throw RenderTreeDecodingFailure(variant: known, codingPath: decoder.codingPath,
+                                            reason: .invalidVariantShape)
+        }
+        do {
+            switch key.stringValue {
+            case "Page": self = .page(try keyed.decode(PageNode.self, forKey: key))
+            case "PageBackground": self = .pageBackground(try keyed.decode(PageBackgroundNode.self, forKey: key))
+            case "Body": self = .body(try keyed.decode(BodyNode.self, forKey: key))
+            case "Column": self = .column(try keyed.decode(UInt16.self, forKey: key))
+            case "TextLine": self = .textLine(try keyed.decode(TextLineNode.self, forKey: key))
+            case "TextRun": self = .textRun(try keyed.decode(TextRunNode.self, forKey: key))
+            case "Table": self = .table(try keyed.decode(TableNode.self, forKey: key))
+            case "TableCell": self = .tableCell(try keyed.decode(TableCellNode.self, forKey: key))
+            case "Line": self = .line(try keyed.decode(LineNode.self, forKey: key))
+            case "Rectangle": self = .rectangle(try keyed.decode(RectangleNode.self, forKey: key))
+            case "Ellipse": self = .ellipse(try keyed.decode(EllipseNode.self, forKey: key))
+            case "Path": self = .path(try keyed.decode(PathNode.self, forKey: key))
+            case "Image": self = .image(try keyed.decode(ImageNode.self, forKey: key))
+            case "Group": self = .group(try keyed.decode(GroupNode.self, forKey: key))
+            case "Equation": self = .equation(try keyed.decode(EquationNode.self, forKey: key))
+            case "FormObject": self = .formObject(try keyed.decode(FormObjectNode.self, forKey: key))
+            case "Placeholder": self = .placeholder(try keyed.decode(PlaceholderNode.self, forKey: key))
+            case "RawSvg": self = .rawSvg(try keyed.decode(RawSvgNode.self, forKey: key))
+            case "FootnoteMarker": self = .footnoteMarker(try keyed.decode(FootnoteMarkerNode.self, forKey: key))
+            default:
+                guard !Self.knownVariantNames.contains(key.stringValue) else {
+                    throw RenderTreeDecodingFailure(variant: key.stringValue, codingPath: decoder.codingPath,
+                                                    reason: .invalidVariantShape)
+                }
+                self = .unknown
+            }
+        } catch let failure as RenderTreeDecodingFailure {
+            throw failure
+        } catch {
+            throw RenderTreeDecodingFailure(error, variant: key.stringValue)
+        }
     }
 }
 

--- a/Sources/RhwpCoreBridge/RenderTree.swift
+++ b/Sources/RhwpCoreBridge/RenderTree.swift
@@ -10,7 +10,7 @@ import Foundation
 // debugDescription/underlyingError는 저장·출력하지 않는다.
 struct RenderTreeDecodingFailure: Error, CustomStringConvertible {
     enum Reason: String {
-        case keyNotFound, typeMismatch, valueNotFound, dataCorrupted, invalidVariantShape
+        case keyNotFound, typeMismatch, valueNotFound, dataCorrupted, invalidVariantShape, unexpectedDecoderError
     }
 
     let variant: String?
@@ -30,7 +30,7 @@ struct RenderTreeDecodingFailure: Error, CustomStringConvertible {
         self.reason = reason
     }
 
-    init(_ error: Error, variant: String? = nil) {
+    init(_ error: Error, variant: String? = nil, fallbackPath: [CodingKey] = []) {
         switch error {
         case DecodingError.keyNotFound(let key, let context):
             self.init(variant: variant, codingPath: context.codingPath + [key], reason: .keyNotFound)
@@ -41,7 +41,7 @@ struct RenderTreeDecodingFailure: Error, CustomStringConvertible {
         case DecodingError.dataCorrupted(let context):
             self.init(variant: variant, codingPath: context.codingPath, reason: .dataCorrupted)
         default:
-            self.init(variant: variant, codingPath: [], reason: .dataCorrupted)
+            self.init(variant: variant, codingPath: fallbackPath, reason: .unexpectedDecoderError)
         }
     }
 
@@ -200,18 +200,22 @@ enum RenderNodeType: Decodable {
         } catch let failure as RenderTreeDecodingFailure {
             throw failure
         } catch {
-            throw RenderTreeDecodingFailure(error, variant: key.stringValue)
+            throw RenderTreeDecodingFailure(error, variant: key.stringValue, fallbackPath: decoder.codingPath + [key])
         }
     }
 }
 
 // MARK: - 노드 데이터 타입
 
+// Core의 usize index metadata는 UInt로 보존한다(macOS 지원 아키텍처는 64-bit).
+// 머리말/꼬리말 para_index의 usize::MAX - i 같은 producer marker도 유효하다.
+// signed Int 변환이나 nil 치환은 이 metadata를 손실시키므로 하지 않는다.
+
 struct PageNode: Decodable {
     let pageIndex: UInt32
     let width: Double
     let height: Double
-    let sectionIndex: Int
+    let sectionIndex: UInt
 
     enum CodingKeys: String, CodingKey {
         case pageIndex = "page_index"
@@ -244,8 +248,8 @@ struct BodyNode: Decodable {
 struct TextLineNode: Decodable {
     let lineHeight: Double
     let baseline: Double
-    let sectionIndex: Int?
-    let paraIndex: Int?
+    let sectionIndex: UInt?
+    let paraIndex: UInt?
 
     enum CodingKeys: String, CodingKey {
         case lineHeight = "line_height"
@@ -260,9 +264,9 @@ struct TextRunNode: Decodable {
     let style: TextStyle
     let charShapeId: UInt32?
     let paraShapeId: UInt32?
-    let sectionIndex: Int?
-    let paraIndex: Int?
-    let charStart: Int?
+    let sectionIndex: UInt?
+    let paraIndex: UInt?
+    let charStart: UInt?
     let cellContext: CellContext?
     let isParaEnd: Bool
     let isLineBreakEnd: Bool
@@ -296,9 +300,9 @@ struct TableNode: Decodable {
     let rowCount: UInt16
     let colCount: UInt16
     let borderFillId: UInt16
-    let sectionIndex: Int?
-    let paraIndex: Int?
-    let controlIndex: Int?
+    let sectionIndex: UInt?
+    let paraIndex: UInt?
+    let controlIndex: UInt?
 
     enum CodingKeys: String, CodingKey {
         case rowCount = "row_count"
@@ -336,9 +340,9 @@ struct LineNode: Decodable {
     let x2: Double
     let y2: Double
     let style: LineStyle
-    let sectionIndex: Int?
-    let paraIndex: Int?
-    let controlIndex: Int?
+    let sectionIndex: UInt?
+    let paraIndex: UInt?
+    let controlIndex: UInt?
     let transform: ShapeTransform
 
     enum CodingKeys: String, CodingKey {
@@ -353,9 +357,9 @@ struct RectangleNode: Decodable {
     let cornerRadius: Double
     let style: ShapeStyle
     let gradient: GradientFillInfo?
-    let sectionIndex: Int?
-    let paraIndex: Int?
-    let controlIndex: Int?
+    let sectionIndex: UInt?
+    let paraIndex: UInt?
+    let controlIndex: UInt?
     let transform: ShapeTransform
 
     enum CodingKeys: String, CodingKey {
@@ -370,9 +374,9 @@ struct RectangleNode: Decodable {
 struct EllipseNode: Decodable {
     let style: ShapeStyle
     let gradient: GradientFillInfo?
-    let sectionIndex: Int?
-    let paraIndex: Int?
-    let controlIndex: Int?
+    let sectionIndex: UInt?
+    let paraIndex: UInt?
+    let controlIndex: UInt?
     let transform: ShapeTransform
 
     enum CodingKeys: String, CodingKey {
@@ -387,9 +391,9 @@ struct PathNode: Decodable {
     let commands: [PathCommand]
     let style: ShapeStyle
     let gradient: GradientFillInfo?
-    let sectionIndex: Int?
-    let paraIndex: Int?
-    let controlIndex: Int?
+    let sectionIndex: UInt?
+    let paraIndex: UInt?
+    let controlIndex: UInt?
     let transform: ShapeTransform
     let lineStyle: LineStyle?
     let connectorEndpoints: [[Double]]?
@@ -406,9 +410,9 @@ struct PathNode: Decodable {
 
 struct ImageNode: Decodable {
     let binDataId: UInt16
-    let sectionIndex: Int?
-    let paraIndex: Int?
-    let controlIndex: Int?
+    let sectionIndex: UInt?
+    let paraIndex: UInt?
+    let controlIndex: UInt?
     let fillMode: String?
     let originalSize: [Double]?
     let originalSizeHU: [Double]?
@@ -433,9 +437,9 @@ struct ImageNode: Decodable {
 }
 
 struct GroupNode: Decodable {
-    let sectionIndex: Int?
-    let paraIndex: Int?
-    let controlIndex: Int?
+    let sectionIndex: UInt?
+    let paraIndex: UInt?
+    let controlIndex: UInt?
 
     enum CodingKeys: String, CodingKey {
         case sectionIndex = "section_index"
@@ -789,7 +793,7 @@ struct CellContext: Decodable {
 }
 
 struct CellPathEntry: Decodable {
-    let controlIndex: Int
+    let controlIndex: UInt
     let cellIndex: Int
     let cellParaIndex: Int
     let textDirection: UInt8

--- a/Sources/RhwpCoreBridge/RhwpDocument.swift
+++ b/Sources/RhwpCoreBridge/RhwpDocument.swift
@@ -267,7 +267,7 @@ class RhwpDocument {
     }
 
     func renderPageTreeThrowing(at page: Int) throws -> RenderNode {
-        guard UInt32(exactly: page) != nil else {
+        guard UInt32(exactly: page) != nil, page < pageCount else {
             throw RhwpRenderTreeQueryError.invalidPageIndex
         }
         guard let json = renderPageTreeJSON(at: page) else {

--- a/Sources/RhwpCoreBridge/RhwpDocument.swift
+++ b/Sources/RhwpCoreBridge/RhwpDocument.swift
@@ -2,6 +2,18 @@ import Darwin
 import Foundation
 import Rhwp
 
+enum RhwpRenderTreeQueryError: Error, CustomStringConvertible {
+    case invalidPageIndex
+    case producerUnavailable
+
+    var description: String {
+        switch self {
+        case .invalidPageIndex: return "render-tree query failed: invalid page index"
+        case .producerUnavailable: return "render-tree query failed: producer returned no JSON"
+        }
+    }
+}
+
 enum RhwpExternalImageOperationStatus: Equatable {
     case ok
     case invalidHandle
@@ -248,21 +260,30 @@ class RhwpDocument {
         return svg
     }
 
-    /// 특정 페이지의 렌더 트리를 반환한다.
+    /// 기존 제품 호출 계약을 유지한다. 진단이 필요한 caller는 throwing API를 사용한다.
+    /// 어느 경로도 문서 JSON이나 decode 오류를 자동으로 로그에 기록하지 않는다.
     func renderPageTree(at page: Int) -> RenderNode? {
-        guard let json = renderPageTreeJSON(at: page),
-              let data = json.data(using: .utf8) else { return nil }
-        return try? JSONDecoder().decode(RenderNode.self, from: data)
+        try? renderPageTreeThrowing(at: page)
     }
 
-    /// 특정 페이지의 렌더 트리 원본 JSON 문자열을 반환한다.
+    func renderPageTreeThrowing(at page: Int) throws -> RenderNode {
+        guard UInt32(exactly: page) != nil else {
+            throw RhwpRenderTreeQueryError.invalidPageIndex
+        }
+        guard let json = renderPageTreeJSON(at: page) else {
+            throw RhwpRenderTreeQueryError.producerUnavailable
+        }
+        return try RenderTreeDecoder.decode(Data(json.utf8))
+    }
+
+    /// C 문자열은 Swift 소유 문자열로 복사한 뒤 모든 반환 경로에서 해제한다.
     func renderPageTreeJSON(at page: Int) -> String? {
-        guard let jsonPtr = rhwp_render_page_tree(handle, UInt32(page)) else {
+        guard let pageIndex = UInt32(exactly: page),
+              let jsonPtr = rhwp_render_page_tree(handle, pageIndex) else {
             return nil
         }
-        let json = String(cString: jsonPtr)
-        rhwp_free_string(jsonPtr)
-        return json
+        defer { rhwp_free_string(jsonPtr) }
+        return String(cString: jsonPtr)
     }
 
     /// 특정 페이지의 overlay image compact JSON 문자열을 반환한다.

--- a/mydocs/manual/build_run_guide.md
+++ b/mydocs/manual/build_run_guide.md
@@ -72,32 +72,24 @@ core 업데이트는 다음 형태로 분리한다.
 ./scripts/build-rust-macos.sh --update-lock
 ```
 
-lock과 현재 산출물의 일치 여부만 확인할 때는 verify 모드를 사용한다.
+로컬·CI에서 source와 ABI 계약을 검증할 때는 portable 모드를 사용한다.
 
 ```bash
-./scripts/build-rust-macos.sh --verify-lock
+./scripts/build-rust-macos.sh --verify-portable
 ```
 
-검증 대상:
+| 검증 | portable | strict |
+|------|----------|--------|
+| Cargo dependency와 lock의 repo/ref/tag/commit/features | 필수 | 필수 |
+| generated header hash/size와 FFI symbol set | 필수 | 필수 |
+| staticlib 존재와 lock reference metadata 형식 | 필수 | 필수 |
+| staticlib reference hash/size 일치 | 제외 | 필수 |
 
-- `RustBridge/Cargo.toml`의 `rhwp` repo/ref
-- `RustBridge/Cargo.lock`의 `rhwp` source commit
-- `rhwp-core.lock`의 repo/ref kind/release tag/commit
-- `Frameworks/universal/librhwp.a` sha256/size
-- `Frameworks/generated_rhwp.h` sha256/size
+기준 환경의 byte 일치 검증은 `./scripts/build-rust-macos.sh --verify-strict`로 실행한다. Rust compiler, Xcode, macOS, archive tool, build path가 달라지면 source와 ABI가 같아도 static archive byte가 달라질 수 있다. strict 실패는 원인이 환경 차이임을 입증하지 않으므로 필요한 경우 기준 환경을 재현한다. 로컬 차이를 수용하기 위해 lock을 자동 갱신하지 않는다.
 
-불일치 유형은 `Cargo.lock mismatch`, `artifact hash mismatch`, `FFI symbol diff`로 분리해 기록한다.
+`Cargo.lock mismatch`/`Cargo.toml mismatch`는 source 계약, `generated header ABI artifact mismatch`/FFI symbol 오류는 ABI, `strict staticlib reference mismatch`는 나머지 검증 후 reference byte 비교 실패다. 검증은 lock을 수정하지 않는다. 승인된 기준 artifact 갱신은 별도 `--update-lock` 작업이다.
 
-`Frameworks/universal/librhwp.a`는 Rust static archive라 Rust compiler, Xcode, macOS runner image, archive tool, build path 차이에 따라 source와 ABI가 같아도 byte hash가 달라질 수 있다. 로컬 strict 검증은 기본적으로 `librhwp.a`와 generated header hash/size를 모두 비교한다. GitHub-hosted CI/release workflow에서는 `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`을 설정해 `librhwp.a` byte hash/size 비교만 제외할 수 있다.
-
-이 skip이 켜져도 다음 검증은 계속 유지한다.
-
-- `rhwp` repo/ref/tag/commit source provenance
-- `RustBridge/Cargo.lock` resolved commit
-- `Frameworks/generated_rhwp.h` hash/size
-- `rhwp-ffi-symbols.txt`와 generated FFI symbol set 비교
-
-strict staticlib byte hash를 release gate로 되돌리려면 Rust toolchain, Xcode, macOS runner image, archive tool, build path 또는 CI 기준 lock 생성 환경을 먼저 고정한다.
+`--verify-lock`은 기존 strict alias를 유지한다. 이 legacy 명령에 한해 `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`로 portable 동작을 유지하고 전환 경고를 출력한다. 새 호출은 명시 모드를 사용한다. `--verify-strict`와 skip env=1 조합, 잘못된 env 값, 중복 모드는 build 전에 실패한다. 무옵션은 기존 build-only 동작이다.
 
 ## Xcode 프로젝트 생성
 

--- a/mydocs/manual/build_run_guide.md
+++ b/mydocs/manual/build_run_guide.md
@@ -89,7 +89,7 @@ core 업데이트는 다음 형태로 분리한다.
 
 `Cargo.lock mismatch`/`Cargo.toml mismatch`는 source 계약, `generated header ABI artifact mismatch`/FFI symbol 오류는 ABI, `strict staticlib reference mismatch`는 나머지 검증 후 reference byte 비교 실패다. 검증은 lock을 수정하지 않는다. 승인된 기준 artifact 갱신은 별도 `--update-lock` 작업이다.
 
-`--verify-lock`은 기존 strict alias를 유지한다. 이 legacy 명령에 한해 `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`로 portable 동작을 유지하고 전환 경고를 출력한다. 새 호출은 명시 모드를 사용한다. `--verify-strict`와 skip env=1 조합, 잘못된 env 값, 중복 모드는 build 전에 실패한다. 무옵션은 기존 build-only 동작이다.
+`--verify-lock`은 기존 strict alias를 유지한다. 이 legacy 명령에 한해 `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`로 portable 동작을 유지하고 전환 경고를 출력한다. 새 호출은 명시 모드를 사용한다. legacy alias/strict에서 잘못된 env 값, strict와 skip env=1 조합, 같은 옵션을 포함한 중복 모드는 build 전에 실패한다. 무옵션 build-only, 명시 portable, update-lock은 legacy env를 무시한다.
 
 ## Xcode 프로젝트 생성
 

--- a/mydocs/manual/ci_workflow_guide.md
+++ b/mydocs/manual/ci_workflow_guide.md
@@ -126,10 +126,10 @@ xcodebuild -project Alhangeul.xcodeproj \
 Rust/core 변경이 있으면 `./scripts/build-rust-macos.sh` 대신 다음 lock 검증을 실행한다.
 
 ```bash
-./scripts/build-rust-macos.sh --verify-lock
+./scripts/build-rust-macos.sh --verify-portable
 ```
 
-PR CI의 macOS validation은 GitHub-hosted runner/toolchain 차이를 고려해 `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`을 설정한다. 이 값은 `Frameworks/universal/librhwp.a` byte hash/size 비교만 제외한다. `rhwp` source provenance, `RustBridge/Cargo.lock`, generated header hash/size, `rhwp-ffi-symbols.txt` 검증은 계속 실패 가능한 gate로 남는다.
+PR CI와 release workflow는 `--verify-portable`을 명시하고 summary에 모드를 기록한다. staticlib byte hash/size 비교만 제외하며 source/Cargo.lock, generated header, FFI symbol과 reference metadata는 실패 가능한 gate다. 별도 skip env는 필요 없다. `test-rust-verification-modes.py`는 Ubuntu에서 fake toolchain으로 CLI 경계 18개를 검사한다. 기준 환경 byte 비교에는 `--verify-strict`를 사용한다.
 
 Build-info fixture와 studio Cargo.lock fingerprint fixture는 Ubuntu `script-checks`에서 먼저 실행해 canonical drift와 provenance verifier 회귀를 Rust build 전에 차단한다. tracked build-info verifier는 macOS validation에서도 다시 실행한다. Build-info verifier는 `rhwp-core.lock`에서 canonical `RhwpCoreBuildInfo.swift` 전체를 생성해 tracked source와 byte 비교하며 파일을 자동 수정하지 않는다. 존재하는 빈 `rhwp_enabled_features`는 유효하지만 key 누락, malformed token, source member/comment 누락·여분은 실패한다.
 

--- a/mydocs/manual/core_dependency_operation_guide.md
+++ b/mydocs/manual/core_dependency_operation_guide.md
@@ -43,7 +43,7 @@
 
 `Frameworks/universal/librhwp.a` hash/size는 reference artifact metadata로 유지한다. 이 값은 기준 환경에서 생성한 Rust bridge static archive 식별자로 유용하지만, Rust compiler, Xcode, macOS runner image, archive tool, build path 차이에 따라 source와 ABI가 같아도 byte-for-byte 값이 달라질 수 있다.
 
-GitHub-hosted CI/release workflow는 `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`로 `librhwp.a` byte hash/size 비교만 제외할 수 있다. 이 경우에도 source provenance, `RustBridge/Cargo.lock`, generated header, FFI symbol 검증은 유지한다. strict staticlib byte hash를 필수 release gate로 복귀하려면 toolchain/runner/build path 또는 CI 기준 lock 생성 환경을 먼저 고정한다.
+로컬·CI·release workflow의 일반 검증은 `--verify-portable`을 사용한다. staticlib byte hash/size 비교만 제외하고 source provenance, Cargo.lock, header, FFI symbol과 reference metadata 검증은 유지한다. 기준 환경 byte 검증은 명시 `--verify-strict`를 사용한다. 환경 차이를 이유로 lock을 자동 갱신하지 않는다. legacy 옵션 호환과 실패 분류는 [build_run_guide.md](build_run_guide.md)를 따른다.
 
 ### Swift build info mirror
 
@@ -67,7 +67,7 @@ Demo/Preview commit pin:
 ./scripts/build-rust-macos.sh --update-lock
 ./scripts/update-rhwp-core-build-info.sh
 ./scripts/verify-rhwp-core-build-info.sh
-./scripts/build-rust-macos.sh --verify-lock
+./scripts/build-rust-macos.sh --verify-portable
 ./scripts/check-no-appkit.sh
 xcodegen generate
 xcodebuild -project Alhangeul.xcodeproj \
@@ -86,7 +86,7 @@ Stable release tag:
 ./scripts/build-rust-macos.sh --update-lock
 ./scripts/update-rhwp-core-build-info.sh
 ./scripts/verify-rhwp-core-build-info.sh
-./scripts/build-rust-macos.sh --verify-lock
+./scripts/build-rust-macos.sh --verify-portable
 ./scripts/check-no-appkit.sh
 xcodegen generate
 xcodebuild -project Alhangeul.xcodeproj \

--- a/mydocs/manual/public_release_runbook.md
+++ b/mydocs/manual/public_release_runbook.md
@@ -155,7 +155,7 @@ release candidate source가 identity와 일치하는지 확인한다.
 git status --short --branch
 bash scripts/ci/read-rhwp-core-lock.sh rhwp_release_tag
 bash scripts/ci/read-rhwp-core-lock.sh rhwp_commit
-./scripts/build-rust-macos.sh --verify-lock
+./scripts/build-rust-macos.sh --verify-portable
 scripts/verify-rhwp-studio-assets.sh
 ./scripts/check-no-appkit.sh
 xcodegen generate

--- a/mydocs/manual/release_distribution_guide.md
+++ b/mydocs/manual/release_distribution_guide.md
@@ -127,7 +127,7 @@
 - [ ] workflow 사용 시 `previous_release_ref` 입력과 delta checklist summary/artifact 확인
 - [ ] release owner가 delta checklist를 누락/과잉 확인용 보조 자료로 보정
 - [ ] `RustBridge/Cargo.toml`, `RustBridge/Cargo.lock`, `rhwp-core.lock` 정합성 확인
-- [ ] `./scripts/build-rust-macos.sh --verify-lock` 통과 (`librhwp.a` byte hash skip 여부와 남는 source/header/ABI 검증 확인)
+- [ ] `./scripts/build-rust-macos.sh --verify-portable` 통과 (portable 모드와 source/header/ABI·reference metadata 검증 확인)
 - [ ] `RhwpCoreBuildInfo.swift`의 release baseline, commit, enabled features가 `rhwp-core.lock`과 일치
 - [ ] `./scripts/verify-rhwp-core-build-info.sh` 통과하고 release workflow가 writer로 drift를 자동 보정하지 않았는지 확인
 - [ ] `scripts/verify-rhwp-studio-assets.sh` 통과

--- a/mydocs/manual/release_packaging_dmg_guide.md
+++ b/mydocs/manual/release_packaging_dmg_guide.md
@@ -17,7 +17,7 @@
 ```bash
 git status --short --branch
 cat rhwp-core.lock
-./scripts/build-rust-macos.sh --verify-lock
+./scripts/build-rust-macos.sh --verify-portable
 scripts/verify-rhwp-studio-assets.sh
 ```
 
@@ -25,7 +25,7 @@ scripts/verify-rhwp-studio-assets.sh
 
 - 작업 브랜치와 릴리스 기준 브랜치가 명확해야 한다.
 - `RustBridge/Cargo.toml`, `RustBridge/Cargo.lock`, `rhwp-core.lock`의 repo/ref/commit 기준이 일치해야 한다.
-- GitHub-hosted workflow에서는 `ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`로 `Frameworks/universal/librhwp.a` byte hash/size 비교만 제외할 수 있다.
+- 로컬·workflow는 `--verify-portable`로 source/header/ABI와 reference metadata를 검사한다. 기준 환경 staticlib byte 비교가 필요하면 `--verify-strict`를 별도로 실행한다.
 - `Frameworks/generated_rhwp.h`의 hash/size는 `rhwp-core.lock`과 일치해야 한다.
 - `rhwp-ffi-symbols.txt`와 generated FFI symbol set이 일치해야 한다.
 - `Sources/HostApp/Resources/rhwp-studio/manifest.json`의 release tag/commit과 bundled entrypoint hash가 현재 resource tree와 일치해야 한다.
@@ -35,7 +35,7 @@ scripts/verify-rhwp-studio-assets.sh
 ## 기본 검증
 
 ```bash
-./scripts/build-rust-macos.sh --verify-lock
+./scripts/build-rust-macos.sh --verify-portable
 ./scripts/check-no-appkit.sh
 xcodegen generate
 xcodebuild -project Alhangeul.xcodeproj \

--- a/mydocs/manual/release_policy_guide.md
+++ b/mydocs/manual/release_policy_guide.md
@@ -154,7 +154,7 @@ provenance 진실 원천:
 | bundled `rhwp-studio` asset | `Sources/HostApp/Resources/rhwp-studio/manifest.json` | release note에 manifest 위치와 tag/commit을 표시하고 `scripts/verify-rhwp-studio-assets.sh`로 검증한다. |
 | Third Party notices | `THIRD_PARTY_LICENSES.md`, `Sources/HostApp/Resources/rhwp-studio/fonts/FONTS.md`, `Sources/HostApp/Resources/Legal/*` | release note에서 canonical 문서 위치를 안내하고, public DMG 안의 app bundle `Contents/Resources/Legal/*` 사본 포함 여부와 내용 동일성을 검증한다. |
 
-CI/release와 로컬 일반 검증은 `--verify-portable`을 명시한다. staticlib byte hash/size 비교만 제외하며 repo/ref/tag/commit, Cargo.lock, generated header, FFI symbol, reference metadata를 검사한다. 기준 환경을 재현한 byte 검증은 `--verify-strict`로 실행한다. strict는 skip env로 완화할 수 없으며 검증 실패를 해결하려고 lock hash를 임의 갱신하지 않는다. legacy 호환은 [빌드 가이드](build_run_guide.md)를 따른다.
+CI/release와 로컬 일반 검증은 `--verify-portable`을 명시한다. staticlib byte hash/size 비교만 제외하며 repo/ref/tag/commit, Cargo.lock, generated header, FFI symbol, reference metadata를 검사한다. 기준 환경을 재현한 byte 검증은 `--verify-strict`로 실행한다. 현재 strict를 정기/수동 workflow로 실행하는 고정 runner job은 없고, staticlib hash/size는 자동 byte 일치 gate가 아닌 reference 기록이다. strict 자동 검증은 기준 toolchain과 archive 재현성을 확보한 뒤 별도로 도입한다. strict는 skip env로 완화할 수 없으며 검증 실패를 해결하려고 lock hash를 임의 갱신하지 않는다. legacy 호환은 [빌드 가이드](build_run_guide.md)를 따른다.
 
 `LICENSE`, `THIRD_PARTY_LICENSES.md`, `Sources/HostApp/Resources/rhwp-studio/fonts/FONTS.md`를 수정하면 `Sources/HostApp/Resources/Legal/*` 사본을 같은 변경 범위에서 갱신한다. Public release 전에는 signed/notarized DMG를 mount한 뒤 app bundle의 `Contents/Resources/Legal/{LICENSE,THIRD_PARTY_LICENSES.md,FONTS.md}`와 release candidate commit의 canonical 문서가 같은지 확인한다.
 

--- a/mydocs/manual/release_policy_guide.md
+++ b/mydocs/manual/release_policy_guide.md
@@ -148,13 +148,13 @@ provenance 진실 원천:
 | 대상 | 진실 원천 | 공개/검증 방식 |
 |------|-----------|---------------|
 | `rhwp` core release tag/commit | `rhwp-core.lock` | release note에 tag/commit을 직접 표시하고 lock 파일을 검증 기준으로 둔다. |
-| Rust bridge staticlib reference metadata | `rhwp-core.lock` | `Frameworks/universal/librhwp.a` hash/size를 기준 환경 reference로 기록한다. GitHub-hosted CI/release에서는 byte hash/size 비교만 skip할 수 있다. |
-| Rust bridge generated header hash/size | `rhwp-core.lock` | release 전 `./scripts/build-rust-macos.sh --verify-lock`으로 검증한다. |
+| Rust bridge staticlib reference metadata | `rhwp-core.lock` | `Frameworks/universal/librhwp.a` hash/size를 기준 환경 reference로 기록한다. `--verify-portable`은 byte hash/size 비교를 제외하고 `--verify-strict`는 기준 환경 일치를 요구한다. |
+| Rust bridge generated header hash/size | `rhwp-core.lock` | release 전 `./scripts/build-rust-macos.sh --verify-portable`으로 검증한다. |
 | FFI ABI surface | `rhwp-ffi-symbols.txt` | 최종 보고서와 PR에서 변경 여부를 기록한다. |
 | bundled `rhwp-studio` asset | `Sources/HostApp/Resources/rhwp-studio/manifest.json` | release note에 manifest 위치와 tag/commit을 표시하고 `scripts/verify-rhwp-studio-assets.sh`로 검증한다. |
 | Third Party notices | `THIRD_PARTY_LICENSES.md`, `Sources/HostApp/Resources/rhwp-studio/fonts/FONTS.md`, `Sources/HostApp/Resources/Legal/*` | release note에서 canonical 문서 위치를 안내하고, public DMG 안의 app bundle `Contents/Resources/Legal/*` 사본 포함 여부와 내용 동일성을 검증한다. |
 
-`ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1`은 GitHub-hosted CI/release workflow에서 `Frameworks/universal/librhwp.a` byte hash/size 비교만 제외하는 정책 env다. 이 env를 사용해도 `rhwp` repo/ref/tag/commit, `RustBridge/Cargo.lock`, generated header, FFI symbol 검증은 유지한다. strict staticlib byte hash를 public release gate로 복귀하려면 Rust toolchain, Xcode, macOS runner image, archive tool, build path 또는 CI 기준 lock 생성 환경을 먼저 고정한다.
+CI/release와 로컬 일반 검증은 `--verify-portable`을 명시한다. staticlib byte hash/size 비교만 제외하며 repo/ref/tag/commit, Cargo.lock, generated header, FFI symbol, reference metadata를 검사한다. 기준 환경을 재현한 byte 검증은 `--verify-strict`로 실행한다. strict는 skip env로 완화할 수 없으며 검증 실패를 해결하려고 lock hash를 임의 갱신하지 않는다. legacy 호환은 [빌드 가이드](build_run_guide.md)를 따른다.
 
 `LICENSE`, `THIRD_PARTY_LICENSES.md`, `Sources/HostApp/Resources/rhwp-studio/fonts/FONTS.md`를 수정하면 `Sources/HostApp/Resources/Legal/*` 사본을 같은 변경 범위에서 갱신한다. Public release 전에는 signed/notarized DMG를 mount한 뒤 app bundle의 `Contents/Resources/Legal/{LICENSE,THIRD_PARTY_LICENSES.md,FONTS.md}`와 release candidate commit의 canonical 문서가 같은지 확인한다.
 

--- a/mydocs/manual/swift_macos_code_rules_guide.md
+++ b/mydocs/manual/swift_macos_code_rules_guide.md
@@ -41,6 +41,16 @@
 - node type, transform, clipping, image, text style 해석을 바꿨다면 문제 샘플에서 `render-debug-compare.sh`를 실행해 core SVG와 native PNG 차이를 확인한다.
 - core SVG와 native PNG가 다르면 [`render_core_native_compare_guide.md`](render_core_native_compare_guide.md)의 판단 흐름에 따라 Swift renderer 문제와 core 문제를 분리한다.
 
+### Render tree decode 오류 계약
+
+`renderPageTree(at:) -> RenderNode?`는 기존 제품 caller를 위해 실패 시 nil을 유지한다. `renderPageTreeThrowing(at:)`와 `RenderTreeDecoder.decode`는 native smoke/CI 등 진단이 필요한 caller에서 사용한다. page 변환 범위 오류와 producer의 null JSON을 `RhwpRenderTreeQueryError`로, envelope/known payload 오류를 `RenderTreeDecodingFailure`로 구분한다.
+
+Known variant의 필수 필드/형식 오류를 `.unknown` 성공으로 바꾸지 않는다. 올바른 단일 enum tag의 future variant는 `.unknown`으로 수용한다. 다중/빈 tag object와 payload variant의 unit 표현은 오류다. 추가 envelope 필드는 무시하므로 legacy `dirty` 호환은 유지한다. 하위 payload enum 전체의 정책이나 pixel parity를 보증하는 계약은 아니다.
+
+Core의 usize index metadata는 UInt로 보존하여 머리말/꼬리말의 큰 unsigned marker를 손실시키지 않는다.
+
+진단은 known variant, schema coding path, 원인 분류만 포함한다. Foundation이 coding path 없는 비-DecodingError를 반환하는 경우 알려진 payload 경로와 `unexpectedDecoderError`를 유지한다. 문서 값, raw JSON, Foundation debugDescription/underlyingError는 오류 객체나 제품 로그에 넣지 않는다. wrapper는 stdout/stderr를 출력하지 않고 진단을 소비하는 CLI만 명시적으로 출력한다. C JSON 문자열은 복사 후 `rhwp_free_string`으로 해제한다.
+
 ## extension 특화 규칙
 
 - Quick Look/Thumbnail은 메모리 사용량을 보수적으로 관리한다.

--- a/mydocs/manual/swift_macos_code_rules_guide.md
+++ b/mydocs/manual/swift_macos_code_rules_guide.md
@@ -43,11 +43,13 @@
 
 ### Render tree decode 오류 계약
 
-`renderPageTree(at:) -> RenderNode?`는 기존 제품 caller를 위해 실패 시 nil을 유지한다. `renderPageTreeThrowing(at:)`와 `RenderTreeDecoder.decode`는 native smoke/CI 등 진단이 필요한 caller에서 사용한다. page 변환 범위 오류와 producer의 null JSON을 `RhwpRenderTreeQueryError`로, envelope/known payload 오류를 `RenderTreeDecodingFailure`로 구분한다.
+`renderPageTree(at:) -> RenderNode?`는 기존 제품 caller를 위해 실패 시 nil을 유지한다. `renderPageTreeThrowing(at:)`와 `RenderTreeDecoder.decode`는 native smoke/CI 등 진단이 필요한 caller에서 사용한다. UInt32 변환 범위와 `pageCount` 밖의 요청은 invalidPageIndex, 유효한 page의 producer null JSON은 producerUnavailable로 구분한다. raw JSON API는 FFI null 경로 검증을 위해 UInt32 변환만 확인한다. envelope/known payload 오류는 `RenderTreeDecodingFailure`다.
 
 Known variant의 필수 필드/형식 오류를 `.unknown` 성공으로 바꾸지 않는다. 올바른 단일 enum tag의 future variant는 `.unknown`으로 수용한다. 다중/빈 tag object와 payload variant의 unit 표현은 오류다. 추가 envelope 필드는 무시하므로 legacy `dirty` 호환은 유지한다. 하위 payload enum 전체의 정책이나 pixel parity를 보증하는 계약은 아니다.
 
 Core의 usize index metadata는 UInt로 보존하여 머리말/꼬리말의 큰 unsigned marker를 손실시키지 않는다.
+
+Known tag 목록은 CaseIterable enum에서 얻고 payload switch는 모든 case를 처리한다. 빈/다중 tag는 단일 variant를 단정하지 않으며 variant가 확정되지 않은 진단은 `unresolved`와 schema path/reason으로 표시한다. macOS 12 최소 지원은 유지하며 최신 OS/CI 성공을 최소 OS runtime 실행 증거로 대신하지 않는다.
 
 진단은 known variant, schema coding path, 원인 분류만 포함한다. Foundation이 coding path 없는 비-DecodingError를 반환하는 경우 알려진 payload 경로와 `unexpectedDecoderError`를 유지한다. 문서 값, raw JSON, Foundation debugDescription/underlyingError는 오류 객체나 제품 로그에 넣지 않는다. wrapper는 stdout/stderr를 출력하지 않고 진단을 소비하는 CLI만 명시적으로 출력한다. C JSON 문자열은 복사 후 `rhwp_free_string`으로 해제한다.
 

--- a/mydocs/orders/20260907.md
+++ b/mydocs/orders/20260907.md
@@ -10,7 +10,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #394 | portable/strict core 검증 모드 분리 | 리뷰 대기 | 구현 완료: 03:42 — CLI 18개·실제 portable build 통과, strict reference 불일치 차단 확인 |
+| #394 | portable/strict core 검증 모드 분리 | 리뷰 대기 | 보완 완료: 05:08 — PR #503 리뷰 반영, CLI 24개·artifact 목록·공개 문서 정렬 |
 | #470 | known RenderNode 실패 진단 | 대기 | #394 다음, 별도 PR 리뷰 |
 | #469 | pinned core render tree golden 계약 검증 | 대기 | #470 다음, 별도 PR 리뷰 |
 

--- a/mydocs/orders/20260907.md
+++ b/mydocs/orders/20260907.md
@@ -11,7 +11,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #394 | portable/strict core 검증 모드 분리 | 리뷰 대기 | 보완 완료: 05:08 — PR #503 리뷰 반영, CLI 24개·artifact 목록·공개 문서 정렬 |
-| #470 | known RenderNode 실패 진단 | 리뷰 대기 | 구현 완료: 03:51 — decoder 18개·4문서 native smoke·HostApp build 통과; PR #503 상속 |
+| #470 | known RenderNode 실패 진단 | 리뷰 대기 | 보완 완료: 05:15 — 24종 tag·UInt 경계·4문서 smoke·HostApp 통과; macOS 12 실행 미검증 |
 | #469 | pinned core render tree golden 계약 검증 | 대기 | #470 다음, 별도 PR 리뷰 |
 
 ## M900 — Release Operations

--- a/mydocs/orders/20260907.md
+++ b/mydocs/orders/20260907.md
@@ -10,7 +10,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #394 | portable/strict core 검증 모드 분리 | 진행 중 | PR #462 선행 판정 완료; 단계 승인 생략 및 PR 게시 승인 |
+| #394 | portable/strict core 검증 모드 분리 | 리뷰 대기 | 구현 완료: 03:42 — CLI 18개·실제 portable build 통과, strict reference 불일치 차단 확인 |
 | #470 | known RenderNode 실패 진단 | 대기 | #394 다음, 별도 PR 리뷰 |
 | #469 | pinned core render tree golden 계약 검증 | 대기 | #470 다음, 별도 PR 리뷰 |
 

--- a/mydocs/orders/20260907.md
+++ b/mydocs/orders/20260907.md
@@ -11,7 +11,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #394 | portable/strict core 검증 모드 분리 | 리뷰 대기 | 구현 완료: 03:42 — CLI 18개·실제 portable build 통과, strict reference 불일치 차단 확인 |
-| #470 | known RenderNode 실패 진단 | 진행 중 | 선행 PR #503 상속, 별도 PR 리뷰 |
+| #470 | known RenderNode 실패 진단 | 리뷰 대기 | 구현 완료: 03:51 — decoder 18개·4문서 native smoke·HostApp build 통과; PR #503 상속 |
 | #469 | pinned core render tree golden 계약 검증 | 대기 | #470 다음, 별도 PR 리뷰 |
 
 ## M900 — Release Operations

--- a/mydocs/orders/20260907.md
+++ b/mydocs/orders/20260907.md
@@ -6,8 +6,17 @@
 |------|--------|------|------|
 | #497 | Sandbox HWP3 변환 복사본 저장 권한 오류 수정 | 완료 | 완료: 00:22 — PR #498 병합·이슈 close, XCTest 184개·저장 6조합·CI 통과 |
 
+## M020 — v0.2.x Skia Quick Look/Thumbnail Backend
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #394 | portable/strict core 검증 모드 분리 | 진행 중 | PR #462 선행 판정 완료; 단계 승인 생략 및 PR 게시 승인 |
+| #470 | known RenderNode 실패 진단 | 대기 | #394 다음, 별도 PR 리뷰 |
+| #469 | pinned core render tree golden 계약 검증 | 대기 | #470 다음, 별도 PR 리뷰 |
+
 ## M900 — Release Operations
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #494 | v0.1.11 public release 준비와 배포 실행 | 완료 | 완료: 02:50 — Release·Homebrew·실제 Sparkle·Finder, PR #501·Pages 검증 완료; devel 최종 기록 인계 |
+| #474 | main/devel 실제 콘텐츠 누락 gate | 대기 | #469 다음, 별도 PR 리뷰; #337은 이번 범위 제외 |

--- a/mydocs/orders/20260907.md
+++ b/mydocs/orders/20260907.md
@@ -11,7 +11,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #394 | portable/strict core 검증 모드 분리 | 리뷰 대기 | 구현 완료: 03:42 — CLI 18개·실제 portable build 통과, strict reference 불일치 차단 확인 |
-| #470 | known RenderNode 실패 진단 | 대기 | #394 다음, 별도 PR 리뷰 |
+| #470 | known RenderNode 실패 진단 | 진행 중 | 선행 PR #503 상속, 별도 PR 리뷰 |
 | #469 | pinned core render tree golden 계약 검증 | 대기 | #470 다음, 별도 PR 리뷰 |
 
 ## M900 — Release Operations

--- a/mydocs/plans/task_m020_394.md
+++ b/mydocs/plans/task_m020_394.md
@@ -1,0 +1,26 @@
+# Task M020 #394 수행계획서
+
+## 목적과 범위
+
+로컬·CI의 portable source/header/ABI 검증을 명시 옵션으로 제공하고, 기준 환경 static archive byte 검증은 strict 옵션으로 분리한다. core pin과 lock artifact hash는 갱신하지 않는다.
+
+작업지시자가 2026-09-07 같은 대화에서 #394 → #470 → #469 → #474의 구현·검증·PR 생성을 단계별 추가 승인 없이 진행하도록 승인했다. 네 PR의 merge와 #337 착수는 포함하지 않는다.
+
+## 계약
+
+- `--verify-portable`: source/Cargo.lock/header/FFI 검증. staticlib 존재와 lock metadata는 검사하되 byte hash/size 비교는 제외한다.
+- `--verify-strict`: 위 검증과 staticlib byte hash/size 일치 요구. 이전 skip env로 약화할 수 없다.
+- `--verify-lock`: 기존 strict 동작과 legacy skip env 호환을 유지하고 명시 옵션으로의 전환을 안내한다.
+- 옵션 충돌·잘못된 legacy env는 build 전에 실패한다. 무옵션 build와 명시 `--update-lock`은 유지한다.
+
+## 순서와 검증
+
+1. 모드·불일치 분류 구현과 격리된 fake toolchain fixture.
+2. CI·release build 호출·운영 문서를 portable 명령으로 정렬하고 YAML/shell/classification 검증.
+3. 실제 macOS portable build, strict 결과 분류, lock 불변 확인과 최종 보고/PR 생성.
+
+브랜치는 `local/task394`, 게시 브랜치는 `publish/task394`, PR base는 `devel`이다. 후속 작업은 앞 작업을 상속한 별도 브랜치/PR로 게시하고 자신의 commit 범위를 본문에 명시한다.
+
+## 선행 PR #462 판정
+
+최신 devel `ed325b2`와 PR head `1993e36`의 재진입 방지 변경을 비교한다. 깊이 1/2/4/8/12인 bounded Body/control 트리와 실제 CoreGraphics renderer를 사용한다. 호출 수 계측만 추가한 복사본에서 PNG가 아닌 원시 RGBA bitmap hash를 비교한다. 원본 renderer와 PR 상태는 변경하지 않는다. 판정 결과와 재현 자료는 단계/최종 보고서에 남긴다.

--- a/mydocs/plans/task_m020_394_impl.md
+++ b/mydocs/plans/task_m020_394_impl.md
@@ -1,0 +1,17 @@
+# Task M020 #394 구현계획서
+
+## Stage 1 — 모드와 실패 계약
+
+`build-rust-macos.sh`에 portable/strict/legacy 모드를 추가한다. portable에서도 누락·손상 lock metadata를 실패시키고 header를 staticlib보다 먼저 검사하여 staticlib byte 차이가 ABI 실패를 가리지 않도록 한다. fixture는 독립 임시 root와 fake build tools를 사용해 전체 CLI의 성공·실패·lock 불변을 검사한다.
+
+검증: CLI help/옵션 충돌, portable archive 차이 허용, strict/legacy archive 차이 차단, legacy skip 호환, env 오류, source commit/header/FFI/metadata 손상 차단. 단계 보고서와 코드를 함께 커밋한다.
+
+## Stage 2 — 호출부와 운영 안내
+
+PR CI/release rehearsal/publish와 로컬 package/release script가 `--verify-portable`을 명시한다. 기존 skip env를 workflow에서 제거하고 summary에 모드를 표시한다. 관련 매뉴얼은 동일 계약을 안내하고 historical report는 수정하지 않는다.
+
+검증: 모든 shell syntax, YAML parse, fixture, classification helper 결과. 단계 보고서와 함께 커밋한다.
+
+## Stage 3 — 실제 검증과 PR
+
+로컬 core build에서 portable 통과를 확인한다. strict 실행 결과는 일치 또는 reference byte mismatch로 기록하고 source/header/ABI 실패와 구분한다. `rhwp-core.lock`, Cargo pin, symbol lock 불변과 git diff를 확인한다. 최종 보고서·오늘할일을 커밋하고 `publish/task394`를 push하여 devel 대상 PR을 생성한다. merge하지 않는다.

--- a/mydocs/plans/task_m020_394_impl.md
+++ b/mydocs/plans/task_m020_394_impl.md
@@ -15,3 +15,7 @@ PR CI/release rehearsal/publish와 로컬 package/release script가 `--verify-po
 ## Stage 3 — 실제 검증과 PR
 
 로컬 core build에서 portable 통과를 확인한다. strict 실행 결과는 일치 또는 reference byte mismatch로 기록하고 source/header/ABI 실패와 구분한다. `rhwp-core.lock`, Cargo pin, symbol lock 불변과 git diff를 확인한다. 최종 보고서·오늘할일을 커밋하고 `publish/task394`를 push하여 devel 대상 PR을 생성한다. merge하지 않는다.
+
+## Stage 4 — PR #503 리뷰 보완
+
+작업지시자가 리뷰 검토서의 권고 순서와 공개 보완 코멘트 게시를 승인했다. writer/verifier의 artifact 목록을 공유하고 header 우선순위를 유지한다. legacy env 검사는 legacy alias/strict에 한정하며 중복 모드는 계속 거부하되 오류를 명확히 한다. 공개 README/CONTRIBUTING과 strict 자동 job 부재를 문서화한다. 격리 CLI는 세 번째 artifact의 기록·검증과 env 비적용 경로까지 검증한다. 검증 후 보고서·오늘할일·기존 PR을 갱신하고 후속 브랜치에 전달한다.

--- a/mydocs/plans/task_m020_470.md
+++ b/mydocs/plans/task_m020_470.md
@@ -1,0 +1,17 @@
+# Task M020 #470 수행계획서
+
+## 목적과 범위
+
+known RenderNodeType의 손상된 payload와 unknown future variant를 구분한다. known key가 있으면 decode 오류를 전파하고, 올바른 externally tagged 형식의 unknown string/object variant는 `.unknown`으로 수용한다. 빈 object, 다중 variant object, known payload를 unit string으로 준 경우는 실패한다.
+
+기존 `renderPageTree(at:) -> RenderNode?`는 유지하고 진단용 throwing API를 추가한다. 진단에는 known variant, schema coding path, DecodingError 분류를 담고 raw JSON·문서 텍스트·경로·underlying debugDescription은 기록하지 않는다. 제품 호출은 로그를 출력하지 않는다.
+
+#394 PR #503 head `de4d374`를 상속한다. 작업지시자가 승인한 연속 작업 범위이며 추가 단계 승인 없이 구현·검증·PR까지 진행한다. merge와 golden producer #469 구현은 제외한다.
+
+## 단계와 검증
+
+1. strict known decoder 및 구조화된 실패 모델, minimal fixture 보강.
+2. optional 호환 API/throwing API와 native smoke 진단 연결, bridge 운영 문서 정리.
+3. decoder fixture·기본 3문서와 HWPX native smoke·HostApp build·no-AppKit·diff 검증 후 최종 보고/별도 PR.
+
+core pin·Rust ABI·renderer layout은 변경하지 않는다. 하위 payload 내부의 별도 enum forward compatibility 정책 전체를 재설계하지 않는다.

--- a/mydocs/plans/task_m020_470_impl.md
+++ b/mydocs/plans/task_m020_470_impl.md
@@ -12,6 +12,10 @@
 
 검증: decoder fixture와 기본 native smoke, HWPX sample. bridge 운영 문서에 진단 책임과 호환 계약 명시. 단계 보고서와 코드 커밋.
 
+### Stage 2 검증 중 확인한 core 계약 보정
+
+KTX/request 실제 core 출력의 TextLine `para_index`는 `usize::MAX - i` marker를 포함한다. 기존 Swift Int decode 실패가 `.unknown`으로 숨겨져 있었다. pinned core `render_tree.rs`의 section/para/control/char_start는 usize이므로 해당 metadata 모델을 UInt로 맞추고 marker를 손실 없이 보존한다. 필수 필드를 optional로 완화하지 않는다. synthetic UInt.max/음수 거부 fixture와 같은 샘플 native/core 비교를 추가한다. Foundation의 비-DecodingError 실패에도 알려진 payload 경로를 유지한다.
+
 ## Stage 3 — 통합 검증·PR
 
 no-AppKit, xcodegen/HostApp Debug build, native smoke와 diff 검증을 정리한다. 개발 산출물은 build.noindex에 둔다. 소스 변경으로 실제 앱 등록 검증을 요구하지 않는다. 계획/단계/최종보고서와 오늘할일을 완료하고 `publish/task470`에서 devel 대상으로 PR을 생성한다. 본문에 선행 PR #503 및 자신의 commit 범위를 명시한다.

--- a/mydocs/plans/task_m020_470_impl.md
+++ b/mydocs/plans/task_m020_470_impl.md
@@ -1,0 +1,17 @@
+# Task M020 #470 구현계획서
+
+## Stage 1 — decode 계약
+
+`RenderTree.swift`에 sanitized error와 `RenderTreeDecoder.decode`를 둔다. known 단일 tag는 payload를 `try`로 읽고 실패를 variant 문맥과 함께 전파한다. unknown 단일 tag는 payload를 해석하지 않는다. 기존 current/legacy/TextRun fixture를 유지하고 필드 누락·타입 오류·null·unknown·tag 형식 오류·중첩 coding path·privacy를 검사한다.
+
+검증: `scripts/ci/test-render-tree-decoder.sh`, `check-no-appkit.sh`, `git diff --check`. 단계 보고서와 코드 커밋.
+
+## Stage 2 — FFI wrapper와 smoke
+
+`renderPageTreeThrowing(at:)`를 추가하고 optional API가 `try?`로 위임한다. 음수/UInt32 범위 밖 page는 변환 전에 안전하게 실패한다. null producer output과 decoder 오류를 구분하며 반환 C 문자열 복사/free 계약을 유지한다. native smoke/debug helper는 throwing decode를 사용한다. 제품 stderr/stdout logging은 추가하지 않는다.
+
+검증: decoder fixture와 기본 native smoke, HWPX sample. bridge 운영 문서에 진단 책임과 호환 계약 명시. 단계 보고서와 코드 커밋.
+
+## Stage 3 — 통합 검증·PR
+
+no-AppKit, xcodegen/HostApp Debug build, native smoke와 diff 검증을 정리한다. 개발 산출물은 build.noindex에 둔다. 소스 변경으로 실제 앱 등록 검증을 요구하지 않는다. 계획/단계/최종보고서와 오늘할일을 완료하고 `publish/task470`에서 devel 대상으로 PR을 생성한다. 본문에 선행 PR #503 및 자신의 commit 범위를 명시한다.

--- a/mydocs/plans/task_m020_470_impl.md
+++ b/mydocs/plans/task_m020_470_impl.md
@@ -19,3 +19,9 @@ KTX/request 실제 core 출력의 TextLine `para_index`는 `usize::MAX - i` mark
 ## Stage 3 — 통합 검증·PR
 
 no-AppKit, xcodegen/HostApp Debug build, native smoke와 diff 검증을 정리한다. 개발 산출물은 build.noindex에 둔다. 소스 변경으로 실제 앱 등록 검증을 요구하지 않는다. 계획/단계/최종보고서와 오늘할일을 완료하고 `publish/task470`에서 devel 대상으로 PR을 생성한다. 본문에 선행 PR #503 및 자신의 commit 범위를 명시한다.
+
+## Stage 4 — PR #504 리뷰 보완
+
+작업지시자 승인에 따라 CellContext의 남은 usize 필드를 UInt로 정렬하고 큰 정수/음수 경계를 검증한다. known tag는 CaseIterable enum과 exhaustive switch로 연결하고 모든 24종의 valid payload와 잘못된 표현을 검증한다. 다중 tag는 variant를 임의 선택하지 않으며 nil variant 진단을 중립적으로 표시한다. throwing API는 pageCount 경계도 invalid index로 분류하고 실제 FFI null 경로는 raw JSON API로 독립 검증한다.
+
+strict known 오류 전파와 macOS 12 deploymentTarget은 유지한다. 작업지시자가 사용할 macOS 12 기기/VM이 없음을 확인했고 self-hosted runner도 없다. 현재 OS/CI 검증과 최소 OS 실행 검증을 구분하여 보고하며 macOS 12 미검증을 병합 전 잔여 조건으로 공개 코멘트에 남긴다.

--- a/mydocs/report/task_m020_394_report.md
+++ b/mydocs/report/task_m020_394_report.md
@@ -1,0 +1,19 @@
+# Task M020 #394 최종 결과보고서
+
+## 결과
+
+일반 로컬·CI·release 검증은 `--verify-portable`, 기준 환경 byte 검증은 `--verify-strict`로 명시한다. 기존 `--verify-lock`과 skip env의 조합은 호환 경고와 함께 유지한다. strict는 skip env로 약화할 수 없다. 검증 중 lock을 수정하지 않는다.
+
+portable은 staticlib byte hash/size 비교만 제외한다. source/Cargo 계약, generated header hash/size, FFI symbols, archive 존재와 lock metadata는 계속 차단 기준이다. header 검증을 먼저 수행하여 strict artifact 실패와 source/ABI 오류를 구분한다. CI/release summary와 운영 문서를 동일하게 정렬했다.
+
+## 검증
+
+격리 fake toolchain의 전체 CLI 회귀 18개, 모든 shell syntax와 workflow YAML parse, 실제 arm64/x86_64 portable build 및 XCFramework 생성 통과. strict는 기존 reference와 다른 로컬 archive를 예상된 오류로 차단했다. core pin/Cargo.lock/FFI symbol lock 불변, no-AppKit와 core build-info 검증 통과. CI 실행은 PR 게시 후 별도 확인한다.
+
+상세: [Stage 1](../working/task_m020_394_stage1.md), [Stage 2](../working/task_m020_394_stage2.md), [Stage 3](../working/task_m020_394_stage3.md).
+
+## 선행 PR #462 판정과 후속
+
+PR #462는 현재 초안 병합 보류다. 합성 중첩 트리에서 depth 12 방문 수가 12,286 → 169로 감소했지만 채워진 픽셀이 10,000 → 6,000으로 달라졌다. 깊이 1은 동등하고 깊이 2부터 내부 clipping 결과가 바뀐다. 실제 문서의 정답을 이 fixture만으로 결정하지 않으며 중첩 overflow 의미·기대 출력 회귀가 필요하다. [Stage 1](../working/task_m020_394_stage1.md)에 재현 조건을 기록했다. PR code/state/public comment는 변경하지 않았다.
+
+#470 → #469 → #474는 선행 작업을 상속한 별도 PR로 진행한다. 네 PR은 devel 대상으로 생성하며 선행 PR 병합 전에는 누적 diff가 보인다. 작업지시자가 리뷰·병합을 결정한다. #337과 release 실행은 이번 배치에 포함하지 않는다.

--- a/mydocs/report/task_m020_394_report.md
+++ b/mydocs/report/task_m020_394_report.md
@@ -12,6 +12,10 @@ portable은 staticlib byte hash/size 비교만 제외한다. source/Cargo 계약
 
 상세: [Stage 1](../working/task_m020_394_stage1.md), [Stage 2](../working/task_m020_394_stage2.md), [Stage 3](../working/task_m020_394_stage3.md).
 
+## 리뷰 보완
+
+[Stage 4](../working/task_m020_394_stage4.md)에서 artifact 목록 공유, legacy env 적용 범위, 중복 옵션 진단과 공개 문서를 보완했다. 격리 CLI는 24개로 확장해 통과했다. 현재 strict 자동 runner가 없으며 staticlib hash/size는 reference 기록이라는 정책을 명시했다.
+
 ## 선행 PR #462 판정과 후속
 
 PR #462는 현재 초안 병합 보류다. 합성 중첩 트리에서 depth 12 방문 수가 12,286 → 169로 감소했지만 채워진 픽셀이 10,000 → 6,000으로 달라졌다. 깊이 1은 동등하고 깊이 2부터 내부 clipping 결과가 바뀐다. 실제 문서의 정답을 이 fixture만으로 결정하지 않으며 중첩 overflow 의미·기대 출력 회귀가 필요하다. [Stage 1](../working/task_m020_394_stage1.md)에 재현 조건을 기록했다. PR code/state/public comment는 변경하지 않았다.

--- a/mydocs/report/task_m020_470_report.md
+++ b/mydocs/report/task_m020_470_report.md
@@ -17,4 +17,8 @@ Known RenderNodeType payload가 손상되면 variant/schema path/cause를 가진
 
 ## PR 관계
 
-선행 #394 PR #503 head `de4d374`를 상속한다. 자신의 변경은 `de4d374..HEAD`, base는 devel이다. 앞 PR 병합 전 누적 diff가 보인다. 다음 #469가 producer golden을 추가하며, #337과 public release는 이번 범위가 아니다. 사용자 리뷰를 위해 merge하지 않는다.
+선행 #394 PR #503 리뷰 보완 head `a011a92`를 상속한다. 자신의 변경은 `a011a92..HEAD`, base는 devel이다. 앞 PR 병합 전 누적 diff가 보인다. 다음 #469가 producer golden을 추가하며, #337과 public release는 이번 범위가 아니다. 사용자 리뷰를 위해 merge하지 않는다.
+
+## 리뷰 보완과 병합 전 조건
+
+[Stage 4](../working/task_m020_470_stage4.md)에서 남은 셀 usize 필드, 24종 tag의 exhaustive dispatch와 wire fixture, 다중 tag 진단, pageCount 경계를 보완했다. decoder·4문서 native smoke·HostApp build가 통과했다. macOS 12 실행 환경이 없어 최소 지원 OS runtime 검증은 미실행이며 병합 전 확인 조건으로 남아 있다. 현재 OS/CI 성공으로 대체하지 않는다.

--- a/mydocs/report/task_m020_470_report.md
+++ b/mydocs/report/task_m020_470_report.md
@@ -1,0 +1,20 @@
+# Task M020 #470 최종 결과보고서
+
+## 결과
+
+Known RenderNodeType payload가 손상되면 variant/schema path/cause를 가진 오류로 실패하며, future 단일 variant는 `.unknown`으로 수용한다. 기존 optional `renderPageTree`는 유지하고 `renderPageTreeThrowing`을 추가했다. wrapper는 로그를 출력하지 않고 문서 값이나 underlying debugDescription을 오류에 저장하지 않는다. native smoke/CI가 진단을 명시적으로 소비한다.
+
+실제 current core의 usize marker가 Swift Int 범위를 넘는 문제도 수정했다. section/para/control/char_start metadata를 UInt로 보존하여 KTX/request의 머리말·꼬리말 텍스트가 더 이상 unknown으로 사라지지 않는다. 필수 필드를 optional로 완화하거나 core/renderer layout을 바꾸지 않았다.
+
+## 검증과 한계
+
+- decoder 성공/실패/forward compatibility/privacy/UInt marker 18개 계약 통과.
+- HWP 3종/HWPX 1종, 실제 FFI page 경계와 null-output, HostApp Debug compile/link, no-AppKit 통과.
+- KTX/request의 core/native 비교 이미지와 이전 decoder 비교를 확인했다. TextRun은 각각 410→415, 102→103으로 복원됐다. core/native pixel parity는 보증하지 않는다.
+- 표준 개발 앱/appex unregister 실행. PlugInKit에는 기존 설치본만 확인했지만 전역 hygiene는 기존 LS 경로와 두 설치본 때문에 통과하지 않았고 설치본을 임의 삭제하지 않았다.
+
+상세: [Stage 1](../working/task_m020_470_stage1.md), [Stage 2](../working/task_m020_470_stage2.md), [Stage 3](../working/task_m020_470_stage3.md).
+
+## PR 관계
+
+선행 #394 PR #503 head `de4d374`를 상속한다. 자신의 변경은 `de4d374..HEAD`, base는 devel이다. 앞 PR 병합 전 누적 diff가 보인다. 다음 #469가 producer golden을 추가하며, #337과 public release는 이번 범위가 아니다. 사용자 리뷰를 위해 merge하지 않는다.

--- a/mydocs/working/task_m020_394_stage1.md
+++ b/mydocs/working/task_m020_394_stage1.md
@@ -1,0 +1,23 @@
+# Task M020 #394 Stage 1 완료보고서
+
+## 구현과 검증
+
+명시 portable/strict와 legacy alias를 분리했다. strict + skip env 충돌과 중복 모드는 build 전 실패한다. portable에서도 artifact 존재와 유효한 hash/size metadata를 요구한다. header를 먼저 검증하여 strict archive mismatch 메시지의 source/header/ABI 통과 주장이 실제 순서와 맞도록 했다. lock은 검증 중 쓰지 않는다.
+
+`python3 scripts/ci/test-rust-verification-modes.py`: 18개 통과. 전체 CLI를 임시 root/fake toolchain으로 실행하여 archive 차이, legacy 호환, 옵션 충돌, commit/features/header/FFI/metadata 손상, lock 불변을 검사했다. 실제 compiler 재현성 검증은 Stage 3에서 구분한다. `bash -n`과 `git diff --check` 통과.
+
+## 선행 PR #462 판정
+
+**현재 초안 병합 보류.** devel `ed325b2`의 renderer에 PR `1993e36`과 같은 guard/defer만 적용한 복사본을 비교했다. 실제 RectangleNode(검정 100×100), Body clip x=10+i/width=80−2i, TextBox 중첩을 사용했다. 두 renderer에는 renderNode 방문 수만 계측했다.
+
+| 깊이 | 현재 방문 | PR 방문 | 현재/PR 채워진 픽셀 |
+|---|---:|---:|---:|
+| 1 | 4 | 4 | 10000 / 10000 |
+| 2 | 10 | 9 | 10000 / 8000 |
+| 4 | 46 | 25 | 10000 / 7600 |
+| 8 | 766 | 81 | 10000 / 6800 |
+| 12 | 12286 | 169 | 10000 / 6000 |
+
+재진입 증폭은 감소하지만 외부 overflow replay 중 내부 Body의 replay가 금지되어 clipping 결과도 달라진다. 실제 upstream 문서에서 어느 출력이 맞는지 이 합성 fixture만으로 확정하지 않는다. 따라서 의도된 중첩 overflow 의미와 출력 기대값을 고정하는 테스트, 최신 devel 재기준화 후 검증이 merge 선행 조건이다. 기존 PR의 macOS CI 성공 기록은 이 사례의 출력 동등성을 보증하지 않는다.
+
+재현 소스·실행 파일·결과는 `build.noindex/pr462-review/`에 보관했다. `bash build.noindex/pr462-review/run.sh`로 재실행할 수 있다. 이번 배치에서는 PR #462의 code/comment/review/state를 변경하지 않았다.

--- a/mydocs/working/task_m020_394_stage2.md
+++ b/mydocs/working/task_m020_394_stage2.md
@@ -1,0 +1,13 @@
+# Task M020 #394 Stage 2 완료보고서
+
+## 변경
+
+PR CI, release rehearsal/publish, 로컬 package/release helper의 일반 검증 명령을 `--verify-portable`로 통일했다. workflow의 legacy skip env를 제거하고 Actions summary에 모드를 명시했다. CLI fixture는 Ubuntu script-checks에 연결했다. 빌드·core·CI·release 매뉴얼의 현재 정책을 정렬했으며 기존 완료 보고서와 공개 release 기록은 유지했다.
+
+## 검증
+
+- `scripts/*.sh`, `scripts/ci/*.sh` 전체 `bash -n` 통과.
+- workflow 전체 Ruby Psych YAML parse 통과.
+- classification의 #394 변경에서 macOS build, Rust verify, release checks가 활성화되고 portable 정책 안내를 확인했다.
+- legacy 옵션/env는 CLI 호환 구현·fixture·호환 설명에만 남는다.
+- `git diff --check` 통과. 실제 배포 helper는 실행하지 않았으며 Stage 3은 build 검증만 수행한다.

--- a/mydocs/working/task_m020_394_stage3.md
+++ b/mydocs/working/task_m020_394_stage3.md
@@ -1,0 +1,12 @@
+# Task M020 #394 Stage 3 완료보고서
+
+## 실제 macOS 검증
+
+- `./scripts/build-rust-macos.sh --verify-portable`: arm64/x86_64 build, universal archive/XCFramework, source/header/FFI 검증 통과(exit 0).
+- `./scripts/build-rust-macos.sh --verify-strict`: source/header/FFI 통과 후 strict staticlib reference mismatch로 의도대로 차단(exit 1). strict byte 일치를 달성했다고 주장하지 않는다.
+- reference SHA256 `25ba743d7e3774c81177e849308fba98ce0e6b7a22eff3d1b6380a11ab9f0544`, 로컬 `062ba3a4f4d73c4b6494c209cc68a9ec188b2668a031b037bbed1ad354ddf5e8`.
+- `check-no-appkit.sh`, `verify-rhwp-core-build-info.sh`, release helper help 통과.
+- core/Cargo pin과 FFI symbol lock은 `origin/devel` 대비 byte 변경 없음.
+- 로그: `build.noindex/task394/{portable,strict}.log`. Stage 1 CLI fixture 18개 및 Stage 2 shell/YAML 검증 통과.
+
+배포·앱 설치·확장 등록은 수행하지 않았다. strict 불일치의 정확한 toolchain 원인 분석과 reproducible archive 구축은 이 이슈의 제외 범위다.

--- a/mydocs/working/task_m020_394_stage4.md
+++ b/mydocs/working/task_m020_394_stage4.md
@@ -1,0 +1,7 @@
+# Task M020 #394 Stage 4 — PR 리뷰 보완
+
+PR #503의 리뷰 1–6을 반영했다. writer/verifier는 header가 앞선 공통 LOCK_ARTIFACTS를 순회한다. legacy env는 legacy alias와 strict에서만 검사하며 build-only/portable/update는 무시한다. 동일 옵션도 계속 중복으로 거부하되 이유를 명시한다. RustBridge/CONTRIBUTING의 기본 명령과 strict 자동 runner가 없는 현재 정책을 정렬했다.
+
+검증: 격리 CLI 24개, shell syntax, git diff --check 통과. 추가 artifact의 metadata 누락 차단과 명시 writer 기록 후 strict 검증, env 비적용 경로, 반복 옵션 진단을 포함한다. 명시 update fixture 외에는 lock 불변을 단언한다. 실제 portable build와 PR CI 결과는 게시 후 보완 코멘트에 실행 결과를 연결한다. core/Cargo/FFI lock은 변경하지 않았다.
+
+근거: `build.noindex/task394/review-cli.log`, `review-portable.log`. 기존 strict 불일치를 새 lock hash로 수용하지 않았고 scheduled strict job은 기준 환경 재현성을 확보한 뒤 별도 도입한다.

--- a/mydocs/working/task_m020_470_stage1.md
+++ b/mydocs/working/task_m020_470_stage1.md
@@ -1,0 +1,7 @@
+# Task M020 #470 Stage 1 완료보고서
+
+known RenderNodeType 24개(19 payload, 5 unit)를 명시적으로 판별한다. payload key가 있으면 `try`로 decode하고 실패를 known variant 문맥과 함께 전파한다. unknown 단일 string/object는 forward compatible `.unknown`이며, 빈/multiple tag object와 known tag의 잘못된 표현은 실패한다.
+
+`RenderTreeDecodingFailure`는 schema coding path, known variant, DecodingError 분류만 보존한다. raw value, debugDescription, underlyingError는 저장하지 않는다. arbitrary dynamic enum tag는 path에 그대로 기록하지 않는다. `RenderTreeDecoder.decode`는 envelope 오류도 동일 구조로 변환한다.
+
+검증: current/legacy/TextRun 성공 3개, future variant 성공 2개, malformed payload/envelope/tag/privacy 진단 11개 통과. 중첩 오류는 `variant=TextRun path=$.children[0].node_type.TextRun.text cause=keyNotFound`로 확인했다. no-AppKit와 diff check 통과. 로그는 `build.noindex/task470-decoder.log`.

--- a/mydocs/working/task_m020_470_stage2.md
+++ b/mydocs/working/task_m020_470_stage2.md
@@ -1,0 +1,15 @@
+# Task M020 #470 Stage 2 완료보고서
+
+## 결과
+
+`renderPageTreeThrowing(at:)`를 추가하고 기존 optional API는 `try?`로 위임한다. 음수/UInt32 범위 밖 page와 producer의 null JSON을 구분한다. C 문자열은 `defer`로 복사 후 해제한다. native smoke/debug helper는 구조화된 오류를 출력하며 제품 wrapper에는 로그를 추가하지 않았다.
+
+실제 smoke에서 기존 decoder가 숨긴 타입 불일치를 발견했다. pinned rhwp `f1f9c6a`의 `renderer/render_tree.rs`는 section/para/control/char_start에 usize를 사용하고, `layout.rs`는 머리말에서 `usize::MAX - i` marker를 사용한다. KTX TextLine의 para_index는 `18446744073709551615`와 `18446744073709551608`을 포함했다. 해당 Swift index metadata를 UInt로 맞춰 손실 없이 보존한다. 필드를 optional/default로 완화하지 않았다. Foundation의 비-DecodingError에도 최소 known payload path와 `unexpectedDecoderError`를 남긴다.
+
+## 검증
+
+- decoder의 16개 기존/신규 계약과 UInt.max marker 보존/음수 거부 추가 2개 통과.
+- native smoke: KTX 415 TextRun/458075 non-white pixels, request 103/71110, exam_kor 133/173728, hwpx-01 269/132731 통과.
+- smoke에서 실제 RhwpDocument의 음수/UInt32 범위 밖 page, optional nil, pageCount 경계의 FFI null-output 오류 구분을 검증했다.
+- no-AppKit, diff check 통과. 산출물은 `build.noindex/task470/`.
+- core/native 상세 비교와 HostApp compile은 Stage 3에서 수행한다. 원본 sample과 core pin은 변경하지 않았다.

--- a/mydocs/working/task_m020_470_stage3.md
+++ b/mydocs/working/task_m020_470_stage3.md
@@ -1,0 +1,14 @@
+# Task M020 #470 Stage 3 완료보고서
+
+## 통합 검증
+
+- decoder 18개 계약, 기본 HWP 3종/HWPX 1종 native smoke, page boundary/producer null-output 검증 통과.
+- `xcodegen generate`, HostApp Debug build 성공(12.301초). no-AppKit, diff check, core/Cargo/FFI lock 불변 확인.
+- KTX/request core SVG·native PNG·diff 생성 및 육안 확인. core/native 차이 비율은 각각 0.556528/0.177364이며 raster 크기 1px 차이, font/gradient/line 표현 차이가 남아 있다. pixel parity 통과로 표시하지 않는다.
+- #394 head `de4d374`의 decoder/document로 같은 native smoke를 별도 컴파일해 비교했다. KTX TextRun 410→415, 한글 scalar 209→234, request TextRun 102→103, 한글 scalar 309→312로 기존 unsigned metadata decode 실패에 가려졌던 텍스트가 복원됐다. renderer source는 변경하지 않았다.
+
+로그/이미지: `build.noindex/task470/{decoder.log,render.log,build.log,baseline.log,compare-host/}`.
+
+## 개발 등록 정리
+
+빌드의 LaunchServices 등록 명령을 확인한 뒤 표준 `check-extension-registration-hygiene.sh --cleanup-dev-registrations`를 실행했다. task470 앱과 appex의 unregister 호출을 기록했고 PlugInKit provider에는 기존 `/Applications` 및 사용자 `Applications` 설치본만 남아 있다. 전체 hygiene 명령은 과거 LaunchServices 경로 잔존과 두 설치본 provider 때문에 exit 1이므로 전역 hygiene 통과라고 보고하지 않는다. 기존 설치본·과거 작업 파일은 보존했다. 이번 작업은 설치본 Finder smoke 또는 release gate가 아니다.

--- a/mydocs/working/task_m020_470_stage4.md
+++ b/mydocs/working/task_m020_470_stage4.md
@@ -1,0 +1,20 @@
+# Task M020 #470 Stage 4 — PR 리뷰 보완
+
+CellContext.parentParaIndex와 CellPathEntry.cellIndex/cellParaIndex를 pinned Rust usize와 같은 UInt로 보존한다. known tag는 CaseIterable enum에서 파생하고 payload switch가 모든 case를 처리하여 수동 이름 집합과의 drift를 방지한다. 다중 tag는 variant를 임의 선택하지 않으며 nil variant를 unresolved로 표시한다. throwing API는 pageCount 밖도 invalidPageIndex로 분류한다. raw JSON API는 실제 FFI null-output 검증을 위해 UInt32 변환만 검사한다.
+
+검증 결과:
+
+- 기존 current/legacy/future/malformed/privacy 계약과 UInt.max 및 UInt.max−1 정밀도 보존 통과.
+- CellContext의 네 unsigned 필드의 큰 정수 보존과 각 음수 거부 통과.
+- 알려진 24종 모두의 valid wire payload/unit decode 및 반대 표현 거부 통과.
+- HWP 3종/HWPX 1종 native smoke와 실제 pageCount/음수/UInt32 경계·FFI null 검증 통과. TextRun은 KTX 415, request 103, exam 133, HWPX 269로 기존 성공 결과와 같다.
+- no-AppKit, xcodegen/HostApp Debug build(16.923초), shell syntax, diff 검증 통과. 최초 build의 Sparkle 다운로드 제한은 네트워크 허용 후 재실행으로 해소했다.
+- core/Cargo/FFI lock과 renderer layout source는 변경하지 않았다.
+
+로그: `build.noindex/task470/review-{decoder,native,build,registration}.log`. Xcode가 등록한 개발 bundle은 표준 등록 위생 helper의 cleanup 대상으로 처리한다. 기존 설치본은 삭제하지 않는다.
+
+## 최소 지원 OS 잔여 조건
+
+현재 실제 실행 OS는 macOS 26.5.2이며 PR CI는 macos-15다. 작업지시자가 macOS 12 기기/VM이 없음을 확인했고 저장소 self-hosted runner도 0개다. 따라서 macOS 12 runtime 검증은 미실행이며 병합 전 확인 조건으로 남긴다. deploymentTarget 상향 또는 known payload의 조용한 unknown 격하로 대신하지 않는다.
+
+macOS 12 환경이 마련되면 실제 OS 버전을 기록한 뒤 `scripts/ci/test-render-tree-decoder.sh`와 `scripts/validate-stage3-render.sh`를 KTX/request/HWPX에 실행한다. #469 반영 후 producer golden도 검증한다. 컴파일 target만 12.0으로 지정하거나 최신 OS에서 성공한 결과를 최소 OS 성공으로 기재하지 않는다.

--- a/scripts/build-rust-macos.sh
+++ b/scripts/build-rust-macos.sh
@@ -17,8 +17,9 @@ GENERATED_SYMBOLS="$OUT/generated_rhwp_symbols.txt"
 UNIVERSAL_LIB="$OUT/universal/librhwp.a"
 STATICLIB_ARTIFACT="Frameworks/universal/librhwp.a"
 LOCK_ARTIFACTS=(
-  "$STATICLIB_ARTIFACT"
+  # Writer and verifier share this ordered list; report header failures before archive drift.
   "Frameworks/generated_rhwp.h"
+  "$STATICLIB_ARTIFACT"
 )
 VERIFY_MODE="none"
 VERIFY_LOCK=0
@@ -37,7 +38,7 @@ Options:
                      Use only with the reference toolchain and build environment.
   --verify-lock      Legacy strict alias; legacy skip env remains supported.
   --update-lock      Build artifacts, then explicitly write reference metadata.
-  (no option)       Build artifacts without lock comparison.
+  (no option)        Build artifacts without lock comparison.
 
 Legacy environment (only --verify-lock):
   ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 selects portable verification.
@@ -58,12 +59,16 @@ while [ "$#" -gt 0 ]; do
 done
 
 if [ "$MODE_COUNT" -gt 1 ]; then
-  echo "ERROR: choose exactly one build/verification mode" >&2
+  echo "ERROR: duplicate or conflicting modes; choose exactly one build/verification mode" >&2
   exit 1
 fi
-case "$LEGACY_SKIP" in
-  0|1) ;;
-  *) echo "ERROR: ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY must be 0 or 1" >&2; exit 1 ;;
+case "$VERIFY_MODE" in
+  verify-lock|verify-strict)
+    case "$LEGACY_SKIP" in
+      0|1) ;;
+      *) echo "ERROR: ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY must be 0 or 1" >&2; exit 1 ;;
+    esac
+    ;;
 esac
 case "$VERIFY_MODE" in
   update-lock) UPDATE_LOCK=1 ;;
@@ -563,7 +568,7 @@ verify_lock_file() {
   fi
 
   local artifact_path
-  for artifact_path in "Frameworks/generated_rhwp.h" "$STATICLIB_ARTIFACT"; do
+  for artifact_path in "${LOCK_ARTIFACTS[@]}"; do
     require_artifact "$artifact_path"
 
     local abs_path

--- a/scripts/build-rust-macos.sh
+++ b/scripts/build-rust-macos.sh
@@ -20,51 +20,69 @@ LOCK_ARTIFACTS=(
   "$STATICLIB_ARTIFACT"
   "Frameworks/generated_rhwp.h"
 )
-SKIP_STATICLIB_HASH_VERIFY="${ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY:-0}"
-UPDATE_LOCK=0
+VERIFY_MODE="none"
 VERIFY_LOCK=0
+UPDATE_LOCK=0
+MODE_COUNT=0
+LEGACY_SKIP="${ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY:-0}"
 
 usage() {
   cat >&2 <<EOF
-Usage: $0 [--update-lock | --verify-lock]
+Usage: $0 [--verify-portable | --verify-strict | --verify-lock | --update-lock]
 
 Options:
-  --update-lock   Build artifacts, then write sha256/size to rhwp-core.lock.
-  --verify-lock   Build artifacts, then compare artifacts with rhwp-core.lock.
+  --verify-portable  Build and verify source/Cargo.lock, header and FFI symbols.
+                     Check staticlib presence/metadata, without byte hash/size comparison.
+  --verify-strict    Also require staticlib reference sha256/size to match.
+                     Use only with the reference toolchain and build environment.
+  --verify-lock      Legacy strict alias; legacy skip env remains supported.
+  --update-lock      Build artifacts, then explicitly write reference metadata.
+  (no option)       Build artifacts without lock comparison.
 
-Environment:
-  ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1
-                  With --verify-lock, skip only byte-for-byte sha256/size
-                  comparison for Frameworks/universal/librhwp.a. Source lock,
-                  Cargo.lock, generated header, and FFI symbol checks still run.
+Legacy environment (only --verify-lock):
+  ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 selects portable verification.
+  Prefer --verify-portable. --verify-strict rejects this override.
 EOF
 }
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --update-lock)
-      UPDATE_LOCK=1
+    --verify-portable|--verify-strict|--verify-lock|--update-lock)
+      MODE_COUNT=$((MODE_COUNT + 1))
+      VERIFY_MODE="${1#--}"
       ;;
-    --verify-lock)
-      VERIFY_LOCK=1
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      echo "ERROR: unknown option: $1" >&2
-      usage
-      exit 1
-      ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "ERROR: unknown option: $1" >&2; usage; exit 1 ;;
   esac
   shift
 done
 
-if [ "$UPDATE_LOCK" -eq 1 ] && [ "$VERIFY_LOCK" -eq 1 ]; then
-  echo "ERROR: --update-lock and --verify-lock cannot be used together" >&2
-  usage
+if [ "$MODE_COUNT" -gt 1 ]; then
+  echo "ERROR: choose exactly one build/verification mode" >&2
   exit 1
+fi
+case "$LEGACY_SKIP" in
+  0|1) ;;
+  *) echo "ERROR: ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY must be 0 or 1" >&2; exit 1 ;;
+esac
+case "$VERIFY_MODE" in
+  update-lock) UPDATE_LOCK=1 ;;
+  verify-lock)
+    if [ "$LEGACY_SKIP" = "1" ]; then VERIFY_MODE=portable; else VERIFY_MODE=strict; fi
+    echo "WARNING: --verify-lock is a legacy alias; use --verify-$VERIFY_MODE explicitly." >&2
+    VERIFY_LOCK=1
+    ;;
+  verify-portable) VERIFY_MODE=portable; VERIFY_LOCK=1 ;;
+  verify-strict)
+    if [ "$LEGACY_SKIP" = "1" ]; then
+      echo "ERROR: --verify-strict conflicts with legacy staticlib skip; unset the environment override." >&2
+      exit 1
+    fi
+    VERIFY_MODE=strict; VERIFY_LOCK=1
+    ;;
+esac
+if [ "$VERIFY_LOCK" -eq 1 ]; then
+  echo "Verification mode: $VERIFY_MODE (source, Cargo.lock, generated header, FFI symbols enforced)"
 fi
 
 require_tool() {
@@ -157,23 +175,15 @@ lock_artifact_value() {
   ' "$LOCK_FILE"
 }
 
-print_staticlib_hash_skip_warning() {
-  local artifact_path="$1"
-  cat >&2 <<EOF
-WARNING: skipping byte-for-byte hash verification for $artifact_path
-         Only the Rust static archive sha256/size comparison is skipped.
-         Source provenance, Cargo.lock, generated header, and FFI symbols remain verified.
-EOF
-}
-
 print_staticlib_hash_mismatch_note() {
   cat >&2 <<EOF
-Note: $STATICLIB_ARTIFACT is a Rust static archive. Its byte hash can differ
-      across Rust, Xcode, macOS runner, archive tool, or build path changes even
-      when source provenance and ABI checks still match. Do not update
-      rhwp-core.lock just to satisfy an unreviewed runner/toolchain difference.
-      GitHub-hosted CI/release workflows may set
-      ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1 under the documented policy.
+Strict reference artifact mismatch: source/header/ABI checks passed, but the Rust
+static archive bytes differ. Rust, Xcode, macOS, archive tools or build paths may
+cause this; this message does not establish the cause or reproducibility.
+For ordinary local/CI source and ABI verification, run:
+  ./scripts/build-rust-macos.sh --verify-portable
+For strict verification, reproduce the reference build environment.
+Do not update rhwp-core.lock merely to accept local archive bytes.
 EOF
 }
 
@@ -553,13 +563,8 @@ verify_lock_file() {
   fi
 
   local artifact_path
-  for artifact_path in "${LOCK_ARTIFACTS[@]}"; do
+  for artifact_path in "Frameworks/generated_rhwp.h" "$STATICLIB_ARTIFACT"; do
     require_artifact "$artifact_path"
-
-    if [ "$artifact_path" = "$STATICLIB_ARTIFACT" ] && [ "$SKIP_STATICLIB_HASH_VERIFY" = "1" ]; then
-      print_staticlib_hash_skip_warning "$artifact_path"
-      continue
-    fi
 
     local abs_path
     local expected_sha256
@@ -573,14 +578,23 @@ verify_lock_file() {
     actual_sha256="$(artifact_sha256 "$abs_path")"
     actual_size="$(artifact_size "$abs_path")"
 
-    if [ -z "$expected_sha256" ] || [ -z "$expected_size" ]; then
-      echo "ERROR: missing lock metadata for artifact: $artifact_path" >&2
-      echo "Run: ./scripts/build-rust-macos.sh --update-lock" >&2
+    if ! [[ "$expected_sha256" =~ ^[0-9a-f]{64}$ ]] || ! [[ "$expected_size" =~ ^[1-9][0-9]*$ ]]; then
+      echo "ERROR: missing or invalid lock metadata for artifact: $artifact_path" >&2
+      echo "Restore the reviewed lock metadata; verification never rewrites it." >&2
       exit 1
     fi
 
+    if [ "$artifact_path" = "$STATICLIB_ARTIFACT" ] && [ "$VERIFY_MODE" = "portable" ]; then
+      echo "Portable: staticlib present; reference metadata valid; byte hash/size comparison excluded."
+      continue
+    fi
+
     if [ "$expected_sha256" != "$actual_sha256" ] || [ "$expected_size" != "$actual_size" ]; then
-      echo "ERROR: artifact hash mismatch: artifact differs from $LOCK_FILE" >&2
+      if [ "$artifact_path" = "$STATICLIB_ARTIFACT" ]; then
+        echo "ERROR: strict staticlib reference mismatch" >&2
+      else
+        echo "ERROR: generated header ABI artifact mismatch" >&2
+      fi
       echo "Artifact: $artifact_path" >&2
       echo "Expected sha256: $expected_sha256" >&2
       echo "Actual sha256:   $actual_sha256" >&2
@@ -589,12 +603,12 @@ verify_lock_file() {
       if [ "$artifact_path" = "$STATICLIB_ARTIFACT" ]; then
         print_staticlib_hash_mismatch_note
       fi
-      echo "Run: ./scripts/build-rust-macos.sh --update-lock if this artifact is intentional." >&2
+      echo "Review source/ABI changes and the reference environment before any explicit lock update." >&2
       exit 1
     fi
   done
 
-  echo "Verified: $LOCK_FILE"
+  echo "Verified ($VERIFY_MODE): $LOCK_FILE"
 }
 
 require_tool cargo

--- a/scripts/ci/classify-pr-changes.sh
+++ b/scripts/ci/classify-pr-changes.sh
@@ -16,10 +16,9 @@ Outputs:
   run_release_checks
 
 Notes:
-  run_rust_verify=true means PR CI should run build-rust-macos.sh --verify-lock
-  for source/core/header/ABI verification. The macOS validation workflow may
-  separately skip only librhwp.a byte hash verification with
-  ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1.
+  run_rust_verify=true means PR CI should run build-rust-macos.sh --verify-portable
+  for source/core/header/ABI verification. Portable mode excludes only
+  librhwp.a byte hash/size comparison while retaining reference metadata checks.
 EOF
 }
 
@@ -232,8 +231,8 @@ print_rust_verify_policy() {
   echo "### Rust verify policy"
   echo
   if [ "$run_rust_verify" = "true" ]; then
-    echo "- \`run_rust_verify=true\` runs \`./scripts/build-rust-macos.sh --verify-lock\` in macOS validation."
-    echo "- PR macOS validation may set \`ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY=1\`, which skips only \`Frameworks/universal/librhwp.a\` byte hash/size comparison."
+    echo "- \`run_rust_verify=true\` runs \`./scripts/build-rust-macos.sh --verify-portable\` in macOS validation."
+    echo "- Portable verification excludes staticlib byte hash/size comparison; source/header/ABI gates remain enforced."
     echo "- Source provenance, Cargo lock, generated header, and FFI symbol checks remain part of Rust verify."
   else
     echo "- \`run_rust_verify=false\`; macOS validation rebuilds Rust bridge artifacts without lock comparison."

--- a/scripts/ci/render_tree_decoder_fixture.swift
+++ b/scripts/ci/render_tree_decoder_fixture.swift
@@ -173,13 +173,18 @@ private func expectDecodeFailure(_ data: Data, variant: String?, path: String,
 }
 
 private func verifyUnsignedCoreIndexMetadata() throws {
-    // JSONSerialization의 Double 변환을 거치지 않고 producer의 usize marker를 재현한다.
+    // 원본 숫자 리터럴을 직접 검사하여 fixture 생성 과정의 숫자 변환을 배제한다.
     let textLine = #"{"id":1,"node_type":{"TextLine":{"line_height":20,"baseline":17,"section_index":0,"para_index":18446744073709551615}},"bbox":{"x":0,"y":0,"width":100,"height":20},"children":[],"visible":true}"#
     let root = try RenderTreeDecoder.decode(Data(textLine.utf8))
     guard case .textLine(let line) = root.nodeType else {
         throw RenderTreeDecoderFixtureError.assertion("core marker TextLine was not decoded")
     }
     try require(line.paraIndex == UInt.max, "unsigned producer marker was lost")
+    let previous = try RenderTreeDecoder.decode(Data(textLine.replacingOccurrences(of: "18446744073709551615", with: "18446744073709551614").utf8))
+    guard case .textLine(let previousLine) = previous.nodeType else {
+        throw RenderTreeDecoderFixtureError.assertion("UInt.max-1 marker TextLine was not decoded")
+    }
+    try require(previousLine.paraIndex == UInt.max - 1, "adjacent unsigned marker was rounded")
     do {
         _ = try RenderTreeDecoder.decode(Data(textLine.replacingOccurrences(of: "18446744073709551615", with: "-1").utf8))
         throw RenderTreeDecoderFixtureError.assertion("negative unsigned index was accepted")
@@ -191,6 +196,71 @@ private func verifyUnsignedCoreIndexMetadata() throws {
                     "unexpected numeric failure classification")
     }
     print("OK: UInt.max core index marker preserved; negative index rejected")
+}
+
+private func verifyUnsignedCellContext() throws {
+    let context = #"{"parent_para_index":18446744073709551615,"path":[{"control_index":18446744073709551615,"cell_index":18446744073709551614,"cell_para_index":18446744073709551615,"text_direction":0}]}"#
+    let json = textRunPayloadJSON.replacingOccurrences(of: #""field_marker": "None""#,
+        with: #""field_marker": "None", "cell_context": "# + context)
+    let root = try RenderTreeDecoder.decode(Data(json.utf8))
+    guard case .textRun(let run) = root.nodeType, let cell = run.cellContext, let entry = cell.path.first else {
+        throw RenderTreeDecoderFixtureError.assertion("missing cell context")
+    }
+    try require(cell.parentParaIndex == UInt.max && entry.controlIndex == UInt.max &&
+                entry.cellIndex == UInt.max - 1 && entry.cellParaIndex == UInt.max,
+                "cell usize values lost or rounded")
+    for field in ["parent_para_index", "control_index", "cell_index", "cell_para_index"] {
+        let value = field == "cell_index" ? "18446744073709551614" : "18446744073709551615"
+        let negative = json.replacingOccurrences(of: "\"\(field)\":\(value)", with: "\"\(field)\":-1")
+        do {
+            _ = try RenderTreeDecoder.decode(Data(negative.utf8))
+            throw RenderTreeDecoderFixtureError.assertion("negative \(field) accepted")
+        } catch let failure as RenderTreeDecodingFailure {
+            try require(failure.variant == "TextRun" && failure.path.hasPrefix("$.node_type.TextRun"),
+                        "cell numeric failure lost payload diagnostic")
+            try require(failure.reason == .dataCorrupted || failure.reason == .unexpectedDecoderError,
+                        "unexpected cell numeric failure")
+        }
+    }
+    print("OK: cell context preserves UInt.max/UInt.max-1; all four unsigned fields reject negatives")
+}
+
+private func verifyEveryKnownVariant() throws {
+    var root = try JSONSerialization.jsonObject(with: Data(textRunPayloadJSON.utf8)) as! [String: Any]
+    let textRun = (root["node_type"] as! [String: Any])["TextRun"]!
+    let transform: [String: Any] = ["rotation": 0, "horz_flip": false, "vert_flip": false]
+    let style: [String: Any] = ["stroke_width": 1, "stroke_dash": "Solid", "opacity": 1]
+    let lineStyle: [String: Any] = ["color": 0, "width": 1, "dash": "Solid", "line_type": "Normal",
+        "start_arrow": "None", "end_arrow": "None", "start_arrow_size": 0, "end_arrow_size": 0]
+    // Independent wire fixtures: removing/renaming an implemented tag must not silently become unknown.
+    let payloads: [String: Any] = [
+        "Page": ["page_index": 0, "width": 100, "height": 100, "section_index": 0],
+        "PageBackground": ["border_width": 0], "Body": [:] as [String: Any], "Column": 0,
+        "TextLine": ["line_height": 20, "baseline": 17], "TextRun": textRun,
+        "Table": ["row_count": 1, "col_count": 1, "border_fill_id": 0],
+        "TableCell": ["col": 0, "row": 0, "col_span": 1, "row_span": 1, "border_fill_id": 0, "text_direction": 0, "clip": false],
+        "Line": ["x1": 0, "y1": 0, "x2": 1, "y2": 1, "style": lineStyle, "transform": transform],
+        "Rectangle": ["corner_radius": 0, "style": style, "transform": transform],
+        "Ellipse": ["style": style, "transform": transform],
+        "Path": ["commands": [], "style": style, "transform": transform],
+        "Image": ["bin_data_id": 1, "transform": transform], "Group": [:] as [String: Any],
+        "Equation": ["svg_content": "", "color_str": "#000000", "color": 0, "font_size": 12],
+        "FormObject": ["form_type": "Edit", "caption": "", "text": ""],
+        "Placeholder": ["fill_color": 0, "stroke_color": 0, "label": ""], "RawSvg": ["svg": ""],
+        "FootnoteMarker": ["number": 1, "text": "1", "base_font_size": 12, "font_family": "FixtureSans", "color": 0],
+    ]
+    let units = ["MasterPage", "Header", "Footer", "FootnoteArea", "TextBox"]
+    try require(Set(payloads.keys).union(units) == RenderNodeType.knownVariantNames, "known tag contract drift")
+    for name in (Array(payloads.keys) + units).sorted() {
+        root["node_type"] = payloads[name].map { [name: $0] as Any } ?? name
+        let decoded = try RenderTreeDecoder.decode(jsonData(root))
+        if case .unknown = decoded.nodeType {
+            throw RenderTreeDecoderFixtureError.assertion("known \(name) silently became unknown")
+        }
+        root["node_type"] = payloads[name] == nil ? [name: NSNull()] as Any : name
+        try expectDecodeFailure(try jsonData(root), variant: name, path: "$.node_type", reason: .invalidVariantShape)
+    }
+    print("OK: all 24 known wire variants decode and reject the opposite unit/payload shape")
 }
 
 private func verifyStrictKnownAndUnknownPolicy() throws {
@@ -222,10 +292,11 @@ private func verifyStrictKnownAndUnknownPolicy() throws {
             throw RenderTreeDecoderFixtureError.assertion("future variant must remain unknown")
         }
     }
-    for value: Any in ["TextRun", ["Header": NSNull()], ["TextRun": payload, "Future_PRIVATE_DOCUMENT": true]] {
+    for value: Any in ["TextRun", ["Header": NSNull()], ["TextRun": payload, "Future_PRIVATE_DOCUMENT": true], ["Body": [:], "TextRun": payload]] {
         root = original
         root["node_type"] = value
-        let variant = (value as? [String: Any])?["Header"] != nil ? "Header" : "TextRun"
+        let object = value as? [String: Any]
+        let variant: String? = object?.count == 2 ? nil : (object?["Header"] != nil ? "Header" : "TextRun")
         try expectDecodeFailure(try jsonData(root), variant: variant, path: "$.node_type", reason: .invalidVariantShape)
     }
     root = original
@@ -249,6 +320,8 @@ private struct RenderTreeDecoderFixture {
             try verifyTextRunPayloadFixture()
             try verifyStrictKnownAndUnknownPolicy()
             try verifyUnsignedCoreIndexMetadata()
+            try verifyUnsignedCellContext()
+            try verifyEveryKnownVariant()
             print(
                 "OK: render tree decoder preserves current/legacy/future variants and diagnoses malformed known/envelope payloads"
             )

--- a/scripts/ci/render_tree_decoder_fixture.swift
+++ b/scripts/ci/render_tree_decoder_fixture.swift
@@ -154,6 +154,71 @@ private func verifyTextRunPayloadFixture() throws {
     }
 }
 
+private func jsonData(_ object: [String: Any]) throws -> Data {
+    try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+}
+
+private func expectDecodeFailure(_ data: Data, variant: String?, path: String,
+                                 reason: RenderTreeDecodingFailure.Reason) throws {
+    do {
+        _ = try RenderTreeDecoder.decode(data)
+        throw RenderTreeDecoderFixtureError.assertion("malformed known/envelope unexpectedly accepted")
+    } catch let failure as RenderTreeDecodingFailure {
+        try require(failure.variant == variant, "unexpected diagnostic variant: \(failure)")
+        try require(failure.path == path, "unexpected diagnostic path: \(failure)")
+        try require(failure.reason == reason, "unexpected diagnostic cause: \(failure)")
+        try require(!failure.description.contains("PRIVATE_DOCUMENT"), "diagnostic leaked document value")
+        print("OK: \(failure)")
+    }
+}
+
+private func verifyStrictKnownAndUnknownPolicy() throws {
+    let original = try JSONSerialization.jsonObject(with: Data(textRunPayloadJSON.utf8)) as! [String: Any]
+    let tagged = original["node_type"] as! [String: Any]
+    let payload = tagged["TextRun"] as! [String: Any]
+    var root = original
+    var missing = payload
+    missing.removeValue(forKey: "text")
+    root["node_type"] = ["TextRun": missing]
+    try expectDecodeFailure(try jsonData(root), variant: "TextRun", path: "$.node_type.TextRun.text", reason: .keyNotFound)
+    var bad = payload
+    bad["text"] = ["PRIVATE_DOCUMENT": "/private/PRIVATE_DOCUMENT.hwp"]
+    root["node_type"] = ["TextRun": bad]
+    try expectDecodeFailure(try jsonData(root), variant: "TextRun", path: "$.node_type.TextRun.text", reason: .typeMismatch)
+    root["node_type"] = ["TextRun": NSNull()]
+    try expectDecodeFailure(try jsonData(root), variant: "TextRun", path: "$.node_type.TextRun", reason: .valueNotFound)
+
+    var parent = try JSONSerialization.jsonObject(with: Data(currentJSON.utf8)) as! [String: Any]
+    root["node_type"] = ["TextRun": missing]
+    parent["children"] = [root]
+    try expectDecodeFailure(try jsonData(parent), variant: "TextRun", path: "$.children[0].node_type.TextRun.text", reason: .keyNotFound)
+
+    for value: Any in ["Future_PRIVATE_DOCUMENT", ["Future_PRIVATE_DOCUMENT": ["text": "PRIVATE_DOCUMENT"]]] {
+        root = original
+        root["node_type"] = value
+        let decoded = try RenderTreeDecoder.decode(jsonData(root))
+        guard case .unknown = decoded.nodeType else {
+            throw RenderTreeDecoderFixtureError.assertion("future variant must remain unknown")
+        }
+    }
+    for value: Any in ["TextRun", ["Header": NSNull()], ["TextRun": payload, "Future_PRIVATE_DOCUMENT": true]] {
+        root = original
+        root["node_type"] = value
+        let variant = (value as? [String: Any])?["Header"] != nil ? "Header" : "TextRun"
+        try expectDecodeFailure(try jsonData(root), variant: variant, path: "$.node_type", reason: .invalidVariantShape)
+    }
+    root = original
+    root["node_type"] = [String: Any]()
+    try expectDecodeFailure(try jsonData(root), variant: nil, path: "$.node_type", reason: .invalidVariantShape)
+    root = original
+    root.removeValue(forKey: "bbox")
+    try expectDecodeFailure(try jsonData(root), variant: nil, path: "$.bbox", reason: .keyNotFound)
+    root = original
+    root["visible"] = "PRIVATE_DOCUMENT"
+    try expectDecodeFailure(try jsonData(root), variant: nil, path: "$.visible", reason: .typeMismatch)
+    try expectDecodeFailure(Data("{PRIVATE_DOCUMENT".utf8), variant: nil, path: "$", reason: .dataCorrupted)
+}
+
 @main
 private struct RenderTreeDecoderFixture {
     static func main() {
@@ -161,8 +226,9 @@ private struct RenderTreeDecoderFixture {
             try verifyFixture(named: "current-without-dirty", json: currentJSON)
             try verifyFixture(named: "legacy-with-dirty", json: legacyJSON)
             try verifyTextRunPayloadFixture()
+            try verifyStrictKnownAndUnknownPolicy()
             print(
-                "OK: render tree decoder accepts current/legacy envelopes and TextRun payload"
+                "OK: render tree decoder preserves current/legacy/future variants and diagnoses malformed known/envelope payloads"
             )
         } catch {
             let message = "ERROR: render tree decoder fixture failed: \(error)\n"

--- a/scripts/ci/render_tree_decoder_fixture.swift
+++ b/scripts/ci/render_tree_decoder_fixture.swift
@@ -172,6 +172,27 @@ private func expectDecodeFailure(_ data: Data, variant: String?, path: String,
     }
 }
 
+private func verifyUnsignedCoreIndexMetadata() throws {
+    // JSONSerialization의 Double 변환을 거치지 않고 producer의 usize marker를 재현한다.
+    let textLine = #"{"id":1,"node_type":{"TextLine":{"line_height":20,"baseline":17,"section_index":0,"para_index":18446744073709551615}},"bbox":{"x":0,"y":0,"width":100,"height":20},"children":[],"visible":true}"#
+    let root = try RenderTreeDecoder.decode(Data(textLine.utf8))
+    guard case .textLine(let line) = root.nodeType else {
+        throw RenderTreeDecoderFixtureError.assertion("core marker TextLine was not decoded")
+    }
+    try require(line.paraIndex == UInt.max, "unsigned producer marker was lost")
+    do {
+        _ = try RenderTreeDecoder.decode(Data(textLine.replacingOccurrences(of: "18446744073709551615", with: "-1").utf8))
+        throw RenderTreeDecoderFixtureError.assertion("negative unsigned index was accepted")
+    } catch let failure as RenderTreeDecodingFailure {
+        // Foundation versions differ: integer overflow may lack a DecodingError codingPath.
+        try require(failure.variant == "TextLine", "numeric failure lost known variant")
+        try require(failure.path.hasPrefix("$.node_type.TextLine"), "numeric failure lost payload path")
+        try require(failure.reason == .dataCorrupted || failure.reason == .unexpectedDecoderError,
+                    "unexpected numeric failure classification")
+    }
+    print("OK: UInt.max core index marker preserved; negative index rejected")
+}
+
 private func verifyStrictKnownAndUnknownPolicy() throws {
     let original = try JSONSerialization.jsonObject(with: Data(textRunPayloadJSON.utf8)) as! [String: Any]
     let tagged = original["node_type"] as! [String: Any]
@@ -227,6 +248,7 @@ private struct RenderTreeDecoderFixture {
             try verifyFixture(named: "legacy-with-dirty", json: legacyJSON)
             try verifyTextRunPayloadFixture()
             try verifyStrictKnownAndUnknownPolicy()
+            try verifyUnsignedCoreIndexMetadata()
             print(
                 "OK: render tree decoder preserves current/legacy/future variants and diagnoses malformed known/envelope payloads"
             )

--- a/scripts/ci/test-render-tree-decoder.sh
+++ b/scripts/ci/test-render-tree-decoder.sh
@@ -10,7 +10,8 @@ Usage: $0
 
 Compiles RenderTree.swift with an isolated fixture and verifies both current
 JSON without the retired dirty field, legacy JSON that still contains it,
-and a complete TextRun/TextStyle payload.
+a complete TextRun/TextStyle payload, strict known-variant failures, unknown
+future variants, malformed envelopes and sanitized nested diagnostics.
 EOF
 }
 

--- a/scripts/ci/test-render-tree-decoder.sh
+++ b/scripts/ci/test-render-tree-decoder.sh
@@ -36,6 +36,8 @@ MODULE_CACHE="$TMP_ROOT/swift-module-cache"
 BIN="$TMP_ROOT/render-tree-decoder-fixture"
 mkdir -p "$MODULE_CACHE"
 
+echo "Decoder runtime: macOS $(sw_vers -productVersion), $(uname -m)"
+
 swiftc -parse-as-library \
   -module-cache-path "$MODULE_CACHE" \
   "$ROOT/Sources/RhwpCoreBridge/RenderTree.swift" \

--- a/scripts/ci/test-rust-verification-modes.py
+++ b/scripts/ci/test-rust-verification-modes.py
@@ -28,7 +28,7 @@ elif name == 'stat':
 '''
 
 
-def run_case(name, flags, expected, needle, *, archive=None, legacy=None, mutation=None):
+def run_case(name, flags, expected, needle, *, archive=None, legacy=None, mutation=None, updated_artifact=None):
     with tempfile.TemporaryDirectory(prefix="rhwp-verify-test-") as tmp:
         root = Path(tmp)
         for directory in ("scripts", "RustBridge", "bin"):
@@ -59,12 +59,31 @@ def run_case(name, flags, expected, needle, *, archive=None, legacy=None, mutati
         output = result.stdout + result.stderr
         assert (result.returncode == 0) == expected, f"{name}: unexpected exit {result.returncode}\n{output}"
         assert needle in output, f"{name}: missing {needle!r}\n{output}"
-        assert before == (root / "rhwp-core.lock").read_bytes(), f"{name}: verification rewrote lock"
+        after = (root / "rhwp-core.lock").read_bytes()
+        if updated_artifact is None:
+            assert before == after, f"{name}: verification rewrote lock"
+        else:
+            assert flags == ["--update-lock"] and expected
+            data = (root / updated_artifact).read_bytes()
+            record = f'path = "{updated_artifact}"\nsha256 = "{hashlib.sha256(data).hexdigest()}"\nsize = {len(data)}'
+            assert record in after.decode(), f"{name}: writer omitted additional artifact"
+            verify_env = dict(env)
+            verify_env.pop("ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY", None)
+            verified = subprocess.run(["bash", str(root / "scripts/build-rust-macos.sh"), "--verify-strict"], env=verify_env, capture_output=True, text=True)
+            assert verified.returncode == 0, verified.stdout + verified.stderr
+            assert after == (root / "rhwp-core.lock").read_bytes(), "post-update verification rewrote lock"
         print(f"PASS: {name}")
 
 
 def replace(path, old, new):
     return lambda root: (root / path).write_text((root / path).read_text().replace(old, new))
+
+
+def add_artifact(root):
+    script = root / "scripts/build-rust-macos.sh"
+    script.write_text(script.read_text().replace('  "$STATICLIB_ARTIFACT"\n)', '  "$STATICLIB_ARTIFACT"\n  "Frameworks/extra.dat"\n)'))
+    (root / "Frameworks").mkdir()
+    (root / "Frameworks/extra.dat").write_bytes(b"extra artifact\n")
 
 
 run_case("portable matching", ["--verify-portable"], True, "Verified (portable)")
@@ -74,9 +93,13 @@ run_case("strict archive drift", ["--verify-strict"], False, "strict staticlib r
 run_case("legacy remains strict", ["--verify-lock"], False, "strict staticlib reference mismatch", archive="different bytes")
 run_case("legacy skip compatibility", ["--verify-lock"], True, "Verified (portable)", archive="different bytes", legacy="1")
 run_case("strict cannot be weakened", ["--verify-strict"], False, "conflicts with legacy", legacy="1")
-run_case("invalid env", ["--verify-portable"], False, "must be 0 or 1", legacy="true")
+run_case("invalid legacy env", ["--verify-lock"], False, "must be 0 or 1", legacy="true")
+run_case("invalid strict env", ["--verify-strict"], False, "must be 0 or 1", legacy="true")
+run_case("portable ignores legacy env", ["--verify-portable"], True, "Verified (portable)", legacy="true")
+run_case("build ignores legacy env", [], True, "Done:", legacy="true")
 run_case("mutually exclusive modes", ["--verify-strict", "--verify-portable"], False, "exactly one")
 run_case("update cannot accompany verify", ["--update-lock", "--verify-portable"], False, "exactly one")
+run_case("repeated mode rejected clearly", ["--verify-portable", "--verify-portable"], False, "duplicate or conflicting modes")
 run_case("unknown flag", ["--verify-typo"], False, "unknown option")
 run_case("portable enforces commit", ["--verify-portable"], False, "core commit differs", mutation=replace("RustBridge/Cargo.lock", COMMIT, "b" * 40))
 run_case("portable enforces features", ["--verify-portable"], False, "enabled features differ", mutation=replace("RustBridge/Cargo.toml", "native-skia", "other"))
@@ -85,4 +108,6 @@ run_case("header failure precedes archive drift", ["--verify-strict"], False, "g
 run_case("portable enforces FFI symbols", ["--verify-portable"], False, "generated FFI symbol set differs", mutation=replace("header", "rhwp_open", "rhwp_changed"))
 run_case("portable requires archive metadata", ["--verify-portable"], False, "missing or invalid lock metadata", mutation=replace("rhwp-core.lock", hashlib.sha256(ARCHIVE).hexdigest(), "bad"))
 run_case("build only remains available", [], True, "Done:", archive="different bytes")
-print("Rust verification mode fixtures passed (18 cases).")
+run_case("new artifact cannot skip verification", ["--verify-portable"], False, "missing or invalid lock metadata", mutation=add_artifact)
+run_case("writer and verifier share artifacts; update ignores legacy env", ["--update-lock"], True, "Updated:", legacy="true", mutation=add_artifact, updated_artifact="Frameworks/extra.dat")
+print("Rust verification mode fixtures passed (24 cases).")

--- a/scripts/ci/test-rust-verification-modes.py
+++ b/scripts/ci/test-rust-verification-modes.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""격리된 fake toolchain으로 build CLI의 검증 경계를 검사한다. 실제 빌드 검증은 별도다."""
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+
+ROOT = Path(__file__).resolve().parents[2]
+HEADER = b"void rhwp_open(void);\n// width_pt height_pt\n"
+ARCHIVE = b"reference archive\n"
+COMMIT = "a" * 40
+MOCK = r'''#!/usr/bin/env python3
+import os, pathlib, sys
+name = pathlib.Path(sys.argv[0]).name
+args = sys.argv[1:]
+if name == 'rustup':
+    print('aarch64-apple-darwin\nx86_64-apple-darwin')
+elif name == 'cbindgen':
+    pathlib.Path(args[args.index('--output') + 1]).write_bytes(pathlib.Path(os.environ['FIXTURE_HEADER']).read_bytes())
+elif name == 'xcrun' and '-output' in args:
+    pathlib.Path(args[args.index('-output') + 1]).write_text(os.environ.get('FIXTURE_ARCHIVE', 'reference archive\n'))
+elif name == 'xcodebuild':
+    pathlib.Path(args[args.index('-output') + 1]).mkdir(parents=True)
+elif name == 'stat':
+    print(pathlib.Path(args[-1]).stat().st_size)
+'''
+
+
+def run_case(name, flags, expected, needle, *, archive=None, legacy=None, mutation=None):
+    with tempfile.TemporaryDirectory(prefix="rhwp-verify-test-") as tmp:
+        root = Path(tmp)
+        for directory in ("scripts", "RustBridge", "bin"):
+            (root / directory).mkdir()
+        shutil.copy2(ROOT / "scripts/build-rust-macos.sh", root / "scripts/build-rust-macos.sh")
+        (root / "RustBridge/Cargo.toml").write_text('[dependencies]\nrhwp = { git = "https://github.com/edwardkim/rhwp.git", tag = "v1.2.3", features = ["native-skia"] }\n')
+        (root / "RustBridge/Cargo.lock").write_text(f'[[package]]\nname = "rhwp"\nsource = "git+https://github.com/edwardkim/rhwp.git?tag=v1.2.3#{COMMIT}"\n')
+        (root / "rhwp-ffi-symbols.txt").write_text("rhwp_open\n")
+        (root / "header").write_bytes(HEADER)
+        lock = f'lock_version = 2\nrhwp_repo = "https://github.com/edwardkim/rhwp.git"\nrhwp_ref_kind = "release-tag"\nrhwp_release_tag = "v1.2.3"\nrhwp_commit = "{COMMIT}"\nrhwp_enabled_features = "native-skia"\n'
+        for path, data in (("Frameworks/universal/librhwp.a", ARCHIVE), ("Frameworks/generated_rhwp.h", HEADER)):
+            lock += f'\n[[artifacts]]\npath = "{path}"\nsha256 = "{hashlib.sha256(data).hexdigest()}"\nsize = {len(data)}\n'
+        (root / "rhwp-core.lock").write_text(lock)
+        for tool in ("cargo", "rustup", "cbindgen", "xcrun", "xcodebuild", "stat"):
+            mock = root / "bin" / tool
+            mock.write_text(MOCK)
+            mock.chmod(0o755)
+        if mutation:
+            mutation(root)
+        before = (root / "rhwp-core.lock").read_bytes()
+        env = dict(os.environ, PATH=f"{root / 'bin'}:{os.environ['PATH']}", FIXTURE_HEADER=str(root / "header"))
+        env.pop("ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY", None)
+        if archive is not None:
+            env["FIXTURE_ARCHIVE"] = archive
+        if legacy is not None:
+            env["ALHANGEUL_SKIP_RHWP_STATICLIB_HASH_VERIFY"] = legacy
+        result = subprocess.run(["bash", str(root / "scripts/build-rust-macos.sh"), *flags], env=env, capture_output=True, text=True)
+        output = result.stdout + result.stderr
+        assert (result.returncode == 0) == expected, f"{name}: unexpected exit {result.returncode}\n{output}"
+        assert needle in output, f"{name}: missing {needle!r}\n{output}"
+        assert before == (root / "rhwp-core.lock").read_bytes(), f"{name}: verification rewrote lock"
+        print(f"PASS: {name}")
+
+
+def replace(path, old, new):
+    return lambda root: (root / path).write_text((root / path).read_text().replace(old, new))
+
+
+run_case("portable matching", ["--verify-portable"], True, "Verified (portable)")
+run_case("portable archive drift", ["--verify-portable"], True, "comparison excluded", archive="different bytes")
+run_case("strict matching", ["--verify-strict"], True, "Verified (strict)")
+run_case("strict archive drift", ["--verify-strict"], False, "strict staticlib reference mismatch", archive="different bytes")
+run_case("legacy remains strict", ["--verify-lock"], False, "strict staticlib reference mismatch", archive="different bytes")
+run_case("legacy skip compatibility", ["--verify-lock"], True, "Verified (portable)", archive="different bytes", legacy="1")
+run_case("strict cannot be weakened", ["--verify-strict"], False, "conflicts with legacy", legacy="1")
+run_case("invalid env", ["--verify-portable"], False, "must be 0 or 1", legacy="true")
+run_case("mutually exclusive modes", ["--verify-strict", "--verify-portable"], False, "exactly one")
+run_case("update cannot accompany verify", ["--update-lock", "--verify-portable"], False, "exactly one")
+run_case("unknown flag", ["--verify-typo"], False, "unknown option")
+run_case("portable enforces commit", ["--verify-portable"], False, "core commit differs", mutation=replace("RustBridge/Cargo.lock", COMMIT, "b" * 40))
+run_case("portable enforces features", ["--verify-portable"], False, "enabled features differ", mutation=replace("RustBridge/Cargo.toml", "native-skia", "other"))
+run_case("portable enforces header", ["--verify-portable"], False, "generated header ABI artifact mismatch", mutation=replace("header", "void", "int"))
+run_case("header failure precedes archive drift", ["--verify-strict"], False, "generated header ABI artifact mismatch", archive="different bytes", mutation=replace("header", "void", "int"))
+run_case("portable enforces FFI symbols", ["--verify-portable"], False, "generated FFI symbol set differs", mutation=replace("header", "rhwp_open", "rhwp_changed"))
+run_case("portable requires archive metadata", ["--verify-portable"], False, "missing or invalid lock metadata", mutation=replace("rhwp-core.lock", hashlib.sha256(ARCHIVE).hexdigest(), "bad"))
+run_case("build only remains available", [], True, "Done:", archive="different bytes")
+print("Rust verification mode fixtures passed (18 cases).")

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -27,7 +27,7 @@ rm -rf "${BUILD_DIR:?}/$BUILD_APP_NAME" "${BUILD_DIR:?}/$BUILD_APP_NAME.dSYM"
 rm -rf "$BUILD_DIR"/Alhangeul*.appex "$BUILD_DIR"/Alhangeul*.appex.dSYM "$BUILD_DIR"/Alhangeul*.swiftmodule
 rm -rf "$BUILD_DIR/include" "$BUILD_DIR/librhwp.a"
 
-"$ROOT/scripts/build-rust-macos.sh" --verify-lock
+"$ROOT/scripts/build-rust-macos.sh" --verify-portable
 
 cd "$ROOT"
 xcodegen generate

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -276,7 +276,7 @@ reset_output() {
 
 build_rust_bridge() {
   info "Verifying Rust bridge artifacts"
-  "$ROOT/scripts/build-rust-macos.sh" --verify-lock
+  "$ROOT/scripts/build-rust-macos.sh" --verify-portable
 }
 
 generate_project() {

--- a/scripts/render_debug_compare.swift
+++ b/scripts/render_debug_compare.swift
@@ -133,7 +133,7 @@ struct RenderDebugCompare {
         guard let treeData = renderTreeJSON.data(using: .utf8) else {
             throw RenderDebugError(description: "render tree JSON is not UTF-8")
         }
-        let tree = try JSONDecoder().decode(RenderNode.self, from: treeData)
+        let tree = try RenderTreeDecoder.decode(treeData)
 
         guard let coreSVG = doc.renderPageSVG(at: pageIndex) else {
             throw RenderDebugError(description: "core SVG is nil")

--- a/scripts/stage3_render_check.swift
+++ b/scripts/stage3_render_check.swift
@@ -45,7 +45,7 @@ struct Stage3RenderCheck {
     }
 
     private static func verifyRenderTreeQueryBoundary(_ document: RhwpDocument) throws {
-        for invalidPage in [-1, Int(UInt32.max) + 1] {
+        for invalidPage in [-1, Int(UInt32.max) + 1, document.pageCount] {
             do {
                 _ = try document.renderPageTreeThrowing(at: invalidPage)
                 throw RenderCheckError(description: "invalid page was accepted")
@@ -56,12 +56,8 @@ struct Stage3RenderCheck {
                 }
             }
         }
-        do {
-            _ = try document.renderPageTreeThrowing(at: document.pageCount)
-            throw RenderCheckError(description: "out-of-range producer query was accepted")
-        } catch RhwpRenderTreeQueryError.producerUnavailable {
-            // A valid UInt32 outside the document tests the real FFI null-output path.
-        }
+        // The raw JSON API deliberately reaches the FFI for pageCount (a valid UInt32).
+        // Its nil assertion above tests actual producer null independently of the public range error.
     }
 
     @MainActor

--- a/scripts/stage3_render_check.swift
+++ b/scripts/stage3_render_check.swift
@@ -44,6 +44,26 @@ struct Stage3RenderCheck {
         }
     }
 
+    private static func verifyRenderTreeQueryBoundary(_ document: RhwpDocument) throws {
+        for invalidPage in [-1, Int(UInt32.max) + 1] {
+            do {
+                _ = try document.renderPageTreeThrowing(at: invalidPage)
+                throw RenderCheckError(description: "invalid page was accepted")
+            } catch RhwpRenderTreeQueryError.invalidPageIndex {
+                guard document.renderPageTree(at: invalidPage) == nil,
+                      document.renderPageTreeJSON(at: invalidPage) == nil else {
+                    throw RenderCheckError(description: "optional query did not preserve nil failure")
+                }
+            }
+        }
+        do {
+            _ = try document.renderPageTreeThrowing(at: document.pageCount)
+            throw RenderCheckError(description: "out-of-range producer query was accepted")
+        } catch RhwpRenderTreeQueryError.producerUnavailable {
+            // A valid UInt32 outside the document tests the real FFI null-output path.
+        }
+    }
+
     @MainActor
     private static func render(inputPath: String, outputDir: URL) throws -> String {
         let inputURL = URL(fileURLWithPath: inputPath)
@@ -54,9 +74,8 @@ struct Stage3RenderCheck {
         }
 
         let pageIndex = 0
-        guard let tree = doc.renderPageTree(at: pageIndex) else {
-            throw RenderCheckError(description: "render tree is nil")
-        }
+        let tree = try doc.renderPageTreeThrowing(at: pageIndex)
+        try verifyRenderTreeQueryBoundary(doc)
 
         var stats = TextStats()
         collectTextStats(tree, into: &stats)


### PR DESCRIPTION
알려진 RenderNodeType의 필수 필드/형식 오류를 `.unknown`으로 숨기지 않고 variant·schema path·cause로 전달합니다. 미래의 단일 variant는 계속 수용하고, 기존 optional API와 별도로 throwing API를 제공합니다. 제품 로그에는 문서 값이나 raw decode 오류를 추가하지 않습니다.

실제 KTX/request 검증에서 core의 unsigned 문단 marker가 Swift Int 범위를 넘어 숨겨지던 문제가 드러났습니다. 해당 index metadata를 UInt로 보존하여 TextRun이 각각 410→415, 102→103으로 복원됩니다. core pin과 renderer source는 변경하지 않았습니다.

검증: 기존 decoder 계약과 24종 tag·unsigned 경계, HWP 3종/HWPX 1종 native smoke, 실제 FFI page 경계/null-output, HostApp Debug build, no-AppKit 통과. core/native 비교 이미지도 확인했으나 pixel parity를 보증하지 않습니다.

선행 PR: #503. 자신의 커밋 범위는 `a011a92..HEAD`이며 base는 devel입니다. 선행 PR 병합 전 누적 diff가 보입니다. 리뷰·병합 순서는 #503 → 이 PR → #469 → #474 순서입니다.

보고서: [최종 결과보고서](https://github.com/postmelee/alhangeul-macos/blob/19aacd598cd996285de78ca84d8c5e4f20a2de77/mydocs/report/task_m020_470_report.md)

Closes #470

개별 변경 비교: [이 작업의 변경만 보기](https://github.com/postmelee/alhangeul-macos/compare/a011a924dd4795de61acd8838405ec5eecacf05e...19aacd598cd996285de78ca84d8c5e4f20a2de77)

리뷰 보완: [보완 내용과 답변](https://github.com/postmelee/alhangeul-macos/pull/504#issuecomment-5561960740), [Stage 4 보고서](https://github.com/postmelee/alhangeul-macos/blob/19aacd598cd996285de78ca84d8c5e4f20a2de77/mydocs/working/task_m020_470_stage4.md).

보완 head `19aacd5` CI: [PR CI 실행 결과](https://github.com/postmelee/alhangeul-macos/actions/runs/34057461132) — 모두 통과.

**잔여 검증 및 병합 승인(2026-09-07): macOS 12 실제 runtime 검증은 사용 가능한 환경이 없어 미실행입니다. 작업지시자는 이 한계를 안내받은 뒤 네 PR의 병합과 정리를 명시 승인했습니다. 최소 지원 OS 실행 검증은 후속 확인 사항으로 유지하며, 현재 OS/CI 성공을 macOS 12 검증으로 간주하지 않습니다.**
